### PR TITLE
trackupstream: Do not call prepare_spec

### DIFF
--- a/scripts/jenkins/track-upstream-and-package.pl
+++ b/scripts/jenkins/track-upstream-and-package.pl
@@ -399,9 +399,6 @@ sub get_osc_package_info()
 
   print "--> Now trying to build package.\n";
 
-  # normalize spec-file
-  system('for spec in *.spec ; do /work/src/bin/tools/prepare_spec $spec > $spec.new && mv $spec.new $spec ; done');
-
   # run osc build
   $OSC_BUILD_LOG="../$project.build.log.0";
   $OSC_BUILD_LOG_OLD="../$project.build.log.1";


### PR DESCRIPTION
The prepare_spec script can change spec files in unwanted ways (removal
of comments, addition of empty lines, etc.), and is only wanted for
packages in IBS.

We will use it when copying the packages from OBS to IBS instead.
