### PR TITLE
add python-oslo-config to trackupstream

### DIFF
--- a/scripts/jenkins/openstack-trackupstream.config.xml.pl
+++ b/scripts/jenkins/openstack-trackupstream.config.xml.pl
@@ -31,6 +31,7 @@ my %tutrigger = (
     python-novaclient
     python-quantumclient
     python-swiftclient
+    python-oslo-config
   ) ],
   "OBS/Cloud:OpenStack:Folsom:Staging" => [ qw(
     openstack-cinder

--- a/scripts/jenkins/openstack-unittest.config.xml.pl
+++ b/scripts/jenkins/openstack-unittest.config.xml.pl
@@ -43,6 +43,8 @@ my $uttrigger = {
                                          "TESTCMD=nosetests",
         'python-swiftclient'          => "COMPONENT=python-swiftclient\n".
                                          "TESTCMD=nosetests",
+        'python-oslo-config'          => "COMPONENT=python-oslo-config\n".
+                                         "TESTCMD=nosetests",
     }
   },
   Folsom => {


### PR DESCRIPTION
This package is now required by nova, glance, keystone etc.
