### PR TITLE
Use nova boot --poll instead of sleeping 30 seconds (hoping it's enough)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -881,9 +881,8 @@ if [ -n "$testsetup" ] ; then
 		nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0
 		nova secgroup-add-rule default tcp 1 65535 0.0.0.0/0
 		nova secgroup-add-rule default udp 1 65535 0.0.0.0/0
-		nova boot --image SP2-64 --flavor m1.smaller --key_name testkey testvm | tee boot.out
+		nova boot --poll --image SP2-64 --flavor m1.smaller --key_name testkey testvm | tee boot.out
 		instanceid=`perl -ne "m/ id [ |]*([0-9a-f-]+)/ && print \\$1" boot.out`
-		sleep 30
                 nova show $instanceid
 		vmip=`nova show $instanceid | perl -ne "m/fixed.network [ |]*([0-9.]+)/ && print \\$1"`
 		echo "VM IP address: $vmip"


### PR DESCRIPTION
We have some failures every now and then that seem to happen because the
boot is taking longer than we sleep and there's no IP address associated
to the instance.
