### PR TITLE
Allow owerwriting domain

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -42,6 +42,7 @@
 #                sets the number of CPU cores assigned to each node (admin and compute)
 
 virtualcloud=${virtualcloud:-virtual}
+cloudfqdn=${cloudfqdn:-$virtualcloud.cloud.suse.de}
 forwardmode=${forwardmode:-nat}
 net_fixed=${net_fixed:-192.168.123}
 net_public=${net_public:-192.168.122}
@@ -134,6 +135,7 @@ function sshrun()
 {
   ssh root@$adminip "
     export debug=$debug ;
+    export cloudfqdn=$cloudfqdn ;
     export cloudsource=$cloudsource ;
     export hacloud=$hacloud ;
     export libvirt_type=$libvirt_type ;
@@ -236,7 +238,7 @@ function h_deploy_admin_image()
 
 function h_add_etchosts_entries()
 {
-  grep -q crowbar /etc/hosts || echo "$adminip crowbar.$virtualcloud.cloud.suse.de crowbar" >> /etc/hosts
+  grep -q crowbar /etc/hosts || echo "$adminip crowbar.$cloudfqdn crowbar" >> /etc/hosts
 }
 
 function h_enable_ksm
@@ -376,7 +378,7 @@ function h_create_libvirt_admin_network_config()
     <mac address='52:54:00:AB:B1:77'/>
     <ip address='$admingw' netmask='$adminnetmask'>
       <dhcp>
-        <host mac="52:54:00:77:77:70" name="crowbar.$virtualcloud.cloud.suse.de" ip="$adminip"/>
+        <host mac="52:54:00:77:77:70" name="crowbar.$cloudfqdn" ip="$adminip"/>
       </dhcp>
     </ip>
     <forward mode='$forwardmode'>

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -6,6 +6,7 @@ test $(uname -m) = x86_64 || echo "ERROR: need 64bit"
 novacontroller=
 novadashboardserver=
 export cloud=${1}
+export cloudfqdn=${cloudfqdn:-$cloud.cloud.suse.de}
 export nodenumber=${nodenumber:-2}
 export nodes=
 export debug=${debug:-0}
@@ -247,7 +248,7 @@ function add_ha_repo()
 
 function prepareinstallcrowbar()
 {
-  echo configure static IP and absolute + resolvable hostname crowbar.$cloud.cloud.suse.de gw:$net.1
+  echo configure static IP and absolute + resolvable hostname crowbar.$cloudfqdn gw:$net.1
   cat > /etc/sysconfig/network/ifcfg-eth0 <<EOF
 NAME='eth0'
 STARTMODE='auto'
@@ -259,12 +260,12 @@ EOF
   ifdown br0
   rm -f /etc/sysconfig/network/ifcfg-br0
   grep -q "^default" /etc/sysconfig/network/routes || echo "default $net.1 - -" > /etc/sysconfig/network/routes
-  echo "crowbar.$cloud.cloud.suse.de" > /etc/HOSTNAME
+  echo "crowbar.$cloudfqdn" > /etc/HOSTNAME
   hostname `cat /etc/HOSTNAME`
   # these vars are used by rabbitmq
   export HOSTNAME=`cat /etc/HOSTNAME`
   export HOST=$HOSTNAME
-  grep -q "$net.*crowbar" /etc/hosts || echo $net.10 crowbar.$cloud.cloud.suse.de crowbar >> /etc/hosts
+  grep -q "$net.*crowbar" /etc/hosts || echo $net.10 crowbar.$cloudfqdn crowbar >> /etc/hosts
   rcnetwork restart
   hostname -f # make sure it is a FQDN
   ping -c 1 `hostname -f`
@@ -593,7 +594,7 @@ function do_installcrowbar()
     exit 84
   fi
 
-  if ! crowbar machines list | grep -q crowbar.$cloud ; then
+  if ! crowbar machines list | grep -q crowbar.$cloudfqdn ; then
     tail -n 90 /root/screenlog.0
     echo "crowbar 2nd self-test failed"
     exit 85


### PR DESCRIPTION
Allow overwriting the domain (that used to be hardcoded to `cloud.suse.de`).

This wasn't tested, yet.
