### PR TITLE
Fix check for libvirt net

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -443,7 +443,9 @@ listen_addr = "0.0.0.0"' >> /etc/libvirt/libvirtd.conf
   rclibvirtd start
   wait_for 300 1 '[ -S /var/run/libvirt/libvirt-sock ]' 'libvirt startup'
 
-  [ -e /etc/libvirt/qemu/networks/$cloud-admin.xml ] || virsh net-create /tmp/$cloud-admin.net.xml
+  if ! virsh net-dumpxml $cloud-admin > /dev/null 2>&1; then
+    virsh net-create /tmp/$cloud-admin.net.xml
+  fi
   virsh net-start $cloud-admin
   if ! virsh create /tmp/$cloud-admin.xml ; then
     echo "=====================================================>>"


### PR DESCRIPTION
It's possible that there's no config file under
/etc/libvirt/qemu/networks/ but the network already exists
(non-persistent).
