### PR TITLE
Added support to configure cloud using ovs+vlan

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -146,6 +146,7 @@ function sshrun()
     export net_admin=$net_admin ;
     export net_public=$net_public ;
     export networkingplugin=$networkingplugin ;
+    export networkingmode=$networkingmode ;
     export nodenumber=$nodenumber ;
     export nosetestparameters=${nosetestparameters} ;
     export tempestoptions='${tempestoptions}' ;
@@ -825,6 +826,12 @@ function usage()
   echo "       : set the number of nodes to be created (excl. admin node)"
   echo "   vcpus=1         (default 1)"
   echo "       : set the number of CPU cores per node (admin and compute)"
+  echo "   networkingplugin"
+  echo "       : Set the networking plugin to be used by neutron (e.g. openvswitch),"
+  echo "         if it isn't defined the barclamp-neutron's default is used."
+  echo "   networkingmode"
+  echo "       : Set the networking mode to be used by neutron (e.g. gre)"
+  echo "         if it isn't defined the barclamp-neutron's default is used."
   echo
   exit 1
 }

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -854,6 +854,12 @@ function custom_configuration()
       if iscloudver 4plus; then
         proposal_set_value neutron default "['attributes']['neutron']['use_lbaas']" "true"
       fi
+      if [ -n "$networkingplugin" ] ; then
+        proposal_set_value neutron default "['attributes']['neutron']['networking_plugin']" "'$networkingplugin'"
+      fi
+      if [ -n "$networkingmode" ] ; then
+        proposal_set_value neutron default "['attributes']['neutron']['networking_mode']" "'$networkingmode'"
+      fi
     ;;
     quantum)
       if [[ $networkingplugin = linuxbridge ]] ; then


### PR DESCRIPTION
To configure neutron using openvswitch with VLAN support set environment
variables `networkingplugin` to `openvswitch` and `networkingmode` to
`vlan`.
