### PR TITLE
Add support to reboot exclusively neutron controller

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -699,6 +699,12 @@ function rebootcompute()
   return $?
 }
 
+function rebootneutron()
+{
+    scp -q qa_crowbarsetup.sh root@$adminip:
+    sshrun "rebootneutron=1 bash qa_crowbarsetup.sh $virtualcloud"
+    return $?
+}
 
 function securitytests()
 {
@@ -935,7 +941,7 @@ function sanity_checks()
 
 ## MAIN ##
 
-allcmds="all all_noreboot instonly plain cleanup prepare setupadmin prepareinstcrowbar instcrowbar instcrowbarfromgit setupcompute instcompute proposal testsetup rebootcrowbar rebootcompute addupdaterepo runupdate testupdate securitytests crowbarbackup crowbarrestore tempest qa_test help"
+allcmds="all all_noreboot instonly plain cleanup prepare setupadmin prepareinstcrowbar instcrowbar instcrowbarfromgit setupcompute instcompute proposal testsetup rebootcrowbar rebootcompute addupdaterepo runupdate testupdate securitytests crowbarbackup crowbarrestore tempest qa_test help rebootneutron"
 wantedcmds=$@
 runcmds=''
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1204,6 +1204,33 @@ function waitforrebootcompute()
   wait_for 100 1 "ping -q -c 1 -w 1 $vmip >/dev/null" "testvm to boot up"
 }
 
+function get_neutron_server_node()
+{
+  NEUTRON_SERVER=$(crowbar neutron proposal show default|ruby -e "require 'rubygems';require 'json';
+  j=JSON.parse(STDIN.read);
+  puts j['deployment']['neutron']['elements']['neutron-server'][0];")
+}
+
+function rebootneutron()
+{
+  get_neutron_server_node
+  echo "Rebooting neutron server: $NEUTRON_SERVER ..."
+
+  ssh $NEUTRON_SERVER "reboot"
+  wait_for 100 1 " ! netcat -z $NEUTRON_SERVER 22 >/dev/null" "node $NEUTRON_SERVER to go down"
+  wait_for 200 3 "netcat -z $NEUTRON_SERVER 22 >/dev/null" "node $NEUTRON_SERVER to be back online"
+
+  wait_for 300 3 "ssh $NEUTRON_SERVER 'rcopenstack-neutron status' |grep -q running" "neutron-server service running state"
+  wait_for 400 3 " ! ssh $NEUTRON_SERVER '. .openrc && neutron agent-list -f csv --quote none'|tail -n+2 | grep -q -v ':-)'" "neutron agents up"
+
+  ssh $NEUTRON_SERVER '. .openrc && neutron agent-list'
+  ssh $NEUTRON_SERVER 'ping -c1 -w1 8.8.8.8' > /dev/null
+  if [ "x$?" != "x0" ]; then
+      echo "Error: ping to 8.8.8.8 from $NEUTRON_SERVER failed."
+      exit 1
+  fi
+}
+
 function create_owasp_testsuite_config()
 {
   get_novadashboardserver
@@ -1499,6 +1526,10 @@ fi
 
 if [ -n "$waitforrebootcompute" ] ; then
   waitforrebootcompute
+fi
+
+if [ -n "$rebootneutron" ] ; then
+    rebootneutron
 fi
 
 if [ -n "$securitytests" ] ; then


### PR DESCRIPTION
Executing `./mkcloud rebootneutron` will reboot the node where
`neutron-server` is running.

This is useful to test how the cloud will behave after rebooting the network,
an expected use case for this is running the following command:

```
# ./mkcloud all_noreboot rebootneutron testsetup
```
