### PR TITLE
qa_crowbarsetup: check if testvm ssh is up actively

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1154,14 +1154,31 @@ function do_testsetup()
             echo "VM not accessible in reasonable time, exiting."
             exit 96
         fi
-        WAITSSH=200
-        echo "Waiting $WAITSSH seconds for the SSH keys to be copied over"
-        sleep $WAITSSH
+
+        set +x
+        echo "Waiting for the SSH keys to be copied over"
+        i=0
+        MAX_RETRIES=40
+        ssh-keygen -R $vmip 2> /dev/null
+        while timeout -k 20 10 ssh $vmip "echo cloud" 2> /dev/null; [ $? != 0 ]
+        do
+            ssh-keygen -R $vmip 2> /dev/null
+            sleep 5  # wait before retry
+            if [ $i -gt $MAX_RETRIES ] ; then
+                echo "VM not accessible via SSH, something could be wrong with SSH keys"
+                exit 97
+            fi
+            i=$((i+1))
+            echo -n "."
+        done
+        ssh-keygen -R $vmip 2> /dev/null
+        set -x
         if ! ssh $vmip curl www3.zq1.de/test ; then
             echo could not reach internet
             exit 95
         fi
         set -x
+
         ssh $vmip modprobe acpiphp # workaround bnc#824915
         nova volume-list | grep -q available || nova volume-create 1 ; sleep 2
         nova volume-list | grep available


### PR DESCRIPTION
This patch changes the way qa_crowbar waits until `testvm` SSH keys are
ready to log in. Originally the script was sleeping for 200 secs and then
just connecting, now the script checks 40 times every 5 seconds to know if
the keys are ready to be used.

`ssh-keygen -R $vmip` is being used, because the server's fingerprint changes
a few seconds after `sshd` started listening connections for the first time.

Also I want to comment that I experienced a couple of failures with the original approach where 200 secs weren't enough to have the SSH keys ready to log in (I didn't see the problem with this patch, but it doesn't mean won't suffer the same issue), here is the relevant stdout/stderr:

<pre>
..........................Waiting for the VM to come up: + '[' 973 = 0 ']'
+ echo -n 'Waiting for the VM to come up: '
+ n=500
+ test 500 -gt 0
+ netcat -z 192.168.122.207 22
+ sleep 1
.+ n=499
+ echo -n .
+ set +x
....Waiting 200 seconds for the SSH keys to be copied over
+ '[' 495 = 0 ']'
+ WAITSSH=200
+ echo 'Waiting 200 seconds for the SSH keys to be copied over'
+ sleep 200
+ ssh 192.168.122.207 curl www3.zq1.de/test
Warning: Permanently added '192.168.122.207' (ECDSA) to the list of known hosts.
Permission denied (publickey,keyboard-interactive).
could not reach internet
ret:95
+ echo could not reach internet
+ exit 95
+ ret=95
+ echo ret:95
+ exit 95</pre>
