### PR TITLE
mkcloud: Pass cinder volume config to crowbar node

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -168,6 +168,9 @@ function sshrun()
 
     export localreposdir_target=$localreposdir_target ;
 
+    export cinder_conf_volume_type=$cinder_conf_volume_type;
+    export cinder_conf_volume_params=$cinder_conf_volume_params;
+
     export TESTHEAD=$TESTHEAD ;
     export NOINSTALLCLOUDPATTERN=$NOINSTALLCLOUDPATTERN ;
     $@


### PR DESCRIPTION
qa_crowbarsetup needs cinder_conf_volume_type and
cinder_conf_volume_params to configure the cinder volume backend
correctly.
