### PR TITLE
create-vm: Use other file for kvm_intel params

### DIFF
--- a/scripts/create-vm.sh
+++ b/scripts/create-vm.sh
@@ -160,8 +160,8 @@ main () {
             if [ `id -u` == 0 ] ; then
                 echo "Running as root, invoking modprobe kvm_$plat."
                 if [ $plat = "intel" ] ; then
-                    if ! grep -q nested /etc/modprobe.d/99-local.conf ; then
-                        echo "options kvm_intel nested=1" | sudo tee /etc/modprobe.d/99-local.conf
+                    if ! grep -q nested /etc/modprobe.d/80-kvm-intel.conf ; then
+                        echo "options kvm_intel nested=1" | sudo tee /etc/modprobe.d/80-kvm-intel.conf
                         modprobe -r kvm_intel
                     fi
                 fi


### PR DESCRIPTION
mkcloud uses /etc/modprobe.d/80-kvm-intel.conf for kvm_intel module
options. Use the same file for create-vm.sh so we don't use two
different places for the module options.
