### PR TITLE
qa_crowbarsetup: use `UserKnownHostsFile=/dev/null`

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1149,10 +1149,8 @@ function do_testsetup()
         echo "Waiting for the SSH keys to be copied over"
         i=0
         MAX_RETRIES=40
-        ssh-keygen -R $vmip 2> /dev/null
-        while timeout -k 20 10 ssh $vmip "echo cloud" 2> /dev/null; [ $? != 0 ]
+        while timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $vmip "echo cloud" 2> /dev/null; [ $? != 0 ]
         do
-            ssh-keygen -R $vmip 2> /dev/null
             sleep 5  # wait before retry
             if [ $i -gt $MAX_RETRIES ] ; then
                 echo "VM not accessible via SSH, something could be wrong with SSH keys"
@@ -1161,7 +1159,6 @@ function do_testsetup()
             i=$((i+1))
             echo -n "."
         done
-        ssh-keygen -R $vmip 2> /dev/null
         set -x
         if ! ssh $vmip curl www3.zq1.de/test ; then
             echo could not reach internet


### PR DESCRIPTION
This patch removes the usage of `ssh-keygen -R` in favor of
`ssh -o UserKnownHostsFile=/dev/null`.
