### PR TITLE
Increase size of ceph disks to 11G

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -237,7 +237,7 @@ function h_create_cloud_lvm()
     adminnode_hdd_size=${adminnode_hdd_size:-15}
     controller_hdd_size=${controller_hdd_size:-20}
     computenode_hdd_size=${computenode_hdd_size:-15}
-    cephvolume_hdd_size=${cephvolume_hdd_size:-5}
+    cephvolume_hdd_size=${cephvolume_hdd_size:-11}
     controller_ceph_hdd_size=${controller_ceph_hdd_size:-25}
     local hdd_size
 


### PR DESCRIPTION
To compute the default weight of the disks, ceph is doing something like:

df -P -k $disk | tail -1 | awk '{ print sprintf("%.2f",$2/1073741824) }'

This gives 0.00 unless the disk is bigger than ~5.5G.

Per recommendation of storage people, just increase the default to 11G.
This should fix https://bugzilla.novell.com/show_bug.cgi?id=886795 on
mkcloud.
