### PR TITLE
First (rough) implementation of a cloud3->cloud4 upgrade

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -787,6 +787,46 @@ function crowbarrestore()
     return $ret
 }
 
+function prepare_cloud4upgrade()
+{
+    ghsc=github.com/SUSE-Cloud
+    mkdir -p ~/$ghsc/
+    pushd ~/$ghsc/
+    if [ -e "suse-cloud-upgrade" ] ; then
+        cd suse-cloud-upgrade/
+        git pull
+    else
+        git clone https://$ghsc/suse-cloud-upgrade.git
+    fi
+    popd
+    rsync -av ~/$ghsc/suse-cloud-upgrade root@$adminip:
+    sshrun "prepare_cloud4upgrade=1 bash -x qa_crowbarsetup.sh $virtualcloud"
+    return $?
+}
+
+function cloud4upgrade_1st()
+{
+    sshrun "cloud4upgrade_1st=1 bash -x qa_crowbarsetup.sh $virtualcloud"
+    return $?
+}
+
+function cloud4upgrade_2nd()
+{
+    sshrun "cloud4upgrade_2nd=1 bash -x qa_crowbarsetup.sh $virtualcloud"
+    return $?
+}
+
+function cloud4upgrade_clients()
+{
+    sshrun "cloud4upgrade_clients=1 bash -x qa_crowbarsetup.sh $virtualcloud"
+    return $?
+}
+
+function cloud4upgrade_reboot_and_redeploy_clients()
+{
+    sshrun "cloud4upgrade_reboot_and_redeploy_clients=1 bash -x qa_crowbarsetup.sh $virtualcloud"
+    return $?
+}
 
 function usage()
 {
@@ -949,7 +989,7 @@ function sanity_checks()
 
 ## MAIN ##
 
-allcmds="all all_noreboot instonly plain cleanup prepare setupadmin prepareinstcrowbar instcrowbar instcrowbarfromgit setupcompute instcompute proposal testsetup rebootcrowbar rebootcompute addupdaterepo runupdate testupdate securitytests crowbarbackup crowbarrestore qa_test help rebootneutron"
+allcmds="all all_noreboot instonly plain cleanup prepare setupadmin prepareinstcrowbar instcrowbar instcrowbarfromgit setupcompute instcompute proposal testsetup rebootcrowbar rebootcompute addupdaterepo runupdate testupdate securitytests crowbarbackup crowbarrestore qa_test help rebootneutron prepare_cloud4upgrade cloud4upgrade_1st cloud4upgrade_2nd cloud4upgrade_clients cloud4upgrade_reboot_and_redeploy_clients"
 wantedcmds=$@
 runcmds=''
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1619,6 +1619,81 @@ function securitytests()
     return $ret
 }
 
+function prepare_cloud4upgrade()
+{
+    # TODO: All running cloud instances should be suspended here
+
+    : ${susedownload:=download.nue.suse.com}
+    CLOUDDISTPATH=/ibs/SUSE:/SLE-11-SP3:/Update:/Cloud4:/Test/images/iso
+    CLOUDDISTISO="S*-CLOUD*Media1.iso"
+    CLOUDLOCALREPOS="SUSE-Cloud-4-official"
+
+    # recreate the SUSE-Cloud Repo with the latest Cloud 4 iso
+    h_prepare_cloud_repos
+
+    # add new Cloud 4 Update and Pool Channels
+    add_mount "SUSE-Cloud-4-Updates" 'you.suse.de:/you/http/download/x86_64/update/SUSE-CLOUD/4/' "/srv/tftpboot/repos/SUSE-Cloud-4-Updates/" "cloud4up"
+    add_mount "SUSE-Cloud-4-Pool" 'you.suse.de:/you/http/download/x86_64/update/SUSE-CLOUD/4-POOL/' "/srv/tftpboot/repos/SUSE-Cloud-4-Pool/" "cloud4pool"
+
+    zypper --non-interactive refresh
+    zypper --non-interactive install suse-cloud-upgrade
+
+    # Upgrade suse-cloud-upgrade to the latest git code (checked out and
+    # copied into admin node by mkcloud)
+    cp ~/suse-cloud-upgrade/suse-cloud-upgrade /usr/sbin/
+    cp ~/suse-cloud-upgrade/lib/* /usr/lib/suse-cloud-upgrade/
+}
+
+function cloud4upgrade_1st()
+{
+    # Disable all openstack proposals stop service on the client
+    echo 'y' | suse-cloud-upgrade upgrade
+}
+
+function cloud4upgrade_2nd()
+{
+    # Upgrade Admin node
+    zypper --non-interactive up -l
+    echo 'y' | suse-cloud-upgrade upgrade
+    crowbar provisioner proposal commit default
+}
+
+function cloud4upgrade_clients()
+{
+    # Upgrade Packages on the client nodes
+    crowbar updater proposal create default
+    proposal_set_value updater default "['attributes']['updater']['zypper']['method']" "'update'"
+    proposal_set_value updater default "['attributes']['updater']['zypper']['licenses_agree']" "true"
+    crowbar updater proposal commit default
+}
+
+function cloud4upgrade_reboot_and_redeploy_clients()
+{
+    local barclamp=""
+    local proposal=""
+    local applied_proposals=""
+    # reboot client nodes
+    echo 'y' | suse-cloud-upgrade reboot-nodes
+
+    # Give it some time and wait for the nodes to be back
+    sleep 60
+    waitnodes nodes
+
+    # reenable and apply the openstack propsals
+    for barclamp in pacemaker database rabbitmq keystone swift ceph glance cinder neutron nova nova_dashboard ceilometer heat trove tempest; do
+        applied_proposals=$(crowbar "$barclamp" proposal list )
+        if test "$applied_proposals" == "No current proposals"; then
+            continue
+        fi
+
+        for proposal in $applied_proposals; do
+            echo "Commiting proposal $proposal of barclamp ${barclamp}..."
+            crowbar "$barclamp" proposal commit "$proposal"
+        done
+    done
+
+    # TODO: restart any suspended instance?
+}
 
 function qa_test()
 {
@@ -1696,6 +1771,26 @@ fi
 
 if [ -n "$waitcompute" ] ; then
     do_waitcompute
+fi
+
+if [ -n "$prepare_cloud4upgrade" ] ; then
+    prepare_cloud4upgrade
+fi
+
+if [ -n "$cloud4upgrade_1st" ] ; then
+    cloud4upgrade_1st
+fi
+
+if [ -n "$cloud4upgrade_2nd" ] ; then
+    cloud4upgrade_2nd
+fi
+
+if [ -n "$cloud4upgrade_clients" ] ; then
+    cloud4upgrade_clients
+fi
+
+if [ -n "$cloud4upgrade_reboot_and_redeploy_clients" ] ; then
+    cloud4upgrade_reboot_and_redeploy_clients
 fi
 
 set_proposalvars


### PR DESCRIPTION
This introduces five new mkcloud commands for testing the different steps of
the cloud3 to cloud4 upgrade as outlined in the manual:

"prepare_cloud4upgrade":
    Sets up the Cloud 4 repos on the admin server and
    installs the latest suse-cloud-upgrade code from a git checkout.

"cloud4upgrade_1st":
    Runs suse_cloud_upgrade upgrade for the first time (the pre step)

"cloud4upgrade_2nd":
    Updates packages on the admin node and runs suse_cloud_upgrade upgrade for
    the second time (post step)

"cloud4upgrade_clients":
    Deploys the updater barclamp on all client nodes to install the cloud 4
    packages

"cloud4upgrade_reboot_and_redeploy_clients":
    Final step. Calls suse_cloud_upgrade reboot-nodes and redeploys all
    barclamps with exisiting proposals on the clients

This currently needs a mkcloud deployed Cloud3 with "cloudsource=GM3" and
"TESTHEAD=1" to have all maintenance updates installed.
