### PR TITLE
Create a second backend for cinder to allow multi-backend testing

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -981,6 +981,11 @@ function custom_configuration()
                         esac
                     done
                 fi
+
+                # add a second backend to enable multi-backend, if not already present
+                if ! crowbar cinder proposal show default | grep -q local-multi; then
+                  proposal_modify_value cinder default "${volumes}" "{ 'backend_driver' => 'local', 'backend_name' => 'local-multi', 'local' => { 'volume_name' => 'cinder-volumes-multi', 'file_size' => 2000, 'file_name' => '/var/lib/cinder/volume-multi.raw'} }" "<<"
+                fi
             else
                 proposal_set_value cinder default "['attributes']['cinder']['volume']['volume_type']" "'${cinder_conf_volume_type}'"
 


### PR DESCRIPTION
We create a local backend; that way we're sure it'll be available.
