### PR TITLE
Enable deployment of cinder v2 & nova v3 APIs on Cloud 4+

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -926,6 +926,10 @@ function custom_configuration()
             if [[ $all_with_ssl = 1 || $nova_with_ssl = 1 ]] ; then
                 enable_ssl_for_nova
             fi
+
+            if iscloudver 4plus ; then
+                proposal_set_value nova default "['attributes']['nova']['enable_v3_api']" "true"
+            fi
         ;;
         nova_dashboard)
             if [[ $all_with_ssl = 1 || $novadashboard_with_ssl = 1 ]] ; then


### PR DESCRIPTION
The idea is to get even more tempest coverage.
