### PR TITLE
Pass --gpg-auto-import-keys --no-gpg-checks when installing python-nose

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1213,7 +1213,7 @@ EOH
 
                     if ! rpm -q python-nose &> /dev/null; then
                         zypper ar http://download.suse.de/ibs/Devel:/Cloud:/Shared:/11-SP3:/Update/standard/Devel:Cloud:Shared:11-SP3:Update.repo
-                        zypper -n install python-nose
+                        zypper -n --gpg-auto-import-keys --no-gpg-checks install python-nose
                         zypper rr Devel_Cloud_Shared_11-SP3_Update
                     fi
 


### PR DESCRIPTION
If we use a build from the SUSE:\* namespace, then we do not have the
Devel:Cloud GPG key already approved.
