### PR TITLE
Add update step to 'plain' command

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -802,8 +802,8 @@ function usage()
     echo "   instcompute proposal addupdaterepo runupdate testsetup rebootcrowbar "
     echo "   rebootcompute help"
     echo
-    echo "   all      -> expands to: cleanup prepare setupadmin prepareinstcrowbar instcrowbar rebootcrowbar setupcompute instcompute proposal testsetup rebootcompute"
-    echo "   all_noreboot -> exp to: cleanup prepare setupadmin prepareinstcrowbar instcrowbar setupcompute instcompute proposal testsetup"
+    echo "   all      -> expands to: cleanup prepare setupadmin addupdaterepo runupdate prepareinstcrowbar instcrowbar rebootcrowbar setupcompute instcompute proposal testsetup rebootcompute"
+    echo "   all_noreboot -> exp to: cleanup prepare setupadmin addupdaterepo runupdate prepareinstcrowbar instcrowbar setupcompute instcompute proposal testsetup"
     echo "   plain    -> expands to: cleanup prepare setupadmin prepareinstcrowbar instcrowbar setupcompute instcompute proposal"
     echo "   instonly -> expands to: cleanup prepare setupadmin prepareinstcrowbar instcrowbar setupcompute instcompute"
     echo


### PR DESCRIPTION
This patches sync the usage documentation for `all` and `all_noreboot` to indicate when they are expanded the update steps are ran.

~~Also it makes `plain` command consistent with `all` and `all_noreboot`.~~
Update: this pull request doesn't modify 'plain'
