### PR TITLE
Add "apt-get update" so latest package are used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,6 @@ test:
 
 # for travis-CI:
 install:
+	sudo apt-get update
 	sudo apt-get -y install libxml-libxml-perl libjson-xs-perl
 	sudo pip install bash8


### PR DESCRIPTION
This fixes the problem that packages are not installable due to outdated
metadata.
