### PR TITLE
mkcloud: stronger check for concurrent uses

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -874,6 +874,25 @@ function runupdate()
     return $?
 }
 
+function check-no-concurrency() # {{{
+{
+    while read ppid pid; do
+        (( $$ == $ppid )) && continue
+        (( $$ == $pid )) && continue
+        [[ -e /proc/$pid ]] || continue
+        declare -a cmdline=($(cat /proc/$pid/cmdline | tr '\0' '\n'))
+        (( 0 == ${#cmdline} )) && continue
+        if [[ "${cmdline[0]}" == "$SHELL" ]]; then
+            if [[ "${cmdline[1]##*/}" == "${SELF##*/}" ]]; then
+                echo >&2 "possibly concurrent use.  Allegedly infringing process:"
+                echo >&2 "pid=$pid cmdline=${cmdline[*]}"
+                return 1
+            fi
+        fi
+    done < <(ps -eo ppid= -o pid=)
+    return 0
+} # }}}
+
 function sanity_checks()
 {
     if test `id -u` != 0 ; then
@@ -883,17 +902,11 @@ function sanity_checks()
         exit 1
     fi
 
-    SCRIPT=$(basename $0)
-    PSFILE=`mktemp /tmp/mkcloud.XXXXXX`
-    ps ax > $PSFILE
-    if [ `grep -v -e grep -e SCREEN $PSFILE | grep $SCRIPT | wc -l` -gt 1 ]  ; then
-        echo "Error: mkcloud was started twice."
-        echo "if you are sure, that they do not conflict, export PARALLEL=yes"
-        echo
-        rm $PSFILE
-        [ "$PARALLEL" = "yes" ] || exit 33
+    if [[ "$PARALLEL" != "yes" ]] && ! check-no-concurrency; then
+        echo >&2 "Error: mkcloud was started twice."
+        echo >&2 "export PARALLEL=yes if you are sure this is not a conflict."
+        exit 33
     fi
-    rm $PSFILE
 
     # always fetch the latest version
     if [ -z "$NOQACROWBARDOWNLOAD" ] ; then


### PR DESCRIPTION
the outgoing code cried wolf when i had mkcloud open
in a text editor, as well as when i tried to run mkcloud
with script -c "... mkcloud ...".
