### PR TITLE
jenkins: Sync trackupstream job from ci.o.o

### DIFF
--- a/scripts/jenkins/ci.opensuse.org/openstack-trackupstream.xml
+++ b/scripts/jenkins/ci.opensuse.org/openstack-trackupstream.xml
@@ -10,72 +10,6 @@
   </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <hudson.security.AuthorizationMatrixProperty>
-      <permission>hudson.model.Item.Configure:jdsn</permission>
-      <permission>hudson.model.Item.Configure:dirkmueller</permission>
-      <permission>hudson.model.Item.Configure:bmwiedemann</permission>
-      <permission>hudson.model.Item.Configure:saschpe</permission>
-      <permission>hudson.scm.SCM.Tag:iartarisi</permission>
-      <permission>hudson.scm.SCM.Tag:vuntz</permission>
-      <permission>hudson.scm.SCM.Tag:jdsn</permission>
-      <permission>hudson.scm.SCM.Tag:mjura</permission>
-      <permission>hudson.scm.SCM.Tag:aspiers</permission>
-      <permission>hudson.scm.SCM.Tag:dirkmueller</permission>
-      <permission>hudson.scm.SCM.Tag:bmwiedemann</permission>
-      <permission>hudson.scm.SCM.Tag:saschpe</permission>
-      <permission>hudson.model.Item.Cancel:iartarisi</permission>
-      <permission>hudson.model.Item.Cancel:vuntz</permission>
-      <permission>hudson.model.Item.Cancel:jdsn</permission>
-      <permission>hudson.model.Item.Cancel:mjura</permission>
-      <permission>hudson.model.Item.Cancel:aspiers</permission>
-      <permission>hudson.model.Item.Cancel:dirkmueller</permission>
-      <permission>hudson.model.Item.Cancel:bmwiedemann</permission>
-      <permission>hudson.model.Item.Cancel:saschpe</permission>
-      <permission>hudson.model.Item.Discover:iartarisi</permission>
-      <permission>hudson.model.Item.Discover:vuntz</permission>
-      <permission>hudson.model.Item.Discover:jdsn</permission>
-      <permission>hudson.model.Item.Discover:mjura</permission>
-      <permission>hudson.model.Item.Discover:aspiers</permission>
-      <permission>hudson.model.Item.Discover:dirkmueller</permission>
-      <permission>hudson.model.Item.Discover:bmwiedemann</permission>
-      <permission>hudson.model.Item.Discover:saschpe</permission>
-      <permission>hudson.model.Run.Update:iartarisi</permission>
-      <permission>hudson.model.Run.Update:vuntz</permission>
-      <permission>hudson.model.Run.Update:jdsn</permission>
-      <permission>hudson.model.Run.Update:mjura</permission>
-      <permission>hudson.model.Run.Update:aspiers</permission>
-      <permission>hudson.model.Run.Update:dirkmueller</permission>
-      <permission>hudson.model.Run.Update:bmwiedemann</permission>
-      <permission>hudson.model.Run.Update:saschpe</permission>
-      <permission>hudson.model.Run.Delete:jdsn</permission>
-      <permission>hudson.model.Run.Delete:dirkmueller</permission>
-      <permission>hudson.model.Run.Delete:bmwiedemann</permission>
-      <permission>hudson.model.Run.Delete:saschpe</permission>
-      <permission>hudson.model.Item.Read:iartarisi</permission>
-      <permission>hudson.model.Item.Read:vuntz</permission>
-      <permission>hudson.model.Item.Read:jdsn</permission>
-      <permission>hudson.model.Item.Read:mjura</permission>
-      <permission>hudson.model.Item.Read:aspiers</permission>
-      <permission>hudson.model.Item.Read:dirkmueller</permission>
-      <permission>hudson.model.Item.Read:anonymous</permission>
-      <permission>hudson.model.Item.Read:bmwiedemann</permission>
-      <permission>hudson.model.Item.Read:saschpe</permission>
-      <permission>hudson.model.Item.Delete:jdsn</permission>
-      <permission>hudson.model.Item.Delete:bmwiedemann</permission>
-      <permission>hudson.model.Item.Delete:saschpe</permission>
-      <permission>hudson.model.Item.Workspace:jdsn</permission>
-      <permission>hudson.model.Item.Workspace:dirkmueller</permission>
-      <permission>hudson.model.Item.Workspace:bmwiedemann</permission>
-      <permission>hudson.model.Item.Workspace:saschpe</permission>
-      <permission>hudson.model.Item.Build:iartarisi</permission>
-      <permission>hudson.model.Item.Build:vuntz</permission>
-      <permission>hudson.model.Item.Build:jdsn</permission>
-      <permission>hudson.model.Item.Build:mjura</permission>
-      <permission>hudson.model.Item.Build:aspiers</permission>
-      <permission>hudson.model.Item.Build:dirkmueller</permission>
-      <permission>hudson.model.Item.Build:bmwiedemann</permission>
-      <permission>hudson.model.Item.Build:saschpe</permission>
-    </hudson.security.AuthorizationMatrixProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.8.2">
       <maxConcurrentPerNode>0</maxConcurrentPerNode>
       <maxConcurrentTotal>0</maxConcurrentTotal>
@@ -118,12 +52,12 @@
         <string>openstack-ironic</string>
         <string>openstack-trove</string>
         <string>openstack-keystone</string>
+        <string>openstack-manila</string>
         <string>openstack-marconi</string>
         <string>openstack-nova</string>
         <string>openstack-neutron</string>
         <string>openstack-quickstart</string>
         <string>openstack-resource-agents</string>
-        <string>openstack-sahara</string>
         <string>openstack-swift</string>
         <string>openstack-tempest</string>
         <string>openstack-tuskar</string>
@@ -138,13 +72,13 @@
         <string>python-keystoneclient</string>
         <string>python-marconiclient</string>
         <string>python-novaclient</string>
+        <string>python-manilaclient</string>
         <string>python-oslo.config</string>
         <string>python-oslo.messaging</string>
         <string>python-oslosphinx</string>
         <string>python-oslo.rootwrap</string>
         <string>python-openstackclient</string>
         <string>python-neutronclient</string>
-        <string>python-saharaclient</string>
         <string>python-swift3</string>
         <string>python-swiftclient</string>
         <string>python-tuskarclient</string>
@@ -161,10 +95,7 @@
       </values>
     </hudson.matrix.LabelAxis>
   </axes>
-  <combinationFilter>! ( ["Cloud:OpenStack:Havana:Staging"].contains(project) &amp;&amp;  ["openstack-trove", "python-saharaclient", "python-designateclient"].contains(component)
-      || ["Cloud:OpenStack:Havana:Staging", "Cloud:OpenStack:Icehouse:Staging"].contains(project) &amp;&amp; [ "openstack-tuskar", "openstack-tuskar_ui", "python-oslo.messaging", "python-oslosphinx", "python-oslo.rootwrap", "python-openstackclient", "python-tuskarclient", "python-troveclient", "tripleo-image-elements", "tripleo-heat-templates", "diskimage-builder", "openstack-designate", "openstack-sahara", "openstack-marconi", "python-ironicclient", "python-marconiclient"].contains(component)
-      || ["Cloud:OpenStack:Icehouse:Staging"].contains(project) &amp;&amp;  ["openstack-ironic", "openstack-marconi", "python-tuskarclient", "python-troveclient", "python-ironicclient", "python-marconiclient", "python-oslo.config" ].contains(component) )
-  </combinationFilter>
+  <combinationFilter>! ( ["Cloud:OpenStack:Havana:Staging"].contains(project)           &amp;&amp;  ["openstack-trove", "python-designateclient", "openstack-utils", "python-manilaclient", "openstack-manila"].contains(component)       || ["Cloud:OpenStack:Havana:Staging", "Cloud:OpenStack:Icehouse:Staging"].contains(project) &amp;&amp; [ "openstack-ironic", "openstack-tuskar", "openstack-tuskar_ui", "python-oslo.messaging", "python-oslosphinx", "python-oslo.rootwrap", "python-openstackclient", "python-tuskarclient", "python-troveclient", "tripleo-image-elements", "tripleo-heat-templates", "diskimage-builder", "openstack-designate", "openstack-marconi", "python-ironicclient", "python-marconiclient", "python-manilaclient", "openstack-manila"].contains(component)       || ["Cloud:OpenStack:Icehouse:Staging"].contains(project) &amp;&amp;  ["openstack-marconi", "python-tuskarclient", "python-troveclient", "python-ironicclient", "python-marconiclient", "python-oslo.config", "python-manilaclient", "openstack-manila" ].contains(component) )</combinationFilter>
   <builders>
     <hudson.tasks.Shell>
       <command>PROJECTSOURCE=OBS/${project}
@@ -245,6 +176,6 @@ track-upstream-and-package.pl</command>
   <publishers/>
   <buildWrappers/>
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
-    <runSequentially>false</runSequentially>
+    <runSequentially>true</runSequentially>
   </executionStrategy>
 </matrix-project>


### PR DESCRIPTION
Sync latest version of openstack-trackupstream from jenkins to git.
Changes:
- Remove <hudson.security.AuthorizationMatrixProperty>
- Remove openstack-sahara and python-saharaclient
- Added openstack-manila and python-manilaclient
- Update CombinationFilter
- Run job sequentially
