### PR TITLE
Expand README file with information for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,63 @@
 This repository contains various scripts which SUSE uses to automate
 development, testing, and CI (continuous integration) of the various
 components of SUSE Cloud, i.e. OpenStack and Crowbar.
+
+# Scripts
+
+This project has several scripts for different automated tasks, some of them are:
+
+* create-vm.sh, creates a fresh KVM VM via libvirt.
+* crowbar-prep.sh, prepare a host for Crowbar admin node installation.
+* [mkcloud.sh](docs/mkcloud.md), script used to build a SUSE Cloud environment
+  for development or testing purposes.
+
+# Contributing
+
+This project uses the pull requests to process contributions,
+[travis-ci](http://travis-ci.org/) to test that your changes are OK to be
+merged.
+
+It's recommended to read
+[Contributing to Open Source on GitHub](https://guides.github.com/activities/contributing-to-open-source)
+and [Forking Projects](https://guides.github.com/activities/forking) if you
+want to get a better understanding of how GitHub pull requests work.
+
+## Testing you changes
+
+The syntax of the shell scripts is checked using
+[bash8](https://pypi.python.org/pypi/bash8), you can install it running.
+
+```
+$ sudo pip install bash8
+```
+
+Once you have installed bash8 and the changes you wanted, you should check the
+syntax of the shell scripts running `make test`, here is an example output of
+a successful execution:
+
+```
+$ make test
+cd scripts ; for f in *.sh mkcloud mkchroot jenkins/{update_automation,*.sh} ; do echo "checking $f" ; bash -n $f || exit 3 ; bash8 --ignore E010,E020 $f || exit 4 ; done
+checking compare-crowbar-upstream.sh
+checking create-vm.sh
+checking crowbar-prep.sh
+checking mkcloud-crowbar-logs.sh
+checking qa_crowbarsetup.sh
+checking setenv.2.sh
+checking setenv.sh
+checking mkcloud
+checking mkchroot
+checking jenkins/update_automation
+checking jenkins/qa_openstack.sh
+checking jenkins/qa_tripleo.sh
+checking jenkins/track-upstream-and-package.sh
+checking jenkins/update_tempest.sh
+cd scripts ; for f in *.pl jenkins/{apicheck,jenkins-job-trigger,*.pl} ; do perl -c $f || exit 2 ; done
+analyse-py-module-deps.pl syntax OK
+jenkins/apicheck syntax OK
+jenkins/jenkins-job-trigger syntax OK
+jenkins/cloud-trackupstream-matrix.pl syntax OK
+jenkins/jenkinsnotify.pl syntax OK
+jenkins/openstack-unittest-testconfig.pl syntax OK
+jenkins/track-upstream-and-package.pl syntax OK
+```

--- a/docs/mkcloud.md
+++ b/docs/mkcloud.md
@@ -1,0 +1,104 @@
+# Installation
+
+`mkcloud` is a script used to build a SUSE Cloud environment for development
+or testing purposes.
+
+## Obtain automation
+
+* Get automation's sources from git:
+
+  ```
+  $ git clone https://github.com/SUSE-Cloud/automation.git
+  ```
+
+## Prepare your system
+
+* Check if `libvirtd` is running and if it isn't start it.
+
+  ```
+  $ sudo service libvirtd status # to check the status
+  $ sudo service libvirtd start  # to start the daemon
+  ```
+
+  It's recommended to configure libvirtd to start on boot.
+
+  * For systems running systemd:
+    ```
+    $ sudo systemctl enable libvirtd
+    ```
+
+  * For systems running SysV:
+    ```
+    $ sudo chkconfig libvirtd on
+    ```
+
+### mkcloud
+
+To use mkcloud the following additional steps are needed:
+
+* Create a disk file where the virtual machines are going to be stored. The
+  minimum recommended is 80 GB.
+
+  ```
+  $ fallocate -l 80G mkcloud.disk
+  ```
+
+* Attach the created disk file to a loop device
+
+  ```
+  $ sudo losetup -f mkcloud.disk
+  ```
+
+* Turn off the firewall, otherwise there are going to be conflicts with the
+  rules added by `libvirt`.
+
+  ```
+  $ sudo service SuSEfirewall2 stop
+  ```
+
+  Disable the firewall service to prevent it from starting on boot.
+
+  * Using systemd:
+    ```
+    $ sudo systemctl disable SuSEfirewall2
+    ```
+  * Using SysV:
+    ```
+    $ sudo service SuSEfirewall2 off
+    ```
+
+# Configuration
+
+## mkcloud
+
+`mkcloud` can be configured using different environment variables, some of
+them are listed below, to get a complete list run `./mkcloud -h`
+
+* `CVOL`, block device used by mkcloud to put LVM partitions, these partitions
+  are used to host the virtual machines. In development environments this is
+  usually a loop device (e.g. `/dev/loop0`)
+* `cloudsource`, defines what version of SUSE Cloud will be deployed (e.g. `susecloud4`)
+* `TESTHEAD`, if this variable is set mkcloud will use `Devel:Cloud:Staging`
+  repository to install and then update the system using the SUSE Cloud
+  repositories (if they are available).
+* `ADMIN_NODE_MEMORY` and `COMPUTE_NODE_MEMORY` define the amount of memory in
+  KB assigned to the admin node and the compute nodes respectively, by default
+  both variables are set to 2 GB.
+
+# Usage
+
+Example usage
+
+```
+$ sudo env CVOL=/dev/loop0 cloudsource=susecloud4 ./mkcloud plain
+```
+
+This will create a cloud with an admin node (crowbar) and 2 nodes (1 for
+compute, 1 for controller).
+
+If you want to run `tempest` in an already created cloud you can run the
+following command:
+
+```
+$ sudo ./mkcloud testsetup
+```


### PR DESCRIPTION
This change adds the following sections to the README file:
- Installation, steps needed to prepare the host in order to use the
  automation scripts
- Configutation, brief description of the most important configuration
  keys and pointing out the complete list is available using `mkcloud -h`.
- Usage, example usage to create a cloud and run tempest.
- Contributing, a short description how to contribute to this repository.

This change expands the README file to include a section about the
'installation' of the automation scripts and steps needed to prepare
the host in order to use the automation scripts.
