### PR TITLE
mkcloud: Simplify list of nodes generation

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -190,7 +190,7 @@ function sshrun()
 function cleanup()
 {
     # cleanup leftover from last run
-    allnodenames=`for i in $(seq 1 $(($nodenumber + 20))) ; do echo -n "node\$i " ; done`
+    allnodenames=$(seq --format="node%.0f" 1 $(($nodenumber + 20)))
     for n in admin $allnodenames ; do
         virsh destroy $cloud-$n
         virsh undefine $cloud-$n


### PR DESCRIPTION
This patch replaces a for-loop with just using 'seq' to generate the
list of nodes that are going to cleaned.
