### PR TITLE
qa_crowbarsetup: replace 'perl alarm' with 'timeout'

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -713,7 +713,7 @@ function allocate()
 
 function sshtest()
 {
-    perl -e "alarm 10 ; exec qw{ssh -o NumberOfPasswordPrompts=0 -o StrictHostKeyChecking=no}, @ARGV" "$@"
+    timeout 10 ssh -o NumberOfPasswordPrompts=0 -o StrictHostKeyChecking=no "$@"
 }
 
 function ssh_password()


### PR DESCRIPTION
This patch replaces perl code in a string with timeout command to kill
ssh in case takes longer than 10 secs to finish.
