### PR TITLE
qa_tripleo.sh: Fix testenv jsonfile creation

### DIFF
--- a/scripts/jenkins/qa_tripleo.sh
+++ b/scripts/jenkins/qa_tripleo.sh
@@ -131,8 +131,8 @@ fi
 
 # Use tripleo-ci from git
 
-if [ ! -d tripleo-ci ]; then
-    git clone git://git.openstack.org/openstack-infra/tripleo-ci
+if [ ! -d /opt/stack/new/tripleo-ci ]; then
+    git clone git://git.openstack.org/openstack-infra/tripleo-ci /opt/stack/new/tripleo-ci
 fi
 
 # Use diskimage-builder from packages
@@ -158,7 +158,7 @@ if [ ! -d /opt/stack/new/tripleo-heat-templates ]; then
     git clone git://git.openstack.org/openstack/tripleo-heat-templates /opt/stack/new/tripleo-heat-templates
 fi
 
-cd tripleo-ci
+cd /opt/stack/new/tripleo-ci
 
 export USE_CACHE=1
 export TRIPLEO_CLEANUP=0


### PR DESCRIPTION
Nodes are automatically added by create-nodes script. No need to do it
manually.
