### PR TITLE
qa_devstack: Add parameters for extra disk setup

### DIFF
--- a/scripts/qa_devstack.sh
+++ b/scripts/qa_devstack.sh
@@ -38,6 +38,13 @@ hardstatus string '%H (%S%?;%u%?) %-Lw%{= BW}%50>%n%f* %t%{-}%+Lw%<'
 EOF
 }
 
+function h_setup_extra_disk()
+{
+    mkfs.ext3 /dev/vdb
+    mkdir -p /opt/stack
+    mount /dev/vdb /opt/stack
+}
+
 function h_setup_devstack()
 {
     zypper -n in git-core crudini
@@ -94,6 +101,10 @@ EOF
 h_echo_header "Setup"
 h_setup_extra_repos
 h_setup_screen
+# setup extra disk if parameters given
+if [ -e "/dev/vdb" ]; then
+    h_setup_extra_disk
+fi
 h_setup_devstack
 h_echo_header "Run devstack"
 sudo -u stack -i <<EOF


### PR DESCRIPTION
The CI job uses a cleanvm instance where the root disk has limited
space. But another disk is available for usage. With the new parameters
EDISK_DEV and EDISK_TARGET this extra disk can be setup and used.
