### PR TITLE
Workaround wickedd problem (bnc#900112)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -650,6 +650,11 @@ EOF
         /opt/dell/bin/json-edit -a attributes.network.networks.nova_floating.ranges.host.end -v 10.122.167.191 $netfile
         # todo? broadcast
     fi
+    if [[ $cloud = virtual && -n $want_sles12 ]] ; then
+        # To avoid problems with: https://bugzilla.suse.com/show_bug.cgi?id=900112 ("wicked" issue)
+        /opt/dell/bin/json-edit -a attributes.network.enable_tx_offloading --raw -v "true" $netfile
+    fi
+
     cp -a $netfile /etc/crowbar/network.json # new place since 2013-07-18
 
     # to allow integration into external DNS:


### PR DESCRIPTION
By enabling tx-offloading in the network barclamp we avoid having the
ETHTOOL_OPTIONS added to the ifcfg files. This works around:
https://bugzilla.suse.com/show_bug.cgi?id=900112
