### PR TITLE
qa_devstack: Add option to disable Tempest run

### DIFF
--- a/scripts/qa_devstack.sh
+++ b/scripts/qa_devstack.sh
@@ -114,9 +114,12 @@ EOF
 h_echo_header "Run tempest"
 # FIXME(toabctl): enable the extensions for tempest
 crudini --set /opt/stack/tempest/etc/tempest.conf network-feature-enabled api_extensions "provider,security-group,dhcp_agent_scheduler,external-net,ext-gw-mode,binding,agent,quotas,l3_agent_scheduler,multi-provider,router,extra_dhcp_opt,allowed-address-pairs,extraroute,metering,fwaas,service-type,lbaas,lbaas_agent_scheduler"
-sudo -u stack -i <<EOF
+
+if [ -z "${DISABLE_TEMPESTRUN}" ]; then
+    sudo -u stack -i <<EOF
 cd /opt/stack/tempest
 ./run_tempest.sh -s -N -C etc/tempest.conf
 EOF
+fi
 
 exit 0


### PR DESCRIPTION
The script can be used to setup devstack in a VM for development as
well. In that case, a automatic Tempest run is not needed and can be
triggered manually.
