### PR TITLE
Use space separator and not break boot.local

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -501,7 +501,7 @@ listen_addr = "0.0.0.0"' >> /etc/libvirt/libvirtd.conf
     wait_for 300 1 "ping -q -c 1 -w 1 $adminip >/dev/null" 'crowbar admin VM'
 
     if ! grep -q "iptables -t nat -F PREROUTING" /etc/init.d/boot.local; then
-        nodehostips=$(seq 81 $((80 + $nodenumber)))
+        nodehostips=$(seq -s ' ' 81 $((80 + $nodenumber)))
         cat >> /etc/init.d/boot.local <<EOS
 iptables -t nat -F PREROUTING
 for i in 22 80 443 3000 4000 4040 ; do


### PR DESCRIPTION
By default seq use '\n' as delimiter (seq (GNU coreutils) 8.23). This broke /etc/init.d/boot.local
