### PR TITLE
Wait for instance to be shut off after "nova stop"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1709,11 +1709,8 @@ function onadmin_rebootcompute()
 function oncontroller_waitforinstance()
 {
     . .openrc
-
-    if ! iscloudver 5plus; then
-        nova list
-        nova start testvm || exit 28
-    fi
+    nova list
+    nova start testvm || exit 28
     nova list
     addfloatingip testvm
     local vmip=`nova show testvm | perl -ne 'm/ fixed.network [ |]*[0-9.]+, ([0-9.]+)/ && print $1'`


### PR DESCRIPTION
We were rebooting the compute node too fast, and the instance was still
marked as ACTIVE, in the powering-off task state which was never
completed.
