### PR TITLE
qa_crowbarsetup: reenable ha repos for cloud3+

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -601,7 +601,7 @@ EOF
     fi
 
     if [ -n "$hacloud" ]; then
-        if [ "$slesdist" = "SLE_11_SP3" ] && iscloudver 5plus ; then
+        if [ "$slesdist" = "SLE_11_SP3" ] && iscloudver 3plus ; then
             add_ha_repo
         else
             echo "Error: You requested a HA setup but for this combination ($cloudsource : $slesdist) no HA setup is available."


### PR DESCRIPTION
Readd HA repositories when using Cloud3 or Cloud4. This was accidentally
remove in 2e35584049.
