### PR TITLE
Enables ceph deployment.

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1219,12 +1219,8 @@ function set_proposalvars()
     iscloudver 5plus && wantmultidns=1
     iscloudver 4plus && wanttempest=1
 
-    # FIXME: Ceph is currently broken
     iscloudver 5 && {
-        # TODO (psalunke): Update the ceph lines when done with the ceph card.
-        echo "WARNING: ceph currently disabled as support for SUSE Storage 1.0 is currently missing"
-        wantceph=
-        echo "WARNING: swift currently disabled, because openstack-swift packages for SLES12 are missing"
+        echo "WARNING: swift currently disabled, becaus openstack-swift packages for SLES12 are missing"
         wantswift=
     }
 


### PR DESCRIPTION
Since the crowbar support for ceph was incomplete, deploying ceph was autoatically disabled. This PR allows ceph to be deployed.

https://github.com/crowbar/barclamp-provisioner/pull/35://github.com/crowbar/barclamp-provisioner/pull/359