### PR TITLE
Adapt to env var change for crowbar-backup

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -851,7 +851,7 @@ function qa_test()
 
 function crowbarbackup()
 {
-    sshrun "AGREEUNSUPPORTED=1 bash -x /usr/sbin/crowbar-backup backup /tmp/backup-crowbar.tar.gz"
+    sshrun "AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup backup /tmp/backup-crowbar.tar.gz"
     ret=$?
     $scp root@$adminip:/tmp/backup-crowbar.tar.gz .
     [ -d "$artifacts_dir" ] && mv backup-crowbar.tar.gz "$artifacts_dir/"
@@ -867,10 +867,10 @@ function crowbarrestore()
         return 56
     fi
     $scp "$btarball" root@$adminip:/tmp/
-    sshrun "AGREEUNSUPPORTED=1 bash -x /usr/sbin/crowbar-backup purge"
+    sshrun "AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup purge"
     # Need to install crowbar-backup again as purge deletes it
     sshrun "zypper --non-interactive in --no-recommends crowbar"
-    sshrun "AGREEUNSUPPORTED=1 bash -x /usr/sbin/crowbar-backup restore /tmp/backup-crowbar.tar.gz"
+    sshrun "AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup restore /tmp/backup-crowbar.tar.gz"
     ret=$?
     return $ret
 }


### PR DESCRIPTION
We now need to set CB_BACKUP_IGNOREWARNING to ignore the warning, as the
script is supported. We keep the old variable to keep working on old
versions of SUSE Cloud.

Needed by https://github.com/SUSE-Cloud/cloud-tools/pull/12