### PR TITLE
mkcloud: don't run /etc/init.d/boot.local

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -644,11 +644,10 @@ listen_addr = "0.0.0.0"' >> /etc/libvirt/libvirtd.conf
 
     wait_for 300 1 "ping -q -c 1 -w 1 $adminip >/dev/null" 'crowbar admin VM'
 
-    if ! grep -q "iptables -t nat -F PREROUTING" /etc/init.d/boot.local &&
-        [ -z "$NOSETUPPORTFORWARDING" ]
-    then
-        nodehostips=$(seq -s ' ' 81 $((80 + $nodenumber)))
-        cat >> /etc/init.d/boot.local <<EOS
+    nodehostips=$(seq -s ' ' 81 $((80 + $nodenumber)))
+    cat > /etc/init.d/boot.mkcloud <<EOS
+#!/bin/bash
+
 iptables -t nat -F PREROUTING
 for i in 22 80 443 3000 4000 4040 ; do
     iptables -I FORWARD -p tcp --dport \$i -j ACCEPT
@@ -661,8 +660,19 @@ done
 iptables -t nat -I PREROUTING -p tcp --dport 6080 -j DNAT --to-destination $net_public.2
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
 EOS
+    chmod +x /etc/init.d/boot.mkcloud
+
+    if ! grep -q "boot.mkcloud" /etc/init.d/boot.local &&
+        [ -z "$NOSETUPPORTFORWARDING" ]
+    then
+        cat >> /etc/init.d/boot.local <<EOS
+
+# --v--v--  Automatically added by mkcloud on `date`
+/etc/init.d/boot.mkcloud
+# --^--^--  End of automatically added section from mkcloud
+EOS
     fi
-    /etc/init.d/boot.local
+    /etc/init.d/boot.mkcloud
 
     wait_for 150 1 "nc -z $adminip 22" 'starting ssh daemon'
 


### PR DESCRIPTION
Instead of appending a large chunk of code to boot.local and then executing
the whole file, write it to a separate file which is then executed and also
invoked from boot.local on boot.  This avoids any unpredictable side-effects
of running boot.local after the system is fully booted up, and also allows us
to cleanly migrate to new behaviour in future on systems which have already
had mkcloud run on them, simply by replacing boot.mkcloud with a new version.