### PR TITLE
qa_crowbarsetup.sh: Only run ceph testsuite if radosgw is deployed

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1894,8 +1894,8 @@ function onadmin_testsetup()
         echo "ceph mons:" $cephmons
         echo "ceph osds:" $cephosds
         echo "ceph radosgw:" $cephradosgws
-        iscloudver 4plus && wantcephtestsuite=1
-        if [ -n "$cephradosgws" ] ; then
+        if iscloudver 4plus && [ -n "$cephradosgws" ] ; then
+            wantcephtestsuite=1
             wantradosgwtest=1
         fi
     fi


### PR DESCRIPTION
The ceph testsuite requires radosgw now