### PR TITLE
qa_crowbarsetup: Add Cloud product repos on admin server

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -655,6 +655,14 @@ function onadmin_prepare_cloud_repos()
                 ;;
         esac
     fi
+
+    # Ensure Pool/Updates repos are always configured on admin server
+    for repo in Pool Updates; do
+        name="SUSE-Cloud-$(getcloudver)-$repo"
+        if ! zypper lr | grep -q "$name"; then
+            safely zypper ar -f "$tftpboot_repos_dir/$name/" $name
+        fi
+    done
 }
 
 


### PR DESCRIPTION
We have some checks in the code now (like in suse-cloud-upgrade) that
require these repos to be configured on the admin server.