### PR TITLE
qa_crowbarsetup: Setup SLES12-Pool repo for SLE12 too

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -706,8 +706,7 @@ function onadmin_set_source_variables()
         ;;
     esac
 
-    # FIXME SLES12-Pool should be here, but it seems to be broken now
-    sles12repolist="SLES12-Updates"
+    sles12repolist="SLES12-Pool SLES12-Updates"
 }
 
 


### PR DESCRIPTION
If it's still broken, we'll fix it. But install-suse-cloud requires it
to be valid.