### PR TITLE
'zypper in' isnt critical command

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -457,7 +457,7 @@ function onhost_enable_ksm
 
 function prepare()
 {
-    safely zypper --non-interactive in --no-recommends \
+    zypper --non-interactive in --no-recommends \
         libvirt kvm lvm2 curl wget bridge-utils \
         dnsmasq netcat-openbsd ebtables
 


### PR DESCRIPTION
i use mkcloud in system where inst zypper, and why use 'zypper in' in each run of mkcloud ?