### PR TITLE
qa_crowbarsetup.sh: use brace expansion

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -385,7 +385,7 @@ function addcloud5testupdates()
 function add_ha_repo()
 {
     local repo
-    for repo in "SLE11-HAE-SP3-Pool" "SLE11-HAE-SP3-Updates" "SLE11-HAE-SP3-Updates-test" ; do
+    for repo in SLE11-HAE-SP3-{Pool,Updates,Updates-test}; do
         if [ "$hacloud" == "2" && "$repo" == "SLE11-HAE-SP3-Updates-test" ] ; then
             continue
         fi
@@ -397,7 +397,7 @@ function add_suse_storage_repo()
 {
     if [ -n "$want_sles12" ] && iscloudver 5plus ; then
         local repo
-        for repo  in "SUSE-Enterprise-Storage-1.0-Pool" "SUSE-Enterprise-Storage-1.0-Updates"; do
+        for repo in SUSE-Enterprise-Storage-1.0-{Pool,Updates}; do
             add_mount "$repo" "clouddata.cloud.suse.de:/srv/nfs/repos/$repo" "$tftpboot_repos12_dir/$repo"
         done
     else


### PR DESCRIPTION
It's easier to immediately see the common prefix this way, which avoids overly
long lines.  We can also drop the superfluous quotes.