### PR TITLE
qa_crowbarsetup.sh: split long lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ bashate:
 	do \
 	    echo "checking $$f"; \
 	    bash -n $$f || exit 3; \
-	    bashate --ignore E010,E020 $$f || exit 4; \
+	    bashate --ignore E010,E011,E020 $$f || exit 4; \
 	done
 
 perlcheck:


### PR DESCRIPTION
Conventional wisdom across the industry is that it is a bad idea to exceed 80 column lines. This is visible in countless areas, from the Linux kernel coding style through to PEP8 and beyond.  Long lines definitely make code harder to read for some people, so even if you don't *personally* feel it increases readability for you, please still be considerate of other people.

It's not just a matter of taste either.  Some user interfaces do not automatically wrap lines, so in those cases long lines can cause significant usability issues.  For example, when viewing diffs on parts of github, the lack of line wrapping means that you have to use a horizontal scroll bar to see the whole line:

![line-chopped](https://cloud.githubusercontent.com/assets/100738/6230142/4063f500-b6b5-11e4-8e75-2e70c5f0af92.png)

This is a major PITA.

In the case where there is an `if` statement with a long conditional, it means that the conditional gets broken across multiple lines.  In this case it's more readable if the `then` is on its own line, so you can clearly see where the conditional ends and the body begins.  This type of approach is advocated in

* http://wiki.bash-hackers.org/scripting/style

This requires ignoring a ridiculous bashate rule (`E011`) which complains if `then` is not on the same line as the `if` beginning a conditional.