### PR TITLE
mkcloud/qa_crowbarsetup: Move backup/restore code to qa_crowbarsetup.sh

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1094,7 +1094,7 @@ function qa_test()
 
 function crowbarbackup()
 {
-    sshrun "AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup backup /tmp/backup-crowbar.tar.gz"
+    sshrun "cloudbackup=1 bash -x qa_crowbarsetup.sh $virtualcloud"
     ret=$?
     $scp root@$adminip:/tmp/backup-crowbar.tar.gz .
     [ -d "$artifacts_dir" ] && mv backup-crowbar.tar.gz "$artifacts_dir/"
@@ -1110,12 +1110,8 @@ function crowbarrestore()
         return 56
     fi
     $scp "$btarball" root@$adminip:/tmp/
-    sshrun "AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup purge"
-    # Need to install crowbar-backup again as purge deletes it
-    sshrun "zypper --non-interactive in --no-recommends crowbar"
-    sshrun "AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup restore /tmp/backup-crowbar.tar.gz"
-    ret=$?
-    return $ret
+    sshrun "cloudrestore=1 bash -x qa_crowbarsetup.sh $virtualcloud"
+    return $?
 }
 
 function prepare_cloudupgrade()

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1106,8 +1106,7 @@ function crowbarrestore()
     btarball=backup-crowbar.tar.gz
     [ -e "$artifacts_dir/$btarball" ] && btarball="$artifacts_dir/$btarball"
     if [ ! -e "$btarball" ] ; then
-        echo "No crowbar backup tarball found."
-        return 56
+        complain 56 "No crowbar backup tarball found."
     fi
     $scp "$btarball" root@$adminip:/tmp/
     sshrun "cloudrestore=1 bash -x qa_crowbarsetup.sh $virtualcloud"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2577,8 +2577,11 @@ function onadmin_cloudbackup()
 function onadmin_cloudrestore()
 {
     AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup purge
+
     # Need to install crowbar-backup again as purge deletes it
     safely zypper --non-interactive in --no-recommends crowbar
+
+    do_set_repos_skip_checks
 
     AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup restore /tmp/backup-crowbar.tar.gz
 }

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2569,6 +2569,20 @@ function onadmin_cloudupgrade_reboot_and_redeploy_clients()
     # TODO: restart any suspended instance?
 }
 
+function onadmin_cloudbackup()
+{
+    AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup backup /tmp/backup-crowbar.tar.gz
+}
+
+function onadmin_cloudrestore()
+{
+    AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup purge
+    # Need to install crowbar-backup again as purge deletes it
+    safely zypper --non-interactive in --no-recommends crowbar
+
+    AGREEUNSUPPORTED=1 CB_BACKUP_IGNOREWARNING=1 bash -x /usr/sbin/crowbar-backup restore /tmp/backup-crowbar.tar.gz
+}
+
 function onadmin_qa_test()
 {
     zypper -n in -y python-{keystone,nova,glance,heat,cinder,ceilometer}client
@@ -2680,6 +2694,14 @@ fi
 
 if [ -n "$cloudupgrade_reboot_and_redeploy_clients" ] ; then
     onadmin_cloudupgrade_reboot_and_redeploy_clients
+fi
+
+if [ -n "$cloudbackup" ] ; then
+    onadmin_cloudbackup
+fi
+
+if [ -n "$cloudrestore" ] ; then
+    onadmin_cloudrestore
 fi
 
 set_proposalvars


### PR DESCRIPTION
This is required so we can set REPOS_SKIP_CHECKS before restoring backup.