### PR TITLE
qa_crowbarsetup: wait a bit to give sshd some time to come up

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1131,6 +1131,9 @@ function onadmin_crowbar_register()
 
     wait_for 150 10 "ping -q -c 1 -w 1 $crowbar_register_node_ip >/dev/null" "ping to return from ${cloud}-lonelynode" "complain 82 'could not ping crowbar_register VM ($crowbar_register_node_ip)'"
 
+    # wait a bit for sshd.service on ${cloud}-lonelynode
+    wait_for 10 10 "ssh_password $crowbar_register_node_ip 'echo'" "ssh to be running on ${cloud}-lonelynode" "complain 82 'sshd is not responding on ($crowbar_register_node_ip)'"
+
     local pubkey=`cat /root/.ssh/id_rsa.pub`
     ssh_password $crowbar_register_node_ip "mkdir -p /root/.ssh; echo '$pubkey' >> /root/.ssh/authorized_keys"
 


### PR DESCRIPTION
after the ping returns from the non-crowbar node, and before we inject any ssh command, we have to give sshd some time to be started.

jenkins failed
```
[snip]
00:01:04 Waiting for: ping to return from g1-lonelynode
00:01:04 + echo
00:01:04 + '[' 150 = 0 ']'
[snip]
00:01:04 + setsid ssh 192.168.253.25 'mkdir -p /root/.ssh; echo '\''ssh-rsa [key] root@crowbar.g1.cloud.suse.de'\'' >> /root/.ssh/authorized_keys'
00:01:04 ssh: connect to host 192.168.253.25 port 22: Connection refused

```

waiting time is arguable, any suggestions?