### PR TITLE
qa_crowbarsetup.sh: don't load mkcloud.config in test mode

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4,7 +4,9 @@
 test $(uname -m) = x86_64 || echo "ERROR: need 64bit"
 
 mkcconf=mkcloud.config
-[ -e $mkcconf ] && source $mkcconf
+if [ -z "$testfunc" ] && [ -e $mkcconf ]; then
+    source $mkcconf
+fi
 
 # defaults
 : ${libvirt_type:=kvm}


### PR DESCRIPTION
When we're running unit tests, skip loading any `mkcloud.config` which could interfere with results.