### PR TITLE
mkcloud: wait_for_if_running readable output

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -292,7 +292,7 @@ function wait_for_if_running()
     local procname=${1}
     local timecount=${2:-300}
 
-    wait_for $timecount 5 "! pidofproc ${procname}" "process '${procname}' to terminate"
+    wait_for $timecount 5 "! pidofproc ${procname} >/dev/null" "process '${procname}' to terminate"
 }
 
 function sshrun()

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -204,7 +204,7 @@ function wait_for_if_running()
     local procname=${1}
     local timecount=${2:-300}
 
-    wait_for $timecount 5 "! pidofproc ${procname}" "process '${procname}' to terminate"
+    wait_for $timecount 5 "! pidofproc ${procname} >/dev/null" "process '${procname}' to terminate"
 }
 
 function die()


### PR DESCRIPTION
prevent it from printing process IDs to stdout
as we just need the exit code