### PR TITLE
mkcloud: avoid zypper errors

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -508,7 +508,7 @@ function onhost_enable_ksm
 function setuphost()
 {
     if is_suse ; then
-        wait_for_if_running zypper
+        export ZYPP_LOCK_TIMEOUT=60
         zypper --non-interactive in --no-recommends \
             libvirt kvm lvm2 curl wget bridge-utils \
             dnsmasq netcat-openbsd ebtables


### PR DESCRIPTION
in the past we often hit cases where multiple zypper calls occurred in parallel.
By using rpm which has proper locking (and waits for it)
we ensure that we have the packages
without someone failing from ensuring the same at the same time