### PR TITLE
qa_crowbarsetup: cleanup and reorder set_proposalvars

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1722,14 +1722,22 @@ function custom_configuration()
 function set_proposalvars()
 {
     # Determine if we went through an upgrade
-    [ -f /etc/cloudsource ] && export cloudsource=$(</etc/cloudsource)
+    if [[ -f /etc/cloudsource ]] ; then
+        export cloudsource=$(</etc/cloudsource)
+    fi
 
     wantswift=1
     [ -z "$want_swift" ] && wantceph=1
-    [[ -n "$wanthyperv" ]] && wantswift= && wantceph= && networkingmode=vlan
+    if [[ $wanthyperv ]] ; then
+        wantswift=
+        wantceph=
+        networkingmode=vlan
+    fi
     wanttempest=
     iscloudver 4plus && wanttempest=1
-    [[ "$want_tempest" = 0 ]] && wanttempest=
+    if [[ $want_tempest == 0 ]] ; then
+        wanttempest=
+    fi
 
     [[ "$nodenumber" -lt 3 || "$cephvolumenumber" -lt 1 ]] && wantceph=
     # we can not use both swift and ceph as each grabs all disks on a node

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1754,12 +1754,16 @@ function set_proposalvars()
     case "$want_ceph" in
         '') ;;
         0)  deployceph= ;;
-        *)  deployceph=1 ;;
+        *)  deployceph=1
+            deployswift=
+        ;;
     esac
     case "$want_swift" in
         '') ;;
         0)  deployswift= ;;
-        *)  deployswift=1 ;;
+        *)  deployswift=1
+            deployceph=
+        ;;
     esac
 
     ### constraints


### PR DESCRIPTION
The set_proposalvars function was hard to read. I was hard to figure out what the defautls are and what consequences several variables had.
This commit should clean this up by making the defaults explicit and listing filters and contraints separately.

* Default storage is neither ceph nor swift.
* Honour both want_ceph and want_swift variables consistently.
* Reorder code that touches wantswift and wantceph to allow
  sanity check.
* Adding headings for code blocks.