### PR TITLE
qa_crowbarsetup: re-order swift/cinder proposal creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ bashate:
 	    echo "checking $$f"; \
 	    bash -n $$f || exit 3; \
 	    bashate --ignore E010,E011,E020 $$f || exit 4; \
+	    ! grep $$'\t' $$f || exit 5; \
 	done
 
 perlcheck:


### PR DESCRIPTION
cinder can not be deployed after swift,
because swift already grabs all disks on a node

partial revert of 41de7530e7c5afd4c56a81bbcc5c13b7d44cdddf