### PR TITLE
qa_crowbarsetup: dont try neutron-l3 on sles12

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1586,8 +1586,9 @@ function custom_configuration()
             fi
 
             # assign neutron-l3 role to one of SLE12 nodes
-            if [ -n "$want_sles12" ] && [ -z "$hacloud"] && iscloudver 5plus ; then
-                sle12node=$(knife search node "target_platform:suse-12.0" -a name | grep ^name: | cut -d : -f 2 | tail -n 1)
+            if [ -n "$want_sles12" ] && [ -z "$hacloud"] && [ -n "$forceneutronsles12" ] && iscloudver 5plus ; then
+                # 2015-03-03 off-by-default because Failed to validate proposal: Role neutron-l3 can't be used for suse 12.0, windows /.*/ platform(s).
+                local sle12node=$(knife search node "target_platform:suse-12.0" -a name | grep ^name: | cut -d : -f 2 | tail -n 1 | sed 's/\s//g')
                 proposal_set_value neutron default "['deployment']['neutron']['elements']['neutron-l3']" "['$sle12node']"
             fi
 


### PR DESCRIPTION
this is a follow-up on 56c244c56e904305032259d2632a3323da2aff22
to disable it by default because it errors with
Failed to validate proposal: Role neutron-l3 can't be used for suse 12.0