### PR TITLE
[WIP] Allow use of vxlan in neutron

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1610,7 +1610,11 @@ function custom_configuration()
             # TODO(toabctl): the milestone/cloud6 check can be removed when milestone 5 is released
             if iscloudver 5 && [[ ! $cloudsource =~ ^M[1-4]+$ ]] || iscloudver 6plus; then
                 if [ "$networkingplugin" = "openvswitch" ] ; then
-                    proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['gre','vlan']"
+                    if [[ "$networkingmode" = vxlan ]] || iscloudver 6plus; then
+                        proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['gre','vxlan','vlan']"
+                    else
+                        proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['gre','vlan']"
+                    fi
                 elif [ "$networkingplugin" = "linuxbridge" ] ; then
                     proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['vlan']"
                 else

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -694,7 +694,7 @@ function onadmin_prepare_cloud_repos()
 function do_set_repos_skip_checks()
 {
     if iscloudver 5plus && [[ $cloudsource =~ develcloud ]]; then
-	# We don't use the proper pool/updates repos when using a devel build
+        # We don't use the proper pool/updates repos when using a devel build
         export REPOS_SKIP_CHECKS+=" SUSE-Cloud-$(getcloudver)-Pool SUSE-Cloud-$(getcloudver)-Updates"
     fi
 }


### PR DESCRIPTION
This only works for Cloud 6+, or for Cloud 5 if we explicitly request
the vxlan networking mode. This way, it's compatible with Cloud 5 GM.

Depends on https://github.com/crowbar/barclamp-neutron/pull/206