### PR TITLE
bash-tests: forbid tab characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ bashate:
 	    echo "checking $$f"; \
 	    bash -n $$f || exit 3; \
 	    bashate --ignore E010,E011,E020 $$f || exit 4; \
+	    ! grep $$'\t' $$f || exit 5; \
 	done
 
 perlcheck:


### PR DESCRIPTION
tabs dont work well with copy-paste,
and can make the life of other tools harder