### PR TITLE
mkcloud: fix when host runs local nameserver

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -872,7 +872,9 @@ function prepareinstcrowbar()
     # qa_crowbarsetup uses static network which needs static resolv.conf
     # so we use the host's external IPv4 resolvers,
     # which must allow queries from routed IPs
-    grep '^nameserver\s*[0-9]*\.' /etc/resolv.conf | sshrun dd of=/etc/resolv.conf
+    grep '^nameserver\s*[0-9]*\.' /etc/resolv.conf |
+        egrep -v 'nameserver (127\.0\.0\.1|localhost)$' |
+        sshrun dd of=/etc/resolv.conf
     onadmin prepareinstallcrowbar
     return $?
 }


### PR DESCRIPTION
If the mkcloud host runs a local nameserver which is referenced in its 
resolv.conf as 127.0.0.1 or localhost, then the admin node should not copy
that line verbatim into its own resolv.conf, because at this early stage of
the admin node install, it will not have its own nameserver.