### PR TITLE
qa_crowbarsetup.sh: unbreak local repo support

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -822,6 +822,7 @@ EOF
         while zypper lr -e - | grep -q '^name='; do
             zypper rr 1
         done
+        mount_localreposdir_target
     fi
 
     onadmin_set_source_variables


### PR DESCRIPTION
57b3348 of #264 accidentally removed the call to the 
`mount_localreposdir_target()` function, which broke use of local repositories.