### PR TITLE
qa_crowbarsetup: fix tempest node assignment in HA mode

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1722,7 +1722,8 @@ function custom_configuration()
         tempest)
             if [[ $hacloud = 1 ]] ; then
                 local tempestnodes
-                tempestnodes=`printf "\"%s\"," $nodescompute`
+                # tempest can only be deployed on one node
+                tempestnodes=`printf "'%s',\n" $nodescompute | head -n 1`
                 tempestnodes="[ ${tempestnodes%,} ]"
                 proposal_set_value tempest default "['deployment']['tempest']['elements']['tempest']" "$tempestnodes"
             fi


### PR DESCRIPTION
The ha support introduced a bug that tempest was deployed on all compute nodes. But it can only be deployed on just one node. This PR fixes that and deploys tempest on the first compute node.