### PR TITLE
mkcloud: watch out for incomplete LVM device filter

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -387,6 +387,24 @@ function onhost_create_cloud_lvm()
             safely lvcreate -n $cloud.node$i-drbd -L ${drbd_hdd_size=}G $cloudvg $next_pv_device
         done
     fi
+
+    echo "Checking for LVs treated by LVM as valid PV devices ..."
+    if lvmdiskscan | egrep "/dev/($cloud/|mapper/$cloud-)"; then
+        error=$(cat <<EOF
+Error: your lvm.conf is not filtering out mkcloud LVs.
+Please fix by adding the following regular expressions
+to the filter value in the devices { } block within your
+/etc/lvm/lvm.conf file:
+
+    "r|/dev/mapper/$cloud.*|", "r|/dev/$cloud/.*|"
+
+The filter should also include something like "r|/dev/dm-1[56]|", but
+the exact values depend on your local system setup and could change
+over time, so please add/modify it manually.
+EOF
+)
+        complain 94 "$error"
+    fi
 }
 
 function onhost_deploy_image()


### PR DESCRIPTION
mkcloud creates LVs for use as DRBD data disks, which are then used by the controller VMs as PVs to build drbd VGs on top of.  However we need to prevent the host from detecting the LVs inside the resulting drbd VGs, because they only concern the controller VM guests.  This requires tweaking `lvm.conf` which is not easy to automate, but we can at least check whether it was done right, and bail if not.

@jdsn This was based on your suggestion for editing `lvm.conf`, but I still don't understand it 100% because it will still detect the `/dev/dm-$i` devices corresponding to these LVs, so what does it really achieve by excluding the `/dev/$vg` and `/dev/mapper/$vg-*` devices?