### PR TITLE
qa_crowbarsetup.sh: fix typo breaking shared services cluster

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -525,8 +525,8 @@ function cluster_node_assignment()
             ;;
             services)
                 clusternodesservices="$nodes"
-                [[ $group =~ "+data" ]]     && clusternamedata=$clusternameces
-                [[ $group =~ "+network" ]]  && clusternamenetwork=$clusternameces
+                [[ $group =~ "+data" ]]     && clusternamedata=$clustername
+                [[ $group =~ "+network" ]]  && clusternamenetwork=$clustername
             ;;
             network)
                 clusternodesnetwork="$nodes"


### PR DESCRIPTION
This typo meant that clusterconfig values such as

  "services+network+data=2"

(i.e. where the services cluster comes first but is also used to host network
and/or data) would break due to the clusternamedata and clusternamenetwork
variables not being set properly.