### PR TITLE
remove safely from service libvirtd start

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -633,7 +633,7 @@ function setupadmin()
     if configure_libvirtd; then # config was changed
         service libvirtd stop
     fi
-    safely service libvirtd start
+    service libvirtd start
     wait_for 300 1 '[ -S /var/run/libvirt/libvirt-sock ]' 'libvirt startup'
 
     if ! virsh net-dumpxml $cloud-admin > /dev/null 2>&1; then


### PR DESCRIPTION
for my system breaks run of mkcloud , I don't have sysv compactibility layer in systemd