### PR TITLE
qa_crowbarsetup: Add aliases to .ssh/config for each node

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1216,6 +1216,11 @@ function onadmin_allocate()
             crowbar machines allocate "$m"
             sleep 10
         done
+        local i=$(echo $m | sed "s/.*-0\?\([^-\.]*\)\..*/\1/g")
+        cat >> .ssh/config <<EOF
+Host node$i
+    HostName $m
+EOF
     done
 
     # check for error 500 in app/models/node_object.rb:635:in `sort_ifs'#012


### PR DESCRIPTION
It's much more convenient to do "ssh node1" than the long name of each
node.

We do not use the crowbar alias mechanism as the nodes can have other
aliases (such as dashboard) through that mechanism, and we do not want
to override this.