### PR TITLE
qa_crowbarsetup: Disable use_l2pop when using linuxbridge

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1713,6 +1713,7 @@ function custom_configuration()
                     fi
                 elif [ "$networkingplugin" = "linuxbridge" ] ; then
                     proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['vlan']"
+                    proposal_set_value neutron default "['attributes']['neutron']['use_l2pop']" "false"
                 else
                     complain 106 "networkingplugin '$networkingplugin' not yet covered in mkcloud"
                 fi


### PR DESCRIPTION
L2 population requires vxlan or gre, and with linuxbridge, we only
enable vlan.