### PR TITLE
qa_crowbarsetup: never check SSL certs

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -344,6 +344,24 @@ function iscloudver()
     return $?
 }
 
+function keystone()
+{
+    command keystone --insecure "$@"
+}
+function glance()
+{
+    command glance --insecure "$@"
+}
+function heat()
+{
+    command heat --insecure "$@"
+}
+export NEUTRONCLIENT_INSECURE=true
+export NOVACLIENT_INSECURE=true
+export SWIFTCLIENT_INSECURE=true
+export CINDERCLIENT_INSECURE=true
+export TROVECLIENT_INSECURE=true
+
 function export_tftpboot_repos_dir()
 {
     tftpboot_repos_dir=/srv/tftpboot/repos


### PR DESCRIPTION
for testing, we always use self-signed certs
and even in production deployments, we have certs
that are only valid for the public-name of the controller node
but not the internal names for admin IPs