### PR TITLE
Crowbar machines list cleanup

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -464,6 +464,25 @@ function get_disk_id_by_serial_and_libvirt_type()
     echo -n "$diskid"
 }
 
+function get_all_nodes()
+{
+    crowbar machines list | LC_ALL=C sort
+}
+
+function get_all_discovered_nodes()
+{
+    # names of discovered nodes start with 'd'
+    # so it is excluding the crowbar node
+    get_all_nodes | grep "^d"
+}
+
+function get_crowbar_node()
+{
+    # crowbar node may have any name, so better use grep -v
+    # and make sure it is only one
+    get_all_nodes | grep -v "^d" | head -n 1
+}
+
 function cluster_node_assignment()
 {
     local nodesavailable


### PR DESCRIPTION
moves the call of 
`crowbar machines list | sort | grep | something`
to a function and replaces all usages of `crowbar machines list`.

This does not save code, but it becomes more readable.