### PR TITLE
mkcloud: read all global variables for parsing from separate scripts

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -128,6 +128,12 @@ pidfile=mkcloud.pid
 trap 'error_exit $? "error caught by trap"' TERM
 exec </dev/null
 
+# read all global variables
+function global_vars()
+{
+    (set -p posix; set) | sed '1,/_=posix/d' | grep ^[a-z].*=
+}
+
 function is_suse()
 {
     grep -qi suse /etc/*release


### PR DESCRIPTION
This could be helpful for later parsing from separate scripts.
This is needed as part of the refactoring/outsourcing functionality
from mkcloud for giving access to mkcloud "internal" variables from
the outside.

output for the `cleanup` step looks like this:
``` bash
admin_node_disk=/dev/cloud/cloud.admin
admin_node_memory=2097152
admingw=192.168.124.1
adminip=192.168.124.10
adminnetmask=255.255.248.0
adminnode_hdd_size=15
adminvcpus=1
allcmds='alias_new_admin alias_compute alias_upgrade alias_testupdate all all_noreboot instonly plain plain_with_upgrade cleanup setuphost prepare setupadmin prepareinstcrowbar instcrowbar instcrowbarfromgit setupcompute instcompute proposal testsetup rebootcrowbar rebootcompute addupdaterepo runupdate testupdate securitytests crowbarbackup crowbarrestore shutdowncloud restartcloud qa_test help rebootneutron prepare_cloudupgrade cloudupgrade_1st cloudupgrade_2nd cloudupgrade_clients cloudupgrade_reboot_and_redeploy_clients setuplonelynodes crowbar_register'
allnodeids=$'1\n2'
allnodeids_without_lonely=$'1\n2'
allnodenames=$'node1\nnode2\nnode3\nnode4\nnode5\nnode6\nnode7\nnode8\nnode9\nnode10\nnode11\nnode12\nnode13\nnode14\nnode15\nnode16\nnode17\nnode18\nnode19\nnode20\nnode21\nnode22'
artifacts_dir=/home/mmeister/cloud/mkcloud/.artifacts
cephvolume_hdd_size=21
cephvolumenumber=1
cinder_backend=
cinder_netapp_login=openstack
cinder_netapp_password=
cinder_netapp_storage_protocol=iscsi
cloud=cloud
cloudbr=cloudbr
cloudfqdn=emil.suse.de
cloudsource=develcloud5
cloudvg=cloud
clusterconfig=
cmd=cleanup
compute_node_memory=2097152
computenode_hdd_size=15
controller_ceph_hdd_size=25
controller_hdd_size=20
controller_node_memory=4194304
cpuflags=
debug_mkcloud=0
debug_qa_crowbarsetup=0
drbd_database_size=20
drbd_hdd_size=0
drbd_rabbitmq_size=20
drbdnode_mac_vol=
emulator=/usr/bin/qemu-system-x86_64
forwardmode=nat
hyperv_node_memory=3000000
install_chef_suse_override=./install-chef-suse.sh
libvirt_type=kvm
localreposdir_src=
localreposdir_target=
lonelynodeids=
machine=qemu-cloud-node22
mnt=/tmp/cloudmnt/16464
name=node22
needcvol=
net=cloud-admin
net_admin=192.168.124
net_fixed=192.168.123
net_public=192.168.122
networkingplugin=openvswitch
next_pv_device=
nodenumber=2
nodenumbercompute=2
nodenumbercomputedefault=2
nodenumberlonelynode=0
pidfile=mkcloud.pid
public_vlan=300
pv_cur_device_no=0
pvlist=
qa_crowbarsetup=/home/mmeister/cloud/MaximilianMeister/automation/scripts/qa_crowbarsetup.sh
scp='scp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null'
sshopts='-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null'
start_time='Tue Apr 28 10:26:28 CEST 2015'
step_aliases='alias_new_admin alias_compute alias_upgrade alias_testupdate'
steplist=cleanup
vcpus=1
vdisk_dir=/dev/cloud
virtualcloud=virtual
vm=cloud-node22
wantedcmds=cleanup
working_dir_orig=/home/mmeister/cloud/mkcloud
```