### PR TITLE
mkcloud: don't delete PTF repo when deleting other repos

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -910,9 +910,10 @@ EOF
     fi
 
     if [ -n "${localreposdir_target}" ]; then
-        while zypper lr -e - | grep -q '^name='; do
-            zypper rr 1
-        done
+        # Delete all repos except PTF repo, because this step could
+        # be called after the addupdaterepo step.
+        zypper lr -e - | sed -n '/^name=/ {s///; /ptf/! p}' | \
+            xargs -r zypper rr
         mount_localreposdir_target
     fi
 


### PR DESCRIPTION
The prepareinstcrowbar step could be called after the addupdaterepo step, so
it shouldn't nuke the PTF repo which addupdaterepo may have added.

Fixes #291.