### PR TITLE
hide the alias_* internal steps (#292)

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1143,14 +1143,6 @@ These steps are expanding to the following steps:
         -> $(expand_steps plain_with_upgrade)
     instonly
         -> $(expand_steps instonly)
-    alias_new_admin
-        -> $(expand_steps alias_new_admin)
-    alias_compute
-        -> $(expand_steps alias_compute)
-    alias_testupdate
-        -> $(expand_steps alias_testupdate)
-    alias_upgrade
-        -> $(expand_steps alias_upgrade)
 
 Steps:
     cleanup:        kill all running VMs, zero out boot sectors of all LVM volumes
@@ -1412,7 +1404,7 @@ function sanity_checks()
 
 
 ## MAIN ##
-step_aliases="alias_new_admin alias_compute alias_upgrade alias_testupdate"
+step_aliases="_new_admin _compute _upgrade _testupdate"
 
 allcmds="$step_aliases all all_noreboot instonly plain plain_with_upgrade cleanup setuphost prepare setupadmin prepareinstcrowbar instcrowbar instcrowbarfromgit setupcompute instcompute proposal testsetup rebootcrowbar rebootcompute addupdaterepo runupdate testupdate securitytests crowbarbackup crowbarrestore shutdowncloud restartcloud qa_test help rebootneutron prepare_cloudupgrade cloudupgrade_1st cloudupgrade_2nd cloudupgrade_clients cloudupgrade_reboot_and_redeploy_clients setuplonelynodes crowbar_register"
 wantedcmds=$@
@@ -1431,19 +1423,19 @@ function expand_steps()
             if [ $onecmd = $cmd ] ; then
                 found=1
                 case "$cmd" in
-                    alias_new_admin)
+                    _new_admin)
                         runcmds="$runcmds cleanup prepare setupadmin addupdaterepo runupdate prepareinstcrowbar instcrowbar"
                     ;;
-                    alias_compute)
+                    _compute)
                         runcmds="$runcmds setupcompute instcompute proposal"
                     ;;
                     all)
-                        runcmds="$runcmds `expand_steps alias_new_admin` rebootcrowbar `expand_steps alias_compute` testsetup rebootcompute"
+                        runcmds="$runcmds `expand_steps _new_admin` rebootcrowbar `expand_steps _compute` testsetup rebootcompute"
                     ;;
                     all_noreboot)
-                        runcmds="$runcmds `expand_steps alias_new_admin` `expand_steps alias_compute` testsetup"
+                        runcmds="$runcmds `expand_steps _new_admin` `expand_steps _compute` testsetup"
                     ;;
-                    alias_testupdate|testupdate)
+                    _testupdate|testupdate)
                         runcmds="$runcmds addupdaterepo runupdate testsetup"
                     ;;
                     plain)
@@ -1452,11 +1444,11 @@ function expand_steps()
                     instonly)
                         runcmds="$runcmds cleanup prepare setupadmin prepareinstcrowbar instcrowbar setupcompute instcompute"
                     ;;
-                    alias_upgrade)
+                    _upgrade)
                         runcmds="$runcmds prepare_cloudupgrade cloudupgrade_1st cloudupgrade_2nd cloudupgrade_clients cloudupgrade_reboot_and_redeploy_clients"
                     ;;
                     plain_with_upgrade)
-                        runcmds="$runcmds `expand_steps plain` addupdaterepo runupdate `expand_steps alias_upgrade`"
+                        runcmds="$runcmds `expand_steps plain` addupdaterepo runupdate `expand_steps _upgrade`"
                     ;;
                     *)
                         runcmds="$runcmds $cmd"


### PR DESCRIPTION
The alias_* steps are for internal use only, so remove them from the usage
text and instead use the _ prefix convention for private/internal symbols.

Fixes #292.