### PR TITLE
mkcloud: bail in cleanup step if lvremove fails

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -324,6 +324,13 @@ function cleanup()
     if [ -d $vdisk_dir ]; then
         find -L $vdisk_dir -name "$cloud.*" -type b | \
             xargs -r lvremove --force
+        if [ $? != 0 ]; then
+            echo >&2
+            echo "Failed to free up previous volumes:" >&2
+            echo >&2
+            find -L $vdisk_dir -name "$cloud.*" -type b
+            exit 42
+        fi
     fi
 
     rm -f /var/run/libvirt/qemu/$cloud-*.xml /var/lib/libvirt/network/$cloud-*.xml \


### PR DESCRIPTION
If we can't clean up LVs from a previous run, then things will fail later on,
so it's best to bail immediately to save time.

Unfortunately we cannot use the safely() function here because shell sucks (no
proper exception handling).