### PR TITLE
increase priority of PTF repo on all nodes

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2524,6 +2524,7 @@ function onadmin_addupdaterepo()
     fi
     zypper modifyrepo -e cloud-ptf >/dev/null 2>&1 ||\
         safely zypper ar $UPR cloud-ptf
+    safely zypper mr -p 90 cloud-ptf
 }
 
 function onadmin_runupdate()

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2032,12 +2032,11 @@ function onadmin_proposal()
     if iscloudver 5plus; then
         update_one_proposal dns default
     fi
-    if [ "$networkingplugin" = "vmware" ] && iscloudver 5plus ; then
-        cmachines=$(get_all_nodes)
-        for machine in $cmachines; do
-            ssh $machine 'zypper mr -p 90 SLE-Cloud-PTF'
-        done
-    fi
+
+    cmachines=$(get_all_nodes)
+    for machine in $cmachines; do
+        ssh $machine 'zypper mr -p 90 SLE-Cloud-PTF'
+    done
 
     local proposals="pacemaker database rabbitmq keystone swift ceph glance cinder neutron nova nova_dashboard ceilometer heat trove tempest"
 


### PR DESCRIPTION
I can't think why anyone would ever place a package in the PTF repo and then *not* want it to be installed in preference to a different version from another repo.  So it makes sense for the PTF repo to have a higher priority than all other repos.