### PR TITLE
qa_crowbarsetup: fill nodescompute var with correct data also in non-HA mode

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -585,7 +585,7 @@ function cluster_node_assignment()
     echo "services cluster:"
     printf "   %s\n" $clusternodesservices
     echo "compute nodes (no cluster):"
-    printf "   %s\n" $nodesavailable
+    printf "   %s\n" $nodescompute
     echo "............................................................"
 }
 
@@ -2046,8 +2046,13 @@ function onadmin_proposal()
         # proposal filter
         case "$proposal" in
             pacemaker)
-                [ -n "$hacloud" ] || continue
-                cluster_node_assignment
+                if [[ $hacloud = 1 ]] ; then
+                    cluster_node_assignment
+                else
+                    # no cluster for non-HA, but get compute nodes
+                    nodescompute=`get_all_discovered_nodes`
+                    continue
+                fi
                 ;;
             ceph)
                 [[ -n "$deployceph" ]] || continue


### PR DESCRIPTION
The variable nodescompute should also contain the correct names of nodes even in non-HA mode.
This PR fixes it. This is needed by the docker feature.