### PR TITLE
fix SLE12 compute nodes

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -856,7 +856,7 @@ function onadmin_set_source_variables()
             CLOUDDISTPATH=/install/SUSE-Cloud-5-$cs/
             CLOUDCOMPUTEPATH=$CLOUDDISTPATH
             CLOUDDISTISO="SUSE-CLOUD*1.iso"
-            CLOUDCOMPUTEISO="SUSE-SLE12-CLOUD-5-COMPUTE-x86_64*Media1.iso"
+            CLOUDCOMPUTEISO="SUSE-SLE12-CLOUD-5-COMPUTE-x86_64-GM-DVD1.iso"
             CLOUDLOCALREPOS="SUSE-Cloud-5-official"
         ;;
         *)


### PR DESCRIPTION
I have a fix for this issue:

    M?|Beta*|RC*|GMC*|GM5|GM5+up)
        cs=$cloudsource
        [[ $cs =~ GM5 ]] && cs=GM
        CLOUDDISTPATH=/install/SUSE-Cloud-5-$cs/
        CLOUDCOMPUTEPATH=$CLOUDDISTPATH
        CLOUDDISTISO="SUSE-CLOUD*1.iso"
        CLOUDCOMPUTEISO="SUSE-SLE12-CLOUD-5-COMPUTE-x86_64-GM-DVD1.iso"
        CLOUDLOCALREPOS="SUSE-Cloud-5-official"
SO CLOUDCOMPUTEISO="SUSE-SLE12-CLOUD-5-COMPUTE-x86_64-GM-DVD1.iso" instead of CLOUDCOMPUTEISO="SUSE-SLE12-CLOUD-5-COMPUTE-x86_64*Media1.iso"

Tested and it works, I can deploy sle 12 guests