### PR TITLE
qa_openstack: zypper dup from cloud repo

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -120,6 +120,9 @@ case "$cloudsource" in
     ;;
 esac
 
+# be sure to use packages from cloud repository
+$zypper dup --no-recommends --from cloud
+
 # when using OSHEAD, dup from there
 if [ -n "$OSHEAD" ]; then
     $zypper dup --from cloudhead


### PR DESCRIPTION
Just in case the base image run i.e. cloud-init which has some packages
which are also in the OpenStack repositories.