### PR TITLE
Extract the Bash code for libvirt handling to python scripts

### DIFF
--- a/scripts/lib/libvirt/cleanup.py
+++ b/scripts/lib/libvirt/cleanup.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import libvirt
+import sys
+import os
+import glob
+import subprocess
+import argparse
+
+conn = libvirt.open("qemu:///system")
+if not conn:
+    print("Failed to open connection to the hypervisor")
+    sys.exit(1)
+
+parser = argparse.ArgumentParser(description="Cleanup libvirt resources.")
+parser.add_argument("cloud", type=str, help="Name of the cloud")
+parser.add_argument("nodenumber", type=int, help="Number of nodes")
+parser.add_argument("cloudbr", type=str, help="Name of the virtual bridge")
+parser.add_argument("public_vlan", type=str, help="Name of the public vlan")
+
+args = parser.parse_args()
+
+def remove_files(files):
+    for f in glob.glob(files):
+        print("removing {}".format(f))
+        os.remove(f)
+
+def main():
+    devnull = open(os.devnull, "w")
+    allnodenames = ["admin"]
+    allnodenames.extend("node%s"%i for i in range(1, args.nodenumber+20))
+
+    try:
+        for nodename in allnodenames:
+            vm = "{}-{}".format(args.cloud, nodename)
+            dom = conn.lookupByName(vm)
+            if dom.isActive():
+                print("destroying {}".format(dom.name()))
+                dom.destroy()
+            if dom.ID():
+                print("undefining {}".format(dom.name()))
+                dom.undefine()
+
+            machine = "{}-{}".format("qemu", vm)
+            machinectl = os.access("/usr/bin/machinectl". os.X_OK)
+            machine_status = subprocess.call(["machinectl", "status", machine], stdout=devnull, stderr=subprocess.STDOUT)
+            if (machinectl == 0 and machine_status == 0):
+                subprocess.call(["machinectl", "terminate", machine]) # workaround bnc#916518
+    except Exception:
+        print("...skipping undefined domains")
+
+    try:
+        net_name = "{}-admin".format(args.cloud)
+        network = conn.networkLookupByName(net_name)
+        print("destroying {}".format(net_name))
+        network.destroy()
+        print("undefining {}".format(net_name))
+        network.undefine()
+    except Exception:
+        print("...skipping undefined network")
+
+    remove_files("/var/run/libvirt/qemu/{}-*.xml".format(args.cloud))
+    remove_files("/var/lib/libvirt/network/{}-*.xml".format(args.cloud))
+    remove_files("/etc/sysconfig/network/ifcfg-{}.{}".format(args.cloudbr, args.public_vlan))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/libvirt/net-start.py
+++ b/scripts/lib/libvirt/net-start.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import libvirt
+import sys
+import argparse
+
+conn = libvirt.open("qemu:///system")
+if not conn:
+    print("Failed to open connection to the hypervisor")
+    sys.exit(1)
+
+parser = argparse.ArgumentParser(description="Start a Virtual Network.")
+parser.add_argument("net", type=str, help="Name of the network")
+
+args = parser.parse_args()
+
+def main():
+    net = args.net
+    print("defining {} network".format(net))
+    networks = conn.listNetworks()
+    if net not in networks:
+        print("defining {} network".format(net))
+        xml = open("/tmp/{}.net.xml".format(net)).read()
+        conn.networkDefineXML(xml)
+    print("starting {} network".format(net))
+    dom = conn.networkLookupByName(net)
+    dom.create()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/libvirt/vm-start.py
+++ b/scripts/lib/libvirt/vm-start.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import libvirt
+import sys
+import argparse
+
+conn = libvirt.open("qemu:///system")
+if conn == None:
+    print("Failed to open connection to the hypervisor")
+    sys.exit(1)
+
+parser = argparse.ArgumentParser(description="Start a Virtual Machine.")
+parser.add_argument("vm", type=str, help="Name of the vm")
+
+args = parser.parse_args()
+
+def main():
+    vm = args.vm
+    try:
+        print("cleaning up {}".format(vm))
+        dom = conn.lookupByName(vm)
+        if dom.isActive():
+            print("destroying {} vm".format(dom.name()))
+            dom.destroy()
+        if dom.ID():
+            print("undefining {} vm".format(dom.name()))
+            dom.undefine()
+    except:
+        print("no domain for {} active".format(vm))
+
+    xml = open("/tmp/{}.xml".format(vm)).read()
+    print("defining {} vm".format(vm))
+    conn.defineXML(xml)
+    if not "dom" in locals():
+        dom = conn.lookupByName(vm)
+    print("booting {} vm".format(vm))
+    dom.create()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -240,15 +240,6 @@ function libvirt_start_daemon()
     wait_for 300 1 '[ -S /var/run/libvirt/libvirt-sock ]' 'libvirt startup'
 }
 
-function libvirt_net_start()
-{
-    local network=$1
-    if ! virsh net-dumpxml $network > /dev/null 2>&1; then
-        virsh net-define /tmp/${network}.net.xml
-    fi
-    virsh net-start $network
-}
-
 function libvirt_vm_start()
 {
     local vm=$1
@@ -270,6 +261,6 @@ function libvirt_setupadmin()
     libvirt_onhost_create_admin_network_config
     libvirt_modprobe_kvm
     libvirt_start_daemon
-    libvirt_net_start $cloud-admin
+    python ${mkcloud_lib_dir}/libvirt/net-start.py $cloud-admin
     libvirt_vm_start $cloud-admin
 }

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -240,21 +240,6 @@ function libvirt_start_daemon()
     wait_for 300 1 '[ -S /var/run/libvirt/libvirt-sock ]' 'libvirt startup'
 }
 
-function libvirt_vm_start()
-{
-    local vm=$1
-    virsh destroy $vm 2>/dev/null
-    virsh undefine $vm 2>/dev/null
-    if ! virsh define /tmp/${vm}.xml ; then
-        echo "=====================================================>>"
-        complain 76 "Could not define VM for: $vm"
-    fi
-    if ! virsh start $vm ; then
-        echo "=====================================================>>"
-        complain 76 "Could not start VM for: $vm"
-    fi
-}
-
 function libvirt_setupadmin()
 {
     libvirt_onhost_create_adminnode_config
@@ -262,5 +247,5 @@ function libvirt_setupadmin()
     libvirt_modprobe_kvm
     libvirt_start_daemon
     python ${mkcloud_lib_dir}/libvirt/net-start.py $cloud-admin
-    libvirt_vm_start $cloud-admin
+    python ${mkcloud_lib_dir}/libvirt/vm-start.py $cloud-admin
 }

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -1,30 +1,3 @@
-function libvirt_cleanup()
-{
-    allnodenames=$(seq --format="node%.0f" 1 $(($nodenumber + 20)))
-    for name in admin $allnodenames ; do
-        local vm=$cloud-$name
-        if LANG=C virsh domstate $vm 2>/dev/null | grep -q running ; then
-            safely virsh destroy $vm
-        fi
-        if virsh domid $vm >/dev/null 2>&1; then
-            safely virsh undefine $vm
-        fi
-        local machine=qemu-$vm
-        if test -x /usr/bin/machinectl && machinectl status $machine 2>/dev/null ; then
-            safely machinectl terminate $machine # workaround bnc#916518
-        fi
-    done
-
-    local net=$cloud-admin
-    if virsh net-uuid $net >/dev/null 2>&1; then
-        virsh net-destroy $net
-        safely virsh net-undefine $net
-    fi
-
-    rm -f /var/run/libvirt/qemu/$cloud-*.xml /var/lib/libvirt/network/$cloud-*.xml \
-            /etc/sysconfig/network/ifcfg-$cloudbr.$public_vlan
-}
-
 function libvirt_onhost_cpuflags_settings()
 { # used for admin and compute nodes
     cpuflags="<cpu match='minimum'>

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -291,7 +291,7 @@ function onadmin()
 function cleanup()
 {
     # cleanup leftover from last run
-    libvirt_cleanup
+    python ${mkcloud_lib_dir}/libvirt/cleanup.py $cloud $nodenumber $cloudbr $public_vlan
 
     if ip link show ${cloudbr}.$public_vlan >/dev/null 2>&1; then
         ip link set ${cloudbr}.$public_vlan down

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -605,7 +605,7 @@ function setuplonelynodes()
             onhost_deploy_image "lonely" "SLE11" $lonely_disk
         fi
 
-        libvirt_vm_start $lonely_node
+        python ${mkcloud_lib_dir}/libvirt/vm-start.py $lonely_node
     done
 }
 
@@ -739,7 +739,7 @@ function setupnodes()
         fi
 
         libvirt_onhost_create_computenode_config /tmp/$cloud-node$i.xml $i $macaddress "$cephvolume" "$drbdvolume"
-        libvirt_vm_start $cloud-node$i
+        python ${mkcloud_lib_dir}/libvirt/vm-start.py $cloud-node$i
     done
     echo "========================================================"
     echo " Note: If you interrupt mkcloud now and want to proceed"

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -55,11 +55,13 @@ fi
 # causes of this is violation of the common shell coding standard which
 # uses uppercase for environment variables and constants, and lowercase
 # for local variables.
+: ${mkcloud_dir:=$(dirname $0)}
+: ${qa_crowbarsetup:=${mkcloud_dir}/qa_crowbarsetup.sh}
+mkcloud_lib_dir=${mkcloud_dir}/lib
 : ${cinder_backend:=''}
 : ${cinder_netapp_storage_protocol:=iscsi}
 : ${cinder_netapp_login:=openstack}
 : ${cinder_netapp_password:=''}
-: ${qa_crowbarsetup:=$(dirname $0)/qa_crowbarsetup.sh}
 : ${virtualcloud:=virtual}
 : ${cloudfqdn:=$virtualcloud.cloud.suse.de}
 : ${forwardmode:=nat}


### PR DESCRIPTION
This is part of the refactoring for mkcloud.

All the libvirt code that has been previously handled by Bash, should be extracted to a more suitable language for the task. We chose python over ruby here because it comes with libvirt bindings, which are available in SLES.

As I have very little experience with python, please give me some input on that.

Further I chose to write the tools as granular as possible, so that one script does only one job, which makes it more maintainable IMO. I thought about putting all libvirt stuff in one script but I didn't see an advantage in that. What do you suggest?

This PR introduces the
* `cleanup` of libvirt resources
* `network` definition and creation
* `vm` definition and creation

The actual creation of the XML files, as well as host specific libvirt configuring (starting the daemon etc) will follow up in this PR, or another.
But I would like to get some feedback from you before continuing.