### PR TITLE
fix lonely_node variable name

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -581,7 +581,7 @@ function setuplonelynodes()
             onhost_deploy_image "lonely" "SLE11" $lonely_disk
         fi
 
-        ${mkcloud_lib_dir}/libvirt/vm-start /tmp/${lonelynode}.xml
+        ${mkcloud_lib_dir}/libvirt/vm-start /tmp/${lonely_node}.xml
     done
 }
 


### PR DESCRIPTION
thank you [jenkins](https://ci.suse.de/job/openstack-mkcloud/3976/)
```
+ /root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/vm-start /tmp/.xml
Traceback (most recent call last):
  File "/root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/vm-start", line 19, in <module>
    main()
  File "/root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/vm-start", line 15, in main
    libvirt_setup.vm_start(args)
  File "/root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/libvirt_setup.py", line 237, in vm_start
    vmname = xml_get_value(args.vmpath, "name")
  File "/root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/libvirt_setup.py", line 215, in xml_get_value
    tree = ET.parse(path)
  File "/usr/lib64/python2.6/xml/etree/ElementTree.py", line 862, in parse
    tree.parse(source, parser)
  File "/usr/lib64/python2.6/xml/etree/ElementTree.py", line 579, in parse
    source = open(source, "rb")
IOError: [Errno 2] No such file or directory: '/tmp/.xml'
```