### PR TITLE
mkcloud: avoid race on loop dev

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -445,8 +445,7 @@ function onhost_deploy_image()
     if fdisk -l $disk | grep -q $offset ; then
         # make a bigger partition 2
         echo -e "d\n2\nn\np\n2\n\n\na\n2\nw" | fdisk $disk
-        loopdevice=`losetup --find`
-        losetup -o $(( $offset * 512 )) $loopdevice $disk
+        loopdevice=$(losetup --find --show -o $(( $offset * 512 )) $loopdevice $disk)
         safely fsck -y -f $loopdevice
         safely resize2fs $loopdevice
         losetup -d $loopdevice


### PR DESCRIPTION
it already happened
that two mkcloud runs both find /dev/loop0 as free
but the 2nd of them finds it busy when it really wants to use it

collision happened in
https://ci.suse.de/view/Cloud/view/Worker/job/openstack-mkcloud/4168/console
https://ci.suse.de/view/Cloud/view/Worker/job/openstack-mkcloud/4169/consoleFull
02:13:19 losetup: /dev/mkcvg0/c4.admin: failed to set up loop device: Device or resource busy