### PR TITLE
Deploy cinder-volume on SLE12 for SOC6+up

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1727,6 +1727,7 @@ function custom_configuration()
             ;;
             cinder)
                 proposal_set_value cinder default "['deployment']['cinder']['elements']['cinder-controller']" "['$sles12controller']"
+                proposal_set_value cinder default "['deployment']['cinder']['elements']['cinder-volume']" "['$sles12controller']"
             ;;
             tempest)
                 proposal_set_value tempest default "['deployment']['tempest']['elements']['tempest']" "['$sles12controller']"


### PR DESCRIPTION
Last change needed to finish
https://trello.com/c/QcOIZeiS/409-5-sle12-make-cinder-roles-deployable-on-sle12

This is possible after https://github.com/crowbar/barclamp-cinder/pull/253 was merged 