### PR TITLE
github-status: support custom message and error status

### DIFF
--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -39,18 +39,6 @@ class GHClientHandler
     )
   end
 
-  def create_success_status(commit, target_url = '')
-    create_status(commit, 'success', @comment_prefix + 'succeeded', target_url)
-  end
-
-  def create_failure_status(commit, target_url = '')
-    create_status(commit, 'failure', @comment_prefix + 'failed', target_url)
-  end
-
-  def create_pending_status(commit, target_url = '')
-    create_status(commit, 'pending', @comment_prefix + 'is pending', target_url)
-  end
-
   def get_full_sha_status(sha)
     status = @client.status(@repository, sha)
     status.statuses.select{ |s| s.context == @context }.first rescue {}

--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -126,6 +126,10 @@ optparse = OptionParser.new do |opts|
     options[:status] = status
   end
 
+  opts.on('-m', '--message MSG', 'Message to show in github next to the status.') do |msg|
+    options[:message] = msg
+  end
+
   opts.on('-h', '--help', 'Show usage') do |h|
     puts opts
     exit


### PR DESCRIPTION
Adding support for the error status, meaning that the test run itself could not be run (while failure means, the test could be run but it failed, so the PR is breaking it).
Also adding support for custom message to be shown in github. Primarily used to describe the error status.