### PR TITLE
qa_crowbarsetup.sh: Remove outdated codepaths

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1899,9 +1899,7 @@ function custom_configuration()
                 proposal_set_value neutron default "['attributes']['neutron']['use_lbaas']" "true"
             fi
 
-            # For Cloud > 5 M4, proposal attribute names changed
-            # TODO(toabctl): the milestone/cloud6 check can be removed when milestone 5 is released
-            if iscloudver 5 && [[ ! $cloudsource =~ ^M[1-4]+$ ]] || iscloudver 6plus; then
+            if iscloudver 5plus; then
                 if [ "$networkingplugin" = "openvswitch" ] ; then
                     if [[ "$networkingmode" = vxlan ]] || iscloudver 6plus; then
                         proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['gre','vxlan','vlan']"


### PR DESCRIPTION
This was for the old neutron proposals, which does not exist
anymore.