### PR TITLE
Rename Cloud-PTF repo to just PTF

### DIFF
--- a/docs/mkcloud.md
+++ b/docs/mkcloud.md
@@ -196,15 +196,15 @@ create a directory for each topic you want to test, to avoid
 accidentally mixing up which PTF packages get applied during a
 particular mkcloud test run.  For example,
 
-    # ptfdir=/data/install/Cloud-PTF/rabbitmq-bugfix
+    # ptfdir=/data/install/PTF/rabbitmq-bugfix
     # mkdir -p $ptfdir
     # cp ~/tmp/build-rpms/IBS_Devel_Cloud_5_crowbar-barclamp-rabbitmq/*.noarch.rpm $ptfdir
 
 Set up Apache on the host to export `$ptfdir` as http://192.168.124.1/ptf/
 
     # cat <<EOF >/etc/apache2/conf.d/cloud-ptf.conf
-    Alias /ptf /data/install/Cloud-PTF/
-    <Directory /data/install/Cloud-PTF/>
+    Alias /ptf /data/install/PTF/
+    <Directory /data/install/PTF/>
         Options +Indexes +FollowSymLinks
         IndexOptions +NameWidth=*
 
@@ -219,4 +219,4 @@ Now it is ready to be used by `mkcloud`:
     # mkcloud plain
 
 Now subsequent `mkcloud` runs will automatically apply any packages
-found under `/data/install/Cloud-PTF/rabbitmq-bugfix`.
+found under `/data/install/PTF/rabbitmq-bugfix`.

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2736,6 +2736,8 @@ function onadmin_addupdaterepo()
     pre_hook $FUNCNAME
 
     local UPR=$tftpboot_repos_dir/Cloud-PTF
+    iscloudver 6plus && UPR=$tftpboot_repos_dir/PTF
+
     mkdir -p $UPR
 
     if [[ -n "$UPDATEREPOS" ]]; then


### PR DESCRIPTION
This changes the path to match what's introduced by
https://github.com/crowbar/crowbar/pull/2108 and
https://github.com/crowbar/barclamp-provisioner/pull/441

Signed-off-by: Tim Serong <tserong@suse.com>