### PR TITLE
fix boot order for lonely nodes

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -26,7 +26,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1'/>
       <target dev='vda' bus='virtio'/>
-      <boot order='2'/>
+      <boot order='3'/>
     </disk>
 
 <disk type='block' device='disk'>
@@ -42,7 +42,7 @@
       <source network='cloud-admin'/>
       <model type='virtio'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
-      <boot order='1'/>
+      <boot order='2'/>
     </interface>
     <serial type='pty'>
       <target port='0'/>

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -31,7 +31,7 @@ $drbdvolume
       <source network='$cloud-admin'/>
       <model type='$nicmodel'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
-      <boot order='1'/>
+      <boot order='2'/>
     </interface>
     <serial type='pty'>
       <target port='0'/>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -142,7 +142,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.emulator = "/usr/bin/qemu-system-x86_64"
         args.vdiskdir = "/dev/cloud"
         args.drbdserial = ""
-        args.bootorder = "2"
+        args.bootorder = "3"
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -550,7 +550,7 @@ function setuplonelynodes()
         mac="52:54:$i2:88:77:$i2"
         local lonely_node
         lonely_node=$cloud-node$i
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac "$cephvolume" "$drbdvolume" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "3" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac "$cephvolume" "$drbdvolume" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "1" > /tmp/$cloud-node$i.xml
 
         local lonely_disk
         lonely_disk="$vdisk_dir/${cloud}.node$i"
@@ -672,7 +672,7 @@ function setupnodes()
             fi
         fi
 
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress $cephvolumenumber "$drbd_serial" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "2" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress $cephvolumenumber "$drbd_serial" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "3" > /tmp/$cloud-node$i.xml
         ${mkcloud_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
     done
 


### PR DESCRIPTION
we want disk to be ordered after network in the default case
but ordered before in the lonely node case