### PR TITLE
qa_crowbarsetup.sh: Follow redirect in curl to Horizon

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2599,7 +2599,7 @@ function onadmin_testsetup()
         complain 62 "no nova contoller - something went wrong"
     fi
     echo "openstack nova contoller: $novacontroller"
-    curl -m 40 -s http://$novacontroller | grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" || complain 101 "simple horizon dashboard test failed"
+    curl -L -m 40 -s http://$novacontroller | grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" || complain 101 "simple horizon dashboard test failed"
 
     wantcephtestsuite=0
     if [[ -n "$deployceph" ]]; then


### PR DESCRIPTION
It seems that with Kilo, Horizon redirects the page by default without
even returning anything, so we need to tell curl to follow the redirect.