### PR TITLE
qa_crowbarsetup.sh: Only set intended roles for SLES12 nodes on Cloud 5

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1358,7 +1358,7 @@ function onadmin_allocate()
     echo "Setting first node to controller..."
     set_node_role_and_platform ${controllernodes[0]} "controller" $controller_os
 
-    if [ -n "$want_sles12" ] && iscloudver 5plus ; then
+    if [ -n "$want_sles12" ] && iscloudver 5 ; then
 
         local nodes=(
             $(get_all_discovered_nodes | tail -n 2)


### PR DESCRIPTION
On Cloud 6, all nodes are SLES 12 by default, so we don't want to
restrict compute roles to only one node.