### PR TITLE
add roundup folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ scripts/jenkins/*.cred
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+
+roundup/


### PR DESCRIPTION
the output of the test suite is not really needed in our version control