### PR TITLE
mkcloud: Raise memory for controller node.

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -1,7 +1,7 @@
 <domain type='kvm'>
   <name>cloud-node1</name>
-  <memory>4194304</memory>
-  <currentMemory>4194304</currentMemory>
+  <memory>5242880</memory>
+  <currentMemory>5242880</currentMemory>
   <vcpu>1</vcpu>
   <os>
     <type arch='x86_64' machine='pc-0.14'>hvm</type>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -136,7 +136,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.macaddress = "52:54:01:77:77:01"
         args.cephvolumenumber = "1"
         args.computenodememory = "2097152"
-        args.controllernodememory = "4194304"
+        args.controllernodememory = "5242880"
         args.libvirttype = "kvm"
         args.vcpus = "1"
         args.emulator = "/usr/bin/qemu-system-x86_64"

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -91,7 +91,7 @@ needcvol=1
 : ${vdisk_dir:=/dev/$cloudvg}
 : ${admin_node_disk:=$vdisk_dir/$cloud.admin}
 : ${admin_node_memory:=2097152}
-: ${controller_node_memory:=4194304}
+: ${controller_node_memory:=5242880}
 : ${compute_node_memory:=2097152}
 : ${hyperv_node_memory:=3000000}
 [[ "$libvirt_type" = "hyperv" && $compute_node_memory -lt $hyperv_node_memory ]] && compute_node_memory=$hyperv_node_memory
@@ -1058,7 +1058,7 @@ Optional
         set the number of CPU cores for admin node
     admin_node_memory (default 2097152)
         Set the memory in KB assigned to admin node
-    controller_node_memory (default 4194304)
+    controller_node_memory (default 5242880)
         Set the memory in KB assigned to compute nodes
     compute_node_memory (default 2097152)
         Set the memory in KB assigned to compute nodes


### PR DESCRIPTION
There is no way to get the controller node into 4GB anymore with
the increased number of services and the much increased memory
usage of OpenStack Kilo. Raise it to get at least jenkins
somewhat green again.