### PR TITLE
allow 'vxlan' as a choice for the 'networkingmode' parameter

### DIFF
--- a/scripts/jenkins/ci.suse.de/openstack-mkcloud.xml
+++ b/scripts/jenkins/ci.suse.de/openstack-mkcloud.xml
@@ -76,6 +76,7 @@ results are analyzed by https://github.com/SUSE-Cloud/automation/blob/master/scr
             <a class="string-array">
               <string>gre</string>
               <string>vlan</string>
+              <string>vxlan</string>
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>


### PR DESCRIPTION
This is a valid choice and is expected by cloud-mkcloud6-ha-trigger.