### PR TITLE
Adjust naming of the PTF channel

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2238,8 +2238,10 @@ function prepare_proposals()
     fi
 
     cmachines=$(get_all_nodes)
+    local ptfchannel="SLE-Cloud-PTF"
+    iscloudver 6plus && ptfchannel="PTF"
     for machine in $cmachines; do
-        ssh $machine 'zypper mr -p 90 SLE-Cloud-PTF'
+        ssh $machine "zypper mr -p 90 $ptfchannel"
     done
 
 }


### PR DESCRIPTION
The PTF channel was recently renamed in Cloud 6.x
to just "PTF".