### PR TITLE
Fix node power check after reboot

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2920,6 +2920,10 @@ function onadmin_rebootcloud()
     for m in $cmachines ; do
         ssh $m "reboot"
         wait_for 100 1 " ! netcat -z $m 22 >/dev/null" "node $m to go down"
+        # "crowbar machines list" returns FQDNs but "crowbar node_state status"
+        # only hostnames. Get hostname part of FQDN
+        m_hostname=$(echo $m| cut -d '.' -f 1)
+        wait_for 400 5 'crowbar node_state status | grep -q -e "$m_hostname\s*Power"'
     done
 
     wait_for 400 5 "! crowbar node_state status | grep ^d | grep -vqiE \"ready$|problem$\"" "nodes are back online"


### PR DESCRIPTION
"crowbar machines list" returns FQDNs but "crowbar node_state status"
only hostnames. Get hostname from FQDN to compare the current node state.