### PR TITLE
Fix mkcloud HA runs

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -823,7 +823,7 @@ function rebootcloud()
 
 function rebootcompute()
 {
-    # compat, remove
+    echo "WARNING: called deprecated rebootcompute step" >&2
     rebootcloud
     return $?
 }

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2717,9 +2717,9 @@ function onadmin_testsetup()
 
     get_novacontroller
     if [ -z "$novacontroller" ] || ! ssh $novacontroller true ; then
-        complain 62 "no nova contoller - something went wrong"
+        complain 62 "no nova controller - something went wrong"
     fi
-    echo "openstack nova contoller: $novacontroller"
+    echo "openstack nova controller: $novacontroller"
     curl -L -m 40 -s -S -k http://$novacontroller | grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" || complain 101 "simple horizon dashboard test failed"
 
     wantcephtestsuite=0

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2404,7 +2404,7 @@ function get_first_node_from_cluster()
 
 # An entry in an elements section can have single or multiple nodes or a cluster alias
 # This function will resolve this element name to a node name.
-function resolve_element_to_node()
+function resolve_element_to_hostname()
 {
     local name="$1"
     name=`printf "%s\n" "$name" | head -n 1`
@@ -2424,7 +2424,7 @@ function get_novacontroller()
         rubyjsonparse "
                     puts j['deployment']['nova']\
                         ['elements']['nova-multi-controller']"`
-    novacontroller=`resolve_element_to_node "$novacontroller"`
+    novacontroller=`resolve_element_to_hostname "$novacontroller"`
 }
 
 function get_novadashboardserver()
@@ -2433,7 +2433,7 @@ function get_novadashboardserver()
         rubyjsonparse "
                     puts j['deployment']['nova_dashboard']\
                         ['elements']['nova_dashboard-server']"`
-    novadashboardserver=`resolve_element_to_node "$novadashboardserver"`
+    novadashboardserver=`resolve_element_to_hostname "$novadashboardserver"`
 }
 
 function get_ceph_nodes()

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -667,7 +667,7 @@ function cluster_node_assignment()
             ;;
         esac
     done
-    nodescloud=$nodesavailable
+    unclustered_nodes=$nodesavailable
 
     echo "............................................................"
     echo "The cluster node assignment (for your information):"
@@ -677,8 +677,8 @@ function cluster_node_assignment()
     printf "   %s\n" $clusternodesnetwork
     echo "services cluster:"
     printf "   %s\n" $clusternodesservices
-    echo "compute nodes (no cluster):"
-    printf "   %s\n" $nodescloud
+    echo "other non-clustered nodes (free for compute / storage):"
+    printf "   %s\n" $unclustered_nodes
     echo "............................................................"
 }
 
@@ -1944,7 +1944,7 @@ function custom_configuration()
 
                 # only use remaining nodes as compute nodes, keep cluster nodes dedicated to cluster only
                 local novanodes
-                novanodes=`printf "\"%s\"," $nodescloud`
+                novanodes=`printf "\"%s\"," $unclustered_nodes`
                 novanodes="[ ${novanodes%,} ]"
                 proposal_set_value nova default "['deployment']['nova']['elements']['nova-multi-compute-${libvirt_type}']" "$novanodes"
             fi
@@ -1978,7 +1978,7 @@ function custom_configuration()
                 # this should be adapted when NFS mode is supported for data cluster
                 proposal_set_value ceilometer default "['attributes']['ceilometer']['use_mongodb']" "false"
                 local ceilometernodes
-                ceilometernodes=`printf "\"%s\"," $nodescloud`
+                ceilometernodes=`printf "\"%s\"," $unclustered_nodes`
                 ceilometernodes="[ ${ceilometernodes%,} ]"
                 proposal_set_value ceilometer default "['deployment']['ceilometer']['elements']['ceilometer-agent']" "$ceilometernodes"
             fi
@@ -2080,7 +2080,7 @@ function custom_configuration()
             if [[ $hacloud = 1 ]] ; then
                 local cinder_volume
                 # fetch one of the compute nodes as cinder_volume
-                cinder_volume=`printf "%s\n" $nodescloud | tail -n 1`
+                cinder_volume=`printf "%s\n" $unclustered_nodes | tail -n 1`
                 proposal_set_value cinder default "['deployment']['cinder']['elements']['cinder-controller']" "['cluster:$clusternameservices']"
                 proposal_set_value cinder default "['deployment']['cinder']['elements']['cinder-volume']" "['$cinder_volume']"
             fi

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2088,10 +2088,10 @@ function custom_configuration()
         ;;
         tempest)
             if [[ $hacloud = 1 ]] ; then
-                local tempestnodes
-                # tempest can only be deployed on one node
-                tempestnodes=`printf "'%s',\n" $nodescloud | head -n 1`
-                tempestnodes="[ ${tempestnodes%,} ]"
+                get_novacontroller
+                # tempest can only be deployed on one node, and we run it on
+                # the same nova controller we use for other stuff.
+                tempestnodes="[ '$novacontroller' ]"
                 proposal_set_value tempest default "['deployment']['tempest']['elements']['tempest']" "$tempestnodes"
             fi
         ;;


### PR DESCRIPTION
This addresses two problems with mkcloud failing when `hacloud=1`:

- a `curl` check of Horizon wasn't going through haproxy
- tempest wasn't being deployed on the same node the tempest test run was triggered on

Supersedes #475.