### PR TITLE
Fix indentation at assignment of allcmds variable

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1242,15 +1242,15 @@ function sanity_checks()
 step_aliases="_new_admin _compute _upgrade _testupdate"
 
 allcmds="$step_aliases all all_noreboot instonly plain \
-plain_with_upgrade cleanup setuphost prepare setupadmin \
-prepareinstcrowbar instcrowbar instcrowbarfromgit setupnodes \
-setupcompute instnodes instcompute proposal testsetup rebootcrowbar \
-rebootcloud addupdaterepo runupdate testupdate securitytests \
-crowbarbackup crowbarrestore shutdowncloud restartcloud qa_test help \
-rebootneutron prepare_cloudupgrade cloudupgrade_1st cloudupgrade_2nd \
-cloudupgrade_clients cloudupgrade_reboot_and_redeploy_clients \
-setuplonelynodes crowbar_register createadminsnapshot \
-restoreadminfromsnapshot cct steps"
+    plain_with_upgrade cleanup setuphost prepare setupadmin \
+    prepareinstcrowbar instcrowbar instcrowbarfromgit setupnodes \
+    setupcompute instnodes instcompute proposal testsetup rebootcrowbar \
+    rebootcloud addupdaterepo runupdate testupdate securitytests \
+    crowbarbackup crowbarrestore shutdowncloud restartcloud qa_test help \
+    rebootneutron prepare_cloudupgrade cloudupgrade_1st cloudupgrade_2nd \
+    cloudupgrade_clients cloudupgrade_reboot_and_redeploy_clients \
+    setuplonelynodes crowbar_register createadminsnapshot \
+    restoreadminfromsnapshot cct steps"
 wantedcmds=$@
 
 function expand_steps()


### PR DESCRIPTION
As @tboerger mentioned in #431 the split lines should get some indentation.
I initially didn't do this as I thought it would add extra spaces between the values.
As it turns out, this is not the case ... except you would use zsh for testing this ;)

Note: Two of the lines now are longer than the 72 characters @aspiers suggested in the other pull request. I decided to keep the line-break where it was to not screw up the diff. If you think it's worth breaking the line earlier, just say so.