### PR TITLE
Docker trigger shouldn't block

### DIFF
--- a/scripts/jenkins/ci.suse.de/cloud-mkcloud6-docker-trigger.xml
+++ b/scripts/jenkins/ci.suse.de/cloud-mkcloud6-docker-trigger.xml
@@ -52,26 +52,6 @@ want_docker=1</properties>
           <projects>openstack-mkcloud</projects>
           <condition>ALWAYS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
-          <block>
-            <buildStepFailureThreshold>
-              <name>FAILURE</name>
-              <ordinal>2</ordinal>
-              <color>RED</color>
-              <completeBuild>true</completeBuild>
-            </buildStepFailureThreshold>
-            <unstableThreshold>
-              <name>UNSTABLE</name>
-              <ordinal>1</ordinal>
-              <color>YELLOW</color>
-              <completeBuild>true</completeBuild>
-            </unstableThreshold>
-            <failureThreshold>
-              <name>FAILURE</name>
-              <ordinal>2</ordinal>
-              <color>RED</color>
-              <completeBuild>true</completeBuild>
-            </failureThreshold>
-          </block>
           <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
         </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
       </configs>


### PR DESCRIPTION
The docker trigger was blocking until "openstack-mkcloud" succeeded.
That doesn't currently happen to often and in that case the docker
trigger was blocking the slave "cloud-trackupstream-sle12".
That slave is also used for pr testing which doesn't work then.