### PR TITLE
[WIP] qa_crowbarsetup.sh: mount remote nfs mounts by IP address

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -20,8 +20,8 @@ fi
 : ${cinder_netapp_storage_protocol:=iscsi}
 : ${cinder_netapp_login:=openstack}
 : ${cinder_netapp_password:=''}
-: ${clouddata:=$(dig -t A +short clouddata.cloud.suse.de)}
-: ${distsuse:=$(dig -t A +short dist.suse.de)}
+: ${clouddata:=clouddata.cloud.suse.de}
+: ${distsuse:=dist.suse.de}
 
 : ${arch:=$(uname -m)}
 
@@ -297,7 +297,7 @@ function add_nfs_mount()
         return
     fi
 
-    echo "$nfs $dir nfs    ro,nosuid,rsize=8192,wsize=8192,hard,intr,nolock  0 0" >> /etc/fstab
+    echo "$nfs $dir nfs    ro,nosuid,rsize=8192,wsize=8192,hard,intr,nolock,x-systemd.requires=dnsmasq.service  0 0" >> /etc/fstab
     safely mount "$dir"
 }
 


### PR DESCRIPTION
On SLE12, named is a compat sysv init script which relies on
$remote_fs to finish starting. if we have remote mounts
that depends on DNS resolution, we don't get it started automatically
since the remote mounting fails.