### PR TITLE
allow for SLE12-based HA in Cloud 6

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1123,11 +1123,10 @@ EOF
     if [ -n "$hacloud" ]; then
         if [ "$slesdist" = "SLE_11_SP3" ] && iscloudver 3plus ; then
             add_ha_repo
+        elif iscloudver 6plus; then
+            add_ha12_repo
         else
             complain 18 "You requested a HA setup but for this combination ($cloudsource : $slesdist) no HA setup is available."
-        fi
-        if iscloudver 6plus; then
-            add_ha12_repo
         fi
     fi
 


### PR DESCRIPTION
The change to `slesdist` for Cloud 6 in #485 exposed a new code path for `hacloud=1` with SLE12.  Technically HA on SLE12 isn't supported yet since https://github.com/crowbar/barclamp-pacemaker/pull/207 is still being tested; however hopefully it will be supported very soon and even before then this will let us test it via Jenkins.