### PR TITLE
Enable trackupstream for manila barclamp on Cloud 5

### DIFF
--- a/scripts/jenkins/ci.suse.de/crowbar-trackupstream.xml
+++ b/scripts/jenkins/ci.suse.de/crowbar-trackupstream.xml
@@ -101,7 +101,9 @@
       </values>
     </hudson.matrix.TextAxis>
   </axes>
-  <combinationFilter>! (   ["Devel:Cloud:4:Staging", "Devel:Cloud:5:Staging"].contains(project)  &amp;&amp;  ["openstack-dashboard-theme-SUSE", "crowbar-barclamp-manila"].contains(component)  )     </combinationFilter>
+  <combinationFilter>! (
+      ( ["Devel:Cloud:4:Staging"].contains(project)  &amp;&amp;  ["crowbar-barclamp-manila"].contains(component) ) ||
+        ["Devel:Cloud:4:Staging", "Devel:Cloud:5:Staging"].contains(project)  &amp;&amp;  ["openstack-dashboard-theme-SUSE", ].contains(component) ) </combinationFilter>
   <builders>
     <hudson.tasks.Shell>
       <command>PROJECTSOURCE=IBS/${project}


### PR DESCRIPTION
Now that we have a manila barclamp there.. :-)