### PR TITLE
Fix cloud upgrade repos

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3007,6 +3007,7 @@ function onadmin_prepare_cloudupgrade()
 
     # recreate the SUSE-Cloud Repo with the latest iso
     onadmin_prepare_cloud_repos
+    onadmin_add_cloud_repo
 
     # Applying the updater barclamp (in onadmin_cloudupgrade_clients) triggers
     # a chef-client run on the admin node (even it the barclamp is not applied


### PR DESCRIPTION
This fixes the mkcloud upgrade test which was broken since the spilt / refactoring of this two methods.