### PR TITLE
Use --visibility=public while creating a glance image

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -194,34 +194,42 @@ mirror=http://149.44.161.38/images # ci1-opensuse
 cirros_base_url="http://download.cirros-cloud.net/0.3.3/"
 cirros_base_url="$mirror"
 cirros_base_name="cirros-0.3.3-x86_64"
+
+# since glanceclient Liberty, --is-public is gone and --visibility should be used
+if glance help image-create|grep -q visibility; then
+    GLANCECLIENT_VISIBILITY_PARAMS=" --visibility=public"
+else
+    GLANCECLIENT_VISIBILITY_PARAMS=" --is-public=true"
+fi
+
 case "$MODE" in
     xen)
-        glance image-create --is-public=True --disk-format=qcow2 --container-format=bare --name jeos-64-pv --copy-from http://clouddata.cloud.suse.de/images/jeos-64-pv.qcow2
-        glance image-create --is-public=True --disk-format=aki --container-format=aki --name=debian-kernel < xen-kernel/vmlinuz-2.6.24-19-xen
-        glance image-create --is-public=True --disk-format=ari --container-format=ari --name=debian-initrd < xen-kernel/initrd.img-2.6.24-19-xen
-        glance image-create --is-public=True --disk-format=ami --container-format=ami --name=debian-5 --property vm_mode=xen ramdisk_id=f663eb9a-986b-466f-bd3e-f0aa2c847eef kernel_id=d654691a-0135-4f6d-9a60-536cf534b284 < debian.5-0.x86.img
+        glance image-create $GLANCECLIENT_VISIBILITY_PARAMS --disk-format=qcow2 --container-format=bare --name jeos-64-pv --copy-from http://clouddata.cloud.suse.de/images/jeos-64-pv.qcow2
+        glance image-create $GLANCECLIENT_VISIBILITY_PARAMS --disk-format=aki --container-format=aki --name=debian-kernel < xen-kernel/vmlinuz-2.6.24-19-xen
+        glance image-create $GLANCECLIENT_VISIBILITY_PARAMS --disk-format=ari --container-format=ari --name=debian-initrd < xen-kernel/initrd.img-2.6.24-19-xen
+        glance image-create $GLANCECLIENT_VISIBILITY_PARAMS --disk-format=ami --container-format=ami --name=debian-5 --property vm_mode=xen ramdisk_id=f663eb9a-986b-466f-bd3e-f0aa2c847eef kernel_id=d654691a-0135-4f6d-9a60-536cf534b284 < debian.5-0.x86.img
     ;;
     lxc)
-        glance image-create --name="debian-5" --is-public=True --disk-format=ami --container-format=ami --copy-from $mirror/debian.5-0.x86.qcow2
+        glance image-create --name="debian-5" $GLANCECLIENT_VISIBILITY_PARAMS --disk-format=ami --container-format=ami --copy-from $mirror/debian.5-0.x86.qcow2
     ;;
     *)
         wget $cirros_base_url/$cirros_base_name-uec.tar.gz
         tar xf $cirros_base_name-uec.tar.gz
-        RAMDISK_ID=$(glance image-create --name="$cirros_base_name-uec-initrd" --is-public=True \
+        RAMDISK_ID=$(glance image-create --name="$cirros_base_name-uec-initrd" $GLANCECLIENT_VISIBILITY_PARAMS \
             --disk-format=ari --container-format=ari < $cirros_base_name-initrd | grep ' id ' | awk '{print $4}')
-        KERNEL_ID=$(glance image-create --name="$cirros_base_name-vmlinuz" --is-public=True \
+        KERNEL_ID=$(glance image-create --name="$cirros_base_name-vmlinuz" $GLANCECLIENT_VISIBILITY_PARAMS \
             --disk-format=aki --container-format=aki < $cirros_base_name-vmlinuz | grep ' id ' | awk '{print $4}')
-        glance image-create --name="$cirros_base_name-uec" --is-public=True \
+        glance image-create --name="$cirros_base_name-uec" $GLANCECLIENT_VISIBILITY_PARAMS \
             --container-format ami --disk-format ami \
             --property kernel_id=$KERNEL_ID --property ramdisk_id=$RAMDISK_ID < $cirros_base_name-blank.img
 
-        glance image-create --name="debian-5" --is-public=True \
+        glance image-create --name="debian-5" $GLANCECLIENT_VISIBILITY_PARAMS \
             --container-format ami --disk-format ami \
             --property kernel_id=$KERNEL_ID --property ramdisk_id=$RAMDISK_ID < $cirros_base_name-blank.img
 
         ssh_user="cirros"
 
-        #glance image-create --name="debian-5" --is-public=True --disk-format=qcow2 --container-format=bare --copy-from http://clouddata.cloud.suse.de/images/cirros-0.3.1-x86_64-disk.img
+        #glance image-create --name="debian-5" $GLANCECLIENT_VISIBILITY_PARAMS --disk-format=qcow2 --container-format=bare --copy-from http://clouddata.cloud.suse.de/images/cirros-0.3.1-x86_64-disk.img
     ;;
 esac
 


### PR DESCRIPTION
--is-public is no longer a valid option when creating a image
with "glance image-create".