### PR TITLE
qa_crowbarsetup: jumbo frames fixing

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -510,6 +510,11 @@ EOS
         cat $user_keyfile | ssh $adminip "cat >> ~/.ssh/authorized_keys"
     fi
     echo "you can now proceed with installing crowbar"
+    # prevent jumbo frames from going out
+    if [[ $want_mtu_size ]] ; then
+        iptables -D FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1500 2>/dev/null
+        iptables -I FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1500
+    fi
 }
 
 function createadminsnapshot()

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1241,8 +1241,10 @@ EOF
     fi
     if [[ $want_mtu_size ]]; then
         echo "Setting MTU to custom value of: $want_mtu_size"
-        /opt/dell/bin/json-edit -a attributes.network.networks.storage.mtu -r -v $want_mtu_size $netfile
-        /opt/dell/bin/json-edit -a attributes.network.networks.admin.mtu -r -v $want_mtu_size $netfile
+        local lnet
+        for lnet in storage nova_fixed os_sdn ; do
+            /opt/dell/bin/json-edit -a attributes.network.networks.$lnet.mtu -r -v $want_mtu_size $netfile
+        done
     fi
 
     cp -a $netfile /etc/crowbar/network.json # new place since 2013-07-18


### PR DESCRIPTION
We use IPs from the admin network to communicate with the outside
and since our switches drop jumbo frames,
we cannot use them there.

OTOH the SDN and nova_fixed networks
are purely internal and thus can safely use jumbo frames.

partial revert of f5811a2