### PR TITLE
qa_openstack: Remove cloud-init plus dependencies

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -128,6 +128,9 @@ $zypper --gpg-auto-import-keys -n ref
 # deinstall some leftover crap from the cleanvm
 $zypper -n rm --force 'python-cheetah < 2.4'
 
+# deinstall cloud-init and dependencies
+$zypper -n rm --force -u cloud-init
+
 # Everything below here is fatal
 set -e
 


### PR DESCRIPTION
When running qa_openstack on an instance on cloud.suse.de and the
instance has cloud-init installed, there might be conflicts while trying
to install the cloud_* patterns due to already installed
packages (i.e. python-paramiko) and a needed vendor change.
Removing cloud-init plus dependencies resolves this.