### PR TITLE
qa_openstack: create flavor without ephemeral disk

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -170,9 +170,9 @@ fi
 
 NOVA_FLAVOR="m1.nano"
 nova flavor-delete $NOVA_FLAVOR || :
-nova flavor-create $NOVA_FLAVOR --ephemeral 20 42 128 0 1
+nova flavor-create $NOVA_FLAVOR 42 128 0 1
 nova flavor-delete m1.micro || :
-nova flavor-create m1.micro --ephemeral 20 84 256 0 1
+nova flavor-create m1.micro 84 256 0 1
 
 # make sure glance is working
 for i in $(seq 1 5); do


### PR DESCRIPTION
The used host image where nova-compute is running has just 10 GB disk
space and since liberty nova-scheduler DiskFilter doesn't find any valid
hosts when using a flavor with 20 GB ephemeral disk.