### PR TITLE
Enable creation of software RAID on nodes

### DIFF
--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -14,7 +14,7 @@ def main():
                         (when this script is called within a loop, this \
                         is usually an incremented number)")
     parser.add_argument("macaddress", type=str, help="MAC Address")
-    parser.add_argument("raidvolumenumber", type=str, help="Number of disks to create RAID")
+    parser.add_argument("raidvolumenumber", type=int, help="Number of disks to create RAID")
     parser.add_argument("cephvolumenumber", type=str, help="Number of Ceph Volumes")
     parser.add_argument("drbdserial", type=str, help="DRBD Volume Serial")
     parser.add_argument("computenodememory", type=str,

--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -14,6 +14,7 @@ def main():
                         (when this script is called within a loop, this \
                         is usually an incremented number)")
     parser.add_argument("macaddress", type=str, help="MAC Address")
+    parser.add_argument("raidvolumenumber", type=str, help="Number of disks to create RAID")
     parser.add_argument("cephvolumenumber", type=str, help="Number of Ceph Volumes")
     parser.add_argument("drbdserial", type=str, help="DRBD Volume Serial")
     parser.add_argument("computenodememory", type=str,

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -29,12 +29,26 @@
       <boot order='3'/>
     </disk>
 
+<disk type='block' device='disk'>
+  <serial>cloud-node1-raid1</serial>
+  <driver name='qemu' type='raw' cache='unsafe'/>
+  <source dev='/dev/cloud/cloud.node1-raid1'/>
+  <target dev='vdb' bus='virtio'/>
+</disk>
+
 
 <disk type='block' device='disk'>
   <serial>cloud-node1-ceph1</serial>
   <driver name='qemu' type='raw' cache='unsafe'/>
   <source dev='/dev/cloud/cloud.node1-ceph1'/>
-  <target dev='vdb' bus='virtio'/>
+  <target dev='vdc' bus='virtio'/>
+</disk>
+
+<disk type='block' device='disk'>
+  <serial>cloud-node1-ceph2</serial>
+  <driver name='qemu' type='raw' cache='unsafe'/>
+  <source dev='/dev/cloud/cloud.node1-ceph2'/>
+  <target dev='vdd' bus='virtio'/>
 </disk>
 
 

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -107,23 +107,23 @@ def compute_config(args, cpu_flags=cpuflags()):
         nodememory = args.controllernodememory
 
     raidvolume = ""
-    if args.raidvolumenumber and args.raidvolumenumber > 1:
-        for i in range(1, int(args.raidvolumenumber)):
-            raid_template = string.Template(readfile(
-                "{0}/extra-volume.xml".format(TEMPLATE_DIR)))
-            raid_values = dict(
-                volume_serial="{0}-node{1}-raid{2}".format(
-                    args.cloud,
-                    args.nodecounter,
-                    i),
-                source_dev="{0}/{1}.node{2}-raid{3}".format(
-                    args.vdiskdir,
-                    args.cloud,
-                    args.nodecounter,
-                    i),
-                target_dev=targetdevprefix + ''.join(alldevices.next()),
-                target_bus=targetbus)
-            raidvolume += "\n" + raid_template.substitute(raid_values)
+    for i in range(1, args.raidvolumenumber):
+        raid_template = string.Template(readfile(
+            "{0}/extra-volume.xml".format(TEMPLATE_DIR)))
+        raid_values = {
+            'volume_serial': "{0}-node{1}-raid{2}".format(
+                args.cloud,
+                args.nodecounter,
+                i),
+            'source_dev': "{0}/{1}.node{2}-raid{3}".format(
+                args.vdiskdir,
+                args.cloud,
+                args.nodecounter,
+                i),
+            'target_dev': targetdevprefix + ''.join(alldevices.next()),
+            'target_bus': targetbus
+        }
+        raidvolume += "\n" + raid_template.substitute(raid_values)
 
     cephvolume = ""
     if args.cephvolumenumber and args.cephvolumenumber > 0:

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -106,6 +106,25 @@ def compute_config(args, cpu_flags=cpuflags()):
     else:
         nodememory = args.controllernodememory
 
+    raidvolume = ""
+    if args.raidvolumenumber and args.raidvolumenumber > 1:
+        for i in range(1, int(args.raidvolumenumber)):
+            raid_template = string.Template(readfile(
+                "{0}/extra-volume.xml".format(TEMPLATE_DIR)))
+            raid_values = dict(
+                volume_serial="{0}-node{1}-raid{2}".format(
+                    args.cloud,
+                    args.nodecounter,
+                    i),
+                source_dev="{0}/{1}.node{2}-raid{3}".format(
+                    args.vdiskdir,
+                    args.cloud,
+                    args.nodecounter,
+                    i),
+                target_dev=targetdevprefix + ''.join(alldevices.next()),
+                target_bus=targetbus)
+            raidvolume += "\n" + raid_template.substitute(raid_values)
+
     cephvolume = ""
     if args.cephvolumenumber and args.cephvolumenumber > 0:
         for i in range(1, int(args.cephvolumenumber) + 1):
@@ -147,6 +166,7 @@ def compute_config(args, cpu_flags=cpuflags()):
         cpuflags=cpu_flags,
         emulator=args.emulator,
         vdisk_dir=args.vdiskdir,
+        raidvolume=raidvolume,
         cephvolume=cephvolume,
         drbdvolume=drbdvolume,
         macaddress=args.macaddress,

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -24,6 +24,7 @@
       <target dev='$target_dev' bus='$target_bus'/>
       <boot order='$bootorder'/>
     </disk>
+$raidvolume
 $cephvolume
 $drbdvolume
     <interface type='network'>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -135,7 +135,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.cloud = "cloud"
         args.nodecounter = "1"
         args.macaddress = "52:54:01:77:77:01"
-        args.raidvolumenumber = "1"
+        args.raidvolumenumber = 0
         args.cephvolumenumber = "1"
         args.computenodememory = "2097152"
         args.controllernodememory = "5242880"
@@ -171,7 +171,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.cloud = "cloud"
         args.nodecounter = "1"
         args.macaddress = "52:54:01:77:77:01"
-        args.raidvolumenumber = "2"
+        args.raidvolumenumber = 2
         args.cephvolumenumber = "2"
         args.computenodememory = "2097152"
         args.controllernodememory = "5242880"

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -123,6 +123,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
             ["cloud",
              "nodecounter",
              "macaddress",
+             "raidvolumenumber",
              "cephvolumenumber",
              "drbdserial",
              "computenodememory",
@@ -134,6 +135,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.cloud = "cloud"
         args.nodecounter = "1"
         args.macaddress = "52:54:01:77:77:01"
+        args.raidvolumenumber = "1"
         args.cephvolumenumber = "1"
         args.computenodememory = "2097152"
         args.controllernodememory = "5242880"
@@ -148,6 +150,42 @@ class TestLibvirtComputeConfig(unittest.TestCase):
 
         should_config = libvirt_setup.readfile(
             "{0}/cloud-node1.xml".format(FIXTURE_DIR))
+        is_config = libvirt_setup.compute_config(args, cpu_flags)
+        self.assertEqual(is_config, should_config)
+
+    # add extra disk for raid and 2 volumes for ceph
+    def test_compute_config_with_raid(self):
+        args = arg_parse(
+            ["cloud",
+             "nodecounter",
+             "macaddress",
+             "raidvolumenumber",
+             "cephvolumenumber",
+             "drbdserial",
+             "computenodememory",
+             "controllernodememory",
+             "libvirttype",
+             "vcpus",
+             "emulator",
+             "vdiskdir"])
+        args.cloud = "cloud"
+        args.nodecounter = "1"
+        args.macaddress = "52:54:01:77:77:01"
+        args.raidvolumenumber = "2"
+        args.cephvolumenumber = "2"
+        args.computenodememory = "2097152"
+        args.controllernodememory = "5242880"
+        args.libvirttype = "kvm"
+        args.vcpus = "1"
+        args.emulator = "/usr/bin/qemu-system-x86_64"
+        args.vdiskdir = "/dev/cloud"
+        args.drbdserial = ""
+        args.bootorder = "3"
+        cpu_flags = libvirt_setup.readfile(
+            "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
+
+        should_config = libvirt_setup.readfile(
+            "{0}/cloud-node1-raid.xml".format(FIXTURE_DIR))
         is_config = libvirt_setup.compute_config(args, cpu_flags)
         self.assertEqual(is_config, should_config)
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -76,6 +76,7 @@ export nodenumber nodenumbercompute nodenumberlonelynode clusterconfig
 # (used only internally to transport this information to qa_crowbarsetup):
 : ${drbdnode_mac_vol:=''}
 : ${cephvolumenumber:=1}
+: ${raidvolumenumber:=1}
 allnodeids_without_lonely=`seq 1 $((nodenumber-nodenumberphys))`
 lonelynodeids=`seq $(( nodenumber + 1 )) $(( nodenumber + nodenumberlonelynode ))`
 allnodeids="$allnodeids_without_lonely $lonelynodeids"
@@ -211,6 +212,7 @@ function sshrun()
         export nosetestparameters=${nosetestparameters} ;
         export tempestoptions='${tempestoptions}' ;
         export cephvolumenumber=$cephvolumenumber ;
+        export raidvolumenumber=$raidvolumenumber ;
         export drbd_database_size=$drbd_database_size ;
         export drbd_rabbitmq_size=$drbd_rabbitmq_size ;
         export shell=$shell ;
@@ -323,6 +325,16 @@ function onhost_create_cloud_lvm()
         test "$i" = "1" && hdd_size=${controller_hdd_size}
         _lvcreate $cloud.node$i $hdd_size $cloudvg $next_pv_device
     done
+    if [ $raidvolumenumber -gt 1 ] ; then
+        for i in $allnodeids ; do
+            for n in $(seq 1 $(($raidvolumenumber-1))) ; do
+                onhost_get_next_pv_device
+                hdd_size=${computenode_hdd_size}
+                test "$i" = "1" && hdd_size=${controller_hdd_size}
+                _lvcreate $cloud.node$i-raid$n $hdd_size $cloudvg $next_pv_device
+            done
+        done
+    fi
 
     if [ $cephvolumenumber -gt 0 ] ; then
         for i in $allnodeids ; do
@@ -694,7 +706,7 @@ function setupnodes()
             fi
         fi
 
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress $cephvolumenumber "$drbd_serial" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "3" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress $raidvolumenumber $cephvolumenumber "$drbd_serial" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "3" > /tmp/$cloud-node$i.xml
         ${mkcloud_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
     done
 
@@ -1033,6 +1045,9 @@ Optional
         set new cloudsource for upgrade process
     TESTHEAD='' | 1  (default='')
         use Media from Devel:Cloud:Staging and add test update repositories (except for GM* targets)
+    raidvolumenumber (default=1)
+        The number of disks to join into the software RAID for each node.
+        Default value of 1 means just one system disk and no RAID.
     cephvolumenumber  (default=1)
         the number of ceph volumes that will be created per node
         note: proposal step does contain a ceph proposal only in SUSE Cloud 4, in

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -76,7 +76,7 @@ export nodenumber nodenumbercompute nodenumberlonelynode clusterconfig
 # (used only internally to transport this information to qa_crowbarsetup):
 : ${drbdnode_mac_vol:=''}
 : ${cephvolumenumber:=1}
-: ${raidvolumenumber:=1}
+: ${raidvolumenumber:=0}
 allnodeids_without_lonely=`seq 1 $((nodenumber-nodenumberphys))`
 lonelynodeids=`seq $(( nodenumber + 1 )) $(( nodenumber + nodenumberlonelynode ))`
 allnodeids="$allnodeids_without_lonely $lonelynodeids"
@@ -1045,9 +1045,9 @@ Optional
         set new cloudsource for upgrade process
     TESTHEAD='' | 1  (default='')
         use Media from Devel:Cloud:Staging and add test update repositories (except for GM* targets)
-    raidvolumenumber (default=1)
+    raidvolumenumber (default=0)
         The number of disks to join into the software RAID for each node.
-        Default value of 1 means just one system disk and no RAID.
+        Mimimal number to setup RAID is 2.
     cephvolumenumber  (default=1)
         the number of ceph volumes that will be created per node
         note: proposal step does contain a ceph proposal only in SUSE Cloud 4, in

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -22,6 +22,7 @@ fi
 : ${cinder_netapp_password:=''}
 : ${clouddata:=$(dig -t A +short clouddata.cloud.suse.de)}
 : ${distsuse:=$(dig -t A +short dist.suse.de)}
+: ${want_raidtype:="raid1"}
 
 : ${arch:=$(uname -m)}
 
@@ -85,6 +86,8 @@ onadmin_help()
         if there is a SLE12 node, deploy neutron-network role into the SLE12 node
     want_mtu_size=<size>|"jumbo" (default='')
         Option to set variable MTU size or select Jumbo Frames for Admin and Storage nodes. 1500 is used if not set.
+    want_raidtype (default='raid1')
+        The type of RAID to create.
 EOUSAGE
 }
 
@@ -1488,9 +1491,8 @@ function onadmin_allocate()
 
     # setup RAID for all nodes
     if [[ $raidvolumenumber -gt 1 ]] ; then
-        raid_type="raid1" #FIXME
         for n in `get_all_discovered_nodes` ; do
-            set_node_raid $n $raid_type $raidvolumenumber
+            set_node_raid $n $want_raidtype $raidvolumenumber
         done
     fi
 


### PR DESCRIPTION
Create extra volumes that should be used for RAID. 
Add first N disks to the RAID array for each node.

Tested with manual mkcloud runs: 
 - worked for raid1 and one node or two nodes
 - also for raid5 and one node

Requires https://github.com/crowbar/crowbar-core/pull/15