### PR TITLE
Set explicit sudo for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: bash
+sudo: required
 install:
   - make install
 script:


### PR DESCRIPTION
While the test run we install packages with sudo. The default behaviour
will change to `sudo: false` in the near future. To prevent test
failures we should explicitly set it.

See http://blog.travis-ci.com/2015-03-31-docker-default-on-the-way/