### PR TITLE
mkcloud: usability improvements for scenario files (crowbar_batch)

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1109,6 +1109,10 @@ Optional
         rally server address
     cct_tests='test1+test2' (default='features')
         Defines which cct_tests should be run while the cct step.
+    scenario='scenario.yaml' (default='')
+        Defines which scenario file should be used. Only works with cloud5 or newer.
+        Currently only the step 'batch' uses such a file.
+        Scenario files have to placed in \${mkcloud_dir}/scenarios/cloud\$(getcloudver).
 EOUSAGE
     onadmin_help
     exit 1
@@ -1248,7 +1252,7 @@ function sanity_checks()
     if [[ " ${steplist[*]} " == *" batch "* ]] ; then
         need_scenario=1
         if [[ -n $scenario ]] ; then
-            scenariofile="${mkcloud_dir}/scenarios/cloud$(getcloudver)/${scenario}.yaml"
+            scenariofile="${mkcloud_dir}/scenarios/cloud$(getcloudver)/${scenario}"
             [[ ! -f $scenariofile ]] && complain 115 "Scenario file not found at $scenariofile"
         else
             complain 114 "Please set a scenario file for crowbar_batch with scenario=foo"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3304,7 +3304,7 @@ function onadmin_run_cct()
 function onadmin_batch()
 {
     if iscloudver 5plus; then
-        crowbar_batch build ${scenario}.yaml
+        crowbar_batch build ${scenario}
         return $?
     else
         complain 116 "crowbar_batch is only supported with cloudversions 5plus"


### PR DESCRIPTION
@nkrinner mentioned he found it confusing that mkcloud appends `.yaml` to the `scenario` name.
He would like to be able to give it a full filename which makes sense as `.yml` is also a common extension for YAML files and my initial approach was a unnecessary limitation to the naming.

Furthermore there was no help text explaining the `scenario` setting yet.