### PR TITLE
mkcloud: Add missing raidvolumenumber to compute-config

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -583,7 +583,7 @@ function setuplonelynodes()
         mac="52:54:$i2:88:77:$i2"
         local lonely_node
         lonely_node=$cloud-node$i
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac "$cephvolume" "$drbdvolume" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "1" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac 0 "$cephvolume" "$drbdvolume" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "1" > /tmp/$cloud-node$i.xml
 
         local lonely_disk
         lonely_disk="$vdisk_dir/${cloud}.node$i"


### PR DESCRIPTION
When calling compute-config, raidvolumenumber must be given since
2a2daadf676a0bc07b7f.