### PR TITLE
add wait_for active status of cnftools image

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2632,6 +2632,8 @@ function oncontroller_testsetup()
             SLE11SP3-x86_64-cfntools | tee glance.out
         imageid=`perl -ne "m/ id [ |]*([0-9a-f-]+)/ && print \\$1" glance.out`
         crudini --set /etc/tempest/tempest.conf orchestration image_ref $imageid
+        # test if is cnftools image prepared for tempest
+        wait_for 300 5 'glance image-show $imageid | grep active &>/dev/null' "prepare cnftools image"
         pushd /var/lib/openstack-tempest-test
         echo 1 > /proc/sys/kernel/sysrq
         ./run_tempest.sh -N $tempestoptions 2>&1 | tee tempest.log


### PR DESCRIPTION
it prevent race condition between preparing cnftools image and ran of tempest suite , on slower connections to $clouddata