### PR TITLE
Crowbar is now behind port 80.

### DIFF
--- a/scripts/mkcloudhost/mkcloude
+++ b/scripts/mkcloudhost/mkcloude
@@ -2,5 +2,5 @@
 n=$(basename $testdir)
 . /root/runtestn $n
 echo env=$testdir n=$n admin=$net_admin disk=$CVOL params="$@"
-echo access from outside via http://crowbar$cloud.cloud.suse.de:3000/ and http://dashboard$cloud.cloud.suse.de/
+echo access from outside via http://crowbar$cloud.cloud.suse.de/ and http://dashboard$cloud.cloud.suse.de/
 exec "$@"


### PR DESCRIPTION
Since port 80 also works with older releases, just link always
that one instead.