### PR TITLE
qa_crowbarsetup.sh: Add SES 2 repos on admin server for Cloud 6+

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -559,6 +559,14 @@ function add_suse_storage_repo()
             add_mount "$repo" "$clouddata:/srv/nfs/repos/$repo" \
                 "$tftpboot_repos12_dir/$repo"
         done
+        if iscloudver 6plus; then
+            for repo in SUSE-Enterprise-Storage-2-{Pool,Updates}; do
+                # Note no zypper alias parameter here since we don't want
+                # to zypper addrepo on the admin node.
+                add_mount "$repo" "$clouddata:/srv/nfs/repos/$repo" \
+                    "$tftpboot_repos12_dir/$repo"
+            done
+        fi
 }
 
 function get_disk_id_by_serial_and_libvirt_type()


### PR DESCRIPTION
We keep the SES 1.0 repos for now as the product hasn't move to SES 2
yet; this patch will only enable people to work on SES 2 integration.