### PR TITLE
dont deploy manila on GM5*

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2409,8 +2409,8 @@ function deploy_single_proposal()
             ;;
         manila)
             if ! iscloudver 6plus; then
-                # manila barclamp only works with SLE12
-                if ! iscloudver 5plus || [ -z "$want_sles12" ]; then
+                # manila barclamp is only in SC6+ and develcloud5 with SLE12CC5
+                if ! [[ "$cloudsource" == "develcloud5" ]] || [ -z "$want_sles12" ]; then
                     continue
                 fi
             fi


### PR DESCRIPTION
Manila barclamp isn't in GM5, GM5+up , nor in QAM queue

This fixes https://github.com/SUSE-Cloud/automation/issues/535

This reverts commit cc2aead6b94bbdeeac57f6a5f6af3a5e1cbb7852.