### PR TITLE
qa_crowbarsetup: Delete horizon proposal before nova proposal

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3393,7 +3393,7 @@ function onadmin_teardown()
 
     # undo propsal create+commit
     local service
-    for service in nova glance ceph swift keystone database `horizon_barclamp`; do
+    for service in `horizon_barclamp` nova glance ceph swift keystone database; do
         crowbar "$service" proposal delete default
         crowbar "$service" delete default
     done


### PR DESCRIPTION
The horizon proposal depends on the nova one, so deleting the nova one
first will fail.