### PR TITLE
qa_crowbarsetup: Add a comment explaining reboot_controller_clusters

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3095,6 +3095,8 @@ function reboot_controller_clusters()
     local cluster
     local machine
 
+    # for HA clusters, we have to reboot each node in the cluster one-by-one to
+    # avoid confusing pacemaker
     for cluster in data network services; do
         local clusternodes_var=$(echo clusternodes${cluster})
         for machine in ${!clusternodes_var}; do


### PR DESCRIPTION
It might not be obvious to everyone why we do it that way...