### PR TITLE
In HA setup deploy neutron-server on the services cluster

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2097,7 +2097,7 @@ function custom_configuration()
             fi
 
             if [[ $hacloud = 1 ]] ; then
-                proposal_set_value neutron default "['deployment']['neutron']['elements']['neutron-server']" "['cluster:$clusternamenetwork']"
+                proposal_set_value neutron default "['deployment']['neutron']['elements']['neutron-server']" "['cluster:$clusternameservices']"
                 # neutron-network role is only available since Cloud5+Updates
                 proposal_set_value neutron default "['deployment']['neutron']['elements']['neutron-network']" "['cluster:$clusternamenetwork']" || \
                     proposal_set_value neutron default "['deployment']['neutron']['elements']['neutron-l3']" "['cluster:$clusternamenetwork']"


### PR DESCRIPTION
It recommened to have the network cluster only host the "neutron-network" role
(that's the one that actually handles the network traffic of the cloud) the
"neutron-server" role is supposed to be deployed on the same node as all the
other service.