### PR TITLE
Disable GPG check on cloud-test media

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2589,7 +2589,8 @@ function oncontroller_testsetup()
     if iscloudver 6plus; then
         local mount_dir="/var/lib/Cloud-Testing"
         rsync_iso "$CLOUDSLE12DISTPATH" "$CLOUDSLE12TESTISO" "$mount_dir"
-        zypper -n ar --refresh -f "$mount_dir" cloud-test
+        zypper -n ar --refresh -c -G -f "$mount_dir" cloud-test
+        zypper_refresh
 
         ensure_packages_installed python-novaclient-test
     fi


### PR DESCRIPTION
There seems to be some weird race with quickly adding a repository
and immediately using it.. libzypp throws this error:

Can't read bad stream: /var/cache/zypp/raw/cloud-testFVigWh/content