### PR TITLE
workaround bnc#946020+bnc#946068

### DIFF
--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import os
 
 import libvirt_setup
 
@@ -34,7 +35,12 @@ def main():
 
     args = parser.parse_args()
 
-    print(libvirt_setup.compute_config(args))
+    # to workaround bnc#946020+bnc#946068 we use the 2.0 machine type
+    # if it is available
+    machine = "pc-i440fx-2.0"
+    if os.system("qemu-kvm -machine \? | grep -q "+machine) != 0:
+        machine = None
+    print(libvirt_setup.compute_config(args, libvirt_setup.cpuflags(), machine))
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -87,7 +87,9 @@ def net_config(args):
     return get_config(values, fin)
 
 
-def compute_config(args, cpu_flags=cpuflags()):
+def compute_config(args, cpu_flags=cpuflags(), machine=None):
+    if not machine:
+        machine = "pc-0.14"
     fin = "{0}/compute-node.xml".format(TEMPLATE_DIR)
     libvirt_type = args.libvirttype
     alldevices = it.chain(it.chain(string.lowercase[1:]),
@@ -165,6 +167,7 @@ def compute_config(args, cpu_flags=cpuflags()):
         nodecounter=args.nodecounter,
         nodememory=nodememory,
         vcpus=args.vcpus,
+        machine=machine,
         cpuflags=cpu_flags,
         emulator=args.emulator,
         vdisk_dir=args.vdiskdir,

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -4,7 +4,7 @@
   <currentMemory>$nodememory</currentMemory>
   <vcpu>$vcpus</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-0.14'>hvm</type>
+    <type arch='x86_64' machine='$machine'>hvm</type>
   </os>
   <features>
     <acpi/>


### PR DESCRIPTION
for SP1's qemu-2.3 we need to specify the 2.0 machine type to avoid both
http://bugzilla.suse.com/show_bug.cgi?id=946068 (no SVM flag in pc-2.3)
http://bugzilla.suse.com/show_bug.cgi?id=946020 (PXE broken in pc-0.14 to 1.4)