### PR TITLE
Skip SUSE-Enterprise-Storage-2-{Pool,Updates} repos check

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -990,8 +990,12 @@ function onadmin_add_cloud_repo()
 function do_set_repos_skip_checks()
 {
     # We don't use the proper pool/updates repos when using a devel build
-    if iscloudver 6plus && [[ $cloudsource =~ develcloud ]]; then
-        export REPOS_SKIP_CHECKS+=" SUSE-OpenStack-Cloud-SLE11-$(getcloudver)-Pool SUSE-OpenStack-Cloud-SLE11-$(getcloudver)-Updates"
+    if iscloudver 6plus; then
+        if[[ $cloudsource =~ develcloud ]]; then
+            export REPOS_SKIP_CHECKS+=" SUSE-OpenStack-Cloud-SLE11-$(getcloudver)-Pool SUSE-OpenStack-Cloud-SLE11-$(getcloudver)-Updates"
+        fi
+        # FIXME(toabctl): Remove this once SES 2 was released!
+        export REPOS_SKIP_CHECKS+=" SUSE-Enterprise-Storage-2-Pool SUSE-Enterprise-Storage-2-Updates"
     elif iscloudver 5plus && [[ $cloudsource =~ (develcloud|GM5$|GM6$) ]]; then
         export REPOS_SKIP_CHECKS+=" SUSE-Cloud-$(getcloudver)-Pool SUSE-Cloud-$(getcloudver)-Updates"
     fi


### PR DESCRIPTION
Fixes:

Error: SUSE-Enterprise-Storage-2-Pool (12.0) does not contain the right \
    repository (/srv/tftpboot/suse-12.0/repos/SUSE-Enterprise-Storage-2-Pool/\
    repodata/repomd.xml is missing repo tag 'obsproduct://build.suse.de/\
    SUSE:SLE-12:Update:Products:Cloud5/ses/2/POOL/x86_64')