### PR TITLE
mkcloud: Use 5GB instead of 20GB for db/rabbitmq DRBD device

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -107,8 +107,8 @@ if [ -n "$hacloud" ]; then
 else
     : ${drbd_hdd_size:=0}
 fi
-: ${drbd_database_size:=20}
-: ${drbd_rabbitmq_size:=20}
+: ${drbd_database_size:=5}
+: ${drbd_rabbitmq_size:=5}
 # pvlist is filled below
 pvlist=
 next_pv_device=
@@ -1075,11 +1075,11 @@ Optional
     drbd_hdd_size  (default 0, or 50 if hacloud is set)
         Set the size in GB of the DRBD data disks attached to the
         nodes in the cluster hosting the database and rabbitmq.
-    drbd_database_size (default 20)
+    drbd_database_size (default 5)
         Set the size in GB of the DRBD LV to request the database barclamp
         to set up within the DRBD data disks attached to the nodes in the
         cluster hosting the database.
-    drbd_rabbitmq_size (default 20)
+    drbd_rabbitmq_size (default 5)
         Set the size in GB of the DRBD LV to request the rabbitmq barclamp
         to set up within the DRBD data disks attached to the nodes in the
         cluster hosting RabbitMQ.

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -103,7 +103,7 @@ needcvol=1
 : ${cephvolume_hdd_size:=21}
 : ${controller_ceph_hdd_size:=25}
 if [ -n "$hacloud" ]; then
-    : ${drbd_hdd_size:=50}
+    : ${drbd_hdd_size:=15}
 else
     : ${drbd_hdd_size:=0}
 fi
@@ -1072,7 +1072,7 @@ Optional
         Set the memory in KB assigned to compute nodes
     compute_node_memory (default 2097152)
         Set the memory in KB assigned to compute nodes
-    drbd_hdd_size  (default 0, or 50 if hacloud is set)
+    drbd_hdd_size  (default 0, or 15 if hacloud is set)
         Set the size in GB of the DRBD data disks attached to the
         nodes in the cluster hosting the database and rabbitmq.
     drbd_database_size (default 5)


### PR DESCRIPTION
20GB is huge and won't be needed for mkcloud; it also takes way too long
to replicate, causing issues in mkcloud (due to either load of
replicating or waiting for the sync when we have to reboot).