### PR TITLE
qa_openstack: Install manila tempest tests

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -325,6 +325,9 @@ if [ -e /etc/tempest/tempest.conf ]; then
         verbose=""
     fi
 
+    # install packages with tempest tests available as plugin
+    $zypper in openstack-manila-test
+
     pushd /var/lib/openstack-tempest-test/
     # check that test listing works - otherwise we run 0 tests and everything seems to be fine
     # because run_tempest.sh doesn't catch the error


### PR DESCRIPTION
Manila uses the new tempest plugin interface to add tempest tests.
So when running "testr list-tests" or "testr run", the tests need
to be installed.
This fixes:

ImportError: No module named manila_tempest_tests.plugin