### PR TITLE
qa_openstack: Skip Manila tempest tests

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -331,10 +331,13 @@ if [ -e /etc/tempest/tempest.conf ]; then
     if ! [ -d ".testrepository" ]; then
         testr init
     fi
-    testr list-tests >/dev/null
+
+    # FIXME(toabctl): Enable Manila tempest tests
+    # exclude manila tests for now (special image needed for running the tests)
+    testr list-tests | grep -v "^manila_tempest_tests" > tests_to_run
 
     test -x "$(type -p tempest-cleanup)" && tempest-cleanup --init-saved-state
-    ./run_tempest.sh -N -t -s $verbose 2>&1 | tee console.log
+    ./run_tempest.sh -N -t -s $verbose -- load-list tests_to_run 2>&1 | tee console.log
     [ ${PIPESTATUS[0]} == 0 ] || exit 4
     popd
 fi


### PR DESCRIPTION
In Liberty, Manila uses the tempest plugin interface to add tests to tempest.
So tempest now runs the Manila tests. The problem is that we need a image
(with nfs and samba installed and some other modifications) to be able
to run the tests.
Skip the tests for now until we have a image available.