### PR TITLE
Revert "qa_openstack: Skip Manila tempest tests"

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -331,13 +331,10 @@ if [ -e /etc/tempest/tempest.conf ]; then
     if ! [ -d ".testrepository" ]; then
         testr init
     fi
-
-    # FIXME(toabctl): Enable Manila tempest tests
-    # exclude manila tests for now (special image needed for running the tests)
-    testr list-tests | grep -v "^manila_tempest_tests" > tests_to_run
+    testr list-tests >/dev/null
 
     test -x "$(type -p tempest-cleanup)" && tempest-cleanup --init-saved-state
-    ./run_tempest.sh -N -t -s $verbose -- load-list tests_to_run 2>&1 | tee console.log
+    ./run_tempest.sh -N -t -s $verbose 2>&1 | tee console.log
     [ ${PIPESTATUS[0]} == 0 ] || exit 4
     popd
 fi


### PR DESCRIPTION
Reverts SUSE-Cloud/automation#564

run_tempest.sh doesn't use the given parameters.