### PR TITLE
Remove restriction to SLE12 hosts

### DIFF
--- a/scripts/crowbar-testbuild.py
+++ b/scripts/crowbar-testbuild.py
@@ -93,7 +93,6 @@ def jenkins_job_trigger(repo, github_opts, cloudsource, ptfdir):
         '-p', 'mode=standard',
         "github_pr=crowbar/%s:%s" % (repo, github_opts),
         "cloudsource=" + cloudsource,
-        'label=openstack-mkcloud-SLE12',
         'UPDATEREPOS=' + htdocs_url + ptfdir,
         'mkcloudtarget=all_noreboot',
         *job_parameters))


### PR DESCRIPTION
Reportedly github-status.rb has been fixed to also run on SLE11
hosts, so remove the restriction so that we can spread out
load quicker.