### PR TITLE
qa_crowbarsetup.sh: Disable SLE12 test updates due to bsc#947537

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1014,7 +1014,7 @@ function onadmin_prepare_cloud_repos()
                 addsles12testupdates
                 ;;
             develcloud6)
-                addsles12testupdates
+                #addsles12testupdates
                 [ -n "$want_sles12sp1" ] && addsles12sp1testupdates
                 ;;
             susecloud6|M?|Beta*|RC*|GMC*|GM6|GM6+up)


### PR DESCRIPTION
The current kernel test update totally breaks our CI, so don't use test
updates for now.

https://bugzilla.suse.com/show_bug.cgi?id=947537