### PR TITLE
Only use the new unprefixed name if it exists

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1327,10 +1327,9 @@ EOF
 
     cd /tmp
 
-    if iscloudver 6plus && [[ ! $cloudsource =~ ^M[1-5]$ ]]; then
-        local netfile="/opt/dell/chef/data_bags/crowbar/template-network.json"
-    else
-        local netfile="/opt/dell/chef/data_bags/crowbar/bc-template-network.json"
+    local netfile="/opt/dell/chef/data_bags/crowbar/bc-template-network.json"
+    if [ -e "/opt/dell/chef/data_bags/crowbar/template-network.json" ] ; then
+        netfile="/opt/dell/chef/data_bags/crowbar/template-network.json"
     fi
 
     local netfilepatch=`basename $netfile`.patch


### PR DESCRIPTION
Fixes build of dc6 without TESTHEAD right now.