### PR TITLE
mkcloud: allow to call onadmin function

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -985,6 +985,7 @@ Steps:
     instcrowbar:    install crowbar and chef on the admin node
     setupnodes:     create the nodes and let crowbar discover them
     instnodes:      allocate and install compute nodes
+    onadmin:        run a step on the admin node - use as onadmin+func+param1
     proposal:       create and apply proposals for default setup
     setup_aliases:  set aliases for the nodes (usually needed for batch step)
     batch:          build proposals from exported crowbar_batch YAML file
@@ -1300,7 +1301,7 @@ allcmds="$step_aliases all all_noreboot all_batch all_batch_noreboot instonly \
     rebootneutron prepare_cloudupgrade cloudupgrade_1st cloudupgrade_2nd \
     cloudupgrade_clients cloudupgrade_reboot_and_redeploy_clients \
     setuplonelynodes crowbar_register createadminsnapshot \
-    restoreadminfromsnapshot cct steps batch setup_aliases"
+    restoreadminfromsnapshot cct steps batch setup_aliases onadmin"
 wantedcmds=$@
 
 function expand_steps()


### PR DESCRIPTION
this allows to add new functions to qa_crowbarsetup
that can be called through mkcloud as
onadmin+funcname
or even
onadmin+func+param1+param2