### PR TITLE
mkcloud: specify output flags for convert

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -400,7 +400,7 @@ function onhost_deploy_image()
         http://clouddata.cloud.suse.de/images/$image
 
     echo "Cloning $role node vdisk from $image ..."
-    safely qemu-img convert -t none -O raw -p $image $disk
+    safely qemu-img convert -t none -O raw -S 0 -p $image $disk
     popd
 
     # only resize if we have a 2nd partition with a rootfs


### PR DESCRIPTION
We need to be explicit about writing a raw outout and disable
sparse file detection to avoid not being able to write sparse
files on block devices (which only works on files)