### PR TITLE
mkcloud: allow to skip the lvm test, to allow mkcloud on shared lvm

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -354,7 +354,7 @@ function onhost_create_cloud_lvm()
     fi
 
     echo "Checking for LVs treated by LVM as valid PV devices ..."
-    if lvmdiskscan | egrep "/dev/($cloudvg/|mapper/$cloudvg-)"; then
+    if [[ $SHAREDVG != 1 ]] && lvmdiskscan | egrep "/dev/($cloudvg/|mapper/$cloudvg-)"; then
         error=$(cat <<EOF
 Error: your lvm.conf is not filtering out mkcloud LVs.
 Please fix by adding the following regular expressions


### PR DESCRIPTION
it was not possible to use mkcloud on an lvm that also contains the base system, this PR allows to skip the sanity check if the lvm is used otherwise