### PR TITLE
mkcloud: wait more for disk to become non-busy

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -412,6 +412,7 @@ function onhost_deploy_image()
         local bdev=/dev/mapper/$part2
         safely fsck -y -f $bdev
         safely resize2fs $bdev
+        time udevadm settle
         sleep 1 # time for dev to become unused
         safely kpartx -dsv $disk
     fi


### PR DESCRIPTION
Error was
+ kpartx -dsv /dev/mkcvg0/g1.admin
device-mapper: remove ioctl on mkcvg0-g1.admin2 failed: Device or resource busy