### PR TITLE
Fix MAC address of lonely node in crowbar_register

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -606,7 +606,7 @@ function crowbar_register()
 {
     for i in $lonelynodeids; do
         local i2=$( printf %02x $i )
-        local mac="52:54:$i2:88:77:$i2"
+        local mac="52:54:77:88:77:$i2"
         sshrun "lonelymac=$mac adminip=$adminip onadmin_crowbar_register"
     done
 }


### PR DESCRIPTION
Followup fix for 74940efcc4cba6f5ae08aadc8559c35db086d4e0