### PR TITLE
qa_crobarsetup: enable serial console for deployed nodes

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2334,6 +2334,7 @@ function custom_configuration()
                 proposal_set_value provisioner default "['attributes']['provisioner']['keep_existing_hostname']" "true"
             fi
 
+            proposal_set_value provisioner default "['attributes']['provisioner']['use_serial_console']" "true"
             proposal_set_value provisioner default "['attributes']['provisioner']['suse']" "{}"
             proposal_set_value provisioner default "['attributes']['provisioner']['suse']['autoyast']" "{}"
             proposal_set_value provisioner default "['attributes']['provisioner']['suse']['autoyast']['repos']" "{}"


### PR DESCRIPTION
This is useful for debugging problems during the node deployment.