### PR TITLE
Revert "qa_crobarsetup: enable serial console for deployed nodes"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2341,7 +2341,6 @@ function custom_configuration()
                 proposal_set_value provisioner default "['attributes']['provisioner']['keep_existing_hostname']" "true"
             fi
 
-            proposal_set_value provisioner default "['attributes']['provisioner']['use_serial_console']" "true"
             proposal_set_value provisioner default "['attributes']['provisioner']['suse']" "{}"
             proposal_set_value provisioner default "['attributes']['provisioner']['suse']['autoyast']" "{}"
             proposal_set_value provisioner default "['attributes']['provisioner']['suse']['autoyast']['repos']" "{}"


### PR DESCRIPTION
This reverts commit ef654e216d330fa254f447e2197818af6518b24d.

Turns out that you can no longer follow the installation process
in YaST if the serial console is enabled.