### PR TITLE
Revert "Disable kernel logging to workaround spammy kernel update"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2617,9 +2617,6 @@ function prepare_proposals()
     iscloudver 6plus && ptfchannel="PTF"
     for machine in $cmachines; do
         ssh $machine "zypper mr -p 90 $ptfchannel"
-        # Temporary workaround for http://bugzilla.suse.com/show_bug.cgi?id=947537
-        # FIXME: remove
-        ssh $machine "echo 0 > /proc/sys/kernel/printk"
     done
 
 }


### PR DESCRIPTION
Kernel was fixed, we can revert.

This reverts commit 1c9cb48c7e885b2c01051d1a5597286c5a14e0be.