### PR TITLE
qa_crowbarsetup: Remove libertycloud as source

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1144,12 +1144,6 @@ function onadmin_set_source_variables()
             CLOUDSLE12TESTISO="CLOUD-6-TESTING-$arch*Media1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-6-devel"
         ;;
-        libertycloud6)
-            CLOUDSLE12DISTPATH=/ibs/Devel:/Cloud:/6:/Liberty/images/iso
-            CLOUDSLE12DISTISO="SUSE-OPENSTACK-CLOUD-6-$arch*Media1.iso"
-            CLOUDSLE12TESTISO="CLOUD-6-TESTING-$arch*Media1.iso"
-            CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-6-devel"
-        ;;
         susecloud6)
             CLOUDSLE12DISTPATH=/ibs/SUSE:/SLE-12-SP1:/Update:/Products:/Cloud6/images/iso/
             CLOUDSLE12DISTISO="SUSE-OPENSTACK-CLOUD-6-$arch*Media1.iso"


### PR DESCRIPTION
Packages in Devel:Cloud:6 are now linked to Cloud:OpenStack:Liberty