### PR TITLE
Scenario for QA setup 2c: HA with SBD, ceph, and kvm compute

### DIFF
--- a/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
@@ -1,0 +1,215 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          @@controller1@@:
+            devices:
+            - "/dev/sda"
+          @@controller2@@:
+            devices:
+            - "/dev/sda"
+      per_node:
+        nodes:
+          @@controller1@@:
+            params: ''
+          @@controller2@@:
+            params: ''
+    drbd:
+      enabled: true
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - @@controller1@@
+      - @@controller2@@
+      hawk-server:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+- barclamp: keystone
+  attributes:
+    ssl:
+      generate_certs: true
+      insecure: true
+    api:
+      protocol: https
+    signing:
+      token_format: UUID
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+- barclamp: ceph
+  attributes:
+    disk_mode: first
+    radosgw:
+      ssl:
+        enabled: true
+        generate_certs: true
+        insecure: true
+    calamari:
+      ssl:
+        enabled: true
+  deployment:
+    elements:
+      ceph-calamari: []
+      ceph-mon:
+      - @@ceph1@@
+      - @@ceph2@@
+      - @@ceph3@@
+      ceph-osd:
+      - @@ceph1@@
+      - @@ceph2@@
+      - @@ceph3@@
+      ceph-radosgw:
+      - @@ceph1@@
+- barclamp: glance
+  attributes:
+    api:
+      protocol: https
+    ssl:
+      generate_certs: true
+      insecure: true
+    default_store: rbd
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+- barclamp: manila
+  attributes:
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: rbd
+      backend_name: rbd
+      rbd:
+        use_crowbar: true
+        config_file: "/etc/ceph/ceph.conf"
+        admin_keyring: "/etc/ceph/ceph.client.admin.keyring"
+        pool: volumes
+        user: cinder
+        secret_uuid: ''
+    api:
+      protocol: https
+    ssl:
+      generate_certs: true
+      insecure: true
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: neutron
+  attributes:
+    use_l2pop: false
+    ml2_mechanism_drivers:
+    - linuxbridge
+    ml2_type_drivers:
+    - vlan
+    ml2_type_drivers_default_provider_network: vlan
+    ml2_type_drivers_default_tenant_network: vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    vnc_keymap: de-de
+    kvm:
+      ksm_enabled: true
+    ssl:
+      enabled: true
+      generate_certs: true
+      insecure: true
+    novnc:
+      ssl:
+        enabled: true
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - @@compute1@@
+      - @@compute2@@
+      nova-compute-qemu: []
+      nova-compute-xen: []
+- barclamp: horizon
+  attributes:
+    apache:
+      ssl: true
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+- barclamp: heat
+  attributes:
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+- barclamp: ceilometer
+  attributes:
+  deployment:
+    elements:
+      ceilometer-agent:
+      - @@compute1@@
+      - @@compute2@@
+      ceilometer-agent-hyperv: []
+      ceilometer-cagent:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware: []
+- barclamp: trove
+  attributes:
+    swift_instance: ''
+    volume_support: true
+  deployment:
+    elements:
+      trove-server:
+      - @@controller1@@
+- barclamp: tempest
+  attributes:
+  deployment:
+    elements:
+      tempest:
+      - @@controller1@@


### PR DESCRIPTION
This is the scenario file for QA setup 2c: HA with SBD, ceph, and kvm compute nodes.

1. Install the nodes with these mkcloud options:

  hacloud=1
  clusterconfig="data=2"
  nodenumber=7
  want_node_roles=controller=2,compute=2,storage=3
  want_node_os=suse-12.1=4,suse-12.0=3
  want_node_aliases=controller=2,compute=2,ceph=3

2. Setup SBD using https://gist.github.com/jsuchome/4a658676db6ea29e924f

3. Run crowbar batch with updated scenario file:
    crowbar_batch --timeout 1200 build qa-scenario-2c-sbd-kvm.yaml