### PR TITLE
Rework wait_node_ready condition

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1801,6 +1801,11 @@ function wait_node_ready()
 {
     local node=$1
     wait_for 300 10 \
+        "crowbar machines show $node state | grep -q '^ready$'" \
+        "node $node to transition to ready" "exit 12"
+    echo "node $node transitioned to \"ready\""
+
+    wait_for 3 10 \
         "netcat -w 3 -z $node 3389 || sshtest $node rpm -q yast2-core" \
         "node $node" "check_node_resolvconf $node; exit 12"
     echo "node $node ready"


### PR DESCRIPTION
Before doing the ssh and rdp checks make sure that the node actually is
transitioned to the "ready" state in crowbar. Otherwise (on really slow
systems) it might happen that mkcloud starts the post_allocate action before
the nodes are really ready for that.