### PR TITLE
Reduce public interface MTU when using openvswitch

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1444,6 +1444,12 @@ EOF
         done
     fi
 
+    # Reduce exterior MTU when using OpenvSwitch networking
+    if [[ "$networkingplugin" = "openvswitch" ]]; then
+        echo "Setting 1450-byte MTU for public interface"
+        /opt/dell/bin/json-edit -a attributes.network.networks.public.mtu -r -v 1450 $netfile
+    fi
+
     # to allow integration into external DNS:
     local f=/opt/dell/chef/cookbooks/bind9/templates/default/named.conf.erb
     grep -q allow-transfer $f || sed -i -e "s#options {#&\n\tallow-transfer { 10.0.0.0/8; };#" $f


### PR DESCRIPTION
In order to facilitate path MTU discovery, we should reduce the public
interface MTU to a value that accomodates the overhead produced by GRE
and VxLAN tunnels. For now the proposal is to have a 1450-byte MTU.