### PR TITLE
Raise number of kept builds to 64

### DIFF
--- a/scripts/jenkins/ci.suse.de/cloud-mkcloud6-gating-trigger.xml
+++ b/scripts/jenkins/ci.suse.de/cloud-mkcloud6-gating-trigger.xml
@@ -6,7 +6,7 @@
 also trigger on publish of iso</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>7</numToKeep>
+    <numToKeep>64</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>


### PR DESCRIPTION
We're typically building roughly 4-5 a day, so this
keeps a history of two weeks (one sprint).