### PR TITLE
qa_crowbarsetup: Increase timeout for horizon simple test

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3205,7 +3205,7 @@ function onadmin_testsetup()
     get_horizon
     echo "openstack horizon server:  $horizonserver"
     echo "openstack horizon service: $horizonservice"
-    curl -L -m 40 -s -S -k http://$horizonservice | \
+    curl -L -m 120 -s -S -k http://$horizonservice | \
         grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" \
     || complain 101 "simple horizon test failed"
 


### PR DESCRIPTION
The simple curl test for the dashboard failed with:

curl: (28) Operation timed out after 31406 milliseconds with 0 bytes
received

But the test passed when executed manually afterwards on the same
cloud. So retry the test 3x to be sure it's failing.