### PR TITLE
Fix openstack-submit job

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-cleanvm.yml
+++ b/scripts/jenkins/jobs-obs/openstack-cleanvm.yml
@@ -67,3 +67,5 @@
         - project: openstack-submit
           condition: SUCCESS
           current-parameters: true
+          predefined-parameters:
+            openstack_project=${openstack_project}


### PR DESCRIPTION
The job is triggered by cleanvm and theoretically the build parameters
should be passed from the cleanvm job to the openstack-submit job.
But that doesn't happen.
So pass the paramter manually to the openstack-submit job.