### PR TITLE
mkcloudhost: drop need for symlinks on mkcloud hosts

### DIFF
--- a/scripts/mkcloudhost/allocpool
+++ b/scripts/mkcloudhost/allocpool
@@ -43,5 +43,5 @@ foreach my $d (@dirs) {
 }
 if(!$found) {die "all dirs (@dirs) are currently in use"}
 print "using testdir=$ENV{testdir}\n";
-exec("/root/mkcloude", @ARGV);
+exec(@ARGV);
 die "exec failed: $!";

--- a/scripts/mkcloudhost/mkcloude
+++ b/scripts/mkcloudhost/mkcloude
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 n=$(basename $testdir)
-. /root/github.com/SUSE-Cloud/automation/scripts/mkcloudhost/runtestn $n
+. ${automationrepo:-/root/github.com/SUSE-Cloud/automation}/scripts/mkcloudhost/runtestn $n
 echo env=$testdir n=$n admin=$net_admin disk=$CVOL params="$@"
 echo access from outside via http://crowbar$cloud.cloud.suse.de/ and http://dashboard$cloud.cloud.suse.de/
 exec "$@"

--- a/scripts/mkcloudhost/mkcloude
+++ b/scripts/mkcloudhost/mkcloude
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 n=$(basename $testdir)
-. /root/runtestn $n
+. /root/github.com/SUSE-Cloud/automation/scripts/mkcloudhost/runtestn $n
 echo env=$testdir n=$n admin=$net_admin disk=$CVOL params="$@"
 echo access from outside via http://crowbar$cloud.cloud.suse.de/ and http://dashboard$cloud.cloud.suse.de/
 exec "$@"


### PR DESCRIPTION
mkcloud workers needed some manual setup, to make this easier and consistent with all mkcloud hosts this PR drops the need to manually set symlinks