### PR TITLE
jenkins-job-trigger: make triggering silent (curl --silent)

### DIFF
--- a/scripts/jenkins/jenkins-job-trigger
+++ b/scripts/jenkins/jenkins-job-trigger
@@ -76,7 +76,7 @@ if ($jtype =~ /^-p$/) {
 }
 
 my $triggerurl=$jurl."/job/".$job;
-my @curlargs=();
+my @curlargs=('--silent', '--show-error');
 push @curlargs, ("-H", "Content-Length: 0");
 
 if ($jobtype eq 'normal') {


### PR DESCRIPTION
switch curl to silent mode, error would still be show but the progress is suppressed