### PR TITLE
qa_crowbarsetup, scenarios: Do not use l2pop key anymore for Cloud 6

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2351,7 +2351,9 @@ function custom_configuration()
                     fi
                 elif [ "$networkingplugin" = "linuxbridge" ] ; then
                     proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['vlan']"
-                    proposal_set_value neutron default "['attributes']['neutron']['use_l2pop']" "false"
+                    if iscloudver 5 || ( iscloudver 6 && [[ $cloudsource =~ ^M[1-7]+$ ]] ); then
+                        proposal_set_value neutron default "['attributes']['neutron']['use_l2pop']" "false"
+                    fi
                 else
                     complain 106 "networkingplugin '$networkingplugin' not yet covered in mkcloud"
                 fi

--- a/scripts/scenarios/cloud6/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -133,7 +133,6 @@ proposals:
       - "@@controller3@@"
 - barclamp: neutron
   attributes:
-    use_l2pop: false
     ml2_mechanism_drivers:
     - linuxbridge
     ml2_type_drivers:

--- a/scripts/scenarios/cloud6/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -147,7 +147,6 @@ proposals:
 
 - barclamp: neutron
   attributes:
-    use_l2pop: false
     ml2_mechanism_drivers:
     - openvswitch
     ml2_type_drivers:

--- a/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
@@ -135,7 +135,6 @@ proposals:
       - @@controller2@@
 - barclamp: neutron
   attributes:
-    use_l2pop: false
     ml2_mechanism_drivers:
     - linuxbridge
     ml2_type_drivers:

--- a/scripts/scenarios/cloud6/qa-scenario-6a-ipmi-kvm-docker.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-6a-ipmi-kvm-docker.yaml
@@ -105,7 +105,6 @@ proposals:
       - "@@controller2@@"
 - barclamp: neutron
   attributes:
-    use_l2pop: false
     ml2_mechanism_drivers:
     - linuxbridge
     ml2_type_drivers:


### PR DESCRIPTION
The key is gone after M7.