### PR TITLE
Set the build name again on the submit job

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-submit.yml
+++ b/scripts/jenkins/jobs-obs/openstack-submit.yml
@@ -57,3 +57,7 @@
               $E $submitcmd $COSS $COMPONENT $COS
           fi
           done
+
+    wrappers:
+      - build-name:
+          name: '#${BUILD_NUMBER} / C:O:${ENV,var="openstack_project"}'


### PR DESCRIPTION
This makes it easier to figure out which :Staging
project got merged recently.