### PR TITLE
Reenable reboot tests for Cloud6 gate (bsc#950798)

### DIFF
--- a/scripts/jenkins/ci.suse.de/cloud-mkcloud6-gating-trigger.xml
+++ b/scripts/jenkins/ci.suse.de/cloud-mkcloud6-gating-trigger.xml
@@ -73,7 +73,7 @@ also trigger on publish of iso</description>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>cloudsource=develcloud6
 nodenumber=2
-mkcloudtarget=all_batch_noreboot
+mkcloudtarget=all_batch
 scenario=cloud6-2nodes-default.yml
 want_node_aliases=controller=1,compute-kvm=1
 </properties>
@@ -114,7 +114,7 @@ want_node_aliases=controller=1,compute-kvm=1
               <properties>cloudsource=develcloud6
 nodenumber=4
 networkingplugin=linuxbridge
-mkcloudtarget=all_noreboot</properties>
+mkcloudtarget=all</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>


### PR DESCRIPTION
With the latest changes in crowbar-core, rebooting the openstack nodes should
work again. (https://bugzilla.suse.com/show_bug.cgi?id=950798)