### PR TITLE
qa_crowbarsetup, scenarios: ceilometer-polling service added

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -41,6 +41,7 @@ clusternamenetwork="network"
 wanthyperv=
 crowbar_api=http://localhost:3000
 crowbar_install_log=/var/log/crowbar/install.log
+ceilometerservice="ceilometer-cagent"
 
 export nodenumber=${nodenumber:-2}
 export tempestoptions=${tempestoptions:--t -s}
@@ -2238,6 +2239,9 @@ function custom_configuration()
     local proposaltype=${2:-default}
     local proposaltypemapped=$proposaltype
     proposaltype=${proposaltype%%+*}
+    if iscloudver 7plus || (iscloudver 6 && ! [[ $cloudsource =~ ^M[1-7]$ ]]); then
+        ceilometerservice="ceilometer-polling"
+    fi
 
     # prepare the proposal file to be edited, it will be read once at the end
     # So, ONLY edit the $pfile  -  DO NOT call "crowbar $x proposal .*" command
@@ -2397,7 +2401,7 @@ function custom_configuration()
         ceilometer)
             if [[ $hacloud = 1 ]] ; then
                 proposal_set_value ceilometer default "['deployment']['ceilometer']['elements']['ceilometer-server']" "['cluster:$clusternameservices']"
-                proposal_set_value ceilometer default "['deployment']['ceilometer']['elements']['ceilometer-cagent']" "['cluster:$clusternameservices']"
+                proposal_set_value ceilometer default "['deployment']['ceilometer']['elements']['$ceilometerservice']" "['cluster:$clusternameservices']"
                 # disabling mongodb, because if in one cluster mode the requirements of drbd and mongodb ha conflict:
                 #   drbd can only use 2 nodes max. <> mongodb ha requires 3 nodes min.
                 # this should be adapted when NFS mode is supported for data cluster

--- a/scripts/scenarios/cloud6/cloud6-2nodes-default.yml
+++ b/scripts/scenarios/cloud6/cloud6-2nodes-default.yml
@@ -120,7 +120,7 @@ proposals:
       ceilometer-agent:
       - @@compute-kvm@@
       ceilometer-agent-hyperv: []
-      ceilometer-cagent:
+      ceilometer-polling:
       - @@controller@@
       ceilometer-server:
       - @@controller@@

--- a/scripts/scenarios/cloud6/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -200,7 +200,7 @@ proposals:
       - "@@compute-kvm2@@"
       - "@@compute-xen2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-cagent:
+      ceilometer-polling:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2a-sbd-kvm.yaml
@@ -259,7 +259,7 @@ proposals:
       ceilometer-agent:
       - "@@computekvm@@"
       ceilometer-agent-hyperv: []
-      ceilometer-cagent:
+      ceilometer-polling:
       - cluster:services
       ceilometer-polling:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -220,7 +220,7 @@ proposals:
       - "@@computekvm2@@"
       - "@@computevmw@@"
       ceilometer-agent-hyperv: []
-      ceilometer-cagent:
+      ceilometer-polling:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
@@ -193,7 +193,7 @@ proposals:
       - @@compute1@@
       - @@compute2@@
       ceilometer-agent-hyperv: []
-      ceilometer-cagent:
+      ceilometer-polling:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa-scenario-6a-ipmi-kvm-docker.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-6a-ipmi-kvm-docker.yaml
@@ -173,7 +173,7 @@ proposals:
       - "@@docker1@@"
       - "@@docker2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-cagent:
+      ceilometer-polling:
       - cluster:services
       ceilometer-server:
       - cluster:services


### PR DESCRIPTION
Services ceiloemter-cagent (ceilometer-agent-central) that runs on Control node to talk to openstack services is deprecated since Kilo. The agent is replaced by a new service ceilometer-polling. The change here updates use of ceilometer-polling service in controller HA deployment. Since the deprecation is applicable only from after Kilo release, the proposal is set only for Cloud6 or later.