### PR TITLE
Prefer ptf packages

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1389,6 +1389,8 @@ EOF
 
     if [ -z "$NOINSTALLCLOUDPATTERN" ] ; then
         safely zypper --no-gpg-checks -n in -l -t pattern cloud_admin
+        # make sure to use packages from PTF repo (needs zypper dup)
+        safely zypper -n dup --from cloud-ptf
     fi
 
     cd /tmp


### PR DESCRIPTION
in a crowbar-testbuild job with a package of the same version (but different build version), the one with the higher build version wins (which is mostly the package not from the ptf repo), even though the ptf repo as a higher priority
a vendor change may also come into play

We analyzed a failed mkcloud run with @mlandres today and found this fix:
Rrunning a zypper dup on the ptf repo ensures that the packages from there are used