### PR TITLE
mkcloud: use host rng for VMs

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-admin.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin.xml
@@ -51,6 +51,9 @@
     <memballoon model='virtio'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
     </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/random</backend>
+    </rng>
     
   </devices>
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -72,5 +72,8 @@
       <model type='cirrus' vram='9216' heads='1'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
     </video>
+    <rng model='virtio'>
+      <backend model='random'>/dev/random</backend>
+    </rng>
   </devices>
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -58,5 +58,8 @@
       <model type='cirrus' vram='9216' heads='1'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
     </video>
+    <rng model='virtio'>
+      <backend model='random'>/dev/random</backend>
+    </rng>
   </devices>
 </domain>

--- a/scripts/lib/libvirt/templates/admin-node.xml
+++ b/scripts/lib/libvirt/templates/admin-node.xml
@@ -47,6 +47,9 @@
     <memballoon model='virtio'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
     </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/random</backend>
+    </rng>
     $local_repository_mount
   </devices>
 </domain>

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -47,5 +47,8 @@ $drbdvolume
       <model type='cirrus' vram='9216' heads='1'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
     </video>
+    <rng model='virtio'>
+      <backend model='random'>/dev/random</backend>
+    </rng>
   </devices>
 </domain>


### PR DESCRIPTION
We want to speed up guest VMs by providing additional entropy from the host.

I would prefer to use /dev/urandom to never exhaust the host pool
(which potentially slows down guests)
but libvirt does not allow it.