### PR TITLE
Use tempest cleanup if available

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -333,8 +333,16 @@ if [ -e /etc/tempest/tempest.conf ]; then
     fi
     testr list-tests >/dev/null
 
-    test -x "$(type -p tempest-cleanup)" && tempest-cleanup --init-saved-state
+    if tempest help cleanup; then
+        tempest cleanup --init-saved-state
+    else
+        test -x "$(type -p tempest-cleanup)" && tempest-cleanup --init-saved-state
+    fi
     ./run_tempest.sh -N -t -s $verbose 2>&1 | tee console.log
-    [ ${PIPESTATUS[0]} == 0 ] || exit 4
+    ret=${PIPESTATUS[0]}
+    if tempest help cleanup; then
+        tempest cleanup
+    fi
+    [ $ret == 0 ] || exit 4
     popd
 fi

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3033,14 +3033,22 @@ function oncontroller_testsetup()
         pushd /var/lib/openstack-tempest-test
         echo 1 > /proc/sys/kernel/sysrq
         if iscloudver 5plus; then
-            /usr/bin/tempest-cleanup --init-saved-state || :
+            if tempest help cleanup; then
+                tempest cleanup --init-saved-state
+            else
+                /usr/bin/tempest-cleanup --init-saved-state || :
+            fi
         fi
         ./run_tempest.sh -N $tempestoptions 2>&1 | tee tempest.log
         tempestret=${PIPESTATUS[0]}
         testr last --subunit | subunit-1to2 > tempest.subunit.log
 
         if iscloudver 5plus; then
-            /usr/bin/tempest-cleanup --delete-tempest-conf-objects || :
+            if tempest help cleanup; then
+                tempest cleanup --delete-tempest-conf-objects
+            else
+                /usr/bin/tempest-cleanup --delete-tempest-conf-objects || :
+            fi
         else
             /var/lib/openstack-tempest-test/bin/tempest_cleanup.sh || :
         fi


### PR DESCRIPTION
Newer versions of tempest have converted from tempest-cleanup
to tempest-cleanup, and immediately broke tempest-cleanup. So
we need to call tempest cleanup when it is available.