### PR TITLE
Setup test job for upstream rpm-packaging initiative

### DIFF
--- a/scripts/jenkins/jobs-obs/macros.yaml
+++ b/scripts/jenkins/jobs-obs/macros.yaml
@@ -6,3 +6,125 @@
           [ -e ~/bin/update_automation ] || wget -O ~/bin/update_automation https://raw.github.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation && chmod a+x ~/bin/update_automation
           # fetch the latest automation updates
           update_automation
+
+
+- builder:
+    name: gerrit-git-prep
+    builders:
+      - shell: |
+          #!/bin/bash -e
+
+          #
+          # NOTE(toabctl): The script is basically a copy of:
+          # https://github.com/openstack-infra/project-config/blob/master/jenkins/scripts/gerrit-git-prep.sh
+          #
+
+          GERRIT_SITE='https://review.openstack.org'
+          GIT_ORIGIN='git://git.openstack.org'
+
+          # git can sometimes get itself infinitely stuck with transient network
+          # errors or other issues with the remote end.  This wraps git in a
+          # timeout/retry loop and is intended to watch over non-local git
+          # processes that might hang.  GIT_TIMEOUT, if set, is passed directly
+          # to timeout(1); otherwise the default value of 0 maintains the status
+          # quo of waiting forever.
+          # usage: git_timed <git-command>
+          function git_timed {
+            local count=0
+            local timeout=0
+
+            if [[ -n "${GIT_TIMEOUT}" ]]; then
+              timeout=${GIT_TIMEOUT}
+            fi
+
+            until timeout -s SIGINT ${timeout} git "$@"; do
+              echo "Command exited with '$?' [git $@] ... retrying"
+              count=$(($count + 1))
+              echo "timeout ${count} for git call: [git $@]"
+              if [ $count -eq 3 ]; then
+                echo $LINENO "Maximum of 3 git retries reached"
+                exit 1
+              fi
+              sleep 5
+            done
+          }
+          if [ -z "$GERRIT_SITE" ]; then
+            echo "The gerrit site name (eg 'https://review.openstack.org') must be the first argument."
+            exit 1
+          fi
+
+          if [ -z "$ZUUL_URL" ]; then
+            echo "The ZUUL_URL must be provided."
+            exit 1
+          fi
+
+          if [ -z "$GIT_ORIGIN" ] || [ -n "$ZUUL_NEWREV" ]; then
+            GIT_ORIGIN="$GERRIT_SITE/p"
+            # git://git.openstack.org/
+            # https://review.openstack.org/p
+          fi
+
+          if [ -z "$ZUUL_REF" ]; then
+            if [ -n "$BRANCH" ]; then
+              echo "No ZUUL_REF so using requested branch $BRANCH from origin."
+              ZUUL_REF=$BRANCH
+              # use the origin since zuul mergers have outdated branches
+              ZUUL_URL=$GIT_ORIGIN
+            else
+              echo "Provide either ZUUL_REF or BRANCH in the calling enviromnent."
+              exit 1
+            fi
+          fi
+
+          if [ ! -z "$ZUUL_CHANGE" ]; then
+            echo "Triggered by: $GERRIT_SITE/$ZUUL_CHANGE"
+          fi
+
+          set -x
+          if [[ ! -e .git ]]; then
+            ls -a
+            rm -fr .[^.]* *
+            if [ -d /opt/git/$ZUUL_PROJECT/.git ]; then
+              git_timed clone file:///opt/git/$ZUUL_PROJECT .
+            else
+              git_timed clone $GIT_ORIGIN/$ZUUL_PROJECT .
+            fi
+          fi
+          git remote set-url origin $GIT_ORIGIN/$ZUUL_PROJECT
+
+          # attempt to work around bugs 925790 and 1229352
+          if ! git_timed remote update; then
+            echo "The remote update failed, so garbage collecting before trying again."
+            git gc
+            git_timed remote update
+          fi
+
+          git reset --hard
+          if ! git clean -x -f -d -q ; then
+            sleep 1
+            git clean -x -f -d -q
+          fi
+
+          if echo "$ZUUL_REF" | grep -q ^refs/tags/; then
+            git_timed fetch --tags $ZUUL_URL/$ZUUL_PROJECT
+            git checkout $ZUUL_REF
+            git reset --hard $ZUUL_REF
+          elif [ -z "$ZUUL_NEWREV" ]; then
+            git_timed fetch $ZUUL_URL/$ZUUL_PROJECT $ZUUL_REF
+            git checkout FETCH_HEAD
+            git reset --hard FETCH_HEAD
+          else
+            git checkout $ZUUL_NEWREV
+            git reset --hard $ZUUL_NEWREV
+          fi
+
+          if ! git clean -x -f -d -q ; then
+            sleep 1
+            git clean -x -f -d -q
+          fi
+
+          if [ -f .gitmodules ]; then
+            git_timed submodule init
+            git_timed submodule sync
+            git_timed submodule update --init
+          fi

--- a/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
@@ -1,0 +1,88 @@
+- job:
+    name: 'openstack-gerrit-rpm-packaging'
+    description: "<b>This job is managed by JJB! Changes must be done in <a href='https://github.com/SUSE-Cloud/automation/tree/master/scripts/jenkins/jobs-obs/'>git</a></b>"
+    node: openstack-rpm-packaging
+    builders:
+      - gerrit-git-prep
+      - shell: |
+          #!/bin/bash -e
+          rpm -qa|grep '\(renderspec\|pymod2pkg\)'
+
+          set -x
+
+          # set vars
+          OBS_BASE_SRC_PROJECT="Cloud:OpenStack:Upstream"
+          OBS_BASE_TARGET_PROJECT="home:suse-cloud-ci:rpm-packaging-openstack"
+          OBS_TEST_PROJECT="${OBS_BASE_TARGET_PROJECT}-${ZUUL_COMMIT}"
+          TEMP_DIR="/tmp/rpm-packaging-${ZUUL_COMMIT}"
+
+          # cleanup
+          rm -rf ${OBS_TEST_PROJECT}
+          rm -rf ${TEMP_DIR}
+          osc rdelete -r -m "rpm-packaging CI cleanup" ${OBS_TEST_PROJECT} || :
+          sleep 3
+
+          # recreate the rpm-packaging tarball (as done by the tar_scm source service)
+          mkdir ${TEMP_DIR}
+          tar --exclude-vcs -cvjf ${TEMP_DIR}/rpm-packaging-0.0.1.tar.bz2 --transform 's,^,rpm-packaging-0.0.1/,' .
+
+          # branch and checkout OBS project
+          osc branch ${OBS_BASE_SRC_PROJECT} "rpm-packaging-openstack" ${OBS_TEST_PROJECT} || :
+          sleep 2
+
+          # create package links (needed if a new .spec.j2 was added)
+          for spec_template in `find -name '*.spec.j2'`; do
+              spec_basename=`basename $spec_template|sed 's/.spec.j2$//'`
+              osc linkpac ${OBS_TEST_PROJECT} "rpm-packaging-openstack" ${OBS_TEST_PROJECT} python-${spec_basename} || :
+          done
+          sleep 2
+
+          # checkout branched project, add updated stuff and commit
+          osc co ${OBS_TEST_PROJECT}
+          cp ${TEMP_DIR}/rpm-packaging-0.0.1.tar.bz2 ${OBS_TEST_PROJECT}/rpm-packaging-openstack
+          pushd ${OBS_TEST_PROJECT}/rpm-packaging-openstack
+          # download source files (needed for i.e. version updates or newly added .spec files)
+          osc service run download_files
+          bash -x pre_checkin.sh
+          osc addremove
+          osc status
+          osc commit -m "rpm-packaging CI (${ZUUL_CHANGES})"
+
+          popd
+          pushd ${OBS_TEST_PROJECT}
+          echo "#################################"
+          echo "https://build.opensuse.org/project/show/${OBS_TEST_PROJECT}"
+          echo "#################################"
+          sleep 5
+
+          # wait for build results (osc wait is buggy - https://github.com/openSUSE/osc/issues/180 )
+          timeout 1h bash -c -- '
+              while true; do
+                  unset pending
+                  unset failed
+                  res=`osc results --csv -w -r SLE_12`
+                  echo ">>: ${res}"
+                  for r in $res; do
+                      # some failures?
+                      if [[ $r =~ (failed$|unresolvable$|broken$) ]]; then
+                          failed=1
+                      fi
+                      # still pending builds?
+                      if [[ $r =~ (blocked$|scheduled$|dispatching$|building$|signing$|finished$|outdated$) ]]; then
+                          pending=1
+                      fi
+                  done
+                  echo ">>: pending: $pending ; failed: $failed"
+                  if [ -n "$pending" ]; then
+                      sleep 5
+                      continue
+                  fi
+                  if [ -n "$failed" ]; then
+                      exit 1
+                  else
+                      break
+                  fi
+              done
+          '
+
+          exit 0


### PR DESCRIPTION
There is now an internal zuul instance connected to review.openstack.org
and ci.opensuse.org . New changes (or "recheck" and "recheck-suse" comments)
trigger a new testbuild.
The testbuild currently does:
- branch Cloud:OpenStack:Upstream/rpm-packaging-openstack
- recreate a tarball with the changes provided by zuul
- checkin in OBS at home:suse-cloud-ci
- wait for the rebuild and report the result back to gerrit