### PR TITLE
mkcloud: refactor static wait

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -476,8 +476,7 @@ function setupadmin()
     wait_for 300 1 "ping -q -c 1 -w 1 $adminip >/dev/null" 'crowbar admin VM'
     wait_for_crowbar_ssh
 
-    echo "waiting some more for sshd+named to start"
-    sleep 25
+    wait_for 20 2 "nc -z $adminip 22" 'sshd to start'
     echo "Injecting public key into admin node..."
     local keyfile=~/.ssh/id_dsa.pub
     local pubkey=`cut -d" " -f2 $keyfile`


### PR DESCRIPTION
drop a static wait and instead check what we are waiting for