### PR TITLE
Split off setupadmin

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -85,13 +85,20 @@ EOS
     /etc/init.d/boot.mkcloud
 }
 
+function libvirt_prepare()
+{
+    # libvirt
+    libvirt_modprobe_kvm
+    libvirt_start_daemon
+
+    # network
+    ${mkcloud_lib_dir}/libvirt/net-config $cloud $cloudbr $admingw $adminnetmask $cloudfqdn $adminip $forwardmode > /tmp/$cloud-admin.net.xml
+    ${mkcloud_lib_dir}/libvirt/net-start /tmp/$cloud-admin.net.xml || exit $?
+    libvirt_net_start
+}
+
 function libvirt_setupadmin()
 {
     ${mkcloud_lib_dir}/libvirt/admin-config $cloud $admin_node_memory $adminvcpus $emulator $admin_node_disk "$localreposdir_src" "$localreposdir_target" > /tmp/$cloud-admin.xml
-    ${mkcloud_lib_dir}/libvirt/net-config $cloud $cloudbr $admingw $adminnetmask $cloudfqdn $adminip $forwardmode > /tmp/$cloud-admin.net.xml
-    libvirt_modprobe_kvm
-    libvirt_start_daemon
-    ${mkcloud_lib_dir}/libvirt/net-start /tmp/$cloud-admin.net.xml || exit $?
-    libvirt_net_start
     ${mkcloud_lib_dir}/libvirt/vm-start /tmp/$cloud-admin.xml || exit $?
 }

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -450,6 +450,7 @@ function prepare()
     onhost_create_cloud_lvm
     onhost_deploy_image "admin" $image "$admin_node_disk"
     onhost_add_etchosts_entries
+    libvirt_prepare
 }
 
 function ssh_password()


### PR DESCRIPTION
split setupadmin from prepare function

by this the admin node can be redeployed without rerunning the libvirt_prepare part

This is needed for the upgrade from Cloud5 to Cloud6 (PR for that is WIP).