### PR TITLE
Remove Juno from trackupstream

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
@@ -10,7 +10,6 @@
           type: user-defined
           name: project
           values:
-            - Cloud:OpenStack:Juno:Staging
             - Cloud:OpenStack:Kilo:Staging
             - Cloud:OpenStack:Liberty:Staging
             - Cloud:OpenStack:Master


### PR DESCRIPTION
Juno is now EOL (See http://docs.openstack.org/releases/)