### PR TITLE
Disable trackupstream for master for now since we are focusing on

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
@@ -12,7 +12,8 @@
           values:
             - Cloud:OpenStack:Kilo:Staging
             - Cloud:OpenStack:Liberty:Staging
-            - Cloud:OpenStack:Master
+              # Temporarily disabled until we have more time
+              # - Cloud:OpenStack:Master
       - axis:
           type: user-defined
           name: component


### PR DESCRIPTION
Liberty

Keeping this disabled for the next month or so will help us
on focusing on getting the Liberty release out.