### PR TITLE
mkcloud: Only use /etc/init.d/boot.mkcloud when needed

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -81,8 +81,10 @@ EOS
 EOS
         fi
     fi
-    chmod +x /etc/init.d/boot.mkcloud
-    /etc/init.d/boot.mkcloud
+    if [ -e "/etc/init.d/boot.mkcloud" ]; then
+        chmod +x /etc/init.d/boot.mkcloud
+        /etc/init.d/boot.mkcloud
+    fi
 }
 
 function libvirt_prepare()


### PR DESCRIPTION
If $NOSETUPPORTFORWARDING is set, the whole boot.mkcloud script is not
needed and also not available. This fixes:

chmod: cannot access ‘/etc/init.d/boot.mkcloud’: No such file or directory