### PR TITLE
qa_crowbarsetup.sh: Identify builds with extra updaterepos

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1115,6 +1115,14 @@ function onadmin_add_cloud_repo()
       cat "$targetdir/isoversion" > /etc/cloudversion
     fi
 
+    # Just document the list of extra repos
+    if [[ -n "$UPDATEREPOS" ]]; then
+        local repo
+        for repo in ${UPDATEREPOS//+/ } ; do
+            echo "+ with extra repo from $repo" >> /etc/cloudversion
+        done
+    fi
+
     echo -n "This cloud was installed on `cat ~/cloud` from: " | \
         cat - /etc/cloudversion >> /etc/motd
     echo $cloudsource > /etc/cloudsource


### PR DESCRIPTION
This makes it easier to detect if a machine was installed with
a non-merged downstream patch.