### PR TITLE
Add an overview multijob for the current state of Cloud6

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-mkcloud7-suse.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mkcloud7-suse.yaml
@@ -1,5 +1,6 @@
 - job:
     name: 'cloud-mkcloud7-suse'
+    project-type: multijob
     node: cloud-trigger
 
     triggers:
@@ -16,26 +17,40 @@
       daysToKeep: -1
 
     builders:
-      - trigger-builds:
-        - project: openstack-mkcloud
-          condition: SUCCESS
-          block: true
-          predefined-parameters: |
-            cloudsource=susecloud7
-            TESTHEAD=
-            want_test_updates=1
-            nodenumber=2
-            mkcloudtarget=all_batch
-            scenario=cloud7-2nodes-default.yml
-            want_node_aliases=controller=1,compute-kvm=1
-        - project: openstack-mkcloud
-          condition: SUCCESS
-          block: true
-          predefined-parameters: |
-            cloudsource=susecloud7
-            TESTHEAD=
-            want_test_updates=1
-            nodenumber=4
-            want_ceph=1
-            networkingplugin=linuxbridge
-            mkcloudtarget=all
+      - multijob:
+          name: 'Standard Gate Checks (non-HA/OVS+Linuxbridge)'
+          condition: SUCCESSFUL
+          projects:
+            - name: openstack-mkcloud
+              node-label: cloud-trigger
+              predefined-parameters: |
+                cloudsource=susecloud7
+                TESTHEAD=
+                want_test_updates=1
+                nodenumber=2
+                mkcloudtarget=all_batch
+                scenario=cloud7-2nodes-default.yml
+                want_node_aliases=controller=1,compute-kvm=1
+            - name: openstack-mkcloud
+              node-label: cloud-trigger
+              predefined-parameters: |
+                cloudsource=susecloud7
+                TESTHEAD=
+                want_test_updates=1
+                nodenumber=4
+                want_ceph=1
+                networkingplugin=linuxbridge
+                mkcloudtarget=all
+      - multijob:
+          name: 'Extra Gate Checks (HA)'
+          condition: SUCCESSFUL
+          projects:
+            - name: openstack-mkcloud
+              node-label: cloud-trigger
+              predefined-parameters: |
+                TESTHEAD=
+                cloudsource=susecloud7
+                nodenumber=4
+                networkingmode=vxlan
+                hacloud=1
+                mkcloudtarget=all_noreboot


### PR DESCRIPTION
This generates a phased multijob that shows all relevant
Base and extra scenarios in one nice view. See here:

https://ci.suse.de/view/Cloud/view/ByTopic/view/Cloud6/job/cloud-mkcloud6-suse-trigger-new/