### PR TITLE
Use nodenumber=4 for ceph testing like in gating check

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-mkcloud6-suse-trigger.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mkcloud6-suse-trigger.yaml
@@ -35,7 +35,7 @@
             cloudsource=susecloud6
             TESTHEAD=
             want_test_updates=1
-            nodenumber=3
+            nodenumber=4
             want_ceph=1
             networkingplugin=linuxbridge
             mkcloudtarget=all


### PR DESCRIPTION
The settings between develcloud and susecloud gating should
be in sync.