### PR TITLE
mkcloudhost: use reserved IP addrs

### DIFF
--- a/scripts/mkcloudhost/boot.mkcloud
+++ b/scripts/mkcloudhost/boot.mkcloud
@@ -12,6 +12,6 @@ for n in $(seq 1 $cloudspernode) ; do
 done
 for x in D I ; do
     iptables -$x FORWARD -d 192.168.0.0/16 -j ACCEPT
-    iptables -t nat -$x POSTROUTING -s 44.0.0.0/8 -j MASQUERADE
+    iptables -t nat -$x POSTROUTING -s 10.164.0.0/15 -j MASQUERADE
 done
 

--- a/scripts/mkcloudhost/cloudfunc
+++ b/scripts/mkcloudhost/cloudfunc
@@ -30,10 +30,10 @@ function mkch_id()
 function routedcloudpublicnet()
 {
     local n=$1
-    local offset=8
+    local offset=164
     local mkch_id=$(mkch_id)
     local base2=$(($mkch_id * $cloudspernode))
     local base1=$(($offset + $base2/256))
     base2=$(($base2 % 256))
-    echo -n 44.$base1.$(($base2+$n-1))
+    echo -n 10.$base1.$(($base2+$n-1))
 }


### PR DESCRIPTION
this makes it easier to route it within Nuremberg later

atm those addrs are just reserved for us in microfocus infoblox DB, but not routed, except over cloud openvpn like old 44.8.0.0/15 range.

already did on mkch[abcd] hosts
ln -sf ~/github.com/SUSE-Cloud/automation/scripts/mkcloudhost/boot.mkcloud /etc/init.d/boot.mkcloud

and already added new routes on gate (in addition to old ones)

but after this is merged, crowbar.v*.cloud.suse.de DNS entries will need to be updated in gate:~/configurer/conf.d/cloudvms.pm