### PR TITLE
Allow onhost function calls

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -249,6 +249,14 @@ function onadmin()
     sshrun onadmin_$cmd "$@"
 }
 
+function onhost()
+{
+    # functions can have parameters, so pass on all except $1
+    local cmd=$1
+    shift
+    onhost_$cmd "$@"
+}
+
 function cleanup()
 {
     # cleanup leftover from last run
@@ -1250,7 +1258,7 @@ allcmds="$step_aliases all all_noreboot all_batch all_batch_noreboot instonly \
     crowbarbackup crowbarrestore shutdowncloud restartcloud qa_test help \
     rebootneutron cloudupgrade \
     setuplonelynodes crowbar_register createadminsnapshot \
-    restoreadminfromsnapshot cct steps batch setup_aliases onadmin"
+    restoreadminfromsnapshot cct steps batch setup_aliases onadmin onhost"
 wantedcmds=$@
 
 function expand_steps()


### PR DESCRIPTION
This allows to run `mkcloud onhost+func` to modify an already deployed cloud (eg. deploy a new admin node).