### PR TITLE
qa_crowbarsetup: add linebreaks to wait_for

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -297,6 +297,7 @@ function wait_for()
     do
         echo -n .
         sleep $timesleep
+        [[ $(($n % 75)) != 0 ]] || echo
         n=$(($n - 1))
     done
     echo


### PR DESCRIPTION
This should help avoid conditions as in
https://ci.suse.de/job/openstack-mkcloud/13201/console
which did not update github status because jenkins stopped it
after no new line was produced for too long.
15:57:39   waiting 800 cycles of 5 seconds = 4000 seconds
15:57:40 .................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................Build timed out (after 60 minutes). Marking the build as failed.
16:57:39 Build was aborted