### PR TITLE
qa_crowbarsetup: Prepare Manila generic driver for testing

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -99,7 +99,7 @@ needcvol=1
 # hdd size defaults (unless defined otherwise)
 : ${adminnode_hdd_size:=15}
 : ${controller_hdd_size:=20}
-: ${computenode_hdd_size:=15}
+: ${computenode_hdd_size:=20}
 : ${cephvolume_hdd_size:=21}
 : ${controller_ceph_hdd_size:=25}
 if [ -n "$hacloud" ]; then

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -80,8 +80,8 @@ export nodenumber nodenumbercompute nodenumberlonelynode clusterconfig
 allnodeids_without_lonely=`seq 1 $((nodenumber-nodenumberphys))`
 lonelynodeids=`seq $(( nodenumber + 1 )) $(( nodenumber + nodenumberlonelynode ))`
 allnodeids="$allnodeids_without_lonely $lonelynodeids"
-: ${vcpus:=1}
-: ${adminvcpus:=$vcpus}
+: ${vcpus:=2}
+: ${adminvcpus:=1}
 cpuflags=''
 working_dir_orig=`pwd`
 : ${artifacts_dir:=$working_dir_orig/.artifacts}


### PR DESCRIPTION
Manila is integrated into Cloud 6 and we want to test it. Upstream
uses the so called "generic driver" as backend and runs tempest tests.
To be able to run the tempest tests we need to prepare the setup.
The generic driver uses a cloud instance as a share server. The instance
mounts a cinder block device, adds a FS on top and uses the common
tools (nfs-server, samba) to export shares.
To manage the share-server, the manila-share service (which may run on
multiple compute nodes) need to acccess the share-server via ssh.
So we basically need:
- a new network which is available on the crowbar nodes
- a neutron provider network to access the nodes in the crowbar network
- a nova instance which has access to the new neutron network

In addition to that, the image used for the nova instance must have some
software preinstalled (i.e. nfs-server, samba). Also some security-group
rules are needed to allow NFS/CIFS traffic between the share server
instance and the consumers (other instances in the tenant).