### PR TITLE
qa_crowbarsetup: improve linebreak in wait_for and add test

### DIFF
--- a/scripts/qa_crowbarsetup-test.sh
+++ b/scripts/qa_crowbarsetup-test.sh
@@ -56,3 +56,12 @@ it_parses_dhcpd_leases() {
     results=`. ./qa_crowbarsetup.sh ; ! onadmin_get_ip_from_dhcp 52:54:03:88:77:07 test/data/dhcpd.leases`
     test "$results" = ""
 }
+
+it_breaks_line_in_wait_for() {
+    results=`. ./qa_crowbarsetup.sh ; wait_for 75 0 false "being true" "exit 0" | grep "^\."`
+    [[ "$results" = "..........................................................................." ]]
+    results=`. ./qa_crowbarsetup.sh ; wait_for 151 0 false "being true" "exit 0" | grep "^\."`
+    [[ "$results" = "...........................................................................
+...........................................................................
+." ]]
+}

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -297,8 +297,8 @@ function wait_for()
     do
         echo -n .
         sleep $timesleep
-        [[ $(($n % 75)) != 0 ]] || echo
         n=$(($n - 1))
+        [[ $(( ($timecount - $n) % 75)) != 0 ]] || echo
     done
     echo
 


### PR DESCRIPTION
This improves PR #740 by breaking exactly after 75 chars except for the last line.
And it adds roundup tests for this.