### PR TITLE
qa_crowbarsetup: only run zypper dup from ptf repo if it is present

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1393,7 +1393,7 @@ EOF
     if [ -z "$NOINSTALLCLOUDPATTERN" ] ; then
         safely zypper --no-gpg-checks -n in -l -t pattern cloud_admin
         # make sure to use packages from PTF repo (needs zypper dup)
-        safely zypper -n dup --from cloud-ptf
+        zypper mr -e cloud-ptf && safely zypper -n dup --from cloud-ptf
     fi
 
     cd /tmp


### PR DESCRIPTION
safely makes the call of zypper dup fail
so if the ptf repo is not present this breaks the deployment

Solution, skip the zypper dup if the repo is not present.