### PR TITLE
Refactoring for controller ha

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -722,8 +722,7 @@ function cluster_node_assignment()
         return 0
     fi
 
-    local nodesavailable
-    nodesavailable=`get_all_discovered_nodes`
+    local nodesavailable=`get_all_discovered_nodes`
 
     # the nodes that contain drbd volumes are defined via drbdnode_mac_vol
     for dmachine in ${drbdnode_mac_vol//+/ } ; do

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -723,6 +723,7 @@ function cluster_node_assignment()
     fi
 
     local nodesavailable=`get_all_discovered_nodes`
+    local dmachine
 
     # the nodes that contain drbd volumes are defined via drbdnode_mac_vol
     for dmachine in ${drbdnode_mac_vol//+/ } ; do

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -735,6 +735,7 @@ function cluster_node_assignment()
         # find and remove drbd nodes from nodesavailable
         for node in $nodesavailable ; do
             if crowbar machines show "$node" | grep "\"macaddress\"" | grep -qi $mac ; then
+                nodesavailable=`remove_node_from_list "$node" "$nodesavailable"`
                 clusternodesdrbd="$clusternodesdrbd $node"
 
                 # assign drbd volume via knife

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -708,6 +708,13 @@ function get_docker_nodes()
     knife search node "roles:`nova_role_prefix`-compute-docker" -a name | grep ^name: | cut -d : -f 2 | sort | sed 's/\s//g'
 }
 
+function remove_node_from_list()
+{
+    local onenode="$1"
+    local list="$@"
+    printf "%s\n" $list | grep -iv "$onenode"
+}
+
 function cluster_node_assignment()
 {
     if [ -n "$clusternodesdata" ] ; then
@@ -1756,7 +1763,7 @@ function onadmin_allocate()
             local i=1
             for node in `printf  "%s\n" $nodesavailable | head -n$number`; do
                 set_node_platform $node $node_os
-                nodesavailable=`printf "%s\n" $nodesavailable | grep -iv $node`
+                nodesavailable=`remove_node_from_list "$node" "$nodesavailable"`
                 i=$((i+1))
             done
         done


### PR DESCRIPTION
This is some refactoring work needed for the support of controller HA in mkcloud.

The missing removal of used data nodes from the list of available nodes may have created some strange bugs/behaviour in the past.
Due to our setup of the mkcloud HA jobs (only one cluster named "data") we never hit this bug on the mkcloud workers. But once the cluster looks different it might be a problem as the data nodes might be used/assigned twice.

The rest is just cleanup.