### PR TITLE
Reduce m1.smaller flavor to 8GB disk

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3142,7 +3142,7 @@ function oncontroller_testsetup()
     done
 
     nova flavor-delete m1.smaller || :
-    nova flavor-create m1.smaller 11 512 10 1
+    nova flavor-create m1.smaller 11 512 8 1
     nova delete testvm  || :
     nova keypair-add --pub_key /root/.ssh/id_rsa.pub testkey
     nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0


### PR DESCRIPTION
I've found several times that an HA deployment fails with **error 43** when running *testsetup*. This is right after tempest test have successfully run and we create an instance with qa_crowbarsetup.

This error seems to be caused by lack of disk space in the compute nodes to spawn the instance. The compute nodes have 13GB on the root partition and about 10GB free. Since the image requires 10GB, sometimes there's not enough space for it.

I have successfully tried manually to spawn the instance with 8GB disk and seems to be created properly. I'm suggesting reducing the m1.smaller flavor to 8GB disk in order to make this situation much less likely.