### PR TITLE
Disable test updates for cloud6

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -53,7 +53,14 @@ export cinder_netapp_login
 export cinder_netapp_password
 export localreposdir_target
 export want_ipmi=${want_ipmi:-false}
-[ -z "$want_test_updates" -a -n "$TESTHEAD" ] && export want_test_updates=1
+if [ -z "$want_test_updates" -a -n "$TESTHEAD" ] ; then
+    if iscloudver 6plus; then
+        echo "NOT ENABLING TEST UPDATES SINCE TEST UPDATES ARE BROKEN (2016-01-11)"
+        echo "**** remove me when fixed"
+    else
+        export want_test_updates=1
+    fi
+fi
 [ "$libvirt_type" = hyperv ] && export wanthyperv=1
 [ "$libvirt_type" = xen ] && export wantxenpv=1 # xenhvm is broken anyway
 


### PR DESCRIPTION
there is a broken test update in the queue right now, let's
not bother with it.