### PR TITLE
Support for more than one controller VM creation

### DIFF
--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -10,14 +10,14 @@ def main():
 
     parser = argparse.ArgumentParser(description="Create Compute Node Config.")
     parser.add_argument("cloud", type=str, help="Name of the Cloud")
-    parser.add_argument("nodecounter", type=str,
+    parser.add_argument("nodecounter", type=int,
                         help="Node Counter \
                         (when this script is called within a loop, this \
                         is usually an incremented number)")
     parser.add_argument("macaddress", type=str, help="MAC Address")
     parser.add_argument("controller_raid_volumes", type=int,
                         help="Number of disks for RAID on controller node")
-    parser.add_argument("cephvolumenumber", type=str, help="Number of Ceph Volumes")
+    parser.add_argument("cephvolumenumber", type=int, help="Number of Ceph Volumes")
     parser.add_argument("drbdserial", type=str, help="DRBD Volume Serial")
     parser.add_argument("computenodememory", type=str,
                         help="Compute Node Memory (kB)")
@@ -32,6 +32,8 @@ def main():
                         help="Virtual Disk Directory (e.g /dev/cloud)")
     parser.add_argument("bootorder", type=str,
                         help="Boot Order (e.g. 2)")
+    parser.add_argument("numcontrollers", type=int, default=1,
+                        help="Number of controller nodes")
 
     args = parser.parse_args()
 

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -105,7 +105,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
         targetdevprefix = "sd"
         targetbus = "ide"
     controller_raid_volumes = args.controller_raid_volumes
-    if args.nodecounter != "1":
+    if args.nodecounter > args.numcontrollers:
         controller_raid_volumes = 0
         nodememory = args.computenodememory
     else:

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -7,16 +7,18 @@ import unittest
 
 import libvirt_setup
 
-FIXTURE_DIR = "{0}/fixtures".format(os.path.dirname(__file__))
-TEMPLATE_DIR = "{0}/templates".format(os.path.dirname(__file__))
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
 
 
 # helper method to create argparse object
 def arg_parse(args):
     parser = argparse.ArgumentParser("ArgParser")
-    for key in args:
-        parser.add_argument(key, type=str)
-    return parser.parse_args(args)
+    for arg in args:
+        key, argtype, value = arg
+        parser.add_argument(key, type=argtype)
+    values = [arg[2] for arg in args]
+    return parser.parse_args(values)
 
 
 class TestLibvirtHelpers(unittest.TestCase):
@@ -69,20 +71,13 @@ class TestLibvirtNetConfig(unittest.TestCase):
 
     def test_net_config(self):
         args = arg_parse(
-            ["cloud",
-             "cloudbr",
-             "admingw",
-             "adminnetmask",
-             "cloudfqdn",
-             "adminip",
-             "forwardmode"])
-        args.cloud = "cloud"
-        args.cloudbr = "cloudbr"
-        args.admingw = "192.168.124.1"
-        args.adminnetmask = "255.255.248.0"
-        args.cloudfqdn = "unittest.suse.de"
-        args.adminip = "192.168.124.10"
-        args.forwardmode = "nat"
+            [("cloud", str, "cloud"),
+             ("cloudbr", str, "cloudbr"),
+             ("admingw", str, "192.168.124.1"),
+             ("adminnetmask", str, "255.255.248.0"),
+             ("cloudfqdn", str, "unittest.suse.de"),
+             ("adminip", str, "192.168.124.10"),
+             ("forwardmode", str, "nat")])
 
         should_config = libvirt_setup.readfile(
             "{0}/cloud-admin.net.xml".format(FIXTURE_DIR))
@@ -94,19 +89,13 @@ class TestLibvirtAdminConfig(unittest.TestCase):
 
     def test_admin_config(self):
         args = arg_parse(
-            ["cloud",
-             "adminnodememory",
-             "adminvcpus",
-             "emulator",
-             "adminnodedisk",
-             "localrepositorymount"])
-        args.cloud = "cloud"
-        args.adminnodememory = "2097152"
-        args.adminvcpus = "1"
-        args.emulator = "/usr/bin/qemu-system-x86_64"
-        args.adminnodedisk = "/dev/cloud/cloud.admin"
-        args.localreposrc = ""
-        args.localrepotgt = ""
+            [("cloud", str, "cloud"),
+             ("adminnodememory", str, "2097152"),
+             ("adminvcpus", str, "1"),
+             ("emulator", str, "/usr/bin/qemu-system-x86_64"),
+             ("adminnodedisk", str, "/dev/cloud/cloud.admin"),
+             ("localreposrc", str, ""),
+             ("localreposgt", str, "")])
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 
@@ -120,31 +109,20 @@ class TestLibvirtComputeConfig(unittest.TestCase):
 
     def test_compute_config(self):
         args = arg_parse(
-            ["cloud",
-             "nodecounter",
-             "macaddress",
-             "controller_raid_volumes",
-             "cephvolumenumber",
-             "drbdserial",
-             "computenodememory",
-             "controllernodememory",
-             "libvirttype",
-             "vcpus",
-             "emulator",
-             "vdiskdir"])
-        args.cloud = "cloud"
-        args.nodecounter = "1"
-        args.macaddress = "52:54:01:77:77:01"
-        args.controller_raid_volumes = 0
-        args.cephvolumenumber = "1"
-        args.computenodememory = "2097152"
-        args.controllernodememory = "5242880"
-        args.libvirttype = "kvm"
-        args.vcpus = "1"
-        args.emulator = "/usr/bin/qemu-system-x86_64"
-        args.vdiskdir = "/dev/cloud"
-        args.drbdserial = ""
-        args.bootorder = "3"
+            [("cloud", str, "cloud"),
+             ("nodecounter", int, "1"),
+             ("macaddress", str, "52:54:01:77:77:01"),
+             ("controller_raid_volumes", int, "0"),
+             ("cephvolumenumber", str, "1"),
+             ("drbdserial", str, ""),
+             ("computenodememory", str, "2097152"),
+             ("controllernodememory", str, "5242880"),
+             ("libvirttype", str, "kvm"),
+             ("vcpus", str, "1"),
+             ("emulator", str, "/usr/bin/qemu-system-x86_64"),
+             ("vdiskdir", str, "/dev/cloud"),
+             ("bootorder", str, "3"),
+             ("numcontrollers", int, "1")])
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 
@@ -156,31 +134,20 @@ class TestLibvirtComputeConfig(unittest.TestCase):
     # add extra disk for raid and 2 volumes for ceph
     def test_compute_config_with_raid(self):
         args = arg_parse(
-            ["cloud",
-             "nodecounter",
-             "macaddress",
-             "controller_raid_volumes",
-             "cephvolumenumber",
-             "drbdserial",
-             "computenodememory",
-             "controllernodememory",
-             "libvirttype",
-             "vcpus",
-             "emulator",
-             "vdiskdir"])
-        args.cloud = "cloud"
-        args.nodecounter = "1"
-        args.macaddress = "52:54:01:77:77:01"
-        args.controller_raid_volumes = 2
-        args.cephvolumenumber = "2"
-        args.computenodememory = "2097152"
-        args.controllernodememory = "5242880"
-        args.libvirttype = "kvm"
-        args.vcpus = "1"
-        args.emulator = "/usr/bin/qemu-system-x86_64"
-        args.vdiskdir = "/dev/cloud"
-        args.drbdserial = ""
-        args.bootorder = "3"
+            [("cloud", str, "cloud"),
+             ("nodecounter", int, "1"),
+             ("macaddress", str, "52:54:01:77:77:01"),
+             ("controller_raid_volumes", int, "2"),
+             ("cephvolumenumber", str, "2"),
+             ("drbdserial", str, ""),
+             ("computenodememory", str, "2097152"),
+             ("controllernodememory", str, "5242880"),
+             ("libvirttype", str, "kvm"),
+             ("vcpus", str, "1"),
+             ("emulator", str, "/usr/bin/qemu-system-x86_64"),
+             ("vdiskdir", str, "/dev/cloud"),
+             ("bootorder", str, "3"),
+             ("numcontrollers", int, "1")])
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -564,7 +564,9 @@ function setuplonelynodes()
         local mac=$(macfunc $i)
         local lonely_node
         lonely_node=$cloud-node$i
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac 0 "$cephvolume" "$drbdvolume" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "1" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac 0 "$cephvolume"\
+            "$drbdvolume" $compute_node_memory $controller_node_memory\
+            $libvirt_type $vcpus $emulator $vdisk_dir "1" 1 > /tmp/$cloud-node$i.xml
 
         local lonely_disk
         lonely_disk="$vdisk_dir/${cloud}.node$i"
@@ -677,6 +679,11 @@ function setupnodes()
 {
     onadmin wait_tftpd || return $?
 
+    local nodenumbercontroller=1
+    if [[ $clusterconfig == *"services"* ]]; then
+        nodenumbercontroller=`echo ${clusterconfig} | sed -e "s/^.*services[^:]*=\([[:digit:]]\+\).*/\1/"`
+    fi
+
     setuppublicnet
     for i in $allnodeids_without_lonely ; do
         local macaddress=$(macfunc $i)
@@ -694,7 +701,10 @@ function setupnodes()
             fi
         fi
 
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress $controller_raid_volumes $cephvolumenumber "$drbd_serial" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "3" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress\
+            $controller_raid_volumes $cephvolumenumber "$drbd_serial"\
+            $compute_node_memory $controller_node_memory $libvirt_type $vcpus\
+            $emulator $vdisk_dir "3" $nodenumbercontroller > /tmp/$cloud-node$i.xml
         ${mkcloud_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
     done
 


### PR DESCRIPTION
In HA deployments, with more than one controller node, only the first controller VM was assigned an increased memory footprint. The other controller VM's got the normal amount of memory leading to some out-of-memory errors. This implementation assigns the same amount of (increased) memory to all controller VMs.

The former implementation already took care of several controller nodes in HA deployments. The number of controller nodes could be specified with the **clusterconfig:services** configuration variable. This implementation doesn't change the behavior of that variable.