### PR TITLE
ensure tftp server is ready before PXE-booting nodes

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -675,6 +675,8 @@ function restartcloud()
 # bring up VMs that will take cloud controller/compute/storage roles
 function setupnodes()
 {
+    onadmin wait_tftpd || return $?
+
     setuppublicnet
     for i in $allnodeids_without_lonely ; do
         local macaddress=$(macfunc $i)

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1879,6 +1879,13 @@ function check_node_resolvconf()
     ssh_password $1 'grep "^nameserver" /etc/resolv.conf || echo fail'
 }
 
+function onadmin_wait_tftpd()
+{
+    wait_for 300 2 \
+        "timeout -k 2 2 tftp $adminip 69 -c get /discovery/x86_64/bios/pxelinux.cfg/default /tmp/default"
+    echo "Crowbar tftp server ready"
+}
+
 function wait_node_ready()
 {
     local node=$1


### PR DESCRIPTION
If the admin server is freshly booted just before running the `setupnodes` step (e.g. if it was preceded by the `createadminsnapshot` step), then the tftp server might not yet be running.  So we need to wait for it before PXE-booting any nodes.