### PR TITLE
qa_crowbarsetup: dropping useless 'sleep 50'

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1743,8 +1743,6 @@ function onadmin_allocate()
         wait_for 100 2 "knife node show -a state $n | grep discovered" \
             "node to enter discovered state"
     done
-    echo "Sleeping 50 more seconds..."
-    sleep 50
     local controllernodes=(
             $(get_all_discovered_nodes | head -n 2)
         )


### PR DESCRIPTION
Meanwhile there is code that waits for all nodes to be discovered. So the 'sleep 50' should not be needed.