### PR TITLE
Fix pending job detection

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
@@ -68,7 +68,7 @@
                           failed=1
                       fi
                       # still pending builds?
-                      if [[ $r =~ (blocked$|scheduled$|dispatching$|building$|signing$|finished$|outdated$) ]]; then
+                      if [[ $r =~ (blocked$|scheduled$|dispatching$|building$|signing$|finished$|unknown|outdated$) ]]; then
                           pending=1
                       fi
                   done


### PR DESCRIPTION
"unknown" is the initial state of a package, we also need
to consider that as pending.