### PR TITLE
Support for more than one controller VM creation

### DIFF
--- a/scripts/lib/libvirt/admin-config
+++ b/scripts/lib/libvirt/admin-config
@@ -1,29 +1,27 @@
 #!/usr/bin/env python
-
 import argparse
 
 import libvirt_setup
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Create Admin Node Config.")
-    parser.add_argument("cloud", type=str, help="Name of the Cloud")
-    parser.add_argument("adminnodememory", type=str,
+    parser.add_argument("cloud", help="Name of the Cloud")
+    parser.add_argument("adminnodememory", type=int,
                         help="Amount of Memory (kB)")
-    parser.add_argument("adminvcpus", type=str, help="Number of VCPUs")
-    parser.add_argument("emulator", type=str,
+    parser.add_argument("adminvcpus", type=int, help="Number of VCPUs")
+    parser.add_argument("emulator",
                         help="Emulator (e.g. /usr/bin/qemu-system-x86_64)")
-    parser.add_argument("adminnodedisk", type=str,
+    parser.add_argument("adminnodedisk",
                         help="Admin Node Disk (/path/to/adminnodedisk)")
-    parser.add_argument("localreposrc", type=str,
+    parser.add_argument("localreposrc",
                         help="Local Repository Directory Source")
-    parser.add_argument("localrepotgt", type=str,
+    parser.add_argument("localrepotgt",
                         help="Local Repository Directory Target")
-
     args = parser.parse_args()
 
     print(libvirt_setup.admin_config(args))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/libvirt/cleanup
+++ b/scripts/lib/libvirt/cleanup
@@ -1,22 +1,19 @@
 #!/usr/bin/env python
-
 import argparse
 
 import libvirt_setup
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Cleanup libvirt resources.")
-    parser.add_argument("cloud", type=str, help="Name of the Cloud")
+    parser.add_argument("cloud", help="Name of the Cloud")
     parser.add_argument("nodenumber", type=int, help="Number of Nodes")
-    parser.add_argument("cloudbr", type=str, help="Name of the Virtual Bridge")
-    parser.add_argument("vlan_public", type=str,
-                        help="ID of the Public VLAN")
-
+    parser.add_argument("cloudbr", help="Name of the Virtual Bridge")
+    parser.add_argument("vlan_public", help="ID of the Public VLAN")
     args = parser.parse_args()
 
     libvirt_setup.cleanup(args)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -29,6 +29,8 @@ def main():
     parser.add_argument("vdiskdir",
                         help="Virtual Disk Directory (e.g /dev/cloud)")
     parser.add_argument("bootorder", type=int, help="Boot Order (e.g. 2)")
+    parser.add_argument("numcontrollers", type=int, default=1,
+                        help="Number of controller nodes")
     args = parser.parse_args()
 
     # to workaround bnc#946020+bnc#946068 we use the 2.0 machine type

--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import argparse
 import os
 
@@ -7,32 +6,29 @@ import libvirt_setup
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Create Compute Node Config.")
-    parser.add_argument("cloud", type=str, help="Name of the Cloud")
-    parser.add_argument("nodecounter", type=str,
+    parser.add_argument("cloud", help="Name of the Cloud")
+    parser.add_argument("nodecounter", type=int,
                         help="Node Counter \
                         (when this script is called within a loop, this \
                         is usually an incremented number)")
-    parser.add_argument("macaddress", type=str, help="MAC Address")
+    parser.add_argument("macaddress", help="MAC Address")
     parser.add_argument("controller_raid_volumes", type=int,
                         help="Number of disks for RAID on controller node")
-    parser.add_argument("cephvolumenumber", type=str, help="Number of Ceph Volumes")
-    parser.add_argument("drbdserial", type=str, help="DRBD Volume Serial")
-    parser.add_argument("computenodememory", type=str,
+    parser.add_argument("cephvolumenumber", type=int,
+                        help="Number of Ceph Volumes")
+    parser.add_argument("drbdserial", help="DRBD Volume Serial")
+    parser.add_argument("computenodememory", type=int,
                         help="Compute Node Memory (kB)")
-    parser.add_argument("controllernodememory", type=str,
+    parser.add_argument("controllernodememory", type=int,
                         help="Controller Node Memory (kB)")
-    parser.add_argument("libvirttype", type=str,
-                        help="Libvirt Type (e.g. kvm)")
-    parser.add_argument("vcpus", type=str, help=" Number of VCPUs")
-    parser.add_argument("emulator", type=str,
+    parser.add_argument("libvirttype", help="Libvirt Type (e.g. kvm)")
+    parser.add_argument("vcpus", type=int, help="Number of VCPUs")
+    parser.add_argument("emulator",
                         help="Emulator (e.g. /usr/bin/qemu-system-x86_64)")
-    parser.add_argument("vdiskdir", type=str,
+    parser.add_argument("vdiskdir",
                         help="Virtual Disk Directory (e.g /dev/cloud)")
-    parser.add_argument("bootorder", type=str,
-                        help="Boot Order (e.g. 2)")
-
+    parser.add_argument("bootorder", type=int, help="Boot Order (e.g. 2)")
     args = parser.parse_args()
 
     # to workaround bnc#946020+bnc#946068 we use the 2.0 machine type
@@ -40,7 +36,9 @@ def main():
     machine = "pc-i440fx-2.0"
     if os.system("qemu-kvm -machine \? | grep -q "+machine) != 0:
         machine = None
-    print(libvirt_setup.compute_config(args, libvirt_setup.cpuflags(), machine))
+    print(libvirt_setup.compute_config(args, libvirt_setup.cpuflags(),
+                                       machine))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -105,7 +105,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
         targetdevprefix = "sd"
         targetbus = "ide"
     controller_raid_volumes = args.controller_raid_volumes
-    if args.nodecounter != "1":
+    if args.nodecounter != 1:
         controller_raid_volumes = 0
         nodememory = args.computenodememory
     else:
@@ -134,7 +134,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
 
     cephvolume = ""
     if args.cephvolumenumber and args.cephvolumenumber > 0:
-        for i in range(1, int(args.cephvolumenumber) + 1):
+        for i in range(1, args.cephvolumenumber+1):
             ceph_template = string.Template(readfile(
                 "{0}/extra-volume.xml".format(TEMPLATE_DIR)))
             ceph_values = dict(

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -104,7 +104,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
         targetdevprefix = "sd"
         targetbus = "ide"
     controller_raid_volumes = args.controller_raid_volumes
-    if args.nodecounter != 1:
+    if args.nodecounter > args.numcontrollers:
         controller_raid_volumes = 0
         nodememory = args.computenodememory
     else:

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -10,8 +10,7 @@ import xml.etree.ElementTree as ET
 
 import libvirt
 
-
-TEMPLATE_DIR = "{0}/templates".format(os.path.dirname(__file__))
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
 
 
 def libvirt_connect():

--- a/scripts/lib/libvirt/net-config
+++ b/scripts/lib/libvirt/net-config
@@ -1,28 +1,22 @@
 #!/usr/bin/env python
-
 import argparse
 
 import libvirt_setup
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Create Admin Network Config")
-    parser.add_argument("cloud", type=str, help="Name of the Cloud")
-    parser.add_argument("cloudbr", type=str, help="Name of the Virtual bridge")
-    parser.add_argument("admingw", type=str,
-                        help="IP Address of the Admin Gateway")
-    parser.add_argument("adminnetmask", type=str,
-                        help="Netmask of the Admin Network")
-    parser.add_argument("cloudfqdn", type=str, help="Name of the Cloud-FQDN")
-    parser.add_argument("adminip", type=str,
-                        help="IP Address of the Admin Node")
-    parser.add_argument("forwardmode", type=str,
-                        help="Forward Mode (e.g. nat)")
-
+    parser.add_argument("cloud", help="Name of the Cloud")
+    parser.add_argument("cloudbr", help="Name of the Virtual bridge")
+    parser.add_argument("admingw", help="IP Address of the Admin Gateway")
+    parser.add_argument("adminnetmask", help="Netmask of the Admin Network")
+    parser.add_argument("cloudfqdn", help="Name of the Cloud-FQDN")
+    parser.add_argument("adminip", help="IP Address of the Admin Node")
+    parser.add_argument("forwardmode", help="Forward Mode (e.g. nat)")
     args = parser.parse_args()
 
     print(libvirt_setup.net_config(args))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/libvirt/net-start
+++ b/scripts/lib/libvirt/net-start
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
-
 import argparse
 
 import libvirt_setup
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Start a Virtual Network")
-    parser.add_argument("netpath", type=str, help="Path to the network XML")
-
+    parser.add_argument("netpath", help="Path to the network XML")
     args = parser.parse_args()
 
     libvirt_setup.net_start(args)

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -6,8 +6,8 @@ import unittest
 
 import libvirt_setup
 
-FIXTURE_DIR = "{0}/fixtures".format(os.path.dirname(__file__))
-TEMPLATE_DIR = "{0}/templates".format(os.path.dirname(__file__))
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
 
 
 # helper method to create argparse object
@@ -187,6 +187,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
             "{0}/cloud-node1-raid.xml".format(FIXTURE_DIR))
         is_config = libvirt_setup.compute_config(args, cpu_flags)
         self.assertEqual(is_config, should_config)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import argparse
 import os
 import tempfile
@@ -101,8 +100,8 @@ class TestLibvirtAdminConfig(unittest.TestCase):
              "adminnodedisk",
              "localrepositorymount"])
         args.cloud = "cloud"
-        args.adminnodememory = "2097152"
-        args.adminvcpus = "1"
+        args.adminnodememory = 2097152
+        args.adminvcpus = 1
         args.emulator = "/usr/bin/qemu-system-x86_64"
         args.adminnodedisk = "/dev/cloud/cloud.admin"
         args.localreposrc = ""
@@ -133,18 +132,18 @@ class TestLibvirtComputeConfig(unittest.TestCase):
              "emulator",
              "vdiskdir"])
         args.cloud = "cloud"
-        args.nodecounter = "1"
+        args.nodecounter = 1
         args.macaddress = "52:54:01:77:77:01"
         args.controller_raid_volumes = 0
-        args.cephvolumenumber = "1"
-        args.computenodememory = "2097152"
-        args.controllernodememory = "5242880"
+        args.cephvolumenumber = 1
+        args.computenodememory = 2097152
+        args.controllernodememory = 5242880
         args.libvirttype = "kvm"
-        args.vcpus = "1"
+        args.vcpus = 1
         args.emulator = "/usr/bin/qemu-system-x86_64"
         args.vdiskdir = "/dev/cloud"
         args.drbdserial = ""
-        args.bootorder = "3"
+        args.bootorder = 3
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 
@@ -169,18 +168,18 @@ class TestLibvirtComputeConfig(unittest.TestCase):
              "emulator",
              "vdiskdir"])
         args.cloud = "cloud"
-        args.nodecounter = "1"
+        args.nodecounter = 1
         args.macaddress = "52:54:01:77:77:01"
         args.controller_raid_volumes = 2
-        args.cephvolumenumber = "2"
-        args.computenodememory = "2097152"
-        args.controllernodememory = "5242880"
+        args.cephvolumenumber = 2
+        args.computenodememory = 2097152
+        args.controllernodememory = 5242880
         args.libvirttype = "kvm"
-        args.vcpus = "1"
+        args.vcpus = 1
         args.emulator = "/usr/bin/qemu-system-x86_64"
         args.vdiskdir = "/dev/cloud"
         args.drbdserial = ""
-        args.bootorder = "3"
+        args.bootorder = 3
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -130,7 +130,8 @@ class TestLibvirtComputeConfig(unittest.TestCase):
              "libvirttype",
              "vcpus",
              "emulator",
-             "vdiskdir"])
+             "vdiskdir",
+             "numcontrollers"])
         args.cloud = "cloud"
         args.nodecounter = 1
         args.macaddress = "52:54:01:77:77:01"
@@ -144,6 +145,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.vdiskdir = "/dev/cloud"
         args.drbdserial = ""
         args.bootorder = 3
+        args.numcontrollers = 1
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 
@@ -166,7 +168,8 @@ class TestLibvirtComputeConfig(unittest.TestCase):
              "libvirttype",
              "vcpus",
              "emulator",
-             "vdiskdir"])
+             "vdiskdir",
+             "numcontrollers"])
         args.cloud = "cloud"
         args.nodecounter = 1
         args.macaddress = "52:54:01:77:77:01"
@@ -180,6 +183,7 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.vdiskdir = "/dev/cloud"
         args.drbdserial = ""
         args.bootorder = 3
+        args.numcontrollers = 1
         cpu_flags = libvirt_setup.readfile(
             "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
 

--- a/scripts/lib/libvirt/vm-start
+++ b/scripts/lib/libvirt/vm-start
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
-
 import argparse
 
 import libvirt_setup
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Start a Virtual Machine")
-    parser.add_argument("vmpath", type=str, help="Path to the VM XML")
-
+    parser.add_argument("vmpath", help="Path to the VM XML")
     args = parser.parse_args()
 
     libvirt_setup.vm_start(args)

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -570,7 +570,10 @@ function setuplonelynodes()
         local mac=$(macfunc $i)
         local lonely_node
         lonely_node=$cloud-node$i
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac 0 "$cephvolume" "$drbdvolume" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "1" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $mac 0\
+            "$cephvolume" "$drbdvolume" $compute_node_memory\
+            $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir\
+            1 1 > /tmp/$cloud-node$i.xml
 
         local lonely_disk
         lonely_disk="$vdisk_dir/${cloud}.node$i"
@@ -683,6 +686,12 @@ function setupnodes()
 {
     onadmin wait_tftpd || return $?
 
+    local nodenumbercontroller=1
+    if [[ $clusterconfig == *services* ]]; then
+        nodenumbercontroller=`echo ${clusterconfig}\
+            | sed -e "s/^.*services[^:]*=\([[:digit:]]\+\).*/\1/"`
+    fi
+
     setuppublicnet
     for i in $allnodeids_without_lonely ; do
         local macaddress=$(macfunc $i)
@@ -700,7 +709,10 @@ function setupnodes()
             fi
         fi
 
-        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress $controller_raid_volumes $cephvolumenumber "$drbd_serial" $compute_node_memory $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir "3" > /tmp/$cloud-node$i.xml
+        ${mkcloud_lib_dir}/libvirt/compute-config $cloud $i $macaddress\
+            $controller_raid_volumes $cephvolumenumber "$drbd_serial"\
+            $compute_node_memory $controller_node_memory $libvirt_type $vcpus\
+            $emulator $vdisk_dir 3 $nodenumbercontroller > /tmp/$cloud-node$i.xml
         ${mkcloud_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
     done
 


### PR DESCRIPTION
In HA deployments, with more than one controller node, only the first controller VM was assigned an increased memory footprint. The other controller VM's got the normal amount of memory leading to some out-of-memory errors. This implementation assigns the same amount of (increased) memory to all controller VMs.

The former implementation already took care of several controller nodes in HA deployments. The number of controller nodes could be specified with the clusterconfig:services configuration variable. This implementation doesn't change the behavior of that variable.

This PR is a simplification of previous https://github.com/SUSE-Cloud/automation/pull/751. It also includes the fixes proposed by @aplanas in https://github.com/SUSE-Cloud/automation/pull/757, so it should supersede both PRs.