### PR TITLE
qa_crowbarsetup: Fix manila service VM details detection

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3003,8 +3003,8 @@ function get_ceph_nodes()
 
 function get_manila_service_instance_details()
 {
-    manila_service_vm_uuid=`oncontroller "source .openrc; openstack server show manila-service -f value -c id"`
-    manila_service_vm_ip=`oncontroller "source .openrc; openstack server show manila-service -f value -c addresses|grep -oP '(?<=\bmanila-service=)[^;]+'"`
+    manila_service_vm_uuid=`oncontroller "source .openrc; openstack --os-project-name manila-service server show manila-service -f value -c id"`
+    manila_service_vm_ip=`oncontroller "source .openrc; openstack --os-project-name manila-service server show manila-service -f value -c addresses|grep -oP '(?<=\bmanila-service=)[^;]+'"`
 }
 
 function addfloatingip()


### PR DESCRIPTION
In 0ef0dc13c17, a new VM is created for Manila's generic driver. The VM
is in an extra project called "manila-service" and to parse the
uuid and the network details with the openstack client, the project
name must be given. Otherwise the details are empty.