### PR TITLE
Cleanup admin node

### DIFF
--- a/scripts/lib/libvirt/cleanup_one_node
+++ b/scripts/lib/libvirt/cleanup_one_node
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import argparse
+
+import libvirt_setup
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description="Cleanup one node via libvirt.")
+    parser.add_argument("nodename", type=str, help="Name of the Node")
+
+    args = parser.parse_args()
+
+    libvirt_setup.domain_cleanup(args.nodename)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -235,7 +235,6 @@ def domain_cleanup(dom):
         pass
 
 
-
 def xml_get_value(path, attrib):
     tree = ET.parse(path)
     return tree.find(attrib).text

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -291,6 +291,15 @@ function cleanup()
     return 0
 }
 
+
+function onhost_cleanup_admin_node()
+{
+    # this function is meant to only clean the admin node
+    # in order to deploy a new one, while keeping all cloud nodes
+
+    ${mkcloud_lib_dir}/libvirt/cleanup_one_node ${cloud}-admin
+}
+
 function onhost_get_next_pv_device()
 {
     if [ -z "$pvlist" ] ; then


### PR DESCRIPTION
support to cleanup admin node inside of an mkcloud deployment - to allow testing the upgrade from cloud5 to cloud6