### PR TITLE
qa_crowbarsetup: Set manilaclient_INSECURE env var

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -440,6 +440,8 @@ export NEUTRONCLIENT_INSECURE=true
 export NOVACLIENT_INSECURE=true
 export SWIFTCLIENT_INSECURE=true
 export CINDERCLIENT_INSECURE=true
+# Extra environment variable because of https://launchpad.net/bugs/1535284
+export manilaclient_INSECURE=true
 export MANILACLIENT_INSECURE=true
 export TROVECLIENT_INSECURE=true
 


### PR DESCRIPTION
It's not full uppercase right now. Keeping the uppercase version in case
this is fixed upstream in the feature.