### PR TITLE
mkcloud: fail on errors during node installation

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -737,14 +737,11 @@ function setupnodes()
 # and wait for nodes to reach the ready state
 function instnodes()
 {
-    onadmin allocate ||\
-        return $?
+    safely onadmin allocate
 
     echo "Waiting for the installation of the nodes ..."
-    onadmin waitcloud
-    onadmin post_allocate
-
-    return $?
+    safely onadmin waitcloud
+    safely onadmin post_allocate
 }
 
 


### PR DESCRIPTION
Some deployments I debugged ignored failures in the installation of the nodes and failed later in the process. To prevent this and follow the rule of fail early, the steps of the instnodes function should exit (via safely) if they detect an error.