### PR TITLE
Add manila generic driver attributes into qa scenario files

### DIFF
--- a/scripts/scenarios/cloud6/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -107,6 +107,16 @@ proposals:
 
 - barclamp: manila
   attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
   deployment:
     elements:
       manila-server:

--- a/scripts/scenarios/cloud6/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2a-sbd-kvm.yaml
@@ -159,6 +159,16 @@ proposals:
 
 - barclamp: manila
   attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
   deployment:
     elements:
       manila-server:

--- a/scripts/scenarios/cloud6/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -111,6 +111,16 @@ proposals:
 
 - barclamp: manila
   attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
   deployment:
     elements:
       manila-server:

--- a/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa-scenario-2c-sbd-kvm.yaml
@@ -108,6 +108,16 @@ proposals:
 
 - barclamp: manila
   attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
   deployment:
     elements:
       manila-server:


### PR DESCRIPTION
Currently all these scenarios are failing due to missing generic driver config, that was added here: https://github.com/SUSE-Cloud/automation/pull/771

Tested successfully here: https://ci.suse.de/view/Cloud/view/ByTopic/view/QA/job/cloud-mkphyscloud-qa-scenario-2a/104/console