### PR TITLE
qa_crowbarsetup: Fail early if manila details are not available

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3023,6 +3023,8 @@ function get_manila_service_instance_details()
 {
     manila_service_vm_uuid=`oncontroller "source .openrc; openstack --os-project-name manila-service server show manila-service -f value -c id"`
     manila_service_vm_ip=`oncontroller "source .openrc; openstack --os-project-name manila-service server show manila-service -f value -c addresses|grep -oP '(?<=\bmanila-service=)[^;]+'"`
+    test -n "$manila_service_vm_uuid" || complain 91 "uuid from manila-service instance not available"
+    test -n "$manila_service_vm_ip" || complain 92 "ip addr from manila-service instance not available"
 }
 
 function addfloatingip()


### PR DESCRIPTION
If uuid and/or ip address are not available for the manila service
VM, abort. Otherwise the Crowbar proposal will fail later due to
the missing values.