### PR TITLE
libvirt_setup: fix cleanup_one_node function

### DIFF
--- a/scripts/lib/libvirt/cleanup_one_node
+++ b/scripts/lib/libvirt/cleanup_one_node
@@ -12,7 +12,7 @@ def main():
 
     args = parser.parse_args()
 
-    libvirt_setup.domain_cleanup(args.nodename)
+    libvirt_setup.cleanup_one_node(args)
 
 if __name__ == "__main__":
     main()

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -185,6 +185,15 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
     return get_config(values, fin)
 
 
+def cleanup_one_node(args):
+    conn = libvirt_connect()
+    try:
+        domain = conn.lookupByName(args.nodename)
+        domain_cleanup(domain)
+    except libvirt.libvirtError:
+        print("no domain found with the name {0}".format(args.nodename))
+
+
 def cleanup(args):
     conn = libvirt_connect()
     domains = [i for i in conn.listAllDomains()


### PR DESCRIPTION
cleanup function expects a dom object and not a string
this was changed (overlooked) as a last refactoring step in the PR #767 

A manual test with this fix was already successful.