### PR TITLE
qa_crowbarsetup: print return code of failed function

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -89,8 +89,10 @@ function complain() # {{{
 } # }}}
 
 safely () {
-    if ! "$@"; then
-        complain 30 "$* failed! Aborting."
+    if "$@"; then
+        true
+    else
+        complain 30 "$* failed! (safelyret=$?) Aborting."
     fi
 }
 


### PR DESCRIPTION
otherwise it can be rather tricky to tell apart failed runs
that all just do exit 30