### PR TITLE
Add qa scenario files without any ssl options

### DIFF
--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -1,0 +1,208 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: ipmi_barclamp
+      sbd:
+        nodes:
+          @@controller1@@:
+            devices:
+            - ''
+          @@controller2@@:
+            devices:
+            - ''
+          @@controller3@@:
+            devices:
+            - ''
+      per_node:
+        nodes:
+          @@controller1@@:
+            params: ''
+          @@controller2@@:
+            params: ''
+          @@controller3@@:
+            params: ''
+    drbd:
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+      hawk-server:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa3/ha-database
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa3/ha-rabbitmq
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+
+- barclamp: keystone
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+
+- barclamp: swift
+  deployment:
+    elements:
+      swift-dispersion:
+      - "@@controller1@@"
+      swift-proxy:
+      - cluster:services
+      swift-ring-compute:
+      - "@@controller1@@"
+      swift-storage:
+      - "@@compute-kvm1@@"
+      - "@@compute-kvm2@@"
+
+- barclamp: glance
+  attributes:
+    default_store: swift
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: local
+      backend_name: file
+      local:
+        volume_name: cinder-volumes
+        file_name: "/var/lib/cinder/volume.raw"
+        file_size: 2000
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: neutron
+  attributes:
+    ml2_mechanism_drivers:
+    - linuxbridge
+    ml2_type_drivers:
+    - vlan
+    ml2_type_drivers_default_provider_network: vlan
+    ml2_type_drivers_default_tenant_network: vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    vnc_keymap: de
+    kvm:
+      ksm_enabled: true
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - "@@compute-kvm1@@"
+      - "@@compute-kvm2@@"
+      nova-compute-qemu: []
+      nova-compute-xen:
+      - "@@compute-xen1@@"
+      - "@@compute-xen2@@"
+
+- barclamp: horizon
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+
+- barclamp: heat
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+
+- barclamp: ceilometer
+  deployment:
+    elements:
+      ceilometer-agent:
+      - "@@compute-kvm1@@"
+      - "@@compute-xen1@@"
+      - "@@compute-kvm2@@"
+      - "@@compute-xen2@@"
+      ceilometer-agent-hyperv: []
+      ceilometer-polling:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: trove
+  attributes:
+    volume_support: true
+  deployment:
+    elements:
+      trove-server:
+      - cluster:services
+
+- barclamp: tempest
+  deployment:
+    elements:
+      tempest:
+      - "@@controller1@@"

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
@@ -1,0 +1,260 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          "@@controller1@@":
+            devices:
+            - "@@sbd_device_services@@"
+          "@@controller2@@":
+            devices:
+            - "@@sbd_device_services@@"
+      per_node:
+        nodes:
+          "@@controller1@@":
+            params: ''
+          "@@controller2@@":
+            params: ''
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      hawk-server:
+      - "@@controller1@@"
+      - "@@controller2@@"
+
+- barclamp: pacemaker
+  name: data
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          "@@data1@@":
+            devices:
+            - "@@sbd_device_data@@"
+          "@@data2@@":
+            devices:
+            - "@@sbd_device_data@@"
+      per_node:
+        nodes:
+          "@@data1@@":
+            params: ''
+          "@@data2@@":
+            params: ''
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - "@@data1@@"
+      - "@@data2@@"
+      hawk-server:
+      - "@@data1@@"
+      - "@@data2@@"
+
+- barclamp: pacemaker
+  name: network
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          "@@network1@@":
+            devices:
+            - "@@sbd_device_network@@"
+          "@@network2@@":
+            devices:
+            - "@@sbd_device_network@@"
+      per_node:
+        nodes:
+          "@@network1@@":
+            params: ''
+          "@@network2@@":
+            params: ''
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - "@@network1@@"
+      - "@@network2@@"
+      hawk-server:
+      - "@@network1@@"
+      - "@@network2@@"
+
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa2/ha-database
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      database-server:
+      - cluster:data
+
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa2/ha-rabbitmq
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:data
+
+- barclamp: keystone
+  attributes:
+    signing:
+      token_format: UUID
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+
+- barclamp: swift
+  attributes:
+    keystone_delay_auth_decision: true
+    allow_versions: true
+  deployment:
+    elements:
+      swift-dispersion:
+      - "@@controller1@@"
+      swift-proxy:
+      - cluster:services
+      swift-ring-compute:
+      - "@@controller1@@"
+      swift-storage:
+      - "@@controller2@@"
+      - "@@computekvm@@"
+
+- barclamp: glance
+  attributes:
+    default_store: swift
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - "@@data1@@"
+      - "@@data2@@"
+
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: local
+      backend_name: default
+      raw:
+        volume_name: cinder-volumes
+        cinder_raw_method: first
+      local:
+        volume_name: cinder-volumes
+        file_name: "/var/lib/cinder/volume.raw"
+        file_size: 2000
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - "@@data1@@"
+      - "@@data2@@"
+
+- barclamp: neutron
+  attributes:
+    ml2_mechanism_drivers:
+    - linuxbridge
+    ml2_type_drivers:
+    - vlan
+    ml2_type_drivers_default_provider_network: vlan
+    ml2_type_drivers_default_tenant_network: vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:network
+      neutron-network:
+      - cluster:network
+
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    vnc_keymap: de
+    kvm:
+      ksm_enabled: true
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - "@@computekvm@@"
+      nova-compute-qemu: []
+      nova-compute-xen: []
+
+- barclamp: horizon
+  attributes:
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+
+- barclamp: heat
+  attributes:
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+
+- barclamp: ceilometer
+  attributes:
+  deployment:
+    elements:
+      ceilometer-agent:
+      - "@@computekvm@@"
+      ceilometer-agent-hyperv: []
+      ceilometer-polling:
+      - cluster:services
+      ceilometer-polling:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware: []
+
+- barclamp: trove
+  attributes:
+    volume_support: true
+  deployment:
+    elements:
+      trove-server:
+        - cluster:services
+
+- barclamp: tempest
+  attributes:
+  deployment:
+    elements:
+      tempest:
+      - "@@controller1@@"

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -1,0 +1,223 @@
+---
+# Placeholders for node devices must be replaced by some real values
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          "@@controller1@@":
+            devices:
+            - "@@sbd_device@@"
+          "@@controller2@@":
+            devices:
+            - "@@sbd_device@@"
+          "@@controller3@@":
+            devices:
+            - "@@sbd_device@@"
+      per_node:
+        nodes:
+          "@@controller1@@":
+            params: ''
+          "@@controller2@@":
+            params: ''
+          "@@controller3@@":
+            params: ''
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+      hawk-server:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa2/ha-database
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa2/ha-rabbitmq
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+
+- barclamp: keystone
+  attributes:
+    signing:
+      token_format: UUID
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+
+- barclamp: swift
+  keystone_delay_auth_decision: true
+  allow_versions: true
+  deployment:
+    elements:
+      swift-dispersion:
+      - "@@controller1@@"
+      swift-proxy:
+      - cluster:services
+      swift-ring-compute:
+      - "@@controller1@@"
+      swift-storage:
+      - "@@computekvm1@@"
+      - "@@computekvm2@@"
+
+- barclamp: glance
+  attributes:
+    default_store: swift
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+# vcenter credentials must be replaced by some real values
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: vmware
+      backend_name: vmware-backend
+      vmware:
+        volume_folder: cinder-vmw-volume
+        host: vcs.qa.suse.de
+        user: "@@vcenter_user@@"
+        password: "@@vcenter_password@@"
+        cluster_name: []
+        insecure: true
+        ca_file: ""
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: neutron
+  attributes:
+    ml2_mechanism_drivers:
+    - openvswitch
+    ml2_type_drivers:
+    - vlan
+    ml2_type_drivers_default_provider_network: vlan
+    ml2_type_drivers_default_tenant_network: vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+
+# vcenter credentials must be replaced by some real values
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    vnc_keymap: de
+    kvm:
+      ksm_enabled: true
+    vcenter:
+      clusters:
+      - QA
+      host: vcs.qa.suse.de
+      user: "@@vcenter_user@@"
+      password: "@@vcenter_password@@"
+
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - "@@computekvm1@@"
+      - "@@computekvm2@@"
+      nova-compute-qemu: []
+      nova-compute-xen: []
+      nova-compute-vmware:
+      - "@@computevmw@@"
+
+- barclamp: horizon
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+
+- barclamp: heat
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+
+- barclamp: ceilometer
+  deployment:
+    elements:
+      ceilometer-agent:
+      - "@@computekvm1@@"
+      - "@@computekvm2@@"
+      - "@@computevmw@@"
+      ceilometer-agent-hyperv: []
+      ceilometer-polling:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware: []
+
+- barclamp: trove
+  attributes:
+    swift_instance: ''
+    volume_support: true
+  deployment:
+    elements:
+      trove-server:
+        - cluster:services
+
+- barclamp: tempest
+  deployment:
+    elements:
+      tempest:
+      - "@@controller1@@"

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c-sbd-kvm.yaml
@@ -1,0 +1,199 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          @@controller1@@:
+            devices:
+            - "/dev/sda"
+          @@controller2@@:
+            devices:
+            - "/dev/sda"
+      per_node:
+        nodes:
+          @@controller1@@:
+            params: ''
+          @@controller2@@:
+            params: ''
+    drbd:
+      enabled: true
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - @@controller1@@
+      - @@controller2@@
+      hawk-server:
+      - @@controller1@@
+      - @@controller2@@
+
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+
+- barclamp: keystone
+  attributes:
+    signing:
+      token_format: UUID
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+
+- barclamp: ceph
+  attributes:
+    disk_mode: first
+  deployment:
+    elements:
+      ceph-calamari: []
+      ceph-mon:
+      - @@ceph1@@
+      - @@ceph2@@
+      - @@ceph3@@
+      ceph-osd:
+      - @@ceph1@@
+      - @@ceph2@@
+      - @@ceph3@@
+      ceph-radosgw:
+      - @@ceph1@@
+
+- barclamp: glance
+  attributes:
+    default_store: rbd
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - @@controller1@@
+      - @@controller2@@
+
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: rbd
+      backend_name: rbd
+      rbd:
+        use_crowbar: true
+        config_file: "/etc/ceph/ceph.conf"
+        admin_keyring: "/etc/ceph/ceph.client.admin.keyring"
+        pool: volumes
+        user: cinder
+        secret_uuid: ''
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - @@controller1@@
+      - @@controller2@@
+
+- barclamp: neutron
+  attributes:
+    ml2_mechanism_drivers:
+    - linuxbridge
+    ml2_type_drivers:
+    - vlan
+    ml2_type_drivers_default_provider_network: vlan
+    ml2_type_drivers_default_tenant_network: vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    vnc_keymap: de
+    kvm:
+      ksm_enabled: true
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - @@compute1@@
+      - @@compute2@@
+      nova-compute-qemu: []
+      nova-compute-xen: []
+
+- barclamp: horizon
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+
+- barclamp: heat
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+
+- barclamp: ceilometer
+  deployment:
+    elements:
+      ceilometer-agent:
+      - @@compute1@@
+      - @@compute2@@
+      ceilometer-agent-hyperv: []
+      ceilometer-polling:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware: []
+
+- barclamp: trove
+  deployment:
+    elements:
+      trove-server:
+      - cluster:services
+
+- barclamp: tempest
+  deployment:
+    elements:
+      tempest:
+      - @@controller1@@

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-6a-ipmi-kvm-docker.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-6a-ipmi-kvm-docker.yaml
@@ -1,0 +1,168 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: ipmi_barclamp
+      sbd:
+        nodes:
+          "@@controller1@@":
+            devices:
+            - ''
+          "@@controller2@@":
+            devices:
+            - ''
+          "@@controller3@@":
+            devices:
+            - ''
+      per_node:
+        nodes:
+          "@@controller1@@":
+            params: ''
+          "@@controller2@@":
+            params: ''
+          "@@controller3@@":
+            params: ''
+    drbd:
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+      hawk-server:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa3/ha-database
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        shared:
+          device: 10.162.26.129:/var/qa3/ha-rabbitmq
+          fstype: nfs
+          options: nfsvers=3
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+
+- barclamp: keystone
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+
+- barclamp: glance
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: local
+      backend_name: local_file
+      local:
+        volume_name: cinder-volumes
+        file_name: "/var/lib/cinder/volume.raw"
+        file_size: 2000
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - "@@controller3@@"
+      - "@@controller1@@"
+      - "@@controller2@@"
+
+- barclamp: neutron
+  attributes:
+    ml2_mechanism_drivers:
+    - linuxbridge
+    ml2_type_drivers:
+    - vlan
+    ml2_type_drivers_default_provider_network: vlan
+    ml2_type_drivers_default_tenant_network: vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    vnc_keymap: de
+    kvm:
+      ksm_enabled: true
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - "@@kvm1@@"
+      - "@@kvm2@@"
+      nova-compute-qemu: []
+      nova-compute-xen: []
+      nova-compute-docker:
+      - "@@docker1@@"
+      - "@@docker2@@"
+
+- barclamp: horizon
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+
+- barclamp: heat
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+
+- barclamp: ceilometer
+  deployment:
+    elements:
+      ceilometer-agent:
+      - "@@kvm2@@"
+      - "@@kvm1@@"
+      - "@@docker1@@"
+      - "@@docker2@@"
+      ceilometer-agent-hyperv: []
+      ceilometer-polling:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware: []
+
+- barclamp: trove
+  deployment:
+    elements:
+      trove-server:
+      - cluster:services
+
+- barclamp: tempest
+  deployment:
+    elements:
+      tempest:
+      - "@@controller1@@"


### PR DESCRIPTION
As already mentioned here https://github.com/SUSE-Cloud/automation/pull/783 , this is the the second batch of our qa scenarios with no ssl configuration. The goal is to have separate scenarios globally for no-ssl, ssl and ssl-insecure setup. 