### PR TITLE
qa_openstack: install genisoimage

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -139,6 +139,9 @@ fi
 # run twice, first installs zypper update, then the rest
 $zypper -n patch --skip-interactive || $zypper -n patch --skip-interactive
 
+# make sure that genisoimage is installed
+$zypper in --no-recommends genisoimage
+
 # grizzly or master does not want dlp
 $zypper rr dlp || true
 


### PR DESCRIPTION
This will fix cleanvm fails in SLE12SP1, like this one:

https://ci.opensuse.org/view/OpenStack/job/openstack-cleanvm/image=SLE_12_SP1,openstack_project=Liberty,slave=cloud-cleanvm/lastBuild/consoleText