### PR TITLE
Recommit neutron proposal after nova proposal

### DIFF
--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
@@ -191,6 +191,7 @@ proposals:
     - vlan
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
+    use_lbaas: false
   deployment:
     elements:
       neutron-server:
@@ -214,6 +215,12 @@ proposals:
       - "@@computekvm@@"
       nova-compute-qemu: []
       nova-compute-xen: []
+
+# Because neutron and nova are deployed on different clusters, we need
+# to commit neutron proposal again after nova to pick up the nova authentication
+- barclamp: neutron
+  attributes:
+    use_lbaas: true
 
 - barclamp: horizon
   attributes:

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a-sbd-kvm.yaml
@@ -215,6 +215,7 @@ proposals:
       insecure: true
     api:
       protocol: https
+    use_lbaas: false
   deployment:
     elements:
       neutron-server:
@@ -245,6 +246,12 @@ proposals:
       - "@@computekvm@@"
       nova-compute-qemu: []
       nova-compute-xen: []
+
+# Because neutron and nova are deployed on different clusters, we need
+# to commit neutron proposal again after nova to pick up the nova authentication
+- barclamp: neutron
+  attributes:
+    use_lbaas: true
 
 - barclamp: horizon
   attributes:


### PR DESCRIPTION
On first commit, the neutron proposal didn't have the
nova authentication credentials yet, so we need to
commit neutron again after nova.