### PR TITLE
Fix manila deployment order

### DIFF
--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -89,27 +89,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
-
 - barclamp: cinder
   attributes:
     volumes:
@@ -189,6 +168,27 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
       - "@@controller1@@"
       - "@@controller2@@"
       - "@@controller3@@"

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
@@ -143,26 +143,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - "@@data1@@"
-      - "@@data2@@"
-
 - barclamp: cinder
   attributes:
     volumes:
@@ -250,6 +230,26 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware: []
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - "@@data1@@"
+      - "@@data2@@"
 
 - barclamp: trove
   attributes:

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -94,27 +94,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
-
 # vcenter credentials must be replaced by some real values
 - barclamp: cinder
   attributes:
@@ -206,6 +185,27 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware: []
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
 
 - barclamp: trove
   attributes:

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c-sbd-kvm.yaml
@@ -88,26 +88,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - @@controller1@@
-      - @@controller2@@
-
 - barclamp: cinder
   attributes:
     volumes:
@@ -185,6 +165,26 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware: []
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - @@controller1@@
+      - @@controller2@@
 
 - barclamp: trove
   deployment:

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -105,27 +105,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
-
 - barclamp: cinder
   attributes:
     volumes:
@@ -228,6 +207,27 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
       - "@@controller1@@"
       - "@@controller2@@"
       - "@@controller3@@"

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a-sbd-kvm.yaml
@@ -157,26 +157,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - "@@data1@@"
-      - "@@data2@@"
-
 - barclamp: cinder
   attributes:
     volumes:
@@ -284,6 +264,26 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware: []
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - "@@data1@@"
+      - "@@data2@@"
 
 # FIXME: disabled due to issues in trove with insecure SSL (https://bugs.launchpad.net/trove/+bug/1535895)
 #- barclamp: trove

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -109,27 +109,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
-
 # vcenter credentials must be replaced by some real values
 - barclamp: cinder
   attributes:
@@ -239,6 +218,27 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware: []
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
 
 # FIXME: disabled due to issues in trove with insecure SSL (https://bugs.launchpad.net/trove/+bug/1535895)
 #- barclamp: trove

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2c-sbd-kvm.yaml
@@ -107,26 +107,6 @@ proposals:
       glance-server:
       - cluster:services
 
-- barclamp: manila
-  attributes:
-    shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: fixed
-        service_instance_password: linux
-        share_volume_fstype: ext3
-  deployment:
-    elements:
-      manila-server:
-      - cluster:services
-      manila-share:
-      - @@controller1@@
-      - @@controller2@@
-
 - barclamp: cinder
   attributes:
     volumes:
@@ -224,6 +204,26 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware: []
+
+- barclamp: manila
+  attributes:
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: fixed
+        service_instance_password: linux
+        share_volume_fstype: ext3
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - @@controller1@@
+      - @@controller2@@
 
 - barclamp: trove
   deployment:


### PR DESCRIPTION
Manila proposal can only be deployed after cinder, glance
and nova have been created.