### PR TITLE
Help crowbar backend to handle renames and allocations

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1917,6 +1917,7 @@ function onadmin_allocate()
     local m
     for m in `get_all_discovered_nodes` ; do
         crowbar machines allocate $m
+        sleep 1
         local i=$(echo $m | sed "s/.*-0\?\([^-\.]*\)\..*/\1/g")
         cat >> .ssh/config <<EOF
 Host node$i

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2969,6 +2969,7 @@ function set_node_alias()
     local node_alias=$2
     if [[ "${node_name}" != "${node_alias}" ]]; then
         crowbar machines rename ${node_name} ${node_alias}
+        sleep 1
     fi
 }
 


### PR DESCRIPTION
Sometimes the requests for renaming and allocation are being ignored by crowbar which causes QA scenarios to fail. Adding a short sleep might help.