### PR TITLE
qa_crowbarsetup: Fix manila share type creation

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3238,7 +3238,7 @@ function oncontroller_testsetup()
 
     if iscloudver 6plus && \
         ! openstack catalog show manila 2>&1 | grep -q "service manila not found" && \
-        ! manila type-list | grep -q "default" ; then
+        ! manila type-list | grep -q "[[:space:]]default[[:space:]]" ; then
         manila type-create default false || complain 79 "manila type-create failed"
     fi
 


### PR DESCRIPTION
When listing share types, the header has a "is_default" string.
So searching for "default" always matches and a share type is never
created.