### PR TITLE
Regenerate spec files before downloading tarballs

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
@@ -41,9 +41,9 @@
           osc co ${OBS_TEST_PROJECT}
           cp ${TEMP_DIR}/rpm-packaging-0.0.1.tar.bz2 ${OBS_TEST_PROJECT}/rpm-packaging-openstack
           pushd ${OBS_TEST_PROJECT}/rpm-packaging-openstack
+          bash -x pre_checkin.sh
           # download source files (needed for i.e. version updates or newly added .spec files)
           osc service run download_files
-          bash -x pre_checkin.sh
           osc addremove
           osc status
           osc commit -m "rpm-packaging CI (${ZUUL_CHANGES})"


### PR DESCRIPTION
Otherwise it doesn't download the tarball ofthe new version
but of the old version, which doesn't make sense