### PR TITLE
qa_openstack: Don't use mirror for now

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -217,7 +217,7 @@ ssh_user="root"
 mirror=http://149.44.161.38/images # ci1-opensuse
 
 cirros_base_url="http://download.cirros-cloud.net/0.3.4/"
-cirros_base_url="$mirror"
+# cirros_base_url="$mirror"
 cirros_base_name="cirros-0.3.4-x86_64"
 
 # since glanceclient Liberty, --is-public is gone and --visibility should be used


### PR DESCRIPTION
Currently 149.44.161.38 is our internal zuul instance. So /images
is not available and the cirros image can not be downloaded.