### PR TITLE
Add possibility to skip manila deployment

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2898,6 +2898,8 @@ function deploy_single_proposal()
             [[ -n "$deployceph" ]] || continue
             ;;
         manila)
+            # manila-service can not be deployed currently with docker
+            [[ -n "$want_docker" ]] || continue
             if ! iscloudver 6plus; then
                 # manila barclamp is only in SC6+ and develcloud5 with SLE12CC5
                 if ! [[ "$cloudsource" == "develcloud5" ]] || [ -z "$want_sles12" ]; then


### PR DESCRIPTION
"want_manila" is a new env var (default '1') which can be set to 0
to disable manila deployment.