### PR TITLE
xen: Add more memory to Xen nodes

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -96,6 +96,8 @@ needcvol=1
 : ${compute_node_memory:=2097152}
 : ${hyperv_node_memory:=3000000}
 [[ "$libvirt_type" = "hyperv" && $compute_node_memory -lt $hyperv_node_memory ]] && compute_node_memory=$hyperv_node_memory
+: ${xen_node_memory:=4000000}
+[[ "$libvirt_type" = "xen" && $compute_node_memory -lt $xen_node_memory ]] && compute_node_memory=$xen_node_memory
 # hdd size defaults (unless defined otherwise)
 : ${adminnode_hdd_size:=15}
 : ${controller_hdd_size:=20}


### PR DESCRIPTION
When using Xen, dom0 uses half of the memory and with our current xen job,
nova-compute can not be started due to missing memory.
This leads to a ComputerFilter error in the nova scheduler and no
manila-service VM or other VMs during testing can be started.
So add more memory to the nodes.