### PR TITLE
Ceil-swift-proxy-middleware not to use cluster

### DIFF
--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a-ha-kvm-swift.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a-ha-kvm-swift.yaml
@@ -155,7 +155,9 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware:
-      - cluster:services
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
 - barclamp: tempest
   attributes:
   deployment:


### PR DESCRIPTION
In qa scenario 1a, the role ceilometer-swift-proxy-middleware is trying
to use a cluster for it's configuration (it is an HA deployment), but
that option is not supported. Instead this patch replaces the cluster
for its individual members, as it is defined in scenario 1b.