### PR TITLE
jenkins: Add hacloud=1 to cloud-mkcloud6-job-ha-compute

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-mkcloud6-job-ha-compute.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mkcloud6-job-ha-compute.yaml
@@ -19,6 +19,7 @@
             TESTHEAD=1
             cloudsource=develcloud6
             nodenumber=4
+            hacloud=1
             mkcloudtarget=all_batch
             scenario=cloud6-4nodes-compute-ha.yml
             want_node_aliases=controller=2,compute=2


### PR DESCRIPTION
Without this, the HA repos are not used.