### PR TITLE
qa_crowbarsetup: Do not fail when there's no manila proposal

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4066,8 +4066,9 @@ function onadmin_run_cct()
                 # Add functional tests if the proposal is deployed
                 # and the functional test scenario is implemented in cct.
                 for test in "nova" "manila"; do
-                    safely crowbarctl proposal list $test &> /dev/null && \
+                    if crowbarctl proposal list $test &> /dev/null; then
                         cct_tests+="+test:func:${test}client"
+                    fi
                 done
                 ;;
         esac


### PR DESCRIPTION
"false && foobar" is still giving an exit code of 1. We have the same
here, and this makes qa_crowbarsetup fail.