### PR TITLE
qa_crowbarsetup: Add missing pre_hook call in onadmin_batch

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4186,6 +4186,8 @@ function onadmin_setup_aliases()
 
 function onadmin_batch()
 {
+    pre_hook $FUNCNAME
+
     if iscloudver 5plus; then
         sed -i "s/##hypervisor_ip##/$admingw/g" ${scenario}
         if iscloudver 7plus || (iscloudver 6 && ! [[ $cloudsource =~ ^M[1-8]$ ]]); then


### PR DESCRIPTION
This matters because setcloudnetvars wasn't called.