### PR TITLE
scenarios: Add required "path_to_private_key" to manila

### DIFF
--- a/scripts/scenarios/cloud6/cloud6-2nodes-default.yml
+++ b/scripts/scenarios/cloud6/cloud6-2nodes-default.yml
@@ -60,6 +60,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/cloud6-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud6/cloud6-4nodes-compute-ha.yml
@@ -178,6 +178,7 @@ proposals:
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
   deployment:
     elements:
       manila-server:

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -182,6 +182,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a-sbd-kvm.yaml
@@ -239,6 +239,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -196,6 +196,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c-sbd-kvm.yaml
@@ -176,6 +176,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b-ipmi-kvm-xen.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b-ipmi-kvm-xen.yaml
@@ -221,6 +221,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a-sbd-kvm.yaml
@@ -273,6 +273,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b-sbd-kvm-vmware.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b-sbd-kvm-vmware.yaml
@@ -229,6 +229,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2c-sbd-kvm.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2c-sbd-kvm.yaml
@@ -215,6 +215,7 @@ proposals:
         service_instance_user: root
         service_instance_password: linux
         share_volume_fstype: ext3
+        path_to_private_key: ""
         service_instance_name_or_id: ##manila_instance_name_or_id##
         service_net_name_or_ip: ##service_net_name_or_ip##
         tenant_net_name_or_ip: ##tenant_net_name_or_ip##


### PR DESCRIPTION
"path_to_private_key" is now mandatory when deploying manila.