### PR TITLE
qa_crowbarsetup: Wait for node name to be resolvable before ssh'ing in

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1747,6 +1747,7 @@ function set_node_raid()
     local t=$(mktemp).json
     knife node show -F json "$node" > $t
 
+    wait_for 10 5 "host $node &> /dev/null" "$node to be resolvable in DNS"
     # to find out available disks, we need to look at the nodes directly
     raid_disks=`ssh $node lsblk -n -d | cut -d' ' -f 1 | head -n $disks_count`
     raid_disks=`printf "\"/dev/%s\"," $raid_disks`


### PR DESCRIPTION
When we set the raid type for a node, we ssh in. However, it could be
that the DNS hasn't been udpated yet (there's a small race window
there). So wait for that.