### PR TITLE
Allow access to high-ports in manila-service-vm

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3201,6 +3201,7 @@ function oncontroller_manila_generic_driver_setup()
     nova secgroup-add-rule $sec_group icmp -1 -1 0.0.0.0/0
     nova secgroup-add-rule $sec_group tcp 22 22 0.0.0.0/0
     nova secgroup-add-rule $sec_group tcp 2049 2049 0.0.0.0/0
+    nova secgroup-add-rule $sec_group tcp 20000 65535 0.0.0.0/0
     nova secgroup-add-rule $sec_group udp 2049 2049 0.0.0.0/0
     nova secgroup-add-rule $sec_group udp 445 445 0.0.0.0/0
     nova secgroup-add-rule $sec_group tcp 445 445 0.0.0.0/0


### PR DESCRIPTION
The manila service VM needs to receive traffic on high ports
as they are used by NFS for mount negotiation (the rpc services
mountd, lockd and statd are listening on unpredictable high
ports)