### PR TITLE
qa_crowbarsetup: Look for errors in glance-scrubber log

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3328,6 +3328,8 @@ function oncontroller_testsetup()
     if iscloudver 6plus || [[ $cloudsource =~ develcloud ]]; then
         su - glance -s /bin/sh -c "/usr/bin/glance-scrubber" \
             || complain 113 "Glance scrubber doesn't work properly"
+        grep -v glance_store /var/log/glance/scrubber.log | grep ERROR \
+            && complain 114 "Unexpected errors in glance-scrubber logs"
     fi
 
     if [ -n "$want_docker" ] ; then


### PR DESCRIPTION
It seems glance-scrubber doesn't always exit with non-0 on failures, so
also look at the logs for errors.

Note that we filter out glance_store errors because they're not
relevant, and always happen with the default config:
  ERROR glance_store._drivers.filesystem [-] Specify at least 'filesystem_store_datadir' or 'filesystem_store_datadirs' option