### PR TITLE
qa_crowbarsetup: Wait for chef-client run after restore

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4064,6 +4064,8 @@ function onadmin_crowbarrestore()
             crowbar_restore_status
             complain 37 "Crowbar restore from backup failed."
         fi
+        # wait for chef-client run to be completed
+        flock -w 120 /var/chef/cache/chef-client-running.pid true
     else
         do_set_repos_skip_checks
 


### PR DESCRIPTION
Otherwise, we might be too fast and use crowbar while it's not fully
reconfigured yet.

Workaround until https://github.com/crowbar/crowbar-core/pull/359 is
ready and merged.