### PR TITLE
qa_crowbarsetup: dont build RAID without disks (bsc#967878)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1752,7 +1752,7 @@ function set_node_raid()
     local t=$(mktemp).json
     knife node show -F json "$node" > $t
 
-    wait_for 10 5 "host $node &> /dev/null" "$node to be resolvable in DNS"
+    wait_for 10 5 "getent hosts $node &> /dev/null" "$node name to be resolvable"
     # to find out available disks, we need to look at the nodes directly
     raid_disks=`ssh $node lsblk -n -d | cut -d' ' -f 1 | head -n $disks_count`
     test -n "$raid_disks" || complain 90 "no raid disks found on $node"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1755,6 +1755,7 @@ function set_node_raid()
     wait_for 10 5 "host $node &> /dev/null" "$node to be resolvable in DNS"
     # to find out available disks, we need to look at the nodes directly
     raid_disks=`ssh $node lsblk -n -d | cut -d' ' -f 1 | head -n $disks_count`
+    test -n "$raid_disks" || complain 90 "no raid disks found on $node"
     raid_disks=`printf "\"/dev/%s\"," $raid_disks`
     raid_disks="[ ${raid_disks%,} ]"
 


### PR DESCRIPTION
this makes other problems more obvious such as
++ ssh d52-54-77-77-77-01.vd3.cloud.suse.de lsblk -n -d
++ cut '-d ' -f 1
++ head -n 2
ssh: Could not resolve hostname d52-54-77-77-77-01.vd3.cloud.suse.de: Name or service not known
+ raid_disks=