### PR TITLE
Fix glance-scrubber test for cloud 5 and older

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3328,7 +3328,9 @@ function oncontroller_testsetup()
 
     #test for Glance scrubber service, added after bnc#930739
     if iscloudver 6plus || [[ $cloudsource =~ develcloud ]]; then
-        su - glance -s /bin/sh -c "/usr/bin/glance-scrubber" \
+        configargs="--config-dir /etc/glance"
+        iscloudver 6plus && configargs=""
+        su - glance -s /bin/sh -c "/usr/bin/glance-scrubber $configargs" \
             || complain 113 "Glance scrubber doesn't work properly"
         grep -v glance_store /var/log/glance/scrubber.log | grep ERROR \
             && complain 114 "Unexpected errors in glance-scrubber logs"


### PR DESCRIPTION
Cloud5 and older used a different way of invocing glance-scrubber
from cron, so it makes sense to use that one instead.