### PR TITLE
Check return value of osc in rpm-packaging job

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-gerrit-rpm-packaging.yaml
@@ -63,6 +63,10 @@
                   unset pending
                   unset failed
                   res=`osc results --csv -w -r SLE_12`
+                  if [ $? -ne 0 ]; then
+                      sleep 5
+                      continue
+                  fi
                   echo ">>: ${res}"
                   for r in $res; do
                       # some failures?


### PR DESCRIPTION
Otherwise in case the osc commands fails, the job exits with 0 and
the build looks good ut in fact it's maybe broken.
This happened i.e. when osc returned non-zero and reported:

SSL Error: (104, 'Connection reset by peer')