### PR TITLE
qa_devstack: Be sure which is installed

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -90,7 +90,7 @@ function h_setup_extra_disk {
 }
 
 function h_setup_devstack {
-    $zypper in git-core
+    $zypper in git-core which
     # git clone https://github.com/openstack-dev/devstack.git $DEVSTACK_DIR
     git clone https://github.com/dirkmueller/devstack.git $DEVSTACK_DIR
 


### PR DESCRIPTION
It's required to run devstack. The shell builtin doesn't work as expected.