### PR TITLE
qa_devstack: Switch back to upstream repo

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -93,8 +93,7 @@ function h_setup_extra_disk {
 
 function h_setup_devstack {
     $zypper in git-core which
-    # git clone https://github.com/openstack-dev/devstack.git $DEVSTACK_DIR
-    git clone https://github.com/dirkmueller/devstack.git $DEVSTACK_DIR
+    git clone https://github.com/openstack-dev/devstack.git $DEVSTACK_DIR
 
     # setup non-root user (username is "stack")
     (cd $DEVSTACK_DIR && ./tools/create-stack-user.sh)


### PR DESCRIPTION
Our SUSE fixes are merged so there's no need to use a private
repo for devstack.