### PR TITLE
mkcloud: pass custom URLs to qa_crowbarsetup

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -204,6 +204,8 @@ function sshrun()
         export cloud=$virtualcloud ;
         # hostname of NFS server with repos and images:
         export clouddata=$clouddata ;
+        export distsuse=$distsuse ;
+        export susedownload=$susedownload ;
         export cloudfqdn=$cloudfqdn ;
         export cloudsource=$cloudsource ;
         export upgrade_cloudsource=$upgrade_cloudsource ;


### PR DESCRIPTION
In order to allow to overwrite the URLs for distsuse, susedownload
and clouddata all these variables need to be passed to qa_crobarsetup.