### PR TITLE
qa_crowbarsetup: improve reboot test coverage

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3484,10 +3484,10 @@ function oncontroller_testsetup()
     fi
 
     # cleanup so that we can run testvm without leaking volumes, IPs etc
-    nova remove-floating-ip "$instanceid" "$floatingip"
-    nova floating-ip-delete "$floatingip"
-    nova stop "$instanceid"
-    wait_for 100 1 "test \"x\$(nova show \"$instanceid\" | perl -ne 'm/ status [ |]*([a-zA-Z]+)/ && print \$1')\" == xSHUTOFF" "testvm to stop"
+    #nova remove-floating-ip "$instanceid" "$floatingip"
+    #nova floating-ip-delete "$floatingip"
+    #nova stop "$instanceid"
+    #wait_for 100 1 "test \"x\$(nova show \"$instanceid\" | perl -ne 'm/ status [ |]*([a-zA-Z]+)/ && print \$1')\" == xSHUTOFF" "testvm to stop"
 
     if iscloudver 6plus ; then
         # check that no port is in binding_failed state


### PR DESCRIPTION
because we observed a problem with
cinder local loop-device backend
where the thin volume was not activated on boot
thus tgtd errors ; and one cannot start instance with that attached volume
