### PR TITLE
better handling of manila image download

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3232,8 +3232,12 @@ function oncontroller_manila_generic_driver_setup()
     local sec_group="manila-service"
     local neutron_net=$sec_group
 
-    wget --progress=dot:mega -nc -O $service_image_name \
-        "$service_image_url" || complain 73 "manila image not found"
+    local ret=$(wget --progress=dot:mega -nc -O $service_image_name "$service_image_url" 2>&1 >/dev/null)
+    if [[ $ret =~ "already there; not retrieving" ]]; then
+        echo $ret
+    elif [[ $ret =~ "Not Found" ]]; then
+        complain 73 "manila image not found"
+    fi
 
     . .openrc
     manila_service_tenant_id=`openstack project create manila-service -f value -c id`


### PR DESCRIPTION
the problem is when the image is already there, which happens to be
the case in an upgrade scenario, wget comes back with 1 and though
runs into the complain


```
18:52:29 + wget --progress=dot:mega -nc -O manila-service-image.qcow2 http://149.44.176.43/images/other/manila-service-image.qcow2
18:52:29 File `manila-service-image.qcow2' already there; not retrieving.
18:52:29 + complain 73 'manila image not found'
18:52:29 + local ex=73
18:52:29 + shift
18:52:29 + printf 'Error: %s\n' 'manila image not found'
```