### PR TITLE
Automatically determine a default nodenumber for physical clouds

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1104,7 +1104,7 @@ Optional
         Set the size in GB of data disk attached in compute nodes with enabled 'cephvolumenumber'
     controller_ceph_hdd_size (default 25)
         Set the size in GB of data disk attached in controller node  with enabled 'cephvolumenumber'
-    nodenumber=2    (default 2)
+    nodenumber=2    (default 2 for virtual clouds)
         set the number of nodes to be created for the cloud (excluding admin node)
         In HA mode (hacloud=1) the nodes needed for clusters are subtracted from nodenumber; the
         remaining nodes are compute nodes.

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -49,7 +49,7 @@ crowbar_api_installer_path=/installer/installer
 crowbar_api_digest="--digest -u crowbar:crowbar"
 crowbar_install_log=/var/log/crowbar/install.log
 
-export nodenumber=${nodenumber:-2}
+export nodenumber
 export tempestoptions=${tempestoptions:--t -s}
 export want_sles12
 [[ "$want_sles12" = 0 ]] && want_sles12=
@@ -213,8 +213,7 @@ setcloudnetvars()
             want_ipmi=true
         ;;
         qa4)
-            nodenumber=7
-            nodenumbertotal=8
+            nodenumbertotal=7
             net=${netp}.66
             net_public=$net
             vlan_public=715
@@ -241,7 +240,8 @@ setcloudnetvars()
             want_ipmi=true
         ;;
         virtual)
-                    true # defaults are fine (and overridable)
+            nodenumber=2
+            true # defaults are fine (and overridable)
         ;;
         cumulus)
             net=$netp.189
@@ -251,7 +251,8 @@ setcloudnetvars()
             vlan_fixed=578
         ;;
         *)
-                    true # defaults are fine (and overridable)
+            nodenumber=2
+            true # defaults are fine (and overridable)
         ;;
     esac
     test -n "$nodenumbertotal" && nodenumber=${nodenumber:-$nodenumbertotal}


### PR DESCRIPTION
kbaikov pointed out that he'd prefer to have cloud=qaX select the
full sized cloud by default rather than the previous default of 2 nodes.