### PR TITLE
Disable manila functional tests for now

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4208,7 +4208,9 @@ function onadmin_run_cct()
         esac
 
         if iscloudver 6plus; then
-            for test in "nova" "manila"; do
+            # 2017-03-29: manila functional tests are hitting frequently a timeout, disable for now
+            # for test in "nova" "manila"; do
+            for test in "nova" ; do
                 if crowbarctl proposal list $test &> /dev/null; then
                     cct_tests+="+test:func:${test}client"
                 fi


### PR DESCRIPTION
They frequently timeout / fail which causes a lot more trouble than
its worth. Fixing it is tracked in https://trello.com/c/jafB2kpq