### PR TITLE
set testr with update alternatives

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3177,6 +3177,12 @@ function oncontroller_run_tempest()
 {
     local image_name="SLES11-SP3-x86_64-cfntools"
 
+    # make sure /etc/alternatives/testr is set correctly
+    # otherwise it could point e.g. to /usr/bin/testr-2.6
+    # on a system (with /usr/bin/testr-2.7) where it doesn't exist
+    # same goes for subunit-2to1
+    testr -h || update-alternatives --auto testr && update-alternatives --auto subunit-2to1
+
     # Upload a Heat-enabled image
     if ! glance_image_exists $image_name; then
         curl -s \


### PR DESCRIPTION
in an upgrade from 5to6 somehow testr points to /usr/bin/testr-2.6
which soes not exist. there is /usr/bin/testr-2.7 instead so we
need to set the right path with update-alternatives


```
17:10:42 + ./run_tempest.sh -N -t -s
17:10:42 + tee tempest.log
17:10:42 ./run_tempest.sh: line 90: testr: command not found
17:10:42 ./run_tempest.sh: line 107: testr: command not found
17:10:42 ./run_tempest.sh: line 107: subunit-2to1: command not found
```