### PR TITLE
qa_openstack: Fix openstackquickstartrc debugging

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -203,9 +203,9 @@ if [ -n "$QUICKSTART_DEBUG" ]; then
     test -e /tmp/openstack-loopback-lvm && \
         cp /tmp/openstack-loopback-lvm /usr/sbin/openstack-loopback-lvm && \
         echo "WARN: using /tmp/openstack-loopback-lvm"
-    test -e /tmp/rcopenstackquickstartrc && \
-        cp /tmp/rcopenstackquickstartrc /etc/rcopenstackquickstartrc && \
-        echo "WARN: using /tmp/rcopenstackquickstartrc"
+    test -e /tmp/openstackquickstartrc && \
+        cp /tmp/openstackquickstartrc /etc/openstackquickstartrc && \
+        echo "WARN: using /tmp/openstackquickstartrc"
 fi
 
 crudini=crudini


### PR DESCRIPTION
commit 7861e41a0cb1d introduced the wrong variable. The correct
name is "openstackquickstartrc".