### PR TITLE
adapt the simple crowbar test

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1964,14 +1964,8 @@ Host node$i
 EOF
     done
 
-    # check for error 500 in app/models/node_object.rb:635:in `sort_ifs'#012
-    curl -m 9 -s $crowbar_api_digest $crowbar_api | \
-        tee /root/crowbartest.out
-    if grep -q "Exception caught" /root/crowbartest.out; then
+    onadmin_is_crowbar_api_available || \
         complain 27 "simple crowbar test failed"
-    fi
-
-    rm -f /root/crowbartest.out
 }
 
 function sshtest()
@@ -4118,7 +4112,7 @@ function onadmin_crowbarpurge()
 function onadmin_is_crowbar_api_available()
 {
     local http_code
-    http_code=`curl $crowbar_api_digest -s -o /dev/null -w '%{http_code}' $crowbar_api`
+    http_code=`curl $crowbar_api_digest -s -o /dev/null -w '%{http_code}' ${crowbar_api}/nodes.json`
     [[ $http_code =~ [23].. ]]
 }
 


### PR DESCRIPTION
curl on http://localhost:3000 (the root) routes to nodes#index, so
in relation to crowbar/crowbar-core#455 we have to replace all the
non json format http requests with a json formatted request

one more fix to advance in the gating of https://github.com/crowbar/crowbar-core/pull/455 (https://ci.suse.de/job/openstack-mkcloud/21101/console)