### PR TITLE
jjb: Fix build name in IBS macros

### DIFF
--- a/scripts/jenkins/jobs-ibs/macros.yaml
+++ b/scripts/jenkins/jobs-ibs/macros.yaml
@@ -3,5 +3,5 @@
     name: mkphyscloud-qa-common-wrappers
     wrappers:
       - build-name:
-          name: #${BUILD_NUMBER}: ${ENV,var="cloudsource"} (${ENV,var="nodenumber"}/${ENV,var="mkcloudtarget"} ${ENV,var="hacloud"})
+          name: '#${BUILD_NUMBER}: ${ENV,var="cloudsource"} (${ENV,var="nodenumber"}/${ENV,var="mkcloudtarget"} ${ENV,var="hacloud"})'
       - timestamps


### PR DESCRIPTION
Add quotes to the given build name string. Otherwise the build name is empty.