### PR TITLE
Switch to bash and make test for hacloud consistent

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -62,7 +62,7 @@ setcloudnetvars $virtualcloud
 : ${adminnetmask:=255.255.248.0}
 # the default nodenumber of compute nodes
 nodenumbercomputedefault=2
-[ -n "$hacloud" ] && nodenumbercomputedefault=1
+[[ $hacloud ]] && nodenumbercomputedefault=1
 : ${nodenumber:=$nodenumbercomputedefault}
 : ${nodenumbercompute:=$nodenumbercomputedefault}
 # expect to have this many physical machines attached via $mkch_physcloudif
@@ -105,7 +105,7 @@ needcvol=1
 : ${computenode_hdd_size:=20}
 : ${cephvolume_hdd_size:=21}
 : ${controller_ceph_hdd_size:=25}
-if [ -n "$hacloud" ]; then
+if [[ $hacloud ]]; then
     : ${drbd_hdd_size:=15}
 else
     : ${drbd_hdd_size:=0}
@@ -1257,7 +1257,7 @@ function sanity_checks()
     fi
 
     # checking clusterconfig
-    if [ -n "$hacloud" -a -z "$clusterconfig" ] ; then
+    if [[ $hacloud && ! $clusterconfig ]] ; then
         echo "Examples for clusterconfig:"
         echo '3 clusters: clusterconfig="data=2:network=3:services=3"'
         echo '2 clusters: clusterconfig="services+data=2:network=3"'

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -527,7 +527,7 @@ function addsp3testupdates()
     add_mount "SLES11-SP3-Updates-test" \
         $distsuseip':/dist/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/11-SP3:/x86_64/update/' \
         "$tftpboot_repos_dir/SLES11-SP3-Updates-test/" "sp3tup"
-    [ -n "$hacloud" ] && add_mount "SLE11-HAE-SP3-Updates-test" \
+    [[ $hacloud ]] && add_mount "SLE11-HAE-SP3-Updates-test" \
         $distsuseip':/dist/ibs/SUSE:/Maintenance:/Test:/SLE-HAE:/11-SP3:/x86_64/update/' \
         "$tftpboot_repos_dir/SLE11-HAE-SP3-Updates-test/"
 }
@@ -549,7 +549,7 @@ function addsles12sp1testupdates()
     add_mount "SLES12-SP1-Updates-test" \
         $distsuseip':/dist/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP1:/x86_64/update/' \
         "$tftpboot_repos12sp1_dir/SLES12-SP1-Updates-test/" "sles12sp1tup"
-    [ -n "$hacloud" ] && add_mount "SLE12-SP1-HA-Updates-test" \
+    [[ $hacloud ]] && add_mount "SLE12-SP1-HA-Updates-test" \
         $distsuseip':/dist/ibs/SUSE:/Maintenance:/Test:/SLE-HA:/12-SP1:/x86_64/update/' \
         "$tftpboot_repos12sp1_dir/SLE12-SP1-HA-Updates-test/"
     echo "FIXME: setup Storage 2.1 test channels once available"
@@ -1445,7 +1445,7 @@ EOF
         fi
     fi
 
-    if [ -n "$hacloud" ]; then
+    if [[ $hacloud ]]; then
         if [ "$slesdist" = "SLE_11_SP3" ] && iscloudver 3plus ; then
             add_ha_repo
         elif iscloudver 6plus; then
@@ -2656,7 +2656,7 @@ function custom_configuration()
             fi
 
             # assign neutron-network role to one of SLE12 nodes
-            if [ -n "$want_sles12" ] && [ -z "$hacloud" ] && [ -n "$want_neutronsles12" ] && iscloudver 5plus ; then
+            if [[ $want_sles12 && ! $hacloud && $want_neutronsles12 ]] && iscloudver 5plus ; then
                 proposal_set_value neutron default "['deployment']['neutron']['elements']['neutron-network']" "['$sles12plusnode']"
             fi
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # based on https://github.com/SUSE/cloud/wiki/SUSE-Cloud-Installation-Manual
 
 test $(uname -m) = x86_64 || echo "ERROR: need 64bit"


### PR DESCRIPTION
The shebang references /bin/sh which is not required to link to /bin/bash.
Since the script uses bash features (the [[ ]] test for instance) it may break
if the user decides to use a shell other than bash as /bin/sh.

The legal valus of $hacloud are specified as '' or 1 by mkcloud. This patch
makes testing of $hacloud consistent throughout the script.