### PR TITLE
Fix check for the crowbar installer

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1592,7 +1592,7 @@ function do_installcrowbar_cloud6plus()
     service crowbar status || service crowbar stop
     service crowbar start
 
-    wait_for 30 10 "[[ \`curl -s -o /dev/null -w '%{http_code}' $crowbar_api/installer \` = 200 ]]" "crowbar installer to be available"
+    wait_for 30 10 "onadmin_is_crowbar_api_available" "crowbar service to start"
 
     if crowbar_install_status | grep -q '"success": *true' ; then
         echo "Crowbar is already installed. The current crowbar install status is:"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1594,12 +1594,6 @@ function do_installcrowbar_cloud6plus()
 
     wait_for 30 10 "[[ \`curl -s -o /dev/null -w '%{http_code}' $crowbar_api/installer \` = 200 ]]" "crowbar installer to be available"
 
-    # temporarily support old-new and final installer paths
-    if [[ `curl -s -o /dev/null -w "%{http_code}" $crowbar_api$crowbar_api_installer_path` = "404"  ]] ; then
-        crowbar_api_installer_path=/installer
-    fi
-
-
     if crowbar_install_status | grep -q '"success": *true' ; then
         echo "Crowbar is already installed. The current crowbar install status is:"
         crowbar_install_status


### PR DESCRIPTION
Use generic function to check if the installer is available.
Drop temporary code that was needed by early Cloud6 milestones only.

This PR depends on: PR #964 