### PR TITLE
Use version variable in template

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-gating-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-gating-template.yaml
@@ -47,7 +47,7 @@
           name: 'Extra Gate Checks (HA)'
           condition: SUCCESSFUL
           projects:
-            - name: cloud-mkcloud6-job-ha
+            - name: cloud-mkcloud{version}-job-ha
               node-label: cloud-trigger
 
     publishers:


### PR DESCRIPTION
We need to use the version variable in the template otherwise the
version is in every gating the same.