### PR TITLE
Make some kernel optimzations fail gracefully

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -447,11 +447,12 @@ function onhost_add_etchosts_entries()
 function onhost_enable_ksm
 {
     # enable kernel-samepage-merging to save RAM
-    echo 0 > /sys/kernel/mm/ksm/merge_across_nodes
-    echo 1 > /sys/kernel/mm/ksm/run
-    echo 1000 > /sys/kernel/mm/ksm/pages_to_scan
+    [[ -w /sys/kernel/mm/ksm/merge_across_nodes ]] && echo 0 > /sys/kernel/mm/ksm/merge_across_nodes
+    [[ -w /sys/kernel/mm/ksm/run ]] && echo 1 > /sys/kernel/mm/ksm/run
+    [[ -w /sys/kernel/mm/ksm/pages_to_scan ]] && echo 1000 > /sys/kernel/mm/ksm/pages_to_scan
+
     # huge pages can not be shared or swapped, so do not use them
-    echo never > /sys/kernel/mm/transparent_hugepage/enabled
+    [[ -w /sys/kernel/mm/transparent_hugepage/enabled ]] && echo never > /sys/kernel/mm/transparent_hugepage/enabled
 }
 
 function setuphost()


### PR DESCRIPTION
Depending on the kernel configuration, some of the mm/ksm entries in sysfs
might be missing. This patch changes mkcloud to not fail in case of missing
entries.