### PR TITLE
Fix incorrect `continue` statement

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2936,21 +2936,21 @@ function deploy_single_proposal()
     # proposal filter
     case "$proposal" in
         nfs_client)
-            [[ $hacloud = 1 ]] || continue
+            [[ $hacloud = 1 ]] || return
             ;;
         pacemaker)
-            [[ $hacloud = 1 ]] || continue
+            [[ $hacloud = 1 ]] || return
             ;;
         ceph)
-            [[ -n "$deployceph" ]] || continue
+            [[ -n "$deployceph" ]] || return
             ;;
         manila)
             # manila-service can not be deployed currently with docker
-            [[ -n "$want_docker" ]] && continue
+            [[ -n "$want_docker" ]] && return
             if ! iscloudver 6plus; then
                 # manila barclamp is only in SC6+ and develcloud5 with SLE12CC5
                 if ! [[ "$cloudsource" == "develcloud5" ]] || [ -z "$want_sles12" ]; then
-                    continue
+                    return
                 fi
             fi
             if iscloudver 6plus ; then
@@ -2960,22 +2960,20 @@ function deploy_single_proposal()
             fi
             ;;
         swift)
-            [[ -n "$deployswift" ]] || continue
+            [[ -n "$deployswift" ]] || return
             ;;
         trove)
-            iscloudver 5plus || continue
+            iscloudver 5plus || return
             ;;
         tempest)
-            [[ -n "$wanttempest" ]] || continue
+            [[ -n "$wanttempest" ]] || return
             ;;
     esac
 
     # create proposal
     case "$proposal" in
         nfs_client)
-            if [[ $hacloud = 1 ]] ; then
-                do_one_proposal "$proposal" "$clusternameservices"
-            fi
+            do_one_proposal "$proposal" "$clusternameservices"
             ;;
         pacemaker)
             local clustermapped


### PR DESCRIPTION
The `continue` statements in the `case` / `esac` block are vestigial from
refactoring a code block inside a loop [1]. This patch replaces `continue`
with `return`.

[1] 8064efb0e51415ef47ee4d670d67b21825e3c62d