### PR TITLE
Fix the trigger jobs of automation and cct PRs

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-automation-pr-trigger.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-automation-pr-trigger.yaml
@@ -2,6 +2,20 @@
     name: 'cloud-automation-pr-trigger'
     node: cloud-trigger
 
+    parameters:
+      - choice:
+          name: mode
+          choices:
+            - normal
+            - rebuild
+            - forcerebuild
+            - forceall
+          description: |
+              normal: trigger unseen PRs
+              rebuild: trigger unseend and pending PRs
+              forcerebuild: trigger unseen, pending and failed PRs
+              forceall: trigger rebuild for all open PRs
+
     triggers:
       - timed: 'H/30 * * * *'
 

--- a/scripts/jenkins/jobs-ibs/cloud-cct-pr-trigger.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-cct-pr-trigger.yaml
@@ -2,6 +2,20 @@
     name: 'cloud-cct-pr-trigger'
     node: cloud-trigger
 
+    parameters:
+      - choice:
+          name: mode
+          choices:
+            - normal
+            - rebuild
+            - forcerebuild
+            - forceall
+          description: |
+              normal: trigger unseen PRs
+              rebuild: trigger unseend and pending PRs
+              forcerebuild: trigger unseen, pending and failed PRs
+              forceall: trigger rebuild for all open PRs
+
     triggers:
       - timed: 'H/30 * * * *'
 


### PR DESCRIPTION
The conversion to JJB jobs broke these jobs, preventing us to retrigger a run of PRs (needed in case a job is removed from the Jenkins queue - accidentally or jenkins bug).

FYI: the updated jobs are already deployed on jenkins