### PR TITLE
qa_openstack: Enable Magnum

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -221,6 +221,7 @@ if [ -n "$IP" ] ; then
 fi
 sed -i -e "s/with_tempest=no/with_tempest=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_horizon=no/with_horizon=yes/" /etc/openstackquickstartrc
+sed -i -e "s/with_magnum=no/with_magnum=yes/" /etc/openstackquickstartrc
 sed -i -e "s/node_is_compute=.*/node_is_compute=yes/" /etc/openstackquickstartrc
 sed -i -e s/br0/brclean/ /etc/openstackquickstartrc
 unset http_proxy


### PR DESCRIPTION
When running the jenkins job, enable Magnum. This currently installs
only the packages and the cofiguration is not complete but it's better
than nothing.