### PR TITLE
Use a mitaka compatible method for fetching floating ip of manila VM

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3152,7 +3152,7 @@ function get_ceph_nodes()
 function get_manila_service_instance_details()
 {
     manila_service_vm_uuid=`oncontroller "openstack --os-project-name manila-service server show manila-service -f value -c id"`
-    manila_tenant_vm_ip=`oncontroller "openstack --os-project-name manila-service ip floating list -f csv --quote none -c IP -c 'Instance ID'|grep $manila_service_vm_uuid|cut -d ',' -f 1"`
+    manila_tenant_vm_ip=`oncontroller "openstack --os-project-name manila-service server show $manila_service_vm_uuid -f value -c addresses | awk '{print $2}'"`
     test -n "$manila_service_vm_uuid" || complain 91 "uuid from manila-service instance not available"
     test -n "$manila_tenant_vm_ip" || complain 93 "floating ip addr from manila-service instance not available"
 }
@@ -3316,7 +3316,7 @@ function oncontroller_manila_generic_driver_setup()
             timeout 10m nova start manila-service
         fi
         manila_service_vm_uuid=`openstack --os-project-name manila-service server show manila-service -f value -c id`
-        manila_tenant_vm_ip=`openstack --os-project-name manila-service ip floating list -f csv --quote none -c IP -c 'Instance ID'|grep $manila_service_vm_uuid|cut -d ',' -f 1`
+        manila_tenant_vm_ip=`openstack --os-project-name manila-service server show $manila_service_vm_uuid -f value -c addresses | awk '{print $2}'`
     else
         fixed_net_id=`neutron net-show fixed -f value -c id`
         timeout 10m nova boot --poll --flavor 100 --image manila-service-image \


### PR DESCRIPTION
the openstack client output in mitaka changed due to
https://review.openstack.org/#/c/277720
so choose a different method that seems to work between liberty and
mitaka