### PR TITLE
Add new cloudsource: stagingcloud7

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1287,6 +1287,12 @@ function onadmin_set_source_variables()
             CLOUDSLE12TESTISO="CLOUD-7-TESTING-$arch*Media1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-7-official"
         ;;
+        stagingcloud7)
+            CLOUDSLE12DISTPATH=/ibs/Devel:/Cloud:/7:/Staging/images/iso
+            CLOUDSLE12DISTISO="SUSE-OPENSTACK-CLOUD-7-$arch*Media1.iso"
+            CLOUDSLE12TESTISO="CLOUD-7-TESTING-$arch*Media1.iso"
+            CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-7-devel-staging"
+        ;;
         susecloud7)
             CLOUDSLE12DISTPATH=/ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Cloud7/images/iso/
             CLOUDSLE12DISTISO="SUSE-OPENSTACK-CLOUD-7-$arch*Media1.iso"


### PR DESCRIPTION
For QA testing purposes and discussions around testing it's really practical to have a single specific `cloudsource` for staging without messing up with `TESTHEAD`. Staging cloudsource would always point at the staging repos of cloud in development, hence no other stagingclouds for other versions.

By using `cloudsource`+`TESTHEAD` params we actually require **staging repository** data, it deserves its own name reference as it's heavily used by QA in scenario testing and for milestone testing without need for other effects brought about by `TESTHEAD` variable (in fact there is only one). 

Adding `stagingcloudNUMBER` cloudsource does not increase maintainance overhead as it's going to change once a year only with the cloud version. On the other hand it adds flexibility to parse/trigger jenkins jobs with a single param change and improves visual parsing for testing results. `cloudsource` is one of the main parameters that have big impact on jenkins input/output for QA and making it a single one would simplify our communication and work.