### PR TITLE
Enable Barbican in openstackquickstartrc

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -224,6 +224,7 @@ fi
 sed -i -e "s/with_tempest=no/with_tempest=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_horizon=no/with_horizon=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_magnum=no/with_magnum=yes/" /etc/openstackquickstartrc
+sed -i -e "s/with_barbican=no/with_barbican=yes/" /etc/openstackquickstartrc
 sed -i -e "s/node_is_compute=.*/node_is_compute=yes/" /etc/openstackquickstartrc
 sed -i -e s/br0/brclean/ /etc/openstackquickstartrc
 unset http_proxy

--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -357,6 +357,10 @@ EOF
 heat stack-create -f $PWD/testvm.stack teststack
 
 sleep 60
+
+# Check basic Barbican API functionality
+openstack secret list
+
 . /etc/openstackquickstartrc
 
 FLOATING_IP=$(eval echo $(heat output-show teststack server_floating_ip))


### PR DESCRIPTION
This pull request enables Barbican in `openstackquickstartrc` (off by default) and adds a small functionality test to cleanvm.