### PR TITLE
Use correct IP address for nfs server in QA scenarios

### DIFF
--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -138,8 +138,8 @@
           wget --no-check-certificate -Oqa_crowbarsetup.sh "$runner_url"
           wget --no-check-certificate -Oscenario.yml "$scenario_url"
 
-          sed -i -e "s,##shared_nfs_for_database##,10.162.31.220:/var/$cloud/ha-database," scenario.yml
-          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.31.220:/var/$cloud/ha-rabbitmq," scenario.yml
+          sed -i -e "s,##shared_nfs_for_database##,10.162.24.1:/var/$cloud/ha-database," scenario.yml
+          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.24.1:/var/$cloud/ha-rabbitmq," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1b.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1b.yaml
@@ -143,8 +143,8 @@
           wget --no-check-certificate -Oqa_crowbarsetup.sh "$runner_url"
           wget --no-check-certificate -Oscenario.yml "$scenario_url"
 
-          sed -i -e "s,##shared_nfs_for_database##,10.162.31.220:/var/$cloud/ha-database," scenario.yml
-          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.31.220:/var/$cloud/ha-rabbitmq," scenario.yml
+          sed -i -e "s,##shared_nfs_for_database##,10.162.24.1:/var/$cloud/ha-database," scenario.yml
+          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.24.1:/var/$cloud/ha-rabbitmq," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -145,8 +145,8 @@
           wget --no-check-certificate -Oqa_crowbarsetup.sh "$runner_url"
           wget --no-check-certificate -Oscenario.yml "$scenario_url"
 
-          sed -i -e "s,##shared_nfs_for_database##,10.162.31.220:/var/$cloud/ha-database," scenario.yml
-          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.31.220:/var/$cloud/ha-rabbitmq," scenario.yml
+          sed -i -e "s,##shared_nfs_for_database##,10.162.24.1:/var/$cloud/ha-database," scenario.yml
+          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.24.1:/var/$cloud/ha-rabbitmq," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2b.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2b.yaml
@@ -145,8 +145,8 @@
           wget --no-check-certificate -Oqa_crowbarsetup.sh "$runner_url"
           wget --no-check-certificate -Oscenario.yml "$scenario_url"
 
-          sed -i -e "s,##shared_nfs_for_database##,10.162.31.220:/var/$cloud/ha-database," scenario.yml
-          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.31.220:/var/$cloud/ha-rabbitmq," scenario.yml
+          sed -i -e "s,##shared_nfs_for_database##,10.162.24.1:/var/$cloud/ha-database," scenario.yml
+          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.24.1:/var/$cloud/ha-rabbitmq," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-3a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-3a.yaml
@@ -133,7 +133,7 @@
           wget --no-check-certificate -Oqa_crowbarsetup.sh "$runner_url"
           wget --no-check-certificate -Oscenario.yml "$scenario_url"
 
-          sed -i -e "s,##shared_nfs_for_glance##,10.162.31.220:/var/$cloud/ha-glance," scenario.yml
+          sed -i -e "s,##shared_nfs_for_glance##,10.162.24.1:/var/$cloud/ha-glance," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-6a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-6a.yaml
@@ -133,9 +133,9 @@
           wget --no-check-certificate -Oqa_crowbarsetup.sh "$runner_url"
           wget --no-check-certificate -Oscenario.yml "$scenario_url"
 
-          sed -i -e "s,##shared_nfs_for_database##,10.162.31.220:/var/$cloud/ha-database," scenario.yml
-          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.31.220:/var/$cloud/ha-rabbitmq," scenario.yml
-          sed -i -e "s,##shared_nfs_for_glance##,10.162.31.220:/var/$cloud/ha-glance," scenario.yml
+          sed -i -e "s,##shared_nfs_for_database##,10.162.24.1:/var/$cloud/ha-database," scenario.yml
+          sed -i -e "s,##shared_nfs_for_rabbitmq##,10.162.24.1:/var/$cloud/ha-rabbitmq," scenario.yml
+          sed -i -e "s,##shared_nfs_for_glance##,10.162.24.1:/var/$cloud/ha-glance," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 


### PR DESCRIPTION
The IP of interface `eth0` on the server used in https://github.com/SUSE-Cloud/automation/pull/996 proved to cause issues when used for nfs server (timeouts and fenced nodes) , bridge on `eth1` seems to be working properly for nfs.