### PR TITLE
Changes to QA scenarios

### DIFF
--- a/scripts/jenkins/ci.suse.de/openstack-mkcloud.xml
+++ b/scripts/jenkins/ci.suse.de/openstack-mkcloud.xml
@@ -246,7 +246,6 @@ export cephvolumenumber=1 # one disk is either cinder raw, ceph-osd or swift sto
 export debug=0
 export want_neutronsles12=1
 export want_mtu_size=8900
-export rally_server=backup.cloudadm.qa.suse.de
 # to not fail when two concurrent zypper runs happen:
 export ZYPP_LOCK_TIMEOUT=120
 

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -224,6 +224,7 @@
             export cephvolumenumber=0;
             export scenario=scenario.yml "'
 
+            source qa_crowbarsetup.sh
             ./sbd_prepare
 
             timeout --signal=ALRM 60m bash -x -c ". qa_crowbarsetup.sh ; onadmin_runlist batch;"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1524,7 +1524,7 @@ EOF
     fi
     if [[ $cloud =~ qa ]] ; then
         # QA clouds have too few IP addrs, so smaller subnets are used
-        wget -O$netfile http://info.cloudadm.qa.suse.de/net-json/${cloud}_dual
+        wget -O$netfile http://gate.cloud2adm.qa.suse.de/network.json/${cloud}_dual
         if iscloudver 6plus; then
             sed -i 's/bc-template-network/template-network/' $netfile
         fi


### PR DESCRIPTION
* ~~add `export ZYPP_LOCK_TIMEOUT=120` to qa_crowbarsetup.sh`~~
* Unset rally server for openstack-mckloud job (the rally server will be moved to different location, temporarily it will be off)
*  Add new location for network.json files for QA scenarios
*  Source qa_crowbarsetup before setting up sbd in QA scenario 2a

Changes in `qa_crowbarsetup.sh` related to QA scenarios tested here: https://ci.suse.de/view/Cloud/view/QA/job/cloud-mkphyscloud-qa-scenario-1a/97
