### PR TITLE
ceilometer-polling role was renamed (back) to ceilometer-central

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2615,6 +2615,9 @@ function custom_configuration()
             local ceilometerservice="ceilometer-cagent"
             if iscloudver 6plus ; then
                 ceilometerservice="ceilometer-central"
+                if [[ "$cloudsource" == "GM6" ]] ; then
+                    ceilometerservice="ceilometer-polling"
+                fi
             fi
             if [[ $hacloud = 1 ]] ; then
                 proposal_set_value ceilometer default "['deployment']['ceilometer']['elements']['ceilometer-server']" "['cluster:$clusternameservices']"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2614,7 +2614,7 @@ function custom_configuration()
         ceilometer)
             local ceilometerservice="ceilometer-cagent"
             if iscloudver 6plus ; then
-                ceilometerservice="ceilometer-polling"
+                ceilometerservice="ceilometer-central"
             fi
             if [[ $hacloud = 1 ]] ; then
                 proposal_set_value ceilometer default "['deployment']['ceilometer']['elements']['ceilometer-server']" "['cluster:$clusternameservices']"

--- a/scripts/scenarios/cloud6/cloud6-2nodes-default.yml
+++ b/scripts/scenarios/cloud6/cloud6-2nodes-default.yml
@@ -136,7 +136,7 @@ proposals:
       ceilometer-agent:
       - @@compute-kvm@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - @@controller@@
       ceilometer-server:
       - @@controller@@

--- a/scripts/scenarios/cloud6/cloud6-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud6/cloud6-4nodes-compute-ha.yml
@@ -161,7 +161,7 @@ proposals:
       - @@compute1@@
       - @@compute2@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a.yaml
@@ -150,7 +150,7 @@ proposals:
       - "@@compute-kvm1@@"
       - "@@compute-kvm2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b.yaml
@@ -165,7 +165,7 @@ proposals:
       - "@@compute-kvm2@@"
       - "@@compute-xen2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a.yaml
@@ -222,7 +222,7 @@ proposals:
       ceilometer-agent:
       - "@@computekvm@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b.yaml
@@ -188,7 +188,7 @@ proposals:
       - "@@computekvm2@@"
       - "@@computevmw@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2c.yaml
@@ -162,7 +162,7 @@ proposals:
       - @@compute1@@
       - @@compute2@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-3a.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-3a.yaml
@@ -163,7 +163,7 @@ proposals:
       ceilometer-agent-hyperv:
       - "@@compute-hyperv1@@"
       - "@@compute-hyperv2@@"
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-6a.yaml
@@ -170,7 +170,7 @@ proposals:
       - "@@docker1@@"
       - "@@docker2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -185,7 +185,7 @@ proposals:
       - "@@compute-kvm1@@"
       - "@@compute-kvm2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -204,7 +204,7 @@ proposals:
       - "@@compute-kvm2@@"
       - "@@compute-xen2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -259,7 +259,7 @@ proposals:
       ceilometer-agent:
       - "@@computekvm@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -215,7 +215,7 @@ proposals:
       - "@@computekvm2@@"
       - "@@computevmw@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -201,7 +201,7 @@ proposals:
       - @@compute1@@
       - @@compute2@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -204,7 +204,7 @@ proposals:
       - "@@docker1@@"
       - "@@docker2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
+++ b/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
@@ -136,7 +136,7 @@ proposals:
       ceilometer-agent:
       - @@compute-kvm@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - @@controller@@
       ceilometer-server:
       - @@controller@@

--- a/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
@@ -161,7 +161,7 @@ proposals:
       - @@compute1@@
       - @@compute2@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -150,7 +150,7 @@ proposals:
       - "@@compute-kvm1@@"
       - "@@compute-kvm2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
@@ -165,7 +165,7 @@ proposals:
       - "@@compute-kvm2@@"
       - "@@compute-xen2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -222,7 +222,7 @@ proposals:
       ceilometer-agent:
       - "@@computekvm@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -188,7 +188,7 @@ proposals:
       - "@@computekvm2@@"
       - "@@computevmw@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -162,7 +162,7 @@ proposals:
       - @@compute1@@
       - @@compute2@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3a.yaml
@@ -163,7 +163,7 @@ proposals:
       ceilometer-agent-hyperv:
       - "@@compute-hyperv1@@"
       - "@@compute-hyperv2@@"
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
@@ -170,7 +170,7 @@ proposals:
       - "@@docker1@@"
       - "@@docker2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -185,7 +185,7 @@ proposals:
       - "@@compute-kvm1@@"
       - "@@compute-kvm2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -204,7 +204,7 @@ proposals:
       - "@@compute-kvm2@@"
       - "@@compute-xen2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -259,7 +259,7 @@ proposals:
       ceilometer-agent:
       - "@@computekvm@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -215,7 +215,7 @@ proposals:
       - "@@computekvm2@@"
       - "@@computevmw@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -201,7 +201,7 @@ proposals:
       - @@compute1@@
       - @@compute2@@
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -204,7 +204,7 @@ proposals:
       - "@@docker1@@"
       - "@@docker2@@"
       ceilometer-agent-hyperv: []
-      ceilometer-polling:
+      ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services


### PR DESCRIPTION
For both Cloud6 and Cloud7

See https://github.com/crowbar/crowbar-openstack/pull/373 and https://github.com/crowbar/crowbar-openstack/pull/376