### PR TITLE
Fix bug in cloudsnapshot functions

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -588,10 +588,10 @@ function createcloudsnapshot()
     for i in $allnodeids ; do
         wait_for_node_shutdown $cloud-node$i
     done
-    for d in $(lvs | grep $cloudvg | grep snap | awk '{print $1}') ; do
+    for d in $(lvs ${cloudvg} | grep "${cloud}\..*snap" | awk '{print $1}') ; do
         remove_snapshot_volume "${cloudvg}/${d%.snap}"
     done
-    for d in $(lvs | grep $cloudvg | awk '{print $1}') ; do
+    for d in $(lvs ${cloudvg} | grep ${cloud}\. | awk '{print $1}') ; do
         create_snapshot_volume "${cloudvg}/${d}"
     done
     restartcloud
@@ -604,7 +604,7 @@ function restorecloudfromsnapshot()
     for i in $allnodeids ; do
         virsh destroy $cloud-node$i
     done
-    for d in $(lvs | grep $cloudvg | grep snap | awk '{print $1}') ; do
+    for d in $(lvs ${cloudvg} | grep "${cloud}\..*snap" | awk '{print $1}') ; do
         merge_snapshot_volume "${cloudvg}/${d%.snap}"
     done
     createcloudsnapshot


### PR DESCRIPTION
When running cloudsnapshot functions on a system that is running several
mkcloud created clouds, the createcloudsnapshot/restorecloudfromsnapshot
functions are a bit too greedy removing logical volumes.