### PR TITLE
Add better debugging output

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -18,6 +18,7 @@
 
 if [[ $debug_mkcloud = 1 ]] ; then
     set -x
+    PS4='+($(basename ${BASH_SOURCE}):${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
 
 if [ -n "$CVOL" ] ; then

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -11,6 +11,7 @@ fi
 # this needs to be after mkcloud.config got sourced
 if [[ $debug_qa_crowbarsetup = 1 ]] ; then
     set -x
+    PS4='+($(basename ${BASH_SOURCE}):${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
 
 # defaults


### PR DESCRIPTION
This patch adds line number and function information to the debug output of
mkcloud and qa_crowbarsetup.sh (controlled by debug_mkcloud and
debug_qa_crowbarsetup).