### PR TITLE
qa_crowbarsetup: Make cct novaclient test pass on susecloud7

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1394,6 +1394,7 @@ function onadmin_set_source_variables()
         susecloud7)
             CLOUDSLE12DISTPATH=/ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Cloud7/images/iso/
             CLOUDSLE12DISTISO="SUSE-OPENSTACK-CLOUD-7-$arch*Media1.iso"
+            CLOUDSLE12TESTISO="CLOUD-7-TESTING-$arch*Media1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-7-official"
         ;;
         GM4|GM4+up)


### PR DESCRIPTION
The fix was mentioned by Tom in
https://github.com/SUSE-Cloud/automation/pull/1002

Co-Authored-By: Thomas Bechtold <tbechtold@suse.com>