### PR TITLE
Fix small bug in debug prompt

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -18,7 +18,7 @@
 
 if [[ $debug_mkcloud = 1 ]] ; then
     set -x
-    PS4='+($(basename ${BASH_SOURCE}):${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+    PS4='+(${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
 
 if [ -n "$CVOL" ] ; then

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -11,7 +11,7 @@ fi
 # this needs to be after mkcloud.config got sourced
 if [[ $debug_qa_crowbarsetup = 1 ]] ; then
     set -x
-    PS4='+($(basename ${BASH_SOURCE}):${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+    PS4='+(${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
 
 # defaults


### PR DESCRIPTION
Instead of using `basename` to remove the path component from the current
script, use bash internal string modification. This is more robust in cases
where `BASH_SOURCE` is not set.