### PR TITLE
qa_crowbarsetup: Download testiso also with susecloud

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3478,7 +3478,7 @@ function oncontroller_testsetup()
     fi
 
     # prepare test image with the -test packages containing functional tests
-    if iscloudver 6plus && [[ $cloudsource =~ (devel|mitaka)cloud ]]; then
+    if iscloudver 6plus && [[ $cloudsource =~ (devel|mitaka|suse)cloud ]]; then
         local mount_dir="/var/lib/Cloud-Testing"
         rsync_iso "$CLOUDSLE12DISTPATH" "$CLOUDSLE12TESTISO" "$mount_dir"
         zypper -n ar --refresh -c -G -f "$mount_dir" cloud-test


### PR DESCRIPTION
The testiso containing i.e. python-novaclient-test is also
available from the SUSE namespace. So also download the iso
and install the test packages when running with cloudsource=susecloud .

This fixes the cct testing run which triggers some client tests and
needs the corresponding python-*client-test packages.