### PR TITLE
qa_crowbarsetup: Fix reboot step with insecure ssl

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3970,9 +3970,9 @@ function onneutron_wait_for_neutron()
     get_neutron_server_node
 
     wait_for 300 3 "ssh $NEUTRON_SERVER 'rcopenstack-neutron status' |grep -q running" "neutron-server service running state"
-    wait_for 200 3 " ! ssh $NEUTRON_SERVER '. .openrc && neutron agent-list -f csv --quote none'|tail -n+2 | grep -q -v ':-)'" "neutron agents up"
+    wait_for 200 3 " ! ssh $NEUTRON_SERVER '. .openrc && neutron --insecure agent-list -f csv --quote none'|tail -n+2 | grep -q -v ':-)'" "neutron agents up"
 
-    ssh $NEUTRON_SERVER '. .openrc && neutron agent-list'
+    ssh $NEUTRON_SERVER '. .openrc && neutron --insecure agent-list'
     ssh $NEUTRON_SERVER 'ping -c1 -w1 8.8.8.8' > /dev/null
     if [ "x$?" != "x0" ]; then
         complain 14 "ping to 8.8.8.8 from $NEUTRON_SERVER failed."


### PR DESCRIPTION
We're calling the neutron CLI via ssh, so our
NEUTRONCLIENT_INSECURE=true environment variable doesnt work.