### PR TITLE
Fix missing extglob shopt for <= SLE-11

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3,6 +3,8 @@
 
 [[ $(uname -m) =~ ^(aarch64|x86_64)$ ]] || { echo "ERROR: need 64bit" ; exit 1 ; }
 
+shopt -s extglob
+
 mkcconf=mkcloud.config
 if [ -z "$testfunc" ] && [ -e $mkcconf ]; then
     source $mkcconf


### PR DESCRIPTION
Fix missing extglob shopt for <= SLE-11

The extended pattern matching introduced in line 642 of `qa_crowbarsetup.sh` by 9e4595746ad17202b72da750b80294e569af632c requires the `extglob` shell option to be set, an issue on <= SLE-11 images for instance. This patch ensures that it is.
   
Thanks to @gosipyan for finding this problem.