### PR TITLE
Fix for rebootcloud

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -497,6 +497,11 @@ function wait_for_crowbar_ssh()
     wait_for 150 1 "nc -z $adminip 22" 'admin node to start ssh daemon'
 }
 
+function wait_for_crowbar_ntpd()
+{
+    wait_for 200 10 "ntpdate -d $adminip" "admin node ntpd service"
+}
+
 # bring up the VM for crowbar
 function setupadmin()
 {
@@ -770,6 +775,7 @@ function restartcloud()
     libvirt_net_start
     virsh start $cloud-admin
     setuppublicnet
+    wait_for_crowbar_ntpd
     for i in $allnodeids ; do
         virsh start $cloud-node$i
     done


### PR DESCRIPTION
When the cloud is rebooted, the nodes run crowbar_join, which runs ntpdate to
update the nodes' date. Unfortunately the ntpd instance on the crowbar node
takes a while before it considers itself trustworthy enough to give out
temporal advice. This means that the nodes will hang on cowbar_join until
crowbar's ntpd finally pulls itself together. Sometimes ntpd takes longer than
the nodes are willing to wait, and the impatient nodes will not be considered
`ready` by crowbar, i.e. the cloud is not fully up. This patch adds an
additional wait after rebooting the crowbar node.