### PR TITLE
Cleanup of restartcloud

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -582,7 +582,6 @@ function createcloudsnapshot()
         create_snapshot_volume "${cloudvg}/${d}"
     done
     restartcloud
-    wait_for_crowbar_ssh
 }
 
 function restorecloudfromsnapshot()
@@ -773,6 +772,7 @@ function restartcloud()
     for i in $allnodeids ; do
         virsh start $cloud-node$i
     done
+    wait_for_crowbar_ssh
 }
 
 # bring up VMs that will take cloud controller/compute/storage roles


### PR DESCRIPTION
One should reasonably expect that a call to `restartcloud` results in a fully
running cloud, including a working sshd on the admin node.  Following this
logic, the call to `wait_for_crowbar_ssh` in `createcloudsnapshot` belongs
into the `restartcloud` function.