### PR TITLE
libvirt: Fix assignment of PCI addresses

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -35,7 +35,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1-raid1'/>
       <target dev='vdb' bus='virtio'/>
-      <address type='pci' slot='0x21'/>
+      <address type='pci' slot='0x1a'/>
     </disk>
 
 

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -148,7 +148,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
                 args.nodecounter,
                 i),
             'target_dev': targetdevprefix + ''.join(alldevices.next()),
-            'target_slot': '0x2{0}'.format(i),
+            'target_slot': '0x1{0}'.format(hex(i+9)[2:]),
         }, configopts))
 
     cephvolume = ""
@@ -181,7 +181,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
                 args.cloud,
                 args.nodecounter),
             'target_dev': targetdevprefix + ''.join(alldevices.next()),
-            'target_slot': '0x30'},
+            'target_slot': '0x1f'},
             configopts))
 
     values = dict(


### PR DESCRIPTION
Current code fails with:
```
Traceback (most recent call last):
  File "/root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/vm-start", line 16, in <module>
    main()
  File "/root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/vm-start", line 12, in main
    libvirt_setup.vm_start(args)
  File "/root/github.com/SUSE-Cloud/automation/scripts/lib/libvirt/libvirt_setup.py", line 279, in vm_start
    conn.defineXML(xml)
  File "/usr/lib64/python2.7/site-packages/libvirt.py", line 3629, in defineXML
    if ret is None:raise libvirtError('virDomainDefineXML() failed', conn=self)
libvirt.libvirtError: XML error: Invalid PCI address slot='0x30', must be <= 0x1F
```
So let's just not pick addresses above `0x1F`...