### PR TITLE
lib: cpu-default: Drop the mandatory 'monitor' feature

### DIFF
--- a/scripts/lib/libvirt/templates/cpu-default.xml
+++ b/scripts/lib/libvirt/templates/cpu-default.xml
@@ -12,5 +12,4 @@
   <feature policy='require' name='cx16'/>
   <feature policy='require' name='3dnowprefetch'/>
   <feature policy='require' name='cmp_legacy'/>
-  <feature policy='require' name='monitor'/>
 </cpu>


### PR DESCRIPTION
The 'monitor' flag is not well supported as indicated in the QEMU wiki.

Furthermore, it's possible to use the following CPU on the hypervisor
even though it does not support the 'monitor' feature.

~$ grep -m 2 '\(model name\|monitor\)' /proc/cpuinfo | uniq
model name      : AMD Opteron 23xx (Gen 3 Class Opteron)

As a result of which, drop the mandatory requirement for the 'monitor'
feature on the host CPU.

Link: http://wiki.qemu.org/Features/CPUModels#Disabling_features_that_were_always_disabled_on_KVM