### PR TITLE
crowbar-testbuild: add a trailing slash to URL

### DIFF
--- a/scripts/crowbar-testbuild.py
+++ b/scripts/crowbar-testbuild.py
@@ -107,7 +107,9 @@ def jenkins_job_trigger(repo, github_opts, cloudsource, ptfdir):
         '-p',
         "github_pr=crowbar/%s:%s" % (repo, github_opts),
         "cloudsource=" + cloudsource,
-        'UPDATEREPOS=' + htdocs_url + ptfdir,
+        # trailing slash required
+        # to prevent wget from traversing all test-updates
+        'UPDATEREPOS=' + htdocs_url + ptfdir + "/",
         'mkcloudtarget=all_noreboot',
         *job_parameters))
 


### PR DESCRIPTION
needed after c6264f478fb32a401f615b410b303bd65a95ea73
to prevent wget from traversing all test-updates