### PR TITLE
Fix domain undefine for older libvirt installations

### DIFF
--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -209,7 +209,13 @@ def domain_cleanup(dom):
         dom.destroy()
 
     print("undefining {0}".format(dom.name()))
-    dom.undefineFlags(flags=libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+    try:
+        dom.undefineFlags(flags=libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+    except:
+        try:
+            dom.undefine()
+        except:
+            print("failed to undefine {0}".format(dom.name()))
 
 
 def cleanup_one_node(args):


### PR DESCRIPTION
The VIR_DOMAIN_UNDEFINE_NVRAM flag was introduced in libvirt-1.2.9. The
domain undefine command will fail on earlier libvirt installations.