### PR TITLE
qa_crowbarsetup: Stop looking for provisioner-base on discovered nodes

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1949,12 +1949,14 @@ function onadmin_allocate()
     for n in `get_all_discovered_nodes` ; do
         wait_for 100 2 "knife node show -a state $n | grep -q discovered" \
             "node to enter discovered state"
-        # provisioner is the last transition discovered role, so we're
-        # kludging here and wait for the discovered transition to be really
-        # finished.
-        wait_for 100 5 \
-            "get_proposal_role_elements provisioner provisioner-base | grep -q $n" \
-            "node to be in provisioner proposal"
+        if iscloudver 6minus; then
+            # provisioner is the last transition discovered role, so we're
+            # kludging here and wait for the discovered transition to be really
+            # finished.
+            wait_for 100 5 \
+                "get_proposal_role_elements provisioner provisioner-base | grep -q $n" \
+                "node to be in provisioner proposal"
+        fi
     done
     local controllernodes=(
             $(get_all_discovered_nodes | head -n 2)


### PR DESCRIPTION
This role is added later on starting with Cloud 7+. And the race during discovery
should be gone.

This is required for https://github.com/crowbar/crowbar-core/pull/516 -- note that the change should not be done without that PR.