### PR TITLE
scripts: qa_crowbarsetup.sh: Triple the crowbar installation timeout

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1705,7 +1705,7 @@ function do_installcrowbar_cloud6plus()
     curl -s -X POST $crowbar_api$crowbar_api_installer_path/start.json || complain 39 "crowbar is not running"
 
     wait_for 9 2 "crowbar_install_status | grep -q '\"installing\": *true'" "crowbar to start installing" "tail -n 500 $crowbar_install_log ; complain 88 'crowbar did not start to install'"
-    wait_for 60 10 "crowbar_install_status | grep -q '\"installing\": *false'" "crowbar to finish installing" "tail -n 500 $crowbar_install_log ; complain 89 'crowbar installation failed'"
+    wait_for 180 10 "crowbar_install_status | grep -q '\"installing\": *false'" "crowbar to finish installing" "tail -n 500 $crowbar_install_log ; complain 89 'crowbar installation failed'"
     if ! crowbar_install_status | grep -q '\"success\": *true' ; then
         tail -n 500 $crowbar_install_log
         crowbar_install_status


### PR DESCRIPTION
10 minutes are not enough to install crowbar on smaller hosts so
triple the timeout interval. However, that shouldn't matter for bigger
and/or faster hosts since the script will detect when the crowbar has
actually been installed and move on.