### PR TITLE
Revert to default vlan value for os_sdn network

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -264,7 +264,7 @@ setcloudnetvars()
     vlan_storage=${vlan_storage:-200}
     vlan_public=${vlan_public:-300}
     vlan_fixed=${vlan_fixed:-500}
-    vlan_sdn=${vlan_sdn:-$vlan_storage}
+    vlan_sdn=${vlan_sdn:-400}
     net_fixed=${net_fixed:-192.168.123}
     net_public=${net_public:-192.168.122}
     net_storage=${net_storage:-192.168.125}


### PR DESCRIPTION
At this point we use the same vlan for the `storage` and the `os_sdn` network
in our deployments. By default (as defined by `template-network.json`) those
two networks are on different vlans though. This patch restores the default
behavior.