### PR TITLE
Remove reminiscence of Cloud 4

### DIFF
--- a/scripts/crowbar-testbuild.py
+++ b/scripts/crowbar-testbuild.py
@@ -26,21 +26,18 @@ import sh
 from sh import Command
 
 IBS_MAPPING = {
-    'release/stoney/master': 'Devel:Cloud:4:Staging',
     'release/tex/master':    'Devel:Cloud:5:Staging',
     'stable/3.0':            'Devel:Cloud:6:Staging',
     'master':                'Devel:Cloud:7:Staging'
 }
 
 REPO_MAPPING = {
-    'release/stoney/master': 'SLE_11_SP3',
     'release/tex/master':    'SLE_11_SP3',
     'stable/3.0':            'SLE_12_SP1',
     'master':                'SLE_12_SP2'
 }
 
 CLOUDSRC = {
-    'release/stoney/master': 'develcloud4',
     'release/tex/master':    'develcloud5',
     'stable/3.0':            'develcloud6',
     'master':                'develcloud7'

--- a/scripts/jenkins/ci.suse.de/crowbar-trackupstream.xml
+++ b/scripts/jenkins/ci.suse.de/crowbar-trackupstream.xml
@@ -105,13 +105,15 @@
     <hudson.matrix.TextAxis>
       <name>project</name>
       <values>
-        <string>Devel:Cloud:4:Staging</string>
         <string>Devel:Cloud:5:Staging</string>
         <string>Devel:Cloud:6:Staging</string>
       </values>
     </hudson.matrix.TextAxis>
   </axes>
-  <combinationFilter>!(       ( ["Devel:Cloud:4:Staging"].contains(project)  &amp;&amp;       ["crowbar-barclamp-manila"].contains(component)     )   ||      (       ["Devel:Cloud:4:Staging", "Devel:Cloud:5:Staging"].contains(project)  &amp;&amp;       ["openstack-dashboard-theme-SUSE", "crowbar-core", "crowbar-openstack", "crowbar-ha", "crowbar-hyperv", "crowbar-ceph", "release-notes-suse-openstack-cloud"].contains(component)      )   ||     (        ( ! ["Devel:Cloud:4:Staging", "Devel:Cloud:5:Staging"].contains(project) ) &amp;&amp;       component.startsWith('crowbar-barclamp-')     ) )</combinationFilter>
+  <combinationFilter>!(
+      (["Devel:Cloud:5:Staging"].contains(project)  &amp;&amp; ["openstack-dashboard-theme-SUSE", "crowbar-core", "crowbar-openstack", "crowbar-ha", "crowbar-hyperv", "crowbar-ceph", "release-notes-suse-openstack-cloud"].contains(component)      )   ||
+      (( ! ["Devel:Cloud:5:Staging"].contains(project) ) &amp;&amp; component.startsWith('crowbar-barclamp-')))
+  </combinationFilter>
   <builders>
     <hudson.tasks.Shell>
       <command>PROJECTSOURCE=IBS/${project}

--- a/scripts/jenkins/jobs-ibs/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -100,7 +100,6 @@
 
           declare -a master_branches_old=(
               release/tex/master
-              release/stoney/master
           )
 
           declare -a master_branches=(

--- a/scripts/jenkins/jobs-ibs/cloud-mediacheck.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mediacheck.yaml
@@ -15,7 +15,6 @@
           type: user-defined
           name: project
           values:
-            - Devel:Cloud:4
             - Devel:Cloud:5
             - Devel:Cloud:5/SLE_12
             - Devel:Cloud:6/SLE_12_SP1
@@ -38,7 +37,7 @@
             - cloud-trackupstream-sle12
     execution-strategy:
       combination-filter: |
-        (["Devel:Cloud:4", "Devel:Cloud:5", "Devel:Cloud:5/SLE_12", "Devel:Cloud:6", "Devel:Cloud:6/SLE_12_SP1", "Devel:Cloud:7/SLE_12_SP1" ].contains(project) || subproject == ":")
+        (["Devel:Cloud:5", "Devel:Cloud:5/SLE_12", "Devel:Cloud:6", "Devel:Cloud:6/SLE_12_SP1", "Devel:Cloud:7/SLE_12_SP1" ].contains(project) || subproject == ":")
     builders:
       - shell: |
           # temporary, similar to update_automation (not that advanced)

--- a/scripts/jenkins/jobs-ibs/openstack-submit-project.yaml
+++ b/scripts/jenkins/jobs-ibs/openstack-submit-project.yaml
@@ -62,9 +62,6 @@
           OSCBUILDDIST=SLE_12_SP1
 
           case $project in
-          Devel:Cloud:4)
-              OSCBUILDDIST=SLE_11_SP3
-          ;;
           Devel:Cloud:5)
               OSCBUILDDIST=SLE_11_SP3
           ;;


### PR DESCRIPTION
Somebody already deleted all jenkins jobs for Cloud 4, so it
makes sense to remove the remaining cruft as well. mkcloud is
kept in tact as we need it for 4->5 upgrade testing.