### PR TITLE
libvirt_setup: fix xen testing

### DIFF
--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -219,8 +219,11 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
         target_dev=targetdevprefix + 'a',
         bootorder=args.bootorder)
 
-    return get_config(merge_dicts(values, configopts),
-                      os.path.join(TEMPLATE_DIR, "compute-node.xml"))
+    config = get_config(merge_dicts(values, configopts),
+                        os.path.join(TEMPLATE_DIR, "compute-node.xml"))
+    if not hypervisor_has_virtio(libvirt_type):
+        config = re.sub(r"<address type='pci'[^>\n]*>", "", config)
+    return config
 
 
 def domain_cleanup(dom):


### PR DESCRIPTION
and hyperv, which broke in 765b01256f7b74f67e3e75c2e5782ae83a8dbd05
because ide disks dont allow address type pci
https://bugzilla.suse.com/show_bug.cgi?id=987584