### PR TITLE
Only set disks address type in the virtio case (bsc#987584)

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -1,0 +1,67 @@
+<domain type='kvm'>
+  <name>cloud-node1</name>
+  <memory>5242880</memory>
+  <currentMemory>5242880</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-0.14'>hvm</type>
+
+    <nvram>/var/lib/libvirt/cloud-node1_VARS.fd</nvram>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu mode='custom' match='exact'>
+    <model fallback='allow'>core2duo</model>
+    <feature policy='require' name='vmx'/>
+  </cpu>
+
+  <clock offset='utc'/>
+  <on_poweroff>preserve</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='block' device='disk'>
+      <driver name='qemu' type='raw' cache='unsafe'/>
+      <source dev='/dev/cloud/cloud.node1'/>
+      <target dev='sda' bus='ide'/>
+      
+      <boot order='3'/>
+    </disk>
+
+
+    <disk type='block' device='disk'>
+      <serial>cloud-node1-ceph1</serial>
+      <driver name='qemu' type='raw' cache='unsafe'/>
+      <source dev='/dev/cloud/cloud.node1-ceph1'/>
+      <target dev='sdb' bus='ide'/>
+      
+    </disk>
+
+
+    <interface type='network'>
+      <mac address='52:54:01:77:77:01'/>
+      <target dev='cloud-1'/>
+      <source network='cloud-admin'/>
+      <model type='e1000'/>
+      <address type='pci' slot='0x03'/>
+      <boot order='2'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes'/>
+    <video>
+      <model type='cirrus' vram='9216' heads='1'/>
+      <address type='pci' slot='0x02'/>
+    </video>
+
+  </devices>
+</domain>

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -139,9 +139,12 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
         targetdevprefix = "vd"
         configopts['nicmodel'] = 'virtio'
         configopts['target_bus'] = 'virtio'
+        target_address = "<address type='pci' slot='{0}'/>"
     else:
         targetdevprefix = "sd"
         configopts['target_bus'] = 'ide'
+        target_address = ""
+
     controller_raid_volumes = args.controller_raid_volumes
     if args.nodecounter > args.numcontrollers:
         controller_raid_volumes = 0
@@ -166,7 +169,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
                 args.nodecounter,
                 i),
             'target_dev': targetdevprefix + ''.join(alldevices.next()),
-            'target_slot': '0x1{0}'.format(hex(i+9)[2:]),
+            'target_address': target_address.format('0x1' + hex(i+9)[2:]),
         }, configopts))
 
     cephvolume = ""
@@ -185,7 +188,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
                     args.nodecounter,
                     i),
                 'target_dev': targetdevprefix + ''.join(alldevices.next()),
-                'target_slot': '0x1{0}'.format(i),
+                'target_address': target_address.format('0x1' + str(i)),
             }, configopts))
 
     drbdvolume = ""
@@ -199,7 +202,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
                 args.cloud,
                 args.nodecounter),
             'target_dev': targetdevprefix + ''.join(alldevices.next()),
-            'target_slot': '0x1f'},
+            'target_address': target_address.format('0x1f')},
             configopts))
 
     values = dict(
@@ -217,6 +220,7 @@ def compute_config(args, cpu_flags=cpuflags(), machine=None):
         macaddress=args.macaddress,
         videodevices=get_video_devices(),
         target_dev=targetdevprefix + 'a',
+        target_address=target_address.format('0x0a'),
         bootorder=args.bootorder)
 
     return get_config(merge_dicts(values, configopts),

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -19,7 +19,7 @@ $cpuflags
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='$vdisk_dir/$cloud.node$nodecounter'/>
       <target dev='$target_dev' bus='$target_bus'/>
-      <address type='pci' slot='0x0a'/>
+      $target_address
       <boot order='$bootorder'/>
     </disk>
 $raidvolume

--- a/scripts/lib/libvirt/templates/extra-volume.xml
+++ b/scripts/lib/libvirt/templates/extra-volume.xml
@@ -3,5 +3,5 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='$source_dev'/>
       <target dev='$target_dev' bus='$target_bus'/>
-      <address type='pci' slot='$target_slot'/>
+      $target_address
     </disk>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -124,6 +124,29 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         is_config = libvirt_setup.compute_config(args, cpu_flags)
         self.assertEqual(is_config, should_config)
 
+    def test_xen_compute_config(self):
+        args = Arguments()
+        args.cloud = "cloud"
+        args.nodecounter = 1
+        args.macaddress = "52:54:01:77:77:01"
+        args.controller_raid_volumes = 0
+        args.cephvolumenumber = 1
+        args.computenodememory = 2097152
+        args.controllernodememory = 5242880
+        args.libvirttype = "xen"
+        args.vcpus = 1
+        args.emulator = "/usr/bin/qemu-system-x86_64"
+        args.vdiskdir = "/dev/cloud"
+        args.drbdserial = ""
+        args.bootorder = 3
+        args.numcontrollers = 1
+        cpu_flags = libvirt_setup.readfile(
+            "{0}/cpu-intel.xml".format(TEMPLATE_DIR))
+        should_config = libvirt_setup.readfile(
+            "{0}/cloud-node1-xen.xml".format(FIXTURE_DIR))
+        is_config = libvirt_setup.compute_config(args, cpu_flags)
+        self.assertEqual(is_config, should_config)
+
     # add extra disk for raid and 2 volumes for ceph
     def test_compute_config_with_raid(self):
         args = Arguments()


### PR DESCRIPTION
For Xen/HyperV the PCI address is not settable but only an IDE
bus id would be setable (but apparently we don't care about that)
https://bugzilla.suse.com/show_bug.cgi?id=987584