### PR TITLE
qa_crowbarsetup: Only check vendordata if key is set

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3751,7 +3751,9 @@ function oncontroller_testsetup()
         complain 95 could not reach internet
     fi
 
-    wait_for 40 5 "timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $ssh_target curl -s http://169.254.169.254/openstack/latest/vendor_data.json|grep -q custom-key" "Custom vendordata not accessable from VM"
+    if iscloudver 7plus ; then
+        wait_for 40 5 "timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $ssh_target curl -s http://169.254.169.254/openstack/latest/vendor_data.json|grep -q custom-key" "Custom vendordata not accessable from VM"
+    fi
 
     local volumecreateret=0
     local volumeattachret=0

--- a/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
+++ b/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
@@ -108,6 +108,9 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
@@ -132,6 +132,9 @@ proposals:
     use_migration: true
     kvm:
       ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -121,6 +121,9 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
@@ -132,6 +132,9 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -186,6 +186,9 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -155,6 +155,9 @@ proposals:
       host: vcs.qa.suse.de
       user: "@@vcenter_user@@"
       password: "@@vcenter_password@@"
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
 
   deployment:
     elements:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3a.yaml
@@ -130,6 +130,9 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
@@ -136,6 +136,9 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -153,6 +153,9 @@ proposals:
     novnc:
       ssl:
         enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -165,6 +165,9 @@ proposals:
     novnc:
       ssl:
         enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -220,6 +220,9 @@ proposals:
     novnc:
       ssl:
         enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -176,6 +176,9 @@ proposals:
       host: vcs.qa.suse.de
       user: "@@vcenter_user@@"
       password: "@@vcenter_password@@"
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
 
   deployment:
     elements:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -166,6 +166,9 @@ proposals:
       ssl:
         # FIXME: see comment above
         #enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -164,6 +164,9 @@ proposals:
     novnc:
       ssl:
         enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:


### PR DESCRIPTION
We only set the vendordata json blob in Cloud7+ so also do
the check only in Cloud7+.