### PR TITLE
rpm-packaging: Support multiple release updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ python_unittest:
 
 jjb_test:
 	jenkins-jobs --ignore-cache test scripts/jenkins/jobs-ibs:scripts/jenkins/jobs-ibs/templates/ cloud* openstack* > /dev/null
-	jenkins-jobs --ignore-cache test scripts/jenkins/jobs-obs cloud* openstack* > /dev/null
+	jenkins-jobs --ignore-cache test scripts/jenkins/jobs-obs:scripts/jenkins/jobs-obs/templates/ cloud* openstack* > /dev/null
 
 # for travis-CI:
 install: debianinstall genericinstall

--- a/scripts/jenkins/jobs-obs/openstack-upstream-gerrit-rpm-packaging.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-upstream-gerrit-rpm-packaging.yaml
@@ -1,0 +1,7 @@
+- project:
+    name: 'openstack-upstream-gerrit-rpm-packaging'
+    jobs:
+        - 'openstack-upstream-gerrit-rpm-packaging-{release}':
+            release: 'Master'
+        - 'openstack-upstream-gerrit-rpm-packaging-{release}':
+            release: 'Mitaka'

--- a/scripts/jenkins/jobs-obs/openstack-upstream-rpm-packaging-update.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-upstream-rpm-packaging-update.yaml
@@ -1,0 +1,7 @@
+- project:
+    name: 'openstack-upstream-rpm-packaging-update'
+    jobs:
+        - 'openstack-upstream-rpm-packaging-update-{release}':
+            release: 'Master'
+        - 'openstack-upstream-rpm-packaging-update-{release}':
+            release: 'Mitaka'

--- a/scripts/jenkins/jobs-obs/templates/openstack-rpm-packaging-update.yaml
+++ b/scripts/jenkins/jobs-obs/templates/openstack-rpm-packaging-update.yaml
@@ -1,10 +1,10 @@
-- job:
-    name: 'openstack-rpm-packaging-update'
+- job-template:
+    name: 'openstack-upstream-rpm-packaging-update-{release}'
     node: cloud-trackupstream
     description: |
-      Job to update periodically Cloud:OpenStack:Upstream with data from the OpenStack rpm-packaging project.
+      Job to update periodically Cloud:OpenStack:Upstream:{release} with data from the OpenStack rpm-packaging project.
       <b>This job is managed by JJB!</b>
-      Changes must be done in <a href='https://github.com/SUSE-Cloud/automation/tree/master/scripts/jenkins/jobs-obs/'>git</a>
+      Changes must be done in <a href='https://github.com/SUSE-Cloud/automation/tree/master/scripts/jenkins/jobs-obs/templates/'>git</a>
 
     triggers:
       - timed: 'H */4 * * *'
@@ -14,7 +14,7 @@
           #!/bin/bash
           export OSCAPI="https://api.opensuse.org"
           export JHOME="/home/jenkins"
-          export OBS_PROJECT="Cloud:OpenStack:Upstream"
+          export OBS_PROJECT="Cloud:OpenStack:Upstream:{release}"
           export COMPONENT="rpm-packaging-openstack"
           export OBS_CHECKOUT=$JHOME/OBS_CHECKOUT/$OBS_PROJECT
 
@@ -36,8 +36,8 @@
           # also create links for new packages
           echo "creating missing links ..."
           for x in *-SLE_12_SP1.spec; do
-              pkgname=${x//-SLE_12_SP1.spec/}
-              if ! osc ls Cloud:OpenStack:Upstream $pkgname &>/dev/null; then
-                  osc linkpac Cloud:OpenStack:Upstream rpm-packaging-openstack Cloud:OpenStack:Upstream $pkgname
+              pkgname=${{x//-SLE_12_SP1.spec/}}
+              if ! osc ls $OBS_PROJECT $pkgname &>/dev/null; then
+                  osc linkpac $OBS_PROJECT rpm-packaging-openstack $OBS_PROJECT $pkgname
               fi
           done

--- a/scripts/jenkins/jobs-obs/templates/openstack-upstream-gerrit-rpm-packaging.yaml
+++ b/scripts/jenkins/jobs-obs/templates/openstack-upstream-gerrit-rpm-packaging.yaml
@@ -1,6 +1,6 @@
-- job:
-    name: 'openstack-gerrit-rpm-packaging'
-    description: "<b>This job is managed by JJB! Changes must be done in <a href='https://github.com/SUSE-Cloud/automation/tree/master/scripts/jenkins/jobs-obs/'>git</a></b>"
+- job-template:
+    name: 'openstack-upstream-gerrit-rpm-packaging-{release}'
+    description: "<b>This job is managed by JJB! Changes must be done in <a href='https://github.com/SUSE-Cloud/automation/tree/master/scripts/jenkins/jobs-obs/templates/'>git</a></b>"
     node: openstack-rpm-packaging
     builders:
       - gerrit-git-prep
@@ -11,39 +11,39 @@
           set -x
 
           # set vars
-          OBS_BASE_SRC_PROJECT="Cloud:OpenStack:Upstream"
-          OBS_BASE_TARGET_PROJECT="home:suse-cloud-ci:rpm-packaging-openstack"
-          OBS_TEST_PROJECT="${OBS_BASE_TARGET_PROJECT}-${ZUUL_COMMIT}"
-          TEMP_DIR="/tmp/rpm-packaging-${ZUUL_COMMIT}"
+          OBS_BASE_SRC_PROJECT="Cloud:OpenStack:Upstream:{release}"
+          OBS_BASE_TARGET_PROJECT="home:suse-cloud-ci:rpm-packaging-openstack-{release}"
+          OBS_TEST_PROJECT="${{OBS_BASE_TARGET_PROJECT}}-${{ZUUL_COMMIT}}"
+          TEMP_DIR="/tmp/rpm-packaging-${{ZUUL_COMMIT}}"
 
           # cleanup
-          rm -rf ${OBS_TEST_PROJECT}
-          rm -rf ${TEMP_DIR}
-          osc rdelete -r -m "rpm-packaging CI cleanup" ${OBS_TEST_PROJECT} || :
+          rm -rf ${{OBS_TEST_PROJECT}}
+          rm -rf ${{TEMP_DIR}}
+          osc rdelete -r -m "rpm-packaging CI cleanup" ${{OBS_TEST_PROJECT}} || :
           sleep 3
 
           # recreate the rpm-packaging tarball (as done by the tar_scm source service)
-          mkdir ${TEMP_DIR}
-          tar --exclude-vcs -cvjf ${TEMP_DIR}/rpm-packaging-0.0.1.tar.bz2 --transform 's,^,rpm-packaging-0.0.1/,' .
+          mkdir ${{TEMP_DIR}}
+          tar --exclude-vcs -cvjf ${{TEMP_DIR}}/rpm-packaging-0.0.1.tar.bz2 --transform 's,^,rpm-packaging-0.0.1/,' .
 
           # branch and checkout OBS project
           osc branch --add-repositories-block=local \
               --add-repositories-rebuild=local \
-              ${OBS_BASE_SRC_PROJECT} \
-              "rpm-packaging-openstack" ${OBS_TEST_PROJECT} || :
+              ${{OBS_BASE_SRC_PROJECT}} \
+              "rpm-packaging-openstack" ${{OBS_TEST_PROJECT}} || :
           sleep 2
 
           # create package links (needed if a new .spec.j2 was added)
           for spec_template in `find -name '*.spec.j2'`; do
               spec_basename=`basename $spec_template|sed 's/.spec.j2$//'`
-              osc linkpac ${OBS_TEST_PROJECT} "rpm-packaging-openstack" ${OBS_TEST_PROJECT} python-${spec_basename} || :
+              osc linkpac ${{OBS_TEST_PROJECT}} "rpm-packaging-openstack" ${{OBS_TEST_PROJECT}} python-${{spec_basename}} || :
           done
           sleep 2
 
           # checkout branched project, add updated stuff and commit
-          osc co ${OBS_TEST_PROJECT}
-          cp ${TEMP_DIR}/rpm-packaging-0.0.1.tar.bz2 ${OBS_TEST_PROJECT}/rpm-packaging-openstack
-          pushd ${OBS_TEST_PROJECT}/rpm-packaging-openstack
+          osc co ${{OBS_TEST_PROJECT}}
+          cp ${{TEMP_DIR}}/rpm-packaging-0.0.1.tar.bz2 ${{OBS_TEST_PROJECT}}/rpm-packaging-openstack
+          pushd ${{OBS_TEST_PROJECT}}/rpm-packaging-openstack
           osc detachbranch
           osc up
           bash -x pre_checkin.sh
@@ -51,12 +51,12 @@
           osc service localrun download_files
           osc addremove
           osc status
-          osc commit -m "rpm-packaging CI (${ZUUL_CHANGES})"
+          osc commit -m "rpm-packaging CI (${{ZUUL_CHANGES}})"
 
           popd
-          pushd ${OBS_TEST_PROJECT}
+          pushd ${{OBS_TEST_PROJECT}}
           echo "#################################"
-          echo "https://build.opensuse.org/project/show/${OBS_TEST_PROJECT}"
+          echo "https://build.opensuse.org/project/show/${{OBS_TEST_PROJECT}}"
           echo "#################################"
           sleep 5
 
@@ -88,7 +88,7 @@
                   done
 
                   if [ -n "$kickscheduler" ]; then
-                      echo "# $(date)" | osc meta prjconf -F - ${OBS_TEST_PROJECT}
+                      echo "# $(date)" | osc meta prjconf -F - ${{OBS_TEST_PROJECT}}
                       sleep $((RANDOM%60+30))
                       echo "kicking scheduler"
                       continue

--- a/scripts/jenkins/zuul/layout.yaml
+++ b/scripts/jenkins/zuul/layout.yaml
@@ -19,12 +19,18 @@ pipelines:
 projects:
   - name: openstack/rpm-packaging
     rpm-packaging:
-      - openstack-gerrit-rpm-packaging
+      - openstack-upstream-gerrit-rpm-packaging-Master
+      - openstack-upstream-gerrit-rpm-packaging-Mitaka
 
 jobs:
-  - name: openstack-gerrit-rpm-packaging
+  - name: openstack-upstream-gerrit-rpm-packaging-Master
     voting: false
     branch: master
-    failure-pattern: https://build.opensuse.org/project/monitor/home:suse-cloud-ci:rpm-packaging-openstack-{build.build_set.commit}
-    success-pattern: https://build.opensuse.org/project/monitor/home:suse-cloud-ci:rpm-packaging-openstack-{build.build_set.commit}
+    failure-pattern: https://build.opensuse.org/project/monitor/home:suse-cloud-ci:rpm-packaging-openstack-Master-{build.build_set.commit}
+    success-pattern: https://build.opensuse.org/project/monitor/home:suse-cloud-ci:rpm-packaging-openstack-Master-{build.build_set.commit}
 
+  - name: openstack-upstream-gerrit-rpm-packaging-Mitaka
+    voting: false
+    branch: stable/mitaka
+    failure-pattern: https://build.opensuse.org/project/monitor/home:suse-cloud-ci:rpm-packaging-openstack-Mitaka-{build.build_set.commit}
+    success-pattern: https://build.opensuse.org/project/monitor/home:suse-cloud-ci:rpm-packaging-openstack-Mitaka-{build.build_set.commit}


### PR DESCRIPTION
There is now a stable/mitaka branch for the rpm-packaging project.
For the CI, we need to update the available packages for all branches
(now stable/mitaka and master). We use the subprojects in OBS under
Cloud:OpenStack:Upstream for that.