### PR TITLE
Run gating HA job in parallel

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-gating-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-gating-template.yaml
@@ -42,10 +42,6 @@
                 nodenumber=4
                 networkingplugin=linuxbridge
                 mkcloudtarget=all
-      - multijob:
-          name: 'Extra Gate Checks (HA)'
-          condition: SUCCESSFUL
-          projects:
             - name: cloud-mkcloud{version}-job-ha-x86_64
               node-label: cloud-trigger
 


### PR DESCRIPTION
Currently we need more then ~3 hours for a gating. Running HA in parallel
brings this down to ~1 1/2 hours.