### PR TITLE
mkcloud: don't spin a complete core on ksmd on low-cpu count host

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -449,7 +449,9 @@ function onhost_enable_ksm
     # enable kernel-samepage-merging to save RAM
     [[ -w /sys/kernel/mm/ksm/merge_across_nodes ]] && echo 0 > /sys/kernel/mm/ksm/merge_across_nodes
     [[ -w /sys/kernel/mm/ksm/run ]] && echo 1 > /sys/kernel/mm/ksm/run
-    [[ -w /sys/kernel/mm/ksm/pages_to_scan ]] && echo 1000 > /sys/kernel/mm/ksm/pages_to_scan
+    # Don't waste a complete CPU core on low-core count machines
+    local pts=$(($(lscpu -p | grep -vc '^#')*64))
+    [[ -w /sys/kernel/mm/ksm/pages_to_scan ]] && echo $pts > /sys/kernel/mm/ksm/pages_to_scan
 
     # huge pages can not be shared or swapped, so do not use them
     [[ -w /sys/kernel/mm/transparent_hugepage/enabled ]] && echo never > /sys/kernel/mm/transparent_hugepage/enabled


### PR DESCRIPTION
on s390x where we have only one or two cpus, we were spending almost
100% cpu in ksmd, which slows down almost everything