### PR TITLE
Fix for depracated options

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3742,11 +3742,11 @@ function oncontroller_testsetup()
     nova flavor-delete m1.smaller || :
     nova flavor-create m1.smaller 11 512 8 1
     nova delete testvm  || :
-    nova keypair-add --pub_key /root/.ssh/id_rsa.pub testkey
+    nova keypair-add --pub-key /root/.ssh/id_rsa.pub testkey
     nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0
     nova secgroup-add-rule default tcp 1 65535 0.0.0.0/0
     nova secgroup-add-rule default udp 1 65535 0.0.0.0/0
-    timeout 10m nova boot --poll --image $image_name --flavor $flavor --key_name testkey testvm | tee boot.out
+    timeout 10m nova boot --poll --image $image_name --flavor $flavor --nic net-name=fixed --key-name testkey testvm | tee boot.out
     ret=${PIPESTATUS[0]}
     [ $ret != 0 ] && complain 43 "nova boot failed"
     instanceid=`perl -ne "m/ id [ |]*([0-9a-f-]+)/ && print \\$1" boot.out`


### PR DESCRIPTION
`WARNING: Option "--pub_key" is deprecated; use "--pub-key"; this option will be removed in novaclient 3.3.0.`

`WARNING: Option "--key_name" is deprecated; use "--key-name"; this option will be removed in novaclient 3.3.0.`