### PR TITLE
mkcloud: reduce ksm on aarch64 even further

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -450,7 +450,10 @@ function onhost_enable_ksm
     [[ -w /sys/kernel/mm/ksm/merge_across_nodes ]] && echo 0 > /sys/kernel/mm/ksm/merge_across_nodes
     [[ -w /sys/kernel/mm/ksm/run ]] && echo 1 > /sys/kernel/mm/ksm/run
     # Don't waste a complete CPU core on low-core count machines
-    local pts=$(($(lscpu -p | grep -vc '^#')*64))
+    local ppcpu=64
+    # aarch64 machines have high core count but low single-core performance
+    [ $(uname -m) = aarch64 ] && ppcpu=4
+    local pts=$(($(lscpu -p | grep -vc '^#')*$ppcpu))
     [[ -w /sys/kernel/mm/ksm/pages_to_scan ]] && echo $pts > /sys/kernel/mm/ksm/pages_to_scan
 
     # huge pages can not be shared or swapped, so do not use them


### PR DESCRIPTION
The setting on aarch64 workers is completely insane, it basically causes
the cpu to completely stall, triggering lock up detection:

[ 9563.821445] INFO: rcu_sched self-detected stall on CPU
[ 9563.821452]  40-...: (114019 ticks this GP)
idle=f45/140000000000001/0 softirq=382572/382585 fqs=112564
[ 9563.821457]   (t=114023 jiffies g=138434 c=138433 q=393704)
[ 9563.821459] Task dump for CPU 40:
[ 9563.821462] ksmd            R  running task        0   293      2
0x00000002