### PR TITLE
mkcloud_reserve_pool: use arithmetic with seconds

### DIFF
--- a/scripts/mkcloudhost/mkcloud_reserve_pool
+++ b/scripts/mkcloudhost/mkcloud_reserve_pool
@@ -2,8 +2,7 @@
 
 host=$1
 pool_vm=$2
-hours=$3
-minutes=$4
+delay=$3
 message="Did you free VM ${pool_vm} on mkch${host}.cloud.suse.de ?"
 
 if ! [[ $(which xmessage) ]]; then
@@ -11,59 +10,39 @@ if ! [[ $(which xmessage) ]]; then
   exit 1
 fi
 
-if [[ -z $1 ]] || [[ -z $2 ]] || [[ -z $3 ]]
+if [[ ! $host || ! $pool_vm ]]
 then
-  echo "usage ./mkcloud_reserve_pool mkcloudhost pool_vm reminder_hours reminder_minutes"
-  echo "  example: ./mkcloud_reserve_pool mkche 1 16 00"
+  echo "usage ./mkcloud_reserve_pool mkcloudhost pool_vm reminderdelay"
+  echo "  example: ./mkcloud_reserve_pool e 1 90m"
   exit 1
 fi
 
 echo "reserving VM ${pool_vm} on mkch${host}.cloud.suse.de"
 ssh root@mkch${host}.cloud.suse.de "mv /root/pool/${pool_vm} /root/pool/${pool_vm}.${USER}"
 
-case "$hours" in
-     [0-1][0-9] | 2[0-3] ) ;;
-     [0-9] ) hours="0$hours" ;;
-     * ) echo "'$hours' : Not a valid hour ( 0 - 23 )" 1>&2
-         exit 1 ;;
-esac
-
-case "$4" in
-     [0-9] | [0-5][0-9] ) minutes="$4"
-                          shift 2 ;;
-     * ) shift 1
-         minutes="" ;;
-esac
-
-if test -z "$minutes"
-then echo "Enter minutes (random input or timeout after 10 seconds set minutes to 0): "
-     read -t 10 minutes
-     case "$minutes" in
-          [0-9] | [0-5][0-9] ) ;;
-          * ) minutes="0" ;;
-     esac
+if [[ ! $delay ]]
+then echo "Enter reminder delay (empty input or timeout after 10 seconds set delay to 60m): "
+     read -t 10 delay
+     : ${delay:=60m}
 fi
 
-case "$minutes" in
-     [0-5][0-9] ) ;;
-     [0-9] ) minutes="0$minutes" ;;
-     * ) echo "'$minutes' : Not a valid minute ( 0 - 59 )" 1>&2
+case "$delay" in
+     *[0-9m] ) delayseconds=60 ;;
+     *s ) delayseconds=1 ;;
+     *h ) delayseconds=$((60*60)) ;;
+     *d ) delayseconds=$((24*60*60)) ;;
+     * ) echo "'$delay' : does not have a valid time suffix ([dhms])" 1>&2
          exit 1 ;;
 esac
+delaysecs=$(($delayseconds * ${delay%%[dmhs]}))
 
-alarm_time="$hours$minutes"
+alarm_time=$(($(date +%s) + $delaysecs))
 
-echo "At $hours:$minutes you get the xmessage $message"
+echo "After ${delay} = ${delaysecs}s at $(date --date=@$alarm_time '+%F %T') you get the xmessage $message"
 
 set_alarm()
-{ while true
-  do current_time=$( date +%H%M )
-     if test "$current_time" -ge "$alarm_time"
-     then break
-     fi
-     sleep 30
-  done
-  xmessage -nearmouse -timeout 18000 "$hours:$minutes $message"
+{ sleep $delaysecs
+  xmessage -nearmouse -timeout 18000 "$message"
   exit 0
 }
 


### PR DESCRIPTION
allows to specify notification delays longer than a day
and crossing midnight