### PR TITLE
docs: mkcloud: Start the virtlogd service on new installations

### DIFF
--- a/docs/mkcloud.md
+++ b/docs/mkcloud.md
@@ -20,6 +20,14 @@ or testing purposes.
   $ sudo service libvirtd start  # to start the daemon
   ```
 
+  If you are using `libvirtd >= 1.3.0` then you should also start the
+  `virtlogd` service.
+
+  ```
+  $ sudo service virtlogd status # to check the status
+  $ sudo service virtlogd start  # to start the daemon
+  ```
+
   It's recommended to configure libvirtd to start on boot.
 
   * For systems running systemd:

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -109,6 +109,10 @@ function libvirt_do_setuphost()
         safely pvcreate "$cloudpv"
         safely vgcreate "$cloudvg" "$cloudpv"
     fi
+
+    # Start libvirtd and friends
+    sudo service libvirtd status || sudo service libvirtd start
+    sudo service virtlogd status || sudo service virtlogd start
 }
 
 function libvirt_do_sanity_checks()


### PR DESCRIPTION
When using the mkcloud on a new host, starting the libvirt daemon alone
will not start the virtlogd service which leads to the following problem:

libvirt: QEMU Driver error : Domain not found: no domain with matching name 'cloud-admin'
libvirt: XML-RPC error : Failed to connect socket to '/var/run/libvirt/virtlogd-sock': No such file or directory
Traceback (most recent call last):
  File "/root/mchandras/automation/scripts/lib/libvirt/vm-start", line 16, in <module>
    main()
  File "/root/mchandras/automation/scripts/lib/libvirt/vm-start", line 12, in main
    libvirt_setup.vm_start(args)
  File "/root/mchandras/automation/scripts/lib/libvirt/libvirt_setup.py", line 377, in vm_start
    dom.create()
  File "/usr/lib64/python2.7/site-packages/libvirt.py", line 1035, in create
    if ret == -1: raise libvirtError ('virDomainCreate() failed', dom=self)
libvirt.libvirtError: Failed to connect socket to '/var/run/libvirt/virtlogd-sock': No such file or directory

This is because the libvirtd service file does not start virtlogd but it
simply installs it so it can start automatically on the next reboot.

Signed-off-by: Markos Chandras <mchandras@suse.de>