### PR TITLE
Also remove docker node from all other compute node types

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1663,7 +1663,7 @@ EOF
 
     # Workaround broken sleshammer
     if [ "$(uname -m)" = "aarch64" ]; then
-        rpm -Uvh http://clouddata.cloud.suse.de/suse-12.1/aarch64/PTF/sleshammer-aarch64.rpm
+        rpm -Uvh --force http://clouddata.cloud.suse.de/suse-12.1/aarch64/PTF/sleshammer-aarch64.rpm
     fi
 
     cd /tmp

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2781,8 +2781,12 @@ function custom_configuration()
 
             if [ -n "$want_sles12" ] && [ -n "$want_docker" ] ; then
                 proposal_set_value nova default "['deployment']['nova']['elements']['${role_prefix}-compute-docker']" "['$sles12plusnode']"
-                # do not assign another compute role to this node
-                proposal_modify_value nova default "['deployment']['nova']['elements']['${role_prefix}-compute-${libvirt_type}']" "['$sles12plusnode']" "-="
+
+                local computetype
+                for computetype in "xen" "qemu" "lxc" "${libvirt_type}"; do
+                    # do not assign another compute role to this node
+                    proposal_modify_value nova default "['deployment']['nova']['elements']['${role_prefix}-compute-${computetype}']" "['$sles12plusnode']" "-="
+                done
             fi
 
             if [[ $nova_shared_instance_storage = 1 ]] ; then


### PR DESCRIPTION
The proposal creation has some magic to assign nodes to some roles, we
need to undo that in cases where we want to have docker deployment.
In this case the node was autoassigned to qemu because nested virt
wasn't available.