### PR TITLE
Override scenariofile location

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1325,6 +1325,8 @@ Optional
         Defines which scenario file should be used. Only works with cloud5 or newer.
         Currently only the step 'batch' uses such a file.
         Scenario files have to placed in \${mkcloud_dir}/scenarios/cloud\$(getcloudver).
+    scenariofile='/tmp/scenario.yaml' (default=${mkcloud_dir}/scenarios/cloud\$(getcloudver))
+        Override scenariofile location. Requires $scenario to be set as well.
 EOUSAGE
     onadmin_help
     exit 1
@@ -1460,7 +1462,7 @@ function sanity_checks()
     if [[ " ${steplist[*]} " == *" batch "* ]] ; then
         need_scenario=1
         if [[ -n $scenario ]] ; then
-            scenariofile="${mkcloud_dir}/scenarios/cloud$(getcloudver)/${scenario}"
+            : ${scenariofile:="${mkcloud_dir}/scenarios/cloud$(getcloudver)/${scenario}"}
             [[ ! -f $scenariofile ]] && complain 115 "Scenario file not found at $scenariofile"
         else
             complain 114 "Please set a scenario file for crowbar_batch with scenario=foo"


### PR DESCRIPTION
this is more convenient, especially on a shared cloudhost where you
don't want to change the systems mkcloud directory