### PR TITLE
Ensure that SP1 nodes are last

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-sle12sp2.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-sle12sp2.yaml
@@ -41,8 +41,9 @@
               predefined-parameters: |
                 TESTHEAD=1
                 cloudsource=develcloud{version}
-                nodenumber=4
+                nodenumber=5
                 want_sles12sp2=1
+                want_node_os=suse-12.2=3,suse-12.1=2
                 networkingmode=vxlan
                 hacloud=1
                 mkcloudtarget=all_noreboot


### PR DESCRIPTION
Let's have first 2 nodes as SP2 so pacemaker cluster is created
from nodes with same OS version.
One SP2 node for compute and two SP1 one nodes for ceph.
