### PR TITLE
[UNTESTED] fix scenariofile logic and help text

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1331,9 +1331,9 @@ Optional
     scenario='scenario.yaml' (default='')
         Defines which scenario file should be used. Only works with cloud5 or newer.
         Currently only the step 'batch' uses such a file.
-        Scenario files have to placed in \${mkcloud_dir}/scenarios/cloud\$(getcloudver).
-    scenariofile='/tmp/scenario.yaml' (default=${mkcloud_dir}/scenarios/cloud\$(getcloudver))
-        Override scenariofile location. Requires $scenario to be set as well.
+    scenariofile='/tmp/scenario.yaml' (default=${mkcloud_dir}/scenarios/cloud\$(getcloudver)/\$scenario)
+        Full path to scenario file, overriding \$scenario. Required for batch
+        if \$scenario is not set.
 EOUSAGE
     onadmin_help
     exit 1
@@ -1468,12 +1468,13 @@ function sanity_checks()
 
     if [[ " ${steplist[*]} " == *" batch "* ]] ; then
         need_scenario=1
-        if [[ -n $scenario ]] ; then
-            : ${scenariofile:="${mkcloud_dir}/scenarios/cloud$(getcloudver)/${scenario}"}
-            [[ ! -f $scenariofile ]] && complain 115 "Scenario file not found at $scenariofile"
-        else
-            complain 114 "Please set a scenario file for crowbar_batch with scenario=foo"
+        if [[ -z $scenario$scenariofile ]] ; then
+            complain 114 "Please set either scenario or scenariofile for crowbar_batch"
+        elif [[ -n $scenario ]] && [[ -n $scenariofile ]] ; then
+            echo "WARNING: \$scenariofile overrides \$scenario" >&2
         fi
+        : ${scenariofile:="${mkcloud_dir}/scenarios/cloud$(getcloudver)/${scenario}"}
+        [[ ! -f $scenariofile ]] && complain 115 "Scenario file not found at $scenariofile"
     fi
 }
 


### PR DESCRIPTION
cee28264 from #1103 introduced faulty logic and misleading help text.

If `$scenariofile` is set by the user, then `$scenario` is totally ignored. This is because

    : ${foo:=bar}

will not set `$foo` if it was already set.

So if `$scenariofile` is set, it makes more sense to complain (or at least warn) if `$scenario` is set (since it would be ignored) rather than if it's unset.

If that was confusing, maybe this will help:

| scenariofile | scenario | old behaviour          | new behaviour
| ------------ | -------- | ---------------------- | -----------------
|    not set   |  not set | correct behaviour      | no change
|    not set   |    set   | correct behaviour      | no change
|      set     |  not set | incorrectly prohibited | allowed
|      set     |    set   | ignores `$scenario`      | warn
