### PR TITLE
Add Cloud7/SP2 target for mediacheck

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-mediacheck.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mediacheck.yaml
@@ -24,6 +24,7 @@
             - SUSE:SLE-11-SP3:Update:Cloud5:Test
             - SUSE:SLE-12-SP1:Update:Products:Cloud6/SLE_12_SP1
             - SUSE:SLE-12-SP2:Update:Products:Cloud7/SLE_12_SP1
+            - SUSE:SLE-12-SP2:Update:Products:Cloud7/SLE_12_SP2
       - axis:
           type: user-defined
           name: subproject
@@ -37,7 +38,7 @@
             - cloud-trackupstream-sle12
     execution-strategy:
       combination-filter: |
-        (["Devel:Cloud:5", "Devel:Cloud:5/SLE_12", "Devel:Cloud:6", "Devel:Cloud:6/SLE_12_SP1", "Devel:Cloud:7/SLE_12_SP1" ].contains(project) || subproject == ":")
+        (["Devel:Cloud:5", "Devel:Cloud:5/SLE_12", "Devel:Cloud:6", "Devel:Cloud:6/SLE_12_SP1", "Devel:Cloud:7/SLE_12_SP1", "Devel:Cloud:7/SLE_12_SP2" ].contains(project) || subproject == ":")
     builders:
       - shell: |
           # temporary, similar to update_automation (not that advanced)


### PR DESCRIPTION
I have no idea if this is correct, and if this is all that is missing, but https://ci.suse.de/view/Cloud/view/Milestones%20Cloud7/job/cloud-mediacheck/ does not have any Cloud7/SP2 check now.

For example, is it needed as a value in the `execution-strategy:` ?