### PR TITLE
Disable service q-fwaas in for devstack

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -132,7 +132,7 @@ enable_service q-meta
 enable_service q-metering
 # vpn disabled for now. openswan required by devstack but not available in openSUSE
 # enable_service q-vpn
-enable_service q-fwaas
+# enable_service q-fwaas
 enable_service q-lbaas
 
 # for testing


### PR DESCRIPTION

We would like to disable this, because q_fwaas doesn't generate any config file and neutron-l3-agent is failing to start.