### PR TITLE
Add want_sahara variable to jenkins mkcloud job

### DIFF
--- a/scripts/jenkins/ci.suse.de/openstack-mkcloud.xml
+++ b/scripts/jenkins/ci.suse.de/openstack-mkcloud.xml
@@ -196,6 +196,11 @@ Default: -t -s.</description>
           <nodeEligibility class="org.jvnet.jenkins.plugins.nodelabelparameter.node.AllNodeEligibility"/>
         </org.jvnet.jenkins.plugins.nodelabelparameter.LabelParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>want_sahara</name>
+          <description>Set to 1 to deploy Sahara.</description>
+          <defaultValue/>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>want_node_aliases</name>
           <description>List of aliases to assign to nodes. Takes all provided aliases and assign them to available nodes successively.
 


### PR DESCRIPTION
This is to enable manual set of the proper variable to test sahara in jenkins.

See:
https://github.com/crowbar/crowbar-openstack/pull/480
https://github.com/SUSE-Cloud/automation/pull/1126