### PR TITLE
fix cpuflags (and hence ACPI / virsh shutdown) on AMD

### DIFF
--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -33,13 +33,12 @@ def cpuflags():
     cpu_info = readfile("/proc/cpuinfo")
     if re.search("^CPU architecture.* 8", cpu_info, re.MULTILINE):
         cpu_template = "cpu-arm64.xml"
-    if re.search("^vendor_id.*GenuineIntel", cpu_info, re.MULTILINE):
+    elif re.search("^vendor_id.*GenuineIntel", cpu_info, re.MULTILINE):
         cpu_template = "cpu-intel.xml"
-    if re.search("^vendor_id.*IBM/S390", cpu_info, re.MULTILINE):
+    elif re.search("^vendor_id.*AuthenticAMD", cpu_info, re.MULTILINE):
+        cpu_template = "cpu-amd.xml"
+    elif re.search("^vendor_id.*IBM/S390", cpu_info, re.MULTILINE):
         cpu_template = "cpu-s390x.xml"
-
-    if re.search("flags.* npt", cpu_info):
-        return ""
 
     return readfile(os.path.join(TEMPLATE_DIR, cpu_template))
 

--- a/scripts/lib/libvirt/templates/cpu-amd.xml
+++ b/scripts/lib/libvirt/templates/cpu-amd.xml
@@ -1,0 +1,5 @@
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>


### PR DESCRIPTION
The `<features>` was missing from the VM's libvirt config on AMD hosts, and this was causing a lack of ACPI support, which in turn meant that virsh shutdown etc. didn't work, and hence that mkcloud didn't work properly.

Some history:

A long time ago, 5696c1671 originally introduced some logic so that if the `npt` (AMD Nested Page Tables) flag was present in `/proc/cpuinfo` on the host, the <cpu> section would not be included.

Later, PR #343 switched libvirt VM creation code from bash to Python with templates, but at this point `<features>` was always included.

Much more recently, 7fe19ff9 from PR #1049 moved the `<features>` section into the CPU templates, resulting in it missing when the AMD `npt` flag was present.  668a415d then added support for other architectures, but still left AMD broken.