### PR TITLE
disable postgresql to not break the upgrade CI

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-upgrade-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-upgrade-template.yaml
@@ -22,3 +22,4 @@
             nodenumber=2
             mkcloudtarget=plain_with_upgrade testsetup rebootcloud
             label={label}
+            want_postgresql=0


### PR DESCRIPTION
when https://github.com/SUSE-Cloud/automation/pull/1115 which enables
postgresql by default is merged, the upgrade CI will likely be broken
as there is no step yet to setup the database