### PR TITLE
Compute HA: disable swift dispersion

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
@@ -82,8 +82,7 @@ proposals:
         enabled: true
   deployment:
     elements:
-      swift-dispersion:
-      - @@controller1@@
+      swift-dispersion: []
       swift-proxy:
       - cluster:services
       swift-ring-compute:


### PR DESCRIPTION
This just causes a timeout right now since dispersion is just broken
with cloud 7, so remove this for nwo