### PR TITLE
Uefi boot support  on mkcloud

### DIFF
--- a/scripts/lib/libvirt/admin-config
+++ b/scripts/lib/libvirt/admin-config
@@ -18,6 +18,8 @@ def main():
                         help="Local Repository Directory Source")
     parser.add_argument("localrepotgt",
                         help="Local Repository Directory Target")
+    parser.add_argument("firmwaretype",
+                        help="Boot firmware type for the node")
     args = parser.parse_args()
 
     print(libvirt_setup.admin_config(args))

--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -31,6 +31,8 @@ def main():
     parser.add_argument("bootorder", type=int, help="Boot Order (e.g. 2)")
     parser.add_argument("numcontrollers", type=int, default=1,
                         help="Number of controller nodes")
+    parser.add_argument("firmwaretype", default="bios",
+                        help="Boot firmware type for the node")
     args = parser.parse_args()
 
     print(libvirt_setup.compute_config(args, libvirt_setup.cpuflags()))

--- a/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
@@ -1,0 +1,59 @@
+<domain type='kvm'>
+  <name>cloud-admin</name>
+  <memory>2097152</memory>
+  <currentMemory>2097152</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-0.14'>hvm</type>
+<loader readonly='yes' type='pflash'>/usr/share/qemu/ovmf-x86_64-ms-code.bin</loader>
+    <nvram>/var/lib/libvirt/cloud-admin_VARS.fd</nvram>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu mode='custom' match='exact'>
+    <model fallback='allow'>core2duo</model>
+    <feature policy='require' name='vmx'/>
+  </cpu>
+
+  <clock offset='utc'/>
+  <on_poweroff>preserve</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>preserve</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='block' device='disk'>
+      <driver name='qemu' type='raw' cache='unsafe'/>
+      <source dev='/dev/cloud/cloud.admin'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' slot='0x04'/>
+    </disk>
+    <interface type='network'>
+      <mac address='52:54:00:77:77:70'/>
+      <target dev='cloud-a'/>
+      <source network='cloud-admin'/>
+      <model type='virtio'/>
+      <address type='pci' slot='0x03'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes'/>
+    <video>
+      <model type='cirrus' vram='9216' heads='1'/>
+      <address type='pci' slot='0x02'/>
+    </video>
+
+    <memballoon model='virtio' autodeflate='on'>
+      <address type='pci' slot='0x05'/>
+    </memballoon>
+
+  </devices>
+</domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -1,0 +1,70 @@
+<domain type='kvm'>
+  <name>cloud-node1</name>
+  <memory>5242880</memory>
+  <currentMemory>5242880</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-0.14'>hvm</type>
+<loader readonly='yes' type='pflash'>/usr/share/qemu/ovmf-x86_64-ms-code.bin</loader>
+    <nvram>/var/lib/libvirt/cloud-node1_VARS.fd</nvram>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu mode='custom' match='exact'>
+    <model fallback='allow'>core2duo</model>
+    <feature policy='require' name='vmx'/>
+  </cpu>
+
+  <clock offset='utc'/>
+  <on_poweroff>preserve</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>preserve</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='block' device='disk'>
+      <driver name='qemu' type='raw' cache='unsafe'/>
+      <source dev='/dev/cloud/cloud.node1'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' slot='0x0a'/>
+      <boot order='3'/>
+    </disk>
+
+
+    <disk type='block' device='disk'>
+      <serial>cloud-node1-ceph1</serial>
+      <driver name='qemu' type='raw' cache='unsafe'/>
+      <source dev='/dev/cloud/cloud.node1-ceph1'/>
+      <target dev='vdb' bus='virtio'/>
+      <address type='pci' slot='0x11'/>
+    </disk>
+
+
+    <interface type='network'>
+      <mac address='52:54:01:77:77:01'/>
+      <target dev='cloud-1'/>
+      <source network='cloud-admin'/>
+      <model type='virtio'/>
+      <address type='pci' slot='0x03'/>
+      <boot order='2'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes'/>
+    <video>
+      <model type='cirrus' vram='9216' heads='1'/>
+      <address type='pci' slot='0x02'/>
+    </video>
+
+    <memballoon model='virtio' autodeflate='on'>
+      <address type='pci' slot='0x05'/>
+    </memballoon>
+  </devices>
+</domain>

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -56,13 +56,14 @@ def get_machine_arch():
     return os.uname()[4]
 
 
-def get_os_loader():
-    path = '/usr/share/qemu/aavmf-aarch64-code.bin'
+def get_os_loader(firmware_type=None):
+    path = None
+    template = "<loader readonly='yes' type='pflash'>%s</loader>"
     if 'aarch64' in get_machine_arch():
-        return """
-  <loader readonly='yes' type='pflash'>%s</loader>
-""" % path
-    return ""
+        path = "/usr/share/qemu/aavmf-aarch64-code.bin"
+    elif 'x86_64' in get_machine_arch() and firmware_type == "uefi":
+        path = "/usr/share/qemu/ovmf-x86_64-ms-code.bin"
+    return template % path if path else ""
 
 
 def get_video_devices():
@@ -152,9 +153,9 @@ def admin_config(args, cpu_flags=cpuflags()):
         adminvcpus=args.adminvcpus,
         cpuflags=cpu_flags,
         emulator=args.emulator,
-        osloader=get_os_loader(),
         march=get_machine_arch(),
         machine=get_default_machine(args.emulator),
+        osloader=get_os_loader(firmware_type=args.firmwaretype),
         memballoon=get_memballoon_type(),
         maindiskaddress=get_maindisk_address(),
         mainnicaddress=get_mainnic_address(),
@@ -278,7 +279,7 @@ def compute_config(args, cpu_flags=cpuflags()):
         vcpus=args.vcpus,
         march=get_machine_arch(),
         machine=get_default_machine(args.emulator),
-        osloader=get_os_loader(),
+        osloader=get_os_loader(firmware_type=args.firmwaretype),
         cpuflags=cpu_flags,
         consoletype=get_console_type(),
         raidvolume=raidvolume,

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -517,6 +517,8 @@ function dist_to_image_name
             complain 71 "No admin node image defined for this distribution: $dist"
         ;;
     esac
+    iscloudver 7plus && [[ $want_efi ]] && \
+        [[ $arch == x86_64 ]] && image="SLES12-SP2-uefi"
     echo "$image.qcow2"
 }
 

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -74,7 +74,7 @@ function libvirt_prepare()
 
 function libvirt_do_setupadmin()
 {
-    ${scripts_lib_dir}/libvirt/admin-config $cloud $admin_node_memory $adminvcpus $emulator $admin_node_disk "$localreposdir_src" "$localreposdir_target" > /tmp/$cloud-admin.xml
+    ${scripts_lib_dir}/libvirt/admin-config $cloud $admin_node_memory $adminvcpus $emulator $admin_node_disk "$localreposdir_src" "$localreposdir_target" "$firmware_type" > /tmp/$cloud-admin.xml
     ${scripts_lib_dir}/libvirt/vm-start /tmp/$cloud-admin.xml || exit $?
 }
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -123,6 +123,8 @@ pv_cur_device_no=0
 : ${cct_tests:="features:base"}
 host_mtu=$(determine_mtu)
 : ${want_mtu_size:=1500}
+iscloudver 7plus && [[ $arch == x86_64 ]] && \
+    [[ -n $want_efi ]] && firmware_type="uefi"
 
 emulator=/usr/bin/qemu-system-$arch
 if [ -x /usr/bin/qemu-kvm ] && file /usr/bin/qemu-kvm | grep -q ELF; then
@@ -210,6 +212,7 @@ function sshrun
         export adminip=$adminip ;
         export hacloud=$hacloud ;
         export libvirt_type=$libvirt_type ;
+        export firmware_type=$firmware_type ;
         export networkingplugin=$networkingplugin ;
         export networkingmode=$networkingmode ;
         export nosetestparameters=${nosetestparameters} ;
@@ -586,7 +589,8 @@ function setupnodes
         ${scripts_lib_dir}/libvirt/compute-config $cloud $i $macaddress\
             $controller_raid_volumes $cephvolumenumber "$drbd_serial"\
             $compute_node_memory $controller_node_memory $libvirt_type $vcpus\
-            $emulator $vdisk_dir 3 $nodenumbercontroller > /tmp/$cloud-node$i.xml
+            $emulator $vdisk_dir 3 \
+            $nodenumbercontroller "$firmware_type" > /tmp/$cloud-node$i.xml
         ${scripts_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
     done
 
@@ -1063,6 +1067,8 @@ Optional
     want_horizon_integration_test=1 (default='')
         Execute selenium integration tests for Horizon after Tempest. This test is in beta, and
         a fail will not be considered for now.
+    want_efi=1 (default=0)
+        Deploy nodes with EFI. Only available from Cloud7 and later.
     install_chef_suse_override='path/to/script'
         Optional path to an alternate version of install-chef-suse.sh on the mkcloud hostto use
         instead of the one from the packages.  This will be scp'd to the admin node before use.
@@ -1108,6 +1114,7 @@ EOUSAGE
 # computenode_hdd_size
 # cloudbr
 # libvirt_type
+# firmware_type
 # localreposdir_src
 # localreposdir_target
 # wipe


### PR DESCRIPTION
Allow support for firmware_type as a parameter to admin_config and add an option to mkcloud "want_efi" to use UEFI image to boot mkcloud.
