### PR TITLE
Execute Magnum tempest tests for magnum CI job

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -20,5 +20,6 @@
             cloudsource=develcloud{version}
             nodenumber=2
             want_magnum=1
+            ostestroptions=" --regex '^magnum.tests.functional.api'"
             mkcloudtarget=all
             label={label}


### PR DESCRIPTION
Magnum has no non-smoke tempest tests so use the ostestroptions
parameter to do an extra ostestr run with the Magnum tests.