### PR TITLE
Merging mkcloudruns with automation repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ roundup/
 
 .artifacts/
 mkcloud.config
+mkcloud.*
+*.log
+.artifacts
+pids/
+screenlog*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ bashate:
 	for f in \
 	    *.sh mkcloud mkchroot repochecker \
 	    jenkins/{update_automation,*.sh} \
-	    jenkins/ci1/*; \
+	    jenkins/ci1/* ../mkcloudruns/*/*;\
 	do \
 	    echo "checking $$f"; \
 	    bash -n $$f || exit 3; \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ This repository contains various scripts which SUSE uses to automate
 development, testing, and CI (continuous integration) of the various
 components of SUSE Cloud, i.e. OpenStack and Crowbar.
 
+# Developer Environments:
+
+* For using the automation repository for development, testing and training please refer
+  the mkcloudruns folder in this repository. Check the readme in there for more details.
+
 # Scripts
 
 This project has several scripts for different automated tasks, some of them are:

--- a/mkcloudruns/README.md
+++ b/mkcloudruns/README.md
@@ -1,0 +1,135 @@
+MkCloud Runs
+------------
+
+# Description
+
+Run multiple copies of various scenarios of SUSE OpenStack Cloud product
+using mkcloud ([automation repository](https://github.com/SUSE-Cloud/automation)).
+
+This repository is basically a wrapper which automates the boilerplate required
+to start mkcloud with the right configuration settings. Even for non-beginners
+this boilerplate wrapper script should be really handy due to the overwhelming
+amount of configuration options and environment variables used by mkcloud :|.
+
+- Inspiration:
+    > I'm just too lazy.
+- The perfect world:
+    > We do not need these scripts!
+
+# Deploying SUSE CLoud
+
+Follow these steps to deploy the required SUSE Cloud setup.
+
+## Initial Setup
+
+* Clone the repository
+* Setup up libvirt, KVM,LVM as per the automation repo, follow [this link](https://github.com/dguitarbite/automation/blob/master/docs/mkcloud.md)
+* Create a LVM drive either using dd or give it one partition from your disk
+drive.
+* Create PV and VG give the VG name in the config file.
+
+### Libvirt
+
+* Check if `libvirtd` is running and if it isn't start it.
+
+  ```
+  $ sudo systemctl status libvirtd.service # to check the status
+  $ sudo systemctl start libvirtd.service # to start the daemon
+  ```
+
+  It's recommended to configure libvirtd to start on boot.
+    ```
+    $ sudo systemctl enable libvirtd.service
+    ```
+
+* Turn off the firewall, otherwise there are going to be conflicts with the
+  rules added by `libvirt`.
+
+  ```
+  $ sudo service SuSEfirewall2 stop
+  ```
+
+  Disable the firewall service to prevent it from starting on boot.
+
+  * Using systemd:
+    ```
+    $ sudo systemctl disable SuSEfirewall2
+    ```
+  * Using SysV:
+    ```
+    $ sudo service SuSEfirewall2 off
+    ```
+
+### Setup storage for mkcloud.
+
+#### Using file as a disk.
+
+*Note:* Skip this step if you have a dedicated partition or disk for LVM.
+
+To use mkcloud the following additional steps are needed:
+
+* Create a disk file where the virtual machines are going to be stored. The
+  minimum recommended is 80 GB.
+
+  ```
+  $ fallocate -l 80G mkcloud.disk
+  ```
+
+* Attach the created disk file to a loop device
+
+  ```
+  $ sudo losetup -f mkcloud.disk
+  ```
+
+* Check the location of the loop device. Something like `/dev/loop0`.
+  ```
+  $ sudo losetup
+  ```
+
+* Set the `cloudpv` variable in (mkcloudrun)[mkcloudrun] script for using this disk.
+  - Ex: export cloudpv=/dev/loop0
+  - Replace /dev/loop0 with your LVM partition if you want to use a dedicated PV.
+
+
+##Deploy SUSE Cloud
+
+* Configure storage options in the (mkcloudrun)[mkcloudrun] script. Read the comments under LVM.
+* Go to the required folder and run the script `*.mkcloud*`.
+* Ex.:
+    ```
+    $ cd mkcloudconfig/
+    $ cp template user.cloud<ver>
+    $ ...
+    $ cd ..; sudo ./install_suse_cloud
+    ```
+* Scripts are invoked in a screen sessions. The name of the screen session is taken from the name of your configuration file.
+* To monitor the given cloud deployment process join the screen session:
+    ```
+    $ screen -ls
+    $ screen -x <screen_name>
+    ```
+  To move around in the screen session use the command `<C-R>-a, <tab number>`.
+  **Note:** The screen session are mostly invoked as root user, try to use ``sudo screen`` or access as a root user.
+* Monitor the VMs via. virt-manager or virsh. Virt-manager should give you a GUI and easier to use for new users.
+* After the deployment access the dashboards:
+  - Crowbar/Admin Dashboard:
+    + URL: `http://192.168.52.10:3000` *For DevelCloud5.mkcloud1 only*
+    + User: `crowbar` Pass: `crowbar`
+  - OpenStack Dashboard:
+    + URL: `http://192.168.52.81` *For DevelCloud5.mkcloud1 only*
+    + Admin User: `admin` Pass: `crowbar`
+    + OpenStack User: `crowbar` Pass: `crowbar`
+
+##Parallel Mkclouds
+
+* To find out the required IP addresses of the mkcloud steup, go through the
+  mkcloudrun file in this folder. Usually the formual is good to guess the
+required IP addresses.
+* Crowbar admin IP is at xxx.10.
+* Ex: For `cloud number 5` the ip for admin node is 192.168.60.10
+
+##RoadMap
+
+* Add basic CLI to `install_suse_cloud`.
+* Modify the scripts based on others feedback and requirements.
+* Fix automation repository the right way so we do not need these scripts in the first place.

--- a/mkcloudruns/install_suse_cloud
+++ b/mkcloudruns/install_suse_cloud
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -o nounset
+
+commands="cleanup prepare setupadmin addupdaterepo runupdate prepareinstcrowbar instcrowbar rebootcrowbar setupnodes instnodes proposal testsetup cct rebootcloud $@" # all_noreboot
+currentdir=$(pwd)
+
+function deploy_upgrade_clouds() {
+
+    clouds=`seq $1 $2` # Expand the sequence.
+    suse_cloud_config=$3
+
+    # Gracefully close existing screen sessions created by the script.
+    screen -S $suse_cloud_config -X quit
+    # Create new screen sessions.
+    screen -S $suse_cloud_config -d -m -t info_$suse_cloud_config bash -c "cat message; echo \"Cloud Upgrade Step: $suse_cloud_config\"; bash"
+
+    for i in $clouds; do
+        echo "Deploying cloud number $i  -- To Rock but not to roll!!!"
+        # Run similar copies of mkcloud runs in the same screen session as tabs.
+        mkdir -p pids/$i # Create folders for automation pid's files and artifacts.
+        screen -S $suse_cloud_config -X screen -t Cloud$i bash -c "cd pids/$i; source ../../mkcloudconfig/SUSECloud.mkcloud $i; ../../mkcloudconfig/$suse_cloud_config $commands; exec bash"
+        cd $currentdir
+    done
+}
+
+# psalunke: Add a basic API call and warning's with user input
+#       so that we do not redeploy the entire thing and
+#       disrupt other's work for the same ...
+
+function usage() {
+
+    echo "Not Implemented yet!"
+}
+
+# Using deploy cloud function
+# $startnumber & $endnumber expands into a sequence and deploys `range($startnumber, $endnumber)` number of clouds.
+# $cloudscript_name is basically coming from the folder mkcloudconfig/$cloudconfig
+#deploy_upgrade_clouds $startnumber $endnumber $cloudconfig
+# Deploy SUSE Cloud 6 Scenarios
+deploy_upgrade_clouds 1 2 cloud6
+# Deploy SUSE Cloud 7 Scenarios
+deploy_upgrade_clouds 3 4 cloud7
+# Deploy Upgrade Steps
+
+# Step 1
+# Step 2
+# Step 3 ...
+# Todo
+# 1. setup auto-monitoring ...
+# 2. generate workload automatically ...

--- a/mkcloudruns/mkcloudconfig/README.md
+++ b/mkcloudruns/mkcloudconfig/README.md
@@ -1,0 +1,12 @@
+Configure your mkcloud scripts here.
+
+- Update/edit the SUSECloud.mkcloud script for global changes.
+- Create a copy of the template script and name it as you like.
+    - Keeping some naming consistency should be quite handy.
+    - For instance $<username>.$<cloudname> should be quite useful for the same.
+- These names are also reflected on the screen session during the deployment process.
+- In case of shared hosts, strictly follow non-global/personal configuration edits in
+    the copy configuration file created from the template file. Keep the SUSECloud.mkcloud
+    configuration template untouched.
+- Following the above for non-shared hosts should also be more beneficial and avoid
+    unnecessary confusion, provides an easy lookup to see the given deployments configuration!

--- a/mkcloudruns/mkcloudconfig/SUSECloud.mkcloud
+++ b/mkcloudruns/mkcloudconfig/SUSECloud.mkcloud
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Motivation! To have all the common configuration options to be sourced from one location
+# which should allows us to have uniform configuration for all the cluster setups.
+
+# Note: If you wish to deviate your configuration on a shared host, please create a copy
+# from the template and update the changes there. Try not to update this script unless
+# the changes are benefiting everyone. This is also applicable for non-shared hosts too.
+
+n=$1 # Allocated Cloud.
+
+export libvirt_type=kvm
+export nodenumber=5 # Number of nodes (Admin Node not counted)
+#export nodenumbercompute=2 # Set the number of compute nodes
+export TESTHEAD=1 # Use Media from Devel:Cloud:Staging and add test update repositories
+
+#export want_sles12=1 # For Cloud 5
+export want_sles12sp2=1 # For Cloud 7
+
+### Upgrade Related Configuration ###
+# export seamless_upgrade=1
+
+### Node Configuration ###
+
+### Admin Node Configuration ###
+#export admin_node_memory=4194394 # KB's (RAM)
+#export adminvcpus=1 # Default 1 vcpu
+#export adminnode_hdd_size=15 # GB
+
+### Controller Node Configuration ###
+#export controller_node_memory=6291456 # KB's (RAM)
+#export controller_hdd_size=20 # GB
+
+### Compute Node Configuration ###
+#export compute_node_memory=2621440 # KB's (RAM)
+#export comnputenode_hdd_size=20 # GB
+#export vcpus=1 # Default 1 vcpu
+# Change the number of default compute nodes.
+#export nodenumbercomputedefault=2
+
+### Enable Other Services (OpenStack related services and features)
+### Most of these services are disabled by default
+# Enable SUSE Enterprise Storage
+#export want_ceph=1 # Uncomment to enable CEPH
+#export cephvolume_hdd_size=25 # GB
+# This one is also used for extra disk for Cinder Volumes even with Ceph disabled.
+export cephvolumenumber=1
+
+# Enable magnum
+#export want_magnum=1 # Note: Changes the compute node parameters.
+#export want_docker=1 # Upload docker image ...
+
+### HA Configuration ###
+export hacloud=1
+# HA Cluster(s) Configuration
+export clusterconfig="data+services=2" #:network=2"
+# Unless you like to use mac addrs, change the node aliases.
+export want_node_aliases='controller=2,network=1,compute=2,nfsshare=1'
+
+### DRBD Configuration ###
+#export drbd_hdd_size=15 # GB
+#export drbd_database_size=5 # GB
+#export drbd_rabbitmq_size=5 # GB
+
+# DVR: It gets trickier with HA configuration.
+# Set the networking plugin for neutron.
+export networkingplugin=openvswitch
+# Set the networking mode (vlan, vxlan, gre)
+export networkingmode=gre
+export want_dvr=1
+#export host_mtu= # Set given MTU settings...
+
+export PARALLEL=yes
+export net_admin=192.168.$((50+$n*2))
+export net_public=192.168.$((51+$n*2))
+export adminnetmask=255.255.254.0
+
+# Using LVM, run `# pvs & vgs & lvs`
+export cloudvg=cloud6
+
+export virtualcloud=c$n
+export cloud=$virtualcloud

--- a/mkcloudruns/mkcloudconfig/cloud6
+++ b/mkcloudruns/mkcloudconfig/cloud6
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Note: Please document important details for collaboration.
+# Upgrade Step: Starting point ... sholuld ideally be the first step.
+export cloudsource=develcloud6
+
+bash ../../../scripts/mkcloud "$@"

--- a/mkcloudruns/mkcloudconfig/cloud7
+++ b/mkcloudruns/mkcloudconfig/cloud7
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Note: Please document important details for collaboration.
+# Upgrade Step: Finishing Point ... should ideally be the final step.
+# Use this template script to create your copy and update the same in
+# install_suse_cloud script at the root of this repository. That should
+# help you to run parallel clouds and custom configuration.
+
+export cloudsource=susecloud7
+
+bash ../../../scripts/mkcloud "$@"

--- a/mkcloudruns/mkcloudconfig/template
+++ b/mkcloudruns/mkcloudconfig/template
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Note: Please document important details for collaboration.
+# Upgrade Step: Finishing Point ... should ideally be the final step.
+
+export cloudsource=susecloud7
+
+bash ../../../scripts/mkcloud "$@"

--- a/mkcloudruns/pids/README.md
+++ b/mkcloudruns/pids/README.md
@@ -1,0 +1,6 @@
+PID Folder
+==========
+
+This folder is used to create deployment specific folders.
+Which the automation repository uses to store PID files.
+This folder should not be of much use and also heavily git-ignored.


### PR DESCRIPTION
Mkcloudruns repository is a good starting point for the team to
collaborate on unifying all the commonly used configuration options,
variables and more for development and testing environments. This should
address new comers and veterans equally by helping them save a lot of
time. Hopefully we agree on a common policy to update the wrapper
scripts here with new handy variables and options that are eventually
added to the automation repository.

The very need for something like this is a good indicator that
automation repository is having some inherent flaws in the way it is
designed and is being updated. The final aim should be to try and fix
automation repository in the right way so that we do not need to use
these wrapper scripts to eliminate the boilerplate for deploying various
flavours of SUSE OpenStack Cloud.

Note: These scripts are being massively updated, modified and the
experience I have gathered from trainings, personal deployments for
testing and development of various features for Crowbar and OpenStack
are visible in form of code added under the mkcloudruns folder below.

Initial repository: https://github.com/dguitarbite/mkcloudruns

I may be updating some things in this repository over time but should
not be relied upon anymore. Rather clone automation repository and
modify the scripts in there.