### PR TITLE
Allow configuration of btrfs with want_rootfs=btrfs

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-mkcloud7.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mkcloud7.yaml
@@ -14,6 +14,7 @@
     sles12sp2: 0
     jobs:
         - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
+        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
         - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
         - 'cloud-mkcloud{version}-job-docker-{arch}'
         - 'cloud-mkcloud{version}-job-dvr-{arch}'

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-btrfs-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-btrfs-template.yaml
@@ -1,0 +1,28 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-btrfs-{arch}'
+    node: cloud-trigger
+
+    triggers:
+      - timed: 'H H * * *'
+
+    logrotate:
+      numToKeep: 7
+      daysToKeep: -1
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{version}
+            nodenumber=5
+            want_sles12sp2=1
+            want_rootfs=btrfs
+            want_node_os=suse-12.2=3,suse-12.1=2
+            networkingmode=vxlan
+            hacloud=1
+            mkcloudtarget=all_noreboot
+            label={label}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -944,11 +944,11 @@ function testsetup()
 function testname()
 {
     local -a var_names=(ha cluster upgrade ceph cinder drbd net
-        netmode sles12 dvr docker)
+        netmode sles12 dvr docker rootfs)
     local -a var_values=("$hacloud" "$clusterconfig"
         "$upgrade_cloudsource" "$cephvolumenumber" "$cinder_backend"
         "$drbd_hdd_size" "$networkingplugin" "$networkingmode"
-        "$want_sles12" "$want_dvr" "$want_docker")
+        "$want_sles12" "$want_dvr" "$want_docker" "$want_rootfs")
 
     if [[ ${#var_names[@]} != ${#var_values[@]} ]] ; then
         complain 123 "testname error: arrays of different length, please check the code"
@@ -1313,6 +1313,9 @@ Optional
     want_docker=1 (default='')
         Deploy docker image (upload image to glance, create instance based on it etc.).
         Only possible with SLE12 node.
+    want_rootfs=btrfs (default='')
+        Deploy all discovered/pxe booted nodes with BTRFS as root filesystem. if empty,
+        an intrinsic default is chosen. Only possible with SLE12 node.
     want_all_debug=1 (default='')
         Enable debug level logging in barclamp proposals for all proposals.
     want_magnum=1 (default='')

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2141,6 +2141,13 @@ function onadmin_allocate()
         done
     fi
 
+    # set rootfs for all nodes when want_rootfs is set
+    if [ -n "$want_rootfs" ] ; then
+        for node in `get_all_discovered_nodes` ; do
+            set_node_fs $node "$want_rootfs"
+        done
+    fi
+
     echo "Allocating nodes..."
     local m
     for m in `get_all_discovered_nodes` ; do


### PR DESCRIPTION
There is a new requirement for Cloud7 to enable btrfs by default.
Let's add it as an option until subvolume handling has been implemented.