### PR TITLE
Add json metadata to nova barclamp for 2c scenario

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -133,6 +133,9 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
   deployment:
     elements:
       nova-controller:


### PR DESCRIPTION
It's missing in QA scenario and causing builds to fail.