### PR TITLE
Revert: remove options that are not valid for btrfs

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1708,6 +1708,8 @@ EOF
     # to allow integration into external DNS:
     local f=/opt/dell/chef/cookbooks/bind9/templates/default/named.conf.erb
     grep -q allow-transfer $f || sed -i -e "s#options {#&\n\tallow-transfer { 10.0.0.0/8; };#" $f
+    # workaround for performance bug (bnc#770083 and general HDD IO improvement)
+    [[ $want_rootfs = btrfs ]] || sed -i -e 's#<mount>/</mount>$#&<fstopt>data=writeback,barrier=0,noatime</fstopt>#' /opt/dell/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
 
     if iscloudver 6plus ; then
         create_repos_yml


### PR DESCRIPTION
commit 01e64bd88157e89c01a4e2e2402e42b3c9a99fbe

I want to see performance of a run with this patch
maybe it does not matter because of the virtio cache mode
that we use on mkcloud hosts.
