### PR TITLE
Fix user_keyfile upload

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -556,7 +556,7 @@ function setupadmin()
         "
     done
     if [[ -n $user_keyfile ]]; then
-        cat $user_keyfile | ssh $adminip "cat >> ~/.ssh/authorized_keys"
+        cat $user_keyfile | sshrun "cat >> ~/.ssh/authorized_keys"
     fi
     echo "you can now proceed with installing crowbar"
     # prevent jumbo frames from going out


### PR DESCRIPTION
Using plain ssh causes trouble with changing ssh-host-keys of admin node VMs, which we get since we are now building SP2 images in OBS/kiwi. The sshrun wrapper ignores those keys.