### PR TITLE
Substitute ipmi power reset with off and on

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2009,8 +2009,12 @@ function reboot_nodes_via_ipmi()
                 if ipmitool -H $ip -U root -P $pw power status | grep -q "is off"; then
                     ipmitool -H $ip -U root -P $pw power on
                     sleep $((10 + RANDOM % 15))
+                else
+                    ipmitool -H $ip -U root -P $pw power off
+                    wait_for 5 5 "ipmitool -H $ip -U root -P $pw power status | grep -q 'is off'" "node to power off"
+                    ipmitool -H $ip -U root -P $pw power on
                 fi
-                ipmitool -H $ip -U root -P $pw power reset) &
+                ) &
             fi
             sleep $((5 + RANDOM % 5))
         done


### PR DESCRIPTION
Ipmitool power reset often lead to nodes not detecting hard disks.
The manual fix for that is to poweroff the nodes and start again.
This is an attempt to avoid that completely.

This is a copy of the incorrectly branched and closed PR:
https://github.com/SUSE-Cloud/automation/pull/1106