### PR TITLE
Add more compute nodes for Magnum tempest job

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -18,7 +18,8 @@
           predefined-parameters: |
             TESTHEAD=1
             cloudsource=develcloud{version}
-            nodenumber=2
+            nodenumber=3
+            nodenumbercompute=2
             want_magnum=1
             ostestroptions=" --regex '^magnum.tests.functional.api'"
             mkcloudtarget=all


### PR DESCRIPTION
A single compute node is not enough to run magnum. So add another one.