### PR TITLE
Disable ceph and use SLE12SP2 for magnum job nodes

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -21,6 +21,7 @@
             nodenumber=3
             nodenumbercompute=2
             want_magnum=1
+            want_ceph=0
             ostestroptions=" --regex '^magnum.tests.functional.api'"
             mkcloudtarget=all
             label={label}


### PR DESCRIPTION
With Ceph, some nodes would be using SLE12SP1 and we don't want that.