### PR TITLE
Remove Juno from cleanvm

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-cleanvm.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-cleanvm.yaml
@@ -24,7 +24,6 @@
           name: openstack_project
           values:
             - Juno
-            - Kilo
             - Liberty
             - Mitaka
             - Master
@@ -38,7 +37,6 @@
         (
         slave=="cloud-cleanvm"
         && ( openstack_project=="Juno" && (image=="SLE_11_SP3"))
-        || ( openstack_project=="Kilo" && (image=="SLE_12"))
         || ( openstack_project=="Liberty" && (image=="SLE_12_SP1" || image=="SLE_12" || image=="openSUSE-Leap-42.1"))
         || ( openstack_project=="Mitaka" && (image=="SLE_12_SP1" || image=="SLE_12_SP2" || image=="openSUSE-Leap-42.1"))
         || ( openstack_project=="Master" && (image=="openSUSE-Leap-42.1" || image=="SLE_12_SP1" || image=="SLE_12_SP2"))


### PR DESCRIPTION
OpenStack Juno is EOL and not used in our products.