### PR TITLE
mkcloud: explicitly catch broken DNS

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -429,6 +429,7 @@ function onhost_deploy_image()
     local image=$(dist_to_image_name $2)
     local disk=$3
 
+    [[ $clouddata ]] || complain 108 "clouddata IP not set - is DNS broken?"
     pushd /tmp
     safely wget --progress=dot:mega -N \
         http://$clouddata/images/$arch/$image


### PR DESCRIPTION
we had a recent DNS failure resulting in mysterious calls of
wget --progress=dot:mega -N http:///images/x86_64/SP3-64up.qcow2
and this should give a clearer message to the user