### PR TITLE
qa_crowbarsetup: Create keypair for magnum

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3662,6 +3662,11 @@ function oncontroller_magnum_service_setup ()
     if ! openstack flavor show m1.smaller; then
         openstack flavor create --ram 512 --disk 8 --vcpus 1 m1.smaller
     fi
+
+    # default key is used by magnum tempest test
+    if ! openstack keypair show default; then
+        openstack keypair create --public-key /root/.ssh/id_rsa.pub default
+    fi
 }
 
 # code run on controller/dashboard node to do basic tests of deployed cloud


### PR DESCRIPTION
Magnum uses a key called "default" for the tempest tests.
Create this key.