### PR TITLE
Assign magnum-server role to HA cluster for hacloud=1.

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2799,6 +2799,10 @@ function custom_configuration()
         magnum)
             proposal_set_value magnum default "['attributes']['magnum']['trustee']['domain_name']" "'magnum'"
             proposal_set_value magnum default "['attributes']['magnum']['trustee']['domain_admin_name']" "'magnum_domain_admin'"
+
+            if [[ $hacloud = 1 ]] ; then
+                proposal_set_value magnum default "['deployment']['magnum']['elements']['magnum-server']" "['cluster:$clusternameservices']"
+            fi
             ;;
         nova)
             local role_prefix=`nova_role_prefix`


### PR DESCRIPTION
This pull request enables HA for the Magnum barclamp. Merge once https://github.com/crowbar/crowbar-openstack/pull/511 is merged.