### PR TITLE
Added more warnings to Heat created resources

### DIFF
--- a/scripts/jenkins/jobs-obs/heat-templates/openstack-cleanvm.yaml
+++ b/scripts/jenkins/jobs-obs/heat-templates/openstack-cleanvm.yaml
@@ -102,6 +102,7 @@ resources:
         list_join:
           - '_'
           - - 'heat'
+            - 'DONTUSE'
             - { get_param: 'OS::stack_name' }
 
 
@@ -113,6 +114,7 @@ resources:
         list_join:
           - '_'
           - - 'heat'
+            - 'DONTUSE'
             - { get_param: 'OS::stack_name' }
       network:
         get_resource: network
@@ -190,6 +192,12 @@ resources:
   router:
     type: OS::Neutron::Router
     properties:
+      name:
+        list_join:
+          - '_'
+          - - 'heat'
+            - 'DONTUSE'
+            - { get_param: 'OS::stack_name' }
       external_gateway_info:
         network:
           get_param: floating_network
@@ -213,11 +221,18 @@ resources:
   allow_inbound:
     type: OS::Neutron::SecurityGroup
     properties:
-      description: "Allow inbound SSH and HTTP traffic"
+      description:
+        list_join:
+          - ''
+          - - 'CREATED BY HEAT stack '
+            - { get_param: 'OS::stack_name' }
+            - '. DO NOT USE. '
+            - "Allows inbound SSH and HTTP traffic."
       name:
         list_join:
           - '_'
           - - 'heat'
+            - 'DONTUSE'
             - { get_param: 'OS::stack_name' }
       rules:
         - direction: ingress


### PR DESCRIPTION
In order to prevent users from using resources created by the
openstack-cleanvm heat template this commit labels them more
explicitely as being created by Heat.

Background: In an OpenStack project that contains both resources created manually and resources created by Heat stacks clashes occur occasionally. Namely, users that create stuff manually use Neutron networks/subnets or security groups created by a Heat stack. If the stack's owner later attempts to delete the stack, this will fail because its resources remain in use. This commit adjusts resource names and resource descriptions of the openstack-cleanvm heat template to warn users manually creating instances not to use them.