### PR TITLE
Fix jenkins magnum job

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -22,6 +22,6 @@
             nodenumbercompute=2
             want_magnum=1
             want_ceph=0
-            ostestroptions=" --regex '^magnum.tests.functional.api'"
+            ostestroptions= --regex '^magnum.tests.functional.api'
             mkcloudtarget=all
             label={label}


### PR DESCRIPTION
This fixes:

oncontroller_run_tempest(): ostestr '"' --regex '^magnum.tests.functional.api"'
usage: ostestr [-h]
ostestr: error: unrecognized arguments: "