### PR TITLE
Fix storage method for magnum job

### DIFF
--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -21,7 +21,7 @@
             nodenumber=3
             nodenumbercompute=2
             want_magnum=1
-            want_ceph=0
+            storage_method=none
             ostestroptions= --regex '^magnum.tests.functional.api'
             mkcloudtarget=all
             label={label}


### PR DESCRIPTION
want_ceph shouldn't be used anymore in Jenkins (you can still use it when you
run mkcloud locally). But Jenkins has a variable called "storage_method" which
is implemented in the openstack-mkcloud trigger job. And depending on the value
this variable overrides want_ceph and want_swift when the openstack-mkcloud
trigger is used.