### PR TITLE
Allow concurrent runs of upstream packaging tests

### DIFF
--- a/scripts/jenkins/jobs-obs/templates/openstack-upstream-gerrit-rpm-packaging.yaml
+++ b/scripts/jenkins/jobs-obs/templates/openstack-upstream-gerrit-rpm-packaging.yaml
@@ -2,6 +2,10 @@
     name: 'openstack-upstream-gerrit-rpm-packaging-{release}'
     description: "<b>This job is managed by JJB! Changes must be done in <a href='https://github.com/SUSE-Cloud/automation/tree/master/scripts/jenkins/jobs-obs/templates/'>git</a></b>"
     node: openstack-rpm-packaging
+    concurrent: true
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 31
     builders:
       - gerrit-git-prep
       - shell: |


### PR DESCRIPTION
Currently all runs are sequential which is extremely slow.
We can run them concurrently with no modification it seems
so lets do that.

Also set a logrotate for reducing performance impact of many runs
being stored in jenkins database.