### PR TITLE
enhance setup of DNAT port-forwarding

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -65,7 +65,7 @@ function libvirt_net_start()
 #!/bin/bash
 
 iptables -t nat -F PREROUTING
-for i in 22 80 443 3000 4000 4040 5000; do
+for i in 22 80 443 3000 4000 4040 5000 7630; do
     for host in 10 $nodehostips ; do
         offset=80
         [ "\$host" = 10 ] && offset=10

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -57,9 +57,11 @@ function libvirt_net_start()
         ip link set mtu 9000 dev $dev
     done
 
+    boot_mkcloud=/etc/init.d/boot.mkcloud
+
     if [ -z "$NOSETUPPORTFORWARDING" ] ; then
         nodehostips=$(seq -s ' ' 81 $((80 + $nodenumber)))
-        cat > /etc/init.d/boot.mkcloud <<EOS
+        cat > $boot_mkcloud <<EOS
 #!/bin/bash
 
 iptables -t nat -F PREROUTING
@@ -81,14 +83,15 @@ EOS
             cat >> /etc/init.d/boot.local <<EOS
 
 # --v--v--  Automatically added by mkcloud on `date`
-/etc/init.d/boot.mkcloud
+$boot_mkcloud
 # --^--^--  End of automatically added section from mkcloud
 EOS
         fi
     fi
-    if [ -e "/etc/init.d/boot.mkcloud" ]; then
-        chmod +x /etc/init.d/boot.mkcloud
-        /etc/init.d/boot.mkcloud
+
+    if [ -e "$boot_mkcloud" ]; then
+        chmod +x $boot_mkcloud
+        $boot_mkcloud
     fi
 }
 

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -60,6 +60,7 @@ function libvirt_net_start()
     boot_mkcloud=/etc/init.d/boot.mkcloud
 
     if [ -z "$NOSETUPPORTFORWARDING" ] ; then
+        # FIXME: hardcoded assumptions about admin net host range
         nodehostips=$(seq -s ' ' 81 $((80 + $nodenumber)))
         cat > $boot_mkcloud <<EOS
 #!/bin/bash
@@ -67,6 +68,7 @@ function libvirt_net_start()
 
 iptables -t nat -F PREROUTING
 for i in 22 80 443 3000 4000 4040 5000 7630; do
+    # FIXME: hardcoded assumptions about admin IP and admin net host range
     for host in 10 $nodehostips ; do
         offset=80
         [ "\$host" = 10 ] && offset=10

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -69,10 +69,13 @@ for i in 22 80 443 3000 4000 4040 5000; do
     for host in 10 $nodehostips ; do
         offset=80
         [ "\$host" = 10 ] && offset=10
-        iptables -t nat -I PREROUTING -p tcp --dport \$((\$i + \$host - \$offset + 1100)) -j DNAT --to-destination $net_admin.\$host:\$i
+        iptables -t nat -I PREROUTING -p tcp \\
+            --dport \$((\$i + \$host - \$offset + 1100)) \\
+            -j DNAT --to-destination $net_admin.\$host:\$i
     done
 done
-iptables -t nat -I PREROUTING -p tcp --dport 6080 -j DNAT --to-destination $net_public.2
+iptables -t nat -I PREROUTING -p tcp --dport 6080 \\
+    -j DNAT --to-destination $net_public.2
 for x in D I ; do
     iptables -\$x FORWARD -d $net_admin.0/24 -j ACCEPT
     iptables -\$x FORWARD -d $net_public.0/24 -j ACCEPT

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -63,6 +63,7 @@ function libvirt_net_start()
         nodehostips=$(seq -s ' ' 81 $((80 + $nodenumber)))
         cat > $boot_mkcloud <<EOS
 #!/bin/bash
+# Auto-generated from $0 on `date`
 
 iptables -t nat -F PREROUTING
 for i in 22 80 443 3000 4000 4040 5000 7630; do

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -64,7 +64,6 @@ function libvirt_net_start()
 
 iptables -t nat -F PREROUTING
 for i in 22 80 443 3000 4000 4040 5000; do
-    iptables -I FORWARD -p tcp --dport \$i -j ACCEPT
     for host in 10 $nodehostips ; do
         offset=80
         [ "\$host" = 10 ] && offset=10
@@ -72,6 +71,10 @@ for i in 22 80 443 3000 4000 4040 5000; do
     done
 done
 iptables -t nat -I PREROUTING -p tcp --dport 6080 -j DNAT --to-destination $net_public.2
+for x in D I ; do
+    iptables -\$x FORWARD -d $net_admin.0/24 -j ACCEPT
+    iptables -\$x FORWARD -d $net_public.0/24 -j ACCEPT
+done
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
 EOS
         if ! grep -q "boot.mkcloud" /etc/init.d/boot.local ; then

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -79,6 +79,7 @@ for x in D I ; do
 done
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
 EOS
+        chmod +x $boot_mkcloud
         if ! grep -q "boot.mkcloud" /etc/init.d/boot.local ; then
             cat >> /etc/init.d/boot.local <<EOS
 
@@ -89,8 +90,7 @@ EOS
         fi
     fi
 
-    if [ -e "$boot_mkcloud" ]; then
-        chmod +x $boot_mkcloud
+    if [ -x "$boot_mkcloud" ]; then
         $boot_mkcloud
     fi
 }

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1537,7 +1537,7 @@ function sanity_checks()
 step_aliases="_new_admin _compute _upgrade _testupdate"
 
 allcmds="$step_aliases all all_noreboot all_batch all_batch_noreboot instonly \
-    plain plain_with_upgrade cleanup setuphost prepare setupadmin \
+    plain plain_with_upgrade cleanup setuphost prepare libvirt_prepare setupadmin \
     prepareinstcrowbar bootstrapcrowbar instcrowbar instcrowbarfromgit setupnodes \
     setupcompute instnodes instcompute proposal testsetup rebootcrowbar \
     rebootcloud addupdaterepo runupdate testupdate \


### PR DESCRIPTION
Several cleanups and enhancements to the DNAT port forwarding which allows access to cloud VMs on hosts like `blacher.arch.suse.de` which run the clouds on private networks which aren't routable from within the corporate network. The main highlights are:

- Supports separate non-conflicting DNAT ports for each cloud
- Each cloud's `iptables` setup is now written to `/etc/init.d/boot.mkcloud.d/$cloudname`
- `/etc/init.d/boot.mkcloud` is still supported for backwards-compatibility and for `mkch*.cloud.suse.de` hosts
- Guards against duplicate rule insertion
- Doesn't flush the PREROUTING chain every time
- Adds forwarding for Hawk and `mosh`
- Doesn't forward admin server ports on non-admin nodes, and vice-versa.

Supersedes #1193.