### PR TITLE
always log output to a file

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -15,6 +15,12 @@
 # 2. This tool relies on the script qa_crowbarsetup.sh
 # 3. Please 'export' environment variables according to your needs.
 
+: ${cloud:=cloud}
+: ${log_dir:=/var/log/mkcloud/$cloud}
+mkdir -p "$log_dir"
+log_file=$log_dir/`date -Iseconds`.log
+exec >  >(tee -ia $log_file)
+exec 2> >(tee -ia $log_file >&2)
 
 if [[ $debug_mkcloud = 1 ]] ; then
     set -x
@@ -88,7 +94,6 @@ cpuflags=''
 working_dir_orig=`pwd`
 : ${artifacts_dir:=$working_dir_orig/.artifacts}
 start_time=`date`
-: ${cloud:=cloud}
 : ${cloudvg:=cloud}
 needcvol=1
 : ${vdisk_dir:=/dev/$cloudvg}


### PR DESCRIPTION
This eliminates the risk of losing crucial debug output in a long mkcloud run because you forgot to redirect to a file and the terminal/screen/tmux scrollback buffer wasn't big enough.

Closes #1191.