### PR TITLE
Wait ~1min if using ipmitool on QA hw

### DIFF
--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -72,7 +72,7 @@
       - string:
           name: nodenumber
           default: "7"
-          description: Number of nodes to use. Depends on hw_number
+          description: Number of nodes to use; is scenario specific
       - string:
           name: want_ipmi
           default: "true"

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1b.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-1b.yaml
@@ -75,7 +75,7 @@
       - string:
           name: nodenumber
           default: "7"
-          description: Number of nodes to use. Depends on hw_number
+          description: Number of nodes to use; is scenario specific
       - string:
           name: want_ipmi
           default: "true"

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -78,7 +78,7 @@
       - string:
           name: nodenumber
           default: "7"
-          description: Number of nodes to use. Depends on hw_number
+          description: Number of nodes to use; is scenario specific
       - string:
           name: want_ipmi
           default: "true"

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2b.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2b.yaml
@@ -75,8 +75,8 @@
           description: HA configuration for clusters. Make sense only if hacloud=1
       - string:
           name: nodenumber
-          default: "7"
-          description: Number of nodes to use. Depends on hw_number
+          default: "6"
+          description: Number of nodes to use; is scenario specific
       - string:
           name: want_ipmi
           default: "true"

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2c.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-2c.yaml
@@ -78,7 +78,7 @@
       - string:
           name: nodenumber
           default: "7"
-          description: Number of nodes to use. Depends on hw_number
+          description: Number of nodes to use; is scenario specific
       - string:
           name: runner_url
           default: https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/qa_crowbarsetup.sh

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-6a.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-6a.yaml
@@ -71,7 +71,7 @@
       - string:
           name: nodenumber
           default: "7"
-          description: Number of nodes to use. Depends on hw_number
+          description: Number of nodes to use; is scenario specific
       - string:
           name: want_ipmi
           default: "true"

--- a/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-9.yaml
+++ b/scripts/jenkins/qa/cloud-mkphyscloud-qa-scenario-9.yaml
@@ -77,7 +77,7 @@
       - string:
           name: nodenumber
           default: "7"
-          description: Number of nodes to use. Depends on hw_number
+          description: Number of nodes to use; is scenario specific
       - string:
           name: runner_url
           default: https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/qa_crowbarsetup.sh

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2058,21 +2058,22 @@ function reboot_nodes_via_ipmi()
             local ip=$bmc_net.$(($ip4 + $i))
             if [ $i -gt $nodenumber ]; then
                 # power off extra nodes
-                ipmitool -H $ip -U root -P $pw power off &
+                ipmitool -H $ip -U root -P $pw power off
                 wait_for 2 60 "ipmitool -H $ip -U root -P $pw power status | grep -q 'is off'" "node to power off"
             else
                 ping -c 3 $ip > /dev/null || {
                     echo "error: BMC $ip is not reachable!"
                 }
-                (
+
                 ipmitool -H $ip -U root -P $pw lan set 1 defgw ipaddr "${bmc_values[1]}"
                 sleep $((50 + RANDOM % 20))
 
                 if ipmitool -H $ip -U root -P $pw power status | grep -q "is off"; then
                     ipmitool -H $ip -U root -P $pw power on
-                    sleep $((50 + RANDOM % 25))
+                else
+                    ipmitool -H $ip -U root -P $pw power cycle
                 fi
-                ipmitool -H $ip -U root -P $pw power reset) &
+
             fi
             sleep $((50 + RANDOM % 20))
         done

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -239,7 +239,7 @@ setcloudnetvars()
             want_ipmi=true
         ;;
         qa4)
-            nodenumbertotal=8
+            nodenumbertotal=7
             net=${netp}.66
             net_public=$net
             vlan_public=715

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2059,6 +2059,7 @@ function reboot_nodes_via_ipmi()
             if [ $i -gt $nodenumber ]; then
                 # power off extra nodes
                 ipmitool -H $ip -U root -P $pw power off &
+                wait_for 2 60 "ipmitool -H $ip -U root -P $pw power status | grep -q 'is off'" "node to power off"
             else
                 ping -c 3 $ip > /dev/null || {
                     echo "error: BMC $ip is not reachable!"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2068,6 +2068,8 @@ function reboot_nodes_via_ipmi()
                 ipmitool -H $ip -U root -P $pw lan set 1 defgw ipaddr "${bmc_values[1]}"
                 sleep $((50 + RANDOM % 20))
 
+                ipmitool -H $ip -U root -P $pw chassis bootdev pxe
+
                 if ipmitool -H $ip -U root -P $pw power status | grep -q "is off"; then
                     ipmitool -H $ip -U root -P $pw power on
                 else

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2066,6 +2066,7 @@ function reboot_nodes_via_ipmi()
                 }
 
                 ipmitool -H $ip -U root -P $pw lan set 1 defgw ipaddr "${bmc_values[1]}"
+                # Please do not touch this sleep. It is important for the ipmi to work on qa hardware
                 sleep $((50 + RANDOM % 20))
 
                 ipmitool -H $ip -U root -P $pw chassis bootdev pxe
@@ -2077,6 +2078,7 @@ function reboot_nodes_via_ipmi()
                 fi
 
             fi
+            # Please do not touch this sleep. It is important for the ipmi to work on qa hardware
             sleep $((50 + RANDOM % 20))
         done
     done

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -239,7 +239,6 @@ setcloudnetvars()
             want_ipmi=true
         ;;
         qa4)
-            nodenumber=7
             nodenumbertotal=8
             net=${netp}.66
             net_public=$net
@@ -2066,15 +2065,15 @@ function reboot_nodes_via_ipmi()
                 }
                 (
                 ipmitool -H $ip -U root -P $pw lan set 1 defgw ipaddr "${bmc_values[1]}"
-                sleep $((5 + RANDOM % 5))
+                sleep $((50 + RANDOM % 20))
 
                 if ipmitool -H $ip -U root -P $pw power status | grep -q "is off"; then
                     ipmitool -H $ip -U root -P $pw power on
-                    sleep $((10 + RANDOM % 15))
+                    sleep $((50 + RANDOM % 25))
                 fi
                 ipmitool -H $ip -U root -P $pw power reset) &
             fi
-            sleep $((5 + RANDOM % 5))
+            sleep $((50 + RANDOM % 20))
         done
     done
     wait


### PR DESCRIPTION
Recently we were facing issues with QA hw where bmc IPs were messed up. Making the waiting time streched to 1 min seems to resolve that issue.
Beside this scenario 2b was using wrong `nodenumber` param value that was probably the trigger to loosing nodes completely. 
Also the param `nodenumber` description was changed to better reflect its meaning in the JJB files.