### PR TITLE
Drop cvol obsoletion warning

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -21,22 +21,6 @@ if [[ $debug_mkcloud = 1 ]] ; then
     PS4='+(${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
 
-if [ -n "$CVOL" ] ; then
-    cloudpv=$CVOL
-    unset CVOL
-    echo "------------------------------------------------------------------------"
-    echo "The CVOL variable is deprecated."
-    echo "Please either set 'cloudvg' or 'cloudpv'"
-    echo " cloudvg will use an existing lvm and not destroy other volumes"
-    echo " cloudpv will use an lvm pv device exclusively and destroy all volumes"
-    echo
-    echo "Continuing in 20 seconds with fallback (cloudpv=\$CVOL):"
-    echo " cloudpv=$CVOL"
-    echo "Otherwise press Ctrl-C now!"
-    echo "------------------------------------------------------------------------"
-    sleep 20
-fi
-
 # FIXME: separate user-tweakable parameters from script local variables.
 # Currently there is no clearly defined interface point.  One of the
 # causes of this is violation of the common shell coding standard which

--- a/scripts/mkcloudhost/mkcloude
+++ b/scripts/mkcloudhost/mkcloude
@@ -6,6 +6,6 @@ if [[ $(hostname) =~ ^mkch.$ ]] ; then
 else
     . $ar/scripts/mkcloudhost/runtestn $n
 fi
-echo env=$testdir n=$n admin=$net_admin disk=$CVOL params="$@"
+echo env=$testdir n=$n admin=$net_admin cloudpv=$cloudpv cloudvg=$cloudvg params="$@"
 echo access from outside via http://crowbar.$cloud.cloud.suse.de/ and http://dashboard.$cloud.cloud.suse.de/
 exec "$@"


### PR DESCRIPTION
Drop the warning that CVOL is obsolete.
The last usage of CVOL was an informative echo in mkcloude, also dropped with this PR.