### PR TITLE
trackupstream: Track python-mistralclient for C:O:Master

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
@@ -74,6 +74,7 @@
             - python-keystonemiddleware
             - python-magnumclient
             - python-manilaclient
+            - python-mistralclient
             - python-neutronclient
             - python-networking-cisco
             - python-networking-hyperv
@@ -114,6 +115,7 @@
               "python-keystonemiddleware",
               "python-magnumclient",
               "python-manilaclient",
+              "python-mistralclient",
               "python-neutronclient",
               "python-novaclient",
               "python-openstackclient",


### PR DESCRIPTION
Newer python-troveclient versions need a python-mistralclient package.