### PR TITLE
openstack-submit: Use SLE_12_SP2 for Newton gating

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-submit.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-submit.yaml
@@ -34,9 +34,13 @@
               submitcmd="$OSC copypac -K -e"
               OSCBUILDDIST=SLE_12
             ;;
-            Cloud:OpenStack:[MN]*)
+            Cloud:OpenStack:[M]*)
               submitcmd="$OSC copypac -K -e"
               OSCBUILDDIST=SLE_12_SP1
+            ;;
+            Cloud:OpenStack:[N]*)
+              submitcmd="$OSC copypac -K -e"
+              OSCBUILDDIST=SLE_12_SP2
             ;;
             *) echo "Please add support for the project: $project"
               exit 1


### PR DESCRIPTION
When running the openstack-submit job (after a succesful cleanvm job),
look into the SLE_12_SP2 repository when copy packages from Staging
to Non-Staging.