### PR TITLE
[UNTESTED] fix selection of cinder-volume node

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3024,10 +3024,10 @@ function custom_configuration()
 
             if [[ $hacloud = 1 ]] ; then
                 # fetch one of the compute nodes as cinder_volume
-                local cinder_volume=$unclustered_nodes
+                local cinder_volume=($unclustered_nodes)
                 # make sure we do not pick SP1 nodes on cloud7
                 if [ -n "$deployceph" ] && iscloudver 7 ; then
-                    cinder_volume=$unclustered_sles12plusnodes
+                    cinder_volume=($unclustered_sles12plusnodes)
                 fi
                 if [ -z $cinder_volume ]; then
                     complain 105 "No suitable node(s) for ceilometer-agent found."


### PR DESCRIPTION
PR #1195 introduced breakage in Jenkins openstack-mkcloud, because it can cause values of `cinder_volume` such as `"d52-54-77-77-77-03.ve1.cloud.suse.de\nd52-54-77-77-77-04.ve1.cloud.suse.de"`, i.e. multiple hostnames delimited by `"\n"` rather than comma-separated like is correctly done with the other barclamps above.

So instead we assign to an array breaking on whitespace, so that the first host is correctly picked.

Here's an example failure:

    W, [2016-09-08T20:36:56.103076 #8898:0x00000005f37410]  WARN -- Could not recover Chef Crowbar Node on load d52-54-77-77-77-03.ve1.cloud.suse.de
    d52-54-77-77-77-04.ve1.cloud.suse.de: #<URI::InvalidURIError: bad URI(is not URI?): http://localhost:4000/nodes/d52-54-77-77-77-03.ve1.cloud.suse.de
    d52-54-77-77-77-04.ve1.cloud.suse.de>
    I, [2016-09-08T20:36:56.103681 #8898:0x00000005f37410]  INFO -- Completed 500 Internal Server Error in 85ms (ActiveRecord: 8.0ms)
    F, [2016-09-08T20:36:56.104726 #8898:0x00000005f37410] FATAL --
    NoMethodError (undefined method `[]' for nil:NilClass):
      app/models/service_object.rb:744:in `block (2 levels) in violates_exclude_platform_constraint?'
      app/models/service_object.rb:743:in `each'
      app/models/service_object.rb:743:in `any?'
      app/models/service_object.rb:743:in `block in violates_exclude_platform_constraint?'
      app/models/service_object.rb:739:in `each'
      app/models/service_object.rb:739:in `violates_exclude_platform_constraint?'
      app/models/service_object.rb:805:in `block in validate_proposal_constraints'
      app/models/service_object.rb:778:in `each'
      app/models/service_object.rb:778:in `validate_proposal_constraints'
      app/models/service_object.rb:669:in `validate_proposal_after_save'
      app/models/cinder_service.rb:204:in `validate_proposal_after_save'
      app/models/service_object.rb:547:in `save_proposal!'
      app/models/service_object.rb:871:in `_proposal_update'
      app/models/service_object.rb:526:in `proposal_edit'
      app/controllers/barclamp_controller.rb:563:in `proposal_update'

The problem occurs in this line in
`ServiceObject#violates_exclude_platform_constraint?`:

        node = NodeObject.find_node_by_name(element)

`Chef::Node.load` raises the `URI::InvalidURIError` exception which gets caught, turned into a warning, and then `nil` is returned for the node, causing the `NoMethodError` soon after.