### PR TITLE
Make sure path for PTF repos is created

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4406,6 +4406,8 @@ function onadmin_prepare_cloudupgrade_repos_6_to_7()
 
     # create skeleton for PTF repositories
     # during installation, this would be done by install-suse-cloud
+    mkdir -p $tftpboot_repos12sp2_dir/PTF
+    ensure_packages_installed createrepo
     safely createrepo $tftpboot_repos12sp2_dir/PTF
 
     # change system repositories to SP2


### PR DESCRIPTION
Otherwise it could fail like https://ci.suse.de/job/openstack-mkcloud/33753/consoleText : 

```
+(qa_crowbarsetup.sh:4409) onadmin_prepare_cloudupgrade_repos_6_to_7(): safely createrepo /srv/tftpboot/suse-12.2/x86_64/repos/PTF
+(qa_crowbarsetup.sh:111) safely(): createrepo /srv/tftpboot/suse-12.2/x86_64/repos/PTF
Directory /srv/tftpboot/suse-12.2/x86_64/repos/PTF must exist
+(qa_crowbarsetup.sh:114) safely(): complain 30 'createrepo /srv/tftpboot/suse-12.2/x86_64/repos/PTF failed! (safelyret=1) Aborting.'
+(qa_crowbarsetup.sh:105) complain(): local ex=30
+(qa_crowbarsetup.sh:105) complain(): shift
+(qa_crowbarsetup.sh:106) complain(): printf 'Error: %s\n' 'createrepo /srv/tftpboot/suse-12.2/x86_64/repos/PTF failed! (safelyret=1) Aborting.'
Error: createrepo /srv/tftpboot/suse-12.2/x86_64/repos/PTF failed! (safelyret=1) Aborting.
```