### PR TITLE
bsc#988980 Remove ssl option for cinder

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2523,6 +2523,12 @@ function enable_ssl_generic()
             fi
             $p "$a['api']['protocol']" "'https'"
         ;;
+        cinder)
+            # Disabling because of bsc#988980
+            if iscloudver 7plus; then
+                return
+            fi
+        ;;
         manila)
             if ! iscloudver 7plus ; then
                 return


### PR DESCRIPTION
Until this is properly fixed upstream, we can't test cinder with ssl.