### PR TITLE
Fix jenkins-job-build config sample

### DIFF
--- a/scripts/jenkins/jenkins_jobs.ini.sample
+++ b/scripts/jenkins/jenkins_jobs.ini.sample
@@ -1,4 +1,5 @@
 [jenkins]
+query_plugins_info=False
 user=USERNAME
 password=APITOKEN
 url=https://ci.suse.de/


### PR DESCRIPTION
It seems our setup now needs "query_plugins_info=False" otherwise the update
command fails with an error when trying to query the plugins