### PR TITLE
Magnum devstack

### DIFF
--- a/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
+++ b/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
@@ -144,9 +144,17 @@ resources:
                ;;
             esac
 
-            # We cannot do a reverse lookup, so add transient host name to /etc/hosts
+            # We cannot do a reverse lookup, so add transient host name to
+            # /etc/hosts and export HOST_IP for devstack to use.
             export HOST_IP=$(ip addr sh eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f 1)
             echo  "${HOST_IP} $(hostname) $(hostnamectl --transient)" >> /etc/hosts
+
+            # wickedd needs to be configured properly to avoid overriding
+            # the hostname (see <https://bugzilla.opensuse.org/show_bug.cgi?id=974661>).
+            sed -i -e "s/DHCLIENT_SET_HOSTNAME=\"yes\"/DHCLIENT_SET_HOSTNAME=\"no\"/" /etc/sysconfig/network/dhcp
+            sed -i -e "s/DHCLIENT6_SET_HOSTNAME=\"yes\"/DHCLIENT6_SET_HOSTNAME=\"no\"/" /etc/sysconfig/network/dhcp
+            # This is to reapply the config to wickedd
+            ifup all
 
             zypper --non-interactive install bridge-utils git-core \
               python-devel python-pip libopenssl-devel \

--- a/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
+++ b/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
@@ -1,0 +1,224 @@
+heat_template_version: 2015-10-15
+
+description: |
+  This template builds the OpenStack cleanvm virtual machines for various cloud
+  sources (including a TESTHEAD flag) and images.
+
+  Usage examples:
+
+    # Build from Cloud:OpenStack:Mitaka:Staging on SLE12 SP1
+    heat stack-create -f openstack-cleanvm.yaml -P key_name=myuser -P TESTHEAD=1 myuser-cleanvm
+
+    # Build from Cloud:OpenStack:Mitaka on SLE12 SP1
+    heat stack-create -f openstack-cleanvm.yaml -P key_name=myuser myuser-cleanvm
+
+    # Build from Cloud:OpenStack:Liberty on SLE12 SP1
+    heat stack-create -f openstack-cleanvm.yaml \
+      -P key_name=myuser \
+      -P cloudsource=openstackliberty \
+      myuser-cleanvm
+
+    # Build from Cloud:OpenStack:Mitaka on openSUSE Leap 42.1
+    heat stack-create -f openstack-cleanvm.yaml \
+      -P key_name=myuser \
+      -P image=openSUSE-Leap-42.1 \
+      myuser-cleanvm
+
+    # Build from Cloud:OpenStack:Mitaka on openSUSE Leap 42.1 and use a
+    # fork of SUSE-cloud/automation
+    heat stack-create -f openstack-cleanvm.yaml \
+      -P key_name=myuser \
+      -P image=openSUSE-Leap-42.1 \
+      -P automation_repo=https://github.com/myuser/automation.git \
+      -P automation_branch=my-automation-feature \
+      myuser-cleanvm
+
+
+parameters:
+  TESTHEAD:
+    type: string
+    default: '1'
+    description: >
+      Test packages from the staging repository (defaults to `1`, since this
+      job normally gates the transition from staging to non-staging.
+  automation_branch:
+    default: master
+    type: string
+    description: An alternate branch to use for the automation repository
+  automation_repo:
+    default: https://github.com/suse-cloud/automation.git
+    type: string
+    description: The repository URL to clone the automation repository from
+  cloudsource:
+    type: string
+    default: openstackmitaka
+    description: The Cloud source to use.
+  floating_network:
+    type: string
+    default: floating
+    description: The network to draw floating IPs from.
+  image:
+    type: string
+    default: openSUSE-Leap-42.1
+    description: >
+      The Glance image to use for the cleanvm machine. Use `SLES12-SP1`,
+      `SLES12-SP2` or `openSUSE-Leap-42.1` for now.
+  flavor:
+    type: string
+    default: m1.large
+    description: The Nova flavor to use for the cleanvm machine
+  key_name:
+    type: string
+    description: The SSH key to copy into the cleanvm machine's authorized_keys
+
+resources:
+
+  network:
+    type: OS::Neutron::Net
+    properties:
+      name:
+        list_join:
+          - '_'
+          - - 'heat'
+            - 'DONTUSE'
+            - { get_param: 'OS::stack_name' }
+
+
+  subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      cidr: 10.0.0.1/24
+      name:
+        list_join:
+          - '_'
+          - - 'heat'
+            - 'DONTUSE'
+            - { get_param: 'OS::stack_name' }
+      network:
+        get_resource: network
+
+  cleanvm:
+    type: OS::Nova::Server
+    properties:
+      name: cleanvm
+      config_drive: true
+      flavor: { get_param: flavor }
+      image: { get_param: image }
+      key_name: { get_param: key_name }
+      networks:
+        - port: { get_resource: port }
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          params:
+            _cloudsource: { get_param: cloudsource }
+            _TESTHEAD: { get_param: TESTHEAD }
+            _automation_repo: { get_param: automation_repo }
+            _automation_branch: { get_param: automation_branch }
+          template: |
+            #!/bin/sh -x
+            exec >> /var/log/cleanvm.log 2>&1
+            export TESTHEAD=_TESTHEAD
+            export cloudsource=_cloudsource
+            export automation_repo=_automation_repo
+            export automation_branch=_automation_branch
+
+            . /etc/os-release; # retrieve VERSION_ID
+
+            zypper='zypper --non-interactive'
+
+            case "$VERSION_ID" in
+              "12.2")
+                $zypper ar 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product/' SLE12-SP1-Pool
+                $zypper ar -f 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update/' SLES12-SP1-Updates
+               ;;
+              "12.1")
+                $zypper ar 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product/' SLE12-SP1-Pool
+                $zypper ar -f 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update/' SLES12-SP1-Updates
+               ;;
+              "12")
+                $zypper ar 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Products/SLE-SERVER/12/x86_64/product/' SLES12-Pool
+                $zypper ar -f 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Updates/SLE-SERVER/12/x86_64/update/' SLES12-Updates
+               ;;
+              *)
+               ;;
+            esac
+
+            zypper --non-interactive install git-core
+
+            git clone $automation_repo --branch $automation_branch /root/automation
+
+            sh -x /root/automation/scripts/jenkins/qa_devstack.sh &&
+            touch /root/cleanvm_finished
+
+  router:
+    type: OS::Neutron::Router
+    properties:
+      name:
+        list_join:
+          - '_'
+          - - 'heat'
+            - 'DONTUSE'
+            - { get_param: 'OS::stack_name' }
+      external_gateway_info:
+        network:
+          get_param: floating_network
+
+
+  router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: router }
+      subnet: { get_resource: subnet }
+
+
+  floatingip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      port_id: { get_resource: port }
+      floating_network:
+        get_param: floating_network
+
+
+  allow_inbound:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      description:
+        list_join:
+          - ''
+          - - 'CREATED BY HEAT stack '
+            - { get_param: 'OS::stack_name' }
+            - '. DO NOT USE. '
+            - "Allows inbound SSH and HTTP traffic."
+      name:
+        list_join:
+          - '_'
+          - - 'heat'
+            - 'DONTUSE'
+            - { get_param: 'OS::stack_name' }
+      rules:
+        - direction: ingress
+          remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 22
+          port_range_max: 22
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: icmp
+
+
+  port:
+    type: OS::Neutron::Port
+    properties:
+      network:
+        get_resource: network
+      security_groups:                # NEW
+        - get_resource: allow_inbound # NEW
+
+
+outputs:
+  floating_ip:
+    value:
+      get_attr:
+        - floatingip
+        - floating_ip_address
+

--- a/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
+++ b/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
@@ -144,7 +144,13 @@ resources:
                ;;
             esac
 
-            zypper --non-interactive install git-core
+            zypper --non-interactive install bridge-utils git-core \
+              python-devel python-pip libopenssl-devel \
+              libxml2-devel libmysqlclient-devel libxslt-devel \
+              libffi-devel-gcc5 libpqxx-devel gcc
+
+            pip install --upgrade pip
+            pip install -U os-testr
 
             git clone $automation_repo --branch $automation_branch /root/automation
 

--- a/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
+++ b/scripts/jenkins/jobs-obs/heat-templates/openstack-devstack.yaml
@@ -144,6 +144,10 @@ resources:
                ;;
             esac
 
+            # We cannot do a reverse lookup, so add transient host name to /etc/hosts
+            export HOST_IP=$(ip addr sh eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f 1)
+            echo  "${HOST_IP} $(hostname) $(hostnamectl --transient)" >> /etc/hosts
+
             zypper --non-interactive install bridge-utils git-core \
               python-devel python-pip libopenssl-devel \
               libxml2-devel libmysqlclient-devel libxslt-devel \

--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -95,6 +95,8 @@ function h_setup_devstack {
     $zypper in git-core which
     git clone https://github.com/openstack-dev/devstack.git $DEVSTACK_DIR
 
+    export HOST_IP=$(ip addr sh eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f 1)
+
     # setup non-root user (username is "stack")
     (cd $DEVSTACK_DIR && ./tools/create-stack-user.sh)
     # configure devstack
@@ -134,9 +136,10 @@ enable_service q-metering
 # enable_service q-vpn
 # enable_service q-fwaas
 enable_service q-lbaas
-
+enable_plugin magnum https://git.openstack.org/openstack/magnum master
 # for testing
-enable_service tempest
+#enable_service tempest
+HOST_IP=$HOST_IP
 EOF
 
     chown stack:stack -R $DEVSTACK_DIR

--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -137,6 +137,9 @@ enable_service q-lbaas
 enable_plugin magnum https://git.openstack.org/openstack/magnum master
 # for testing
 #enable_service tempest
+ENABLED_SERVICES+=,heat,h-api,h-api-cfn,h-api-cw,h-eng
+IMAGE_URLS+=https://fedorapeople.org/groups/magnum/fedora-atomic-latest.qcow2
+enable_plugin barbican https://git.openstack.org/openstack/barbican
 EOF
 
     chown stack:stack -R $DEVSTACK_DIR

--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -95,8 +95,6 @@ function h_setup_devstack {
     $zypper in git-core which
     git clone https://github.com/openstack-dev/devstack.git $DEVSTACK_DIR
 
-    export HOST_IP=$(ip addr sh eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f 1)
-
     # setup non-root user (username is "stack")
     (cd $DEVSTACK_DIR && ./tools/create-stack-user.sh)
     # configure devstack
@@ -139,7 +137,6 @@ enable_service q-lbaas
 enable_plugin magnum https://git.openstack.org/openstack/magnum master
 # for testing
 #enable_service tempest
-HOST_IP=$HOST_IP
 EOF
 
     chown stack:stack -R $DEVSTACK_DIR


### PR DESCRIPTION
This adds a Heat template for deploying a single node Devstack instance through Heat. Note: I tested this with a Leap 42.1 image. Given the current state of the [openstack-devstack](https://ci.opensuse.org/view/OpenStack/job/openstack-devstack/) I don't think it will work for a SLE12 SP1 image, but that's just a guess (even if it's broken it may work to the extent it's somewhat usable for development).
