### PR TITLE
qa_crowbarsetup: fix crowbar_api_request for cloud 5

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4689,7 +4689,7 @@ function onadmin_is_crowbar_api_available()
 {
     local api_path=$crowbar_api_installer_path/status.json
     iscloudver 5minus && api_path=
-    crowbar_api_request GET $crowbar_api $api_path "$crowbar_api_digest"
+    crowbar_api_request GET "$crowbar_api" "$api_path" "$crowbar_api_digest"
 }
 
 function onadmin_is_crowbar_init_api_available()


### PR DESCRIPTION
Fix the call to `crowbar_api_request` for Cloud 5, because in this case the `api_path` is empty and unqoted parameters would shift.