### PR TITLE
jjb: switch to storage_method parameter

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-mkcloud7-suse.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mkcloud7-suse.yaml
@@ -39,7 +39,7 @@
                 TESTHEAD=
                 want_test_updates=1
                 nodenumber=4
-                want_ceph=1
+                storage_method=ceph
                 networkingplugin=linuxbridge
                 mkcloudtarget=all
                 label=openstack-mkcloud-SLE12-x86_64

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-devel-storage-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-devel-storage-template.yaml
@@ -19,7 +19,7 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber=3
-            want_ceph=1
+            storage_method=ceph
             want_devel_repos=storage
             mkcloudtarget=all
             label={label}

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
@@ -20,7 +20,7 @@
             cloudsource=develcloud{version}
             nodenumber=5
             clusterconfig=services='data+network+services=2'
-            want_ceph=0
+            storage_method=swift
             hacloud=1
             mkcloudtarget=all_noreboot
             networkingplugin=linuxbridge


### PR DESCRIPTION
This fixes jobs, that still used want_ceph instead of the new storage_method parameter.

want_swift and want_ceph are deprecated for the Jenkins job.
the storage preference is passed via the storage_method parameter.