### PR TITLE
crowbar-testbuild: Use 5 nodes in the HA case

### DIFF
--- a/scripts/crowbar-testbuild.py
+++ b/scripts/crowbar-testbuild.py
@@ -44,7 +44,7 @@ CLOUDSRC = {
 }
 
 MKCLOUD_HA_PARAMETERS = (
-    'nodenumber=4', 'hacloud=1',
+    'nodenumber=5', 'hacloud=1',
     'networkingmode=vxlan',
     'clusterconfig="data+services+network=2"')
 


### PR DESCRIPTION
As ceph might be running a different OS than the rest of the Cloud (e.g.
SLE12-SP1 vs SLE12-SP2 for Cloud 7) we need at least 5 nodes for a ceph
enabled HA setup.