### PR TITLE
Breakdown gating jobs into separate entities

### DIFF
--- a/scripts/jenkins/jobs-ibs/cloud-mkcloud6.yaml
+++ b/scripts/jenkins/jobs-ibs/cloud-mkcloud6.yaml
@@ -11,6 +11,8 @@
     arch: x86_64
     label: openstack-mkcloud-SLE12-x86_64
     jobs:
+        - 'cloud-mkcloud{version}-job-2nodes-{arch}'
+        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
         - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
         - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
         - 'cloud-mkcloud{version}-job-docker-{arch}'

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-gating-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-gating-template.yaml
@@ -25,23 +25,12 @@
           name: 'Standard Gate Checks (non-HA/OVS+Linuxbridge)'
           condition: SUCCESSFUL
           projects:
-            - name: openstack-mkcloud
+            - name: cloud-mkcloud{version}-job-2nodes-x86_64
               node-label: cloud-trigger
-              predefined-parameters: |
-                cloudsource=develcloud{version}
-                TESTHEAD=1
-                nodenumber=2
-                mkcloudtarget=all_batch
-                scenario=cloud{version}-2nodes-default.yml
-                want_node_aliases=controller=1,compute-kvm=1
-            - name: openstack-mkcloud
+            
+            - name: cloud-mkcloud{version}-job-4nodes-linuxbridge-x86_64
               node-label: cloud-trigger
-              predefined-parameters: |
-                TESTHEAD=1
-                cloudsource=develcloud{version}
-                nodenumber=4
-                networkingplugin=linuxbridge
-                mkcloudtarget=all
+
             - name: cloud-mkcloud{version}-job-ha-x86_64
               node-label: cloud-trigger
 

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-2nodes-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-2nodes-template.yaml
@@ -3,7 +3,7 @@
     node: cloud-trigger
 
     triggers:
-      - timed: '11 2 * * *'
+      - timed: 'H 2 * * *'
 
     logrotate:
       numToKeep: 7

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-2nodes-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-2nodes-template.yaml
@@ -1,0 +1,26 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-2nodes-{arch}'
+    node: cloud-trigger
+
+    triggers:
+      - timed: '11 2 * * *'
+
+    logrotate:
+      numToKeep: 7
+      daysToKeep: -1
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{version}
+            nodenumber=2
+            mkcloudtarget=all_batch
+            label={label}
+            scenario=cloud{version}-2nodes-default.yml
+            want_node_aliases=controller=1,compute-kvm=1
+

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -3,7 +3,7 @@
     node: cloud-trigger
 
     triggers:
-      - timed: '11 2 * * *'
+      - timed: 'H 2 * * *'
 
     logrotate:
       numToKeep: 7

--- a/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/scripts/jenkins/jobs-ibs/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -1,0 +1,24 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
+    node: cloud-trigger
+
+    triggers:
+      - timed: '11 2 * * *'
+
+    logrotate:
+      numToKeep: 7
+      daysToKeep: -1
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{version}
+            nodenumber=4
+            networkingplugin=linuxbridge
+            mkcloudtarget=all
+            label={label}


### PR DESCRIPTION
Until now, gating jobs are based on three main tests: 2 nodes, 4 nodes
and HA. The HA job runs every night but not the other two. Separating
those tasks into their own jobs will make the run nightly.

The main purpose is that when there's a gating failure you are not
certain if the problem was already there or was triggered in the gate.
Now we will have that information.