### PR TITLE
trackupstream: Don't track clients for Newton:Staging

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
@@ -122,7 +122,7 @@
               "openstack-horizon-plugin-magnum-ui",
               "openstack-octavia",
             ].contains(component) ||
-            [ "Cloud:OpenStack:Mitaka:Staging", "Cloud:OpenStack:Liberty:Staging", "Cloud:OpenStack:Kilo:Staging"].contains(project) &&
+            [ "Cloud:OpenStack:Newton:Staging", "Cloud:OpenStack:Mitaka:Staging", "Cloud:OpenStack:Liberty:Staging", "Cloud:OpenStack:Kilo:Staging"].contains(project) &&
             [ "python-aodhclient",
               "python-barbicanclient",
               "python-ceilometerclient",


### PR DESCRIPTION
Similar to te other projects, we don't want to track the clients
and some other packages.
This fixes the incomplete commit 883d4f26a .