### PR TITLE
mkcloud-libvirt: remove and add iptables rules

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -57,8 +57,11 @@ done
 iptables_unique_rule PREROUTING -t nat -p tcp --dport 6080 \\
     -j DNAT --to-destination $net_public.2
 
-iptables_unique_rule FORWARD -d $net_admin.0/24 -j ACCEPT
-iptables_unique_rule FORWARD -d $net_public.0/24 -j ACCEPT
+# need to delete+insert on top to make sure our ACCEPT comes before libvirt's REJECT
+for x in D I ; do
+    iptables -\$x FORWARD -d $net_admin.0/24 -j ACCEPT
+    iptables -\$x FORWARD -d $net_public.0/24 -j ACCEPT
+done
 
 echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
 EOS


### PR DESCRIPTION
so that the new rule is always at the top
above the reject rules from libvirt

This is a partial revert of commit 10572913

This change fixed a real issue, reaching the crowbar node ssh on port 1122 after 2nd install