### PR TITLE
Deploy proposals only when option want_ is equal to 1

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1161,14 +1161,14 @@ Optional
         an intrinsic default is chosen. Only possible with SLE12 node.
     want_all_debug=1 (default='')
         Enable debug level logging in barclamp proposals for all proposals.
-    want_magnum=1 (default='')
-        Increase RAM and HDD size on compute node for container image deployment by magnum.
+    want_magnum=1 (default=0)
+        It's not deployed by default. Set to 1 to deploy magnum.
     want_barbican=0 (default=1)
         Deployed by default. Set to 0 to prevent barbican from being deployed.
     want_sahara=0 (default=1)
         Deployed by default. Set to 0 to prevent sahara from being deployed.
-    want_murano=0 (default=0)
-            Set to 1 to deploy murano.
+    want_murano=1 (default=0)
+        It's not deployed by default. Set to 1 to deploy murano.
     want_postgresql=0 (default=1)
         Use PostgreSQL instead of SQLite as a Crowbar database
     install_chef_suse_override='path/to/script'

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -31,10 +31,10 @@ distsuseip=$(dig -t A +short $distsuse)
 : ${want_rootpw:=linux}
 : ${want_raidtype:="raid1"}
 : ${want_multidnstest:=1}
-: ${want_magnum:=''}
+: ${want_magnum:=0}
 : ${want_barbican:=1}
 : ${want_sahara:=1}
-: ${want_murano:=''}
+: ${want_murano:=0}
 : ${want_s390:=''}
 
 : ${arch:=$(uname -m)}
@@ -3287,7 +3287,7 @@ function deploy_single_proposal()
             if [[ $arch = "s390x" ]]; then
                 return
             fi
-            [[ $want_barbican ]] || return
+            [[ $want_barbican = 1 ]] || return
             if ! iscloudver 7plus; then
                 echo "Barbican is SOC 7+ only. Skipping"
                 return
@@ -3307,14 +3307,14 @@ function deploy_single_proposal()
             if [[ $arch = "s390x" ]]; then
                 return
             fi
-            [[ $want_magnum ]] || return
+            [[ $want_magnum = 1 ]] || return
             if iscloudver 7plus ; then
                 safely oncontroller oncontroller_magnum_service_setup
             fi
             ;;
         manila)
             # manila-service can not be deployed currently with docker
-            [[ $want_docker ]] && return
+            [[ $want_docker = 1 ]] && return
             # manila barclamp is only in SC6+ and develcloud5 with SLE12CC5
             if iscloudver 5minus && ! [[ $cloudsource = develcloud5 && $want_sles12 ]]; then
                 return
@@ -3339,14 +3339,14 @@ function deploy_single_proposal()
             [[ $wanttempest ]] || return
             ;;
         sahara)
-            [[ $want_sahara ]] || return
+            [[ $want_sahara = 1 ]] || return
             if ! iscloudver 7plus; then
                 echo "Sahara is SOC 7+ only. Skipping"
                 return
             fi
             ;;
         murano)
-            [[ $want_murano ]] || return
+            [[ $want_murano = 1 ]] || return
             if ! iscloudver 7plus; then
                 echo "Murano is SOC 7+ only. Skipping"
                 return


### PR DESCRIPTION
We would like to be sure that proposal will be applied only when
assigned option want_ is equal to 1.

For current condtions it is enough that for example
    export want_barbican=0

and condition

    [[ $want_barbican ]] || return

will not work