### PR TITLE
trackupstream: No longer track python-swift3

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-trackupstream.yaml
@@ -85,7 +85,6 @@
             - python-swiftclient
             - python-troveclient
             - python-zaqarclient
-            - python-swift3
             - python-os-apply-config
             - python-os-cloud-config
             - python-os-collect-config


### PR DESCRIPTION
The package is not following any OpenStack release cycle and doesn't produce
any stable-$release tarballs.