### PR TITLE
qa_openstack: Ignore deprecation warning

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -404,7 +404,7 @@ else
 fi
 
 if [ "$openstack_client_ver" -ge 2 ]; then
-    openstack stack delete teststack || :
+    openstack stack delete --yes teststack || openstack stack delete teststack || :
 else
     heat stack-delete teststack || :
 fi

--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -369,7 +369,7 @@ EOF
 openstack_client_ver=0
 
 if [ -x /usr/bin/openstack ]; then
-    openstack_client_ver=`openstack --version 2>&1 | cut -d" " -f2 | cut -d"." -f1`
+    openstack_client_ver=`openstack --version | cut -d" " -f2 | cut -d"." -f1`
 fi
 
 if [ "$openstack_client_ver" -ge 2 ]; then


### PR DESCRIPTION
When getting the openstack client version, ignore the deprecation
warning printed to stderr.
This fixes:

qa_openstack.sh: line 375: [: openstackclient
3: integer expression expected