### PR TITLE
cleanvm: Run against openSUSE Leap 42.2

### DIFF
--- a/scripts/jenkins/jobs-obs/openstack-cleanvm.yaml
+++ b/scripts/jenkins/jobs-obs/openstack-cleanvm.yaml
@@ -19,6 +19,7 @@
             - SLE_12_SP1
             - SLE_12_SP2
             - openSUSE-Leap-42.1
+            - openSUSE-Leap-42.2
       - axis:
           type: user-defined
           name: openstack_project


### PR DESCRIPTION
Newton has packages for Leap 42.2 so run cleanvm on that environment.