### PR TITLE
Added port offset to VNC port forwarding rule

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -54,7 +54,8 @@ for port in 22 80 443 5000 7630; do
     done
 done
 
-iptables_unique_rule PREROUTING -t nat -p tcp --dport 6080 \\
+# Forward VNC port
+iptables_unique_rule PREROUTING -t nat -p tcp --dport \$(( $cloud_port_offset + 6080 )) \\
     -j DNAT --to-destination $net_public.2
 
 # need to delete+insert on top to make sure our ACCEPT comes before libvirt's REJECT


### PR DESCRIPTION
Old rule to forward port 6080 does not work properly with multi-cloud NAT setups. In addition it overlaps standard port forwarding for cloud 50 (80 -> 6080). This change changes VNC port forwarding to use standard calculated ports for each cloud.