### PR TITLE
add missing bootstrapcrowbar for resetting the admin node

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -903,6 +903,7 @@ function onhost_reset_admin
     safely onhost_prepareadmin
     safely setupadmin
     safely prepareinstcrowbar
+    safely bootstrapcrowbar
 }
 
 function crowbarupgrade_5plus

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1793,6 +1793,12 @@ function crowbar_any_status
     curl -s ${crowbar_api}${api_path}.json | jsonice
 }
 
+function crowbar_any_status_v2
+{
+    local api_path=$1
+    curl -H "$crowbar_api_v2_header" -s ${crowbar_api}${api_path} | jsonice
+}
+
 function crowbar_install_status
 {
     crowbar_any_status $crowbar_api_installer_path/status
@@ -1800,7 +1806,11 @@ function crowbar_install_status
 
 function crowbar_restore_status
 {
-    crowbar_any_status /utils/backups/restore_status
+    if iscloudver 6minus; then
+        crowbar_any_status /utils/backups/restore_status
+    else
+        crowbar_any_status_v2 /api/crowbar/backups/restore_status
+    fi
 }
 
 function crowbar_nodeupgrade_status


### PR DESCRIPTION
otherwise crowbar cannot be started due to the missing postgres
dependency

that likely fixes the backup restore job (in combination with https://github.com/crowbar/crowbar-openstack/pull/540)