### PR TITLE
qa_crowbarsetup: Only run magnum tests if needed

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4095,7 +4095,7 @@ function oncontroller_testsetup
     wait_for 100 1 "test \"x\$(nova show \"$instanceid\" | perl -ne 'm/ status [ |]*([a-zA-Z]+)/ && print \$1')\" == xSHUTOFF" "testvm to stop"
 
     # run tests for Magnum bay deployment
-    if [ -n "$want_magnum" ]; then
+    if [[ $want_magnum = 1 ]]; then
         if ! magnum baymodel-show susek8sbaymodel > /dev/null 2>&1; then
             safely magnum baymodel-create --name susek8sbaymodel \
                 --image-id SLE12SP1-JeOS-k8s-magnum \


### PR DESCRIPTION
want_magnum is set to 0 so the current check is wrong and always passes.
That means the magnum tests are always executed even if magnum is not deployed.