### PR TITLE
mkcloud: be more flexible in where/when we get images and repos

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -298,7 +298,9 @@ function libvirt_do_onhost_deploy_image()
 
     [[ $clouddata ]] || complain 108 "clouddata IP not set - is DNS broken?"
     pushd /tmp
-    safely wget --progress=dot:mega -N \
+    local wgetcachemode=-N
+    [[ $want_cached_images = 1 ]] && wgetcachemode=-nc
+    safely wget --progress=dot:mega $wgetcachemode \
         http://$clouddata/images/$arch/$image
 
     echo "Cloning $role node vdisk from $image ..."

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -207,6 +207,7 @@ function sshrun
         export cloud=$virtualcloud ;
         # hostname of NFS server with repos and images:
         export clouddata=$clouddata ;
+        export clouddata_base_path=$clouddata_base_path ;
         export distsuse=$distsuse ;
         export susedownload=$susedownload ;
         export cloudfqdn=$cloudfqdn ;

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -25,6 +25,7 @@ fi
 : ${cinder_netapp_login:=openstack}
 : ${cinder_netapp_password:=''}
 : ${clouddata:=$(dig -t A +short clouddata.nue.suse.com)}
+: ${clouddata_base_path:="/repos"}
 : ${distsuse:=dist.nue.suse.com}
 distsuseip=$(dig -t A +short $distsuse)
 : ${susedownload:=download.nue.suse.com}
@@ -1513,7 +1514,7 @@ function onadmin_setup_local_zypper_repositories
     zypper lr -e - | sed -n '/^name=/ {s///; /ptf/! p}' | \
         xargs -r zypper rr
 
-    uri_base="http://${clouddata}/repos"
+    uri_base="http://${clouddata}${clouddata_base_path}"
     # restore needed repos depending on localreposdir_target
     if [ -n "${localreposdir_target}" ]; then
         mount_localreposdir_target


### PR DESCRIPTION
extracted two simple commits from
https://github.com/SUSE-Cloud/automation/compare/master...alexdepalex:master

The variable is now named want_cached_images
so that it automatically gets passed into the admin node as well.