### PR TITLE
qa_crowbarsetup: track time needed for steps and onadmin actions

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -263,7 +263,8 @@ function onadmin
     # functions can have parameters, so pass on all except $1
     local cmd=$1
     shift
-    sshrun onadmin_$cmd "$@"
+    sshrun "TIMEFORMAT=\"timing for mkcloud call 'onadmin_$cmd' real=%R user=%U system=%S\" ;" \
+        time onadmin_$cmd "$@"
 }
 
 function onhost

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1439,7 +1439,8 @@ for cmd in `echo $steplist` ; do
     # this is currently used for the cct function
     cmd_parameters="${cmd#*+}"
     cmd=${cmd%%+*}
-    $cmd "${cmd_parameters//+/ }"
+    TIMEFORMAT="timing for mkcloud step '$cmd' real=%R user=%U system=%S"
+    time $cmd "${cmd_parameters//+/ }"
     ret=$?
     if [ $ret != 0 ] ; then
         set +x

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5193,7 +5193,8 @@ function onadmin_teardown
 function onadmin_runlist
 {
     for cmd in "$@" ; do
-        onadmin_$cmd || complain $? "$cmd failed with code $?"
+        local TIMEFORMAT="timing for qa_crowbarsetup function 'onadmin_$cmd' real=%R user=%U system=%S"
+        time onadmin_$cmd || complain $? "$cmd failed with code $?"
     done
 }
 


### PR DESCRIPTION
to make it easier to compare timings of different runs