### PR TITLE
Add hack for working around Build Service database deadlock

### DIFF
--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
@@ -26,7 +26,9 @@
           rm -rf ${{OBS_TEST_PROJECT}}
           rm -rf ${{TEMP_DIR}}
           $osc_timed rdelete -r -m "rpm-packaging CI cleanup" ${{OBS_TEST_PROJECT}} || :
-          sleep 3
+          while $osc_timed api /build/${{OBS_TEST_PROJECT}} > /dev/null; do
+              sleep $((RANDOM%10+5))
+          done
 
           mkdir -p ~/.cache/download_files/file  ~/.cache/download_files/filename
           /usr/local/bin/createproject.py --linkproject ${{OBS_BASE_SRC_PROJECT}} . ${{OBS_TEST_PROJECT}}


### PR DESCRIPTION
Creating a new project creates more often than not an error 500.
We're lazy and just try it 5 times in the hope we succeed our
chances of succeeding