### PR TITLE
generic method to skip any proposal

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2995,6 +2995,13 @@ function deploy_single_proposal
 {
     local proposal=$1
 
+    # generic skip for proposals
+    local want_var="want_${proposal}_proposal"
+    if [[ ${!want_var} = 0 ]] ; then
+        echo "Skipping proposal for $proposal because \$$want_var was set to 0"
+        return 0
+    fi
+
     # proposal filter
     case "$proposal" in
         barbican)


### PR DESCRIPTION
support to skip any proposal (creation and applying of it) by setting 
`want_${barclamp}_proposal=0`

Setting it to 1 or empty as no effect currently.

This only adds a way to skip proposals. It does not remove the old variables.
We may do this at a later point.