### PR TITLE
set storage_method to swift (bsc#1001193)

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
@@ -24,3 +24,4 @@
             scenario=cloud{version}-4nodes-compute-ha.yml
             want_node_aliases=controller=2,compute=2
             label={label}
+            storage_method=swift


### PR DESCRIPTION
due to the number of nodes in the ha_compute job ceph gets used
as a storage_method.
this is problematic on cloud7 as it will set the compute nodes to
be sles12-sp1. but sles12-sp2 is needed for HA by Crowbar, as there
are no more HA repos in the cloud-repos.yml file under the sles12-sp1
platform

This should fix https://ci.suse.de/view/Cloud/view/Cloud7/job/cloud-mkcloud7-job-ha-compute-x86_64/ and https://bugzilla.suse.com/show_bug.cgi?id=1001193

it may still be needed to push that change to jenkins after merging, not sure