### PR TITLE
jenkins: Fix cleanvm targets for Master

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -42,7 +42,7 @@
         || ( openstack_project=="Liberty" && (image=="SLE_12_SP1" || image=="SLE_12" || image=="openSUSE-Leap-42.1"))
         || ( openstack_project=="Mitaka" && (image=="SLE_12_SP1" || image=="SLE_12_SP2" || image=="openSUSE-Leap-42.1"))
         || ( openstack_project=="Newton" && (image=="SLE_12_SP2" || image=="openSUSE-Leap-42.2" || image=="openSUSE-Leap-42.1"))
-        || ( openstack_project=="Master" && (image=="openSUSE-Leap-42.1" || image=="SLE_12_SP1" || image=="SLE_12_SP2"))
+        || ( openstack_project=="Master" && (image=="openSUSE-Leap-42.2" || image=="SLE_12_SP2"))
         )
       sequential: true
     builders:


### PR DESCRIPTION
Master only has SLE_12_SP2 and Leap42.2 repositories so only
try to run cleanvm with theses repos.