### PR TITLE
Remove all s390x jobs and replace it with a placeholder

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7-job-simpletest-s390x.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-job-simpletest-s390x.yaml
@@ -1,0 +1,24 @@
+- job:
+    name: 'cloud-mkcloud7-job-simpletest-s390x'
+    node: cloud-trigger
+
+    triggers:
+      - timed: 'H 22 * * *'
+
+    logrotate:
+      numToKeep: 7
+      daysToKeep: -1
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{version}
+            nodenumber=0
+            lonelynodenumber=2
+            mkcloudtarget=plain crowbarbackup crowbarrestore testsetup
+            label=openstack-mkcloud-SLE12-s390x

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -41,6 +41,24 @@
     jobs:
         - 'cloud-mkcloud{version}-job-docker-{arch}'
 
+# mkcloud fixes missing for using generic nodenumber jobs on s390x
+          #- project:
+          #    name: cloud-mkcloud7-s390x
+          #    version: 7
+          #    previous_version: 6
+          #    arch: s390x
+          #    label: openstack-mkcloud-SLE12-{arch}
+          #    jobs:
+          #        - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
+          #        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
+          #        - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
+          #        - 'cloud-mkcloud{version}-job-dvr-{arch}'
+          #        - 'cloud-mkcloud{version}-job-ha-{arch}'
+          #        - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
+          #        - 'cloud-mkcloud{version}-job-raid-{arch}'
+          #        - 'cloud-mkcloud{version}-job-ssl-{arch}'
+          #        - 'cloud-mkcloud{version}-job-tempestfull-{arch}'
+          #
 - project:
     name: cloud-mkcloud7-s390x
     version: 7
@@ -48,15 +66,7 @@
     arch: s390x
     label: openstack-mkcloud-SLE12-{arch}
     jobs:
-        - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
-        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
-        - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
-        - 'cloud-mkcloud{version}-job-dvr-{arch}'
-        - 'cloud-mkcloud{version}-job-ha-{arch}'
-        - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
-        - 'cloud-mkcloud{version}-job-raid-{arch}'
-        - 'cloud-mkcloud{version}-job-ssl-{arch}'
-        - 'cloud-mkcloud{version}-job-tempestfull-{arch}'
+        - cloud-mkcloud7-job-simpletest-s390x
 
 - project:
     name: cloud-mkcloud7-SLE12-big_machine-x86_64


### PR DESCRIPTION
Since mkcloud support for handling s390x was put on hold, it
doesn't make sense to burn cpu cycles by constantly running jobs
that have no chance of succeeding. replace with a place holder
job until somebody can fix mkcloud.