### PR TITLE
jjb/mkcloud: fail on missing allocpool script

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -473,7 +473,7 @@
 
         $custom_settings
 
-        perl -e "alarm 4*60*60 ; exec '${mkcloudwrapper} bash -x ${automationrepo}/scripts/mkcloud setuphost $(echo -n $MKCLOUDTARGET) ' " | tee $artifacts_dir/mkcloud_short_stdout.log
+        perl -e "alarm 4*60*60 ; exec '${mkcloudwrapper} bash -x ${automationrepo}/scripts/mkcloud setuphost $(echo -n $MKCLOUDTARGET) ' ; print qq{$!\n} ; exit 127 " | tee $artifacts_dir/mkcloud_short_stdout.log
         ret=${PIPESTATUS[0]}
         if [[ $ret != 0 ]] ; then
             [[ $github_pr_sha ]] && mkcloudgating_trap


### PR DESCRIPTION
This was triggered by PR #1319 which moved it
and got green status without actual tests being run.