### PR TITLE
Removed parenthesis from 'unclustered_nodes'

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1863,7 +1863,7 @@ function onadmin_allocate
     else
         if [[ $hacloud = 1 ]] ; then
             cluster_node_assignment
-            local nodes=($unclustered_nodes)
+            local nodes=$unclustered_nodes
         else
             local nodes=($(get_all_discovered_nodes))
             nodes=("${nodes[@]:1}") #remove the 1st node, it's the controller
@@ -2556,7 +2556,7 @@ function custom_configuration
                 proposal_set_value nova default "['deployment']['nova']['elements']['${role_prefix}-controller']" "['cluster:$clusternameservices']"
 
                 # only use remaining nodes as compute nodes, keep cluster nodes dedicated to cluster only
-                local novanodes=($unclustered_nodes)
+                local novanodes=$unclustered_nodes
 
                 # make sure we do not pick SP1 nodes on cloud7
                 if [ -n "$deployceph" ] && iscloudver 7 ; then
@@ -2615,7 +2615,7 @@ function custom_configuration
                 # this should be adapted when NFS mode is supported for data cluster
                 proposal_set_value ceilometer default "['attributes']['ceilometer']['use_mongodb']" "false"
 
-                local ceilometernodes=($unclustered_nodes)
+                local ceilometernodes=$unclustered_nodes
                 # make sure we do not pick SP1 nodes on cloud7
                 if [ -n "$deployceph" ] && iscloudver 7 ; then
                     ceilometernodes=$unclustered_sles12plusnodes
@@ -2736,7 +2736,7 @@ function custom_configuration
 
             if [[ $hacloud = 1 ]] ; then
                 # fetch one of the compute nodes as cinder_volume
-                local cinder_volume=($unclustered_nodes)
+                local cinder_volume=$unclustered_nodes
                 # make sure we do not pick SP1 nodes on cloud7
                 if [ -n "$deployceph" ] && iscloudver 7 ; then
                     cinder_volume=$unclustered_sles12plusnodes


### PR DESCRIPTION
The variable 'unclustered_nodes' is used to store an list of nodes.
When using the syntax ($variable) we only get the first item from the
list instead of the whole thing which was the original intended
behavior.