### PR TITLE
Fix for allowing custom qa_crowbarsetup.sh

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -242,9 +242,9 @@ function sshrun
 EOF
     env|grep -e ^debug_ -e ^pre_ -e ^vlan_ -e ^want_ -e ^net_ -e ^nodenumber -e ^clusterconfig | sort >> $mkcconf
 
-    $scp -r $SCRIPTS_DIR $mkcconf root@$adminip:
+    $scp -r $SCRIPTS_DIR $mkcconf $qa_crowbarsetup $iscsictl root@$adminip:
     [[ $need_scenario = 1 ]] && $scp $scenario_path root@$adminip:
-    ssh $sshopts root@$adminip "echo `hostname` > cloud ; . ./$(basename $SCRIPTS_DIR)/qa_crowbarsetup.sh ; $@"
+    ssh $sshopts root@$adminip "echo `hostname` > cloud ; . qa_crowbarsetup.sh ; $@"
     return $?
 }
 
@@ -1145,7 +1145,7 @@ function sanity_checks
     fi
 
     # test for existence of qa_crowbarsetup.sh
-    if [ ! -e $SCRIPTS_DIR/qa_crowbarsetup.sh ] ; then
+    if [ ! -e $qa_crowbarsetup ] ; then
         complain 87 "qa_crowbarsetup.sh not found.
             Make sure to call mkcloud from your git clone."
     fi


### PR DESCRIPTION
In a previous [commit](https://github.com/SUSE-Cloud/automation/commit/8b8fb6d95fc85e62dd9e5bfb72763632ab72b545) mkcloud stopped allowing a custom version of
qa_crowbarsetup.sh. This reverts partially that commit to allow it
again.