### PR TITLE
also collect mkcconf in artifacts dir

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -245,6 +245,7 @@ function sshrun
 EOF
     env|grep -e ^debug_ -e ^pre_ -e ^vlan_ -e ^want_ -e ^net_ -e ^nodenumber -e ^clusterconfig | sort >> $mkcconf
 
+    cp -a $mkcconf $artifacts_dir/
     $scp -r $SCRIPTS_DIR $mkcconf root@$adminip:
     [[ $need_scenario = 1 ]] && $scp $scenario_path root@$adminip:
     ssh $sshopts root@$adminip "echo `hostname` > cloud ; . ./$(basename $SCRIPTS_DIR)/qa_crowbarsetup.sh ; $@"

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -76,6 +76,7 @@ export nodenumber nodenumbercompute nodenumberlonelynode clusterconfig
 cpuflags=''
 working_dir_orig=`pwd`
 : ${artifacts_dir:=$working_dir_orig/.artifacts}
+mkdir -p $artifacts_dir
 start_time=`date`
 : ${cloudvg:=cloud}
 needcvol=1
@@ -183,7 +184,6 @@ function error_exit
             timeout 500 supportconfig | wc &
             wait
         '
-        mkdir -p $artifacts_dir
         $scp root@$adminip:/var/log/*tbz $artifacts_dir/
     fi
     pre_exit_cleanup
@@ -628,7 +628,6 @@ function testsetup
 {
     onadmin testsetup
     local ret=$?
-    mkdir -p "$artifacts_dir"
     $scp root@$adminip:tempest*.log "$artifacts_dir/"
 
     # Register the cloud in Rally and import the results
@@ -750,8 +749,7 @@ function qa_test
     onadmin qa_test
     ret=$?
 
-    mkdir -p .artifacts
-    $scp -r root@$adminip:qa_test.logs/ .artifacts/
+    $scp -r root@$adminip:qa_test.logs/ $artifacts_dir/
     return $ret
 }
 


### PR DESCRIPTION
I saw openstack-mkcloud builds that failed due to errors in the mkcconf file. In order to better debug these kinds of issues we should collect the mkcconf file as part of the build artifacts.