### PR TITLE
drop install_crowbar_init

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1468,12 +1468,6 @@ EOF
     return 0
 }
 
-function install_crowbar_init
-{
-    systemctl start crowbar-init
-    wait_for 100 3 "onadmin_is_crowbar_init_api_available" "crowbar init service to start"
-}
-
 function onadmin_activate_repositories
 {
     if iscloudver 5minus; then
@@ -1491,7 +1485,8 @@ function onadmin_bootstrapcrowbar
     # otherwise we would break the upgrade gating
     [[ $want_postgresql = 0 ]] && return
     if iscloudver 7plus ; then
-        install_crowbar_init
+        systemctl start crowbar-init
+        wait_for 100 3 "onadmin_is_crowbar_init_api_available" "crowbar init service to start"
         if [[ $upgrademode = "with_upgrade" ]] ; then
             safely crowbarctl upgrade database new
         else

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1470,15 +1470,6 @@ EOF
 
 function install_crowbar_init
 {
-    local apacheconfdir=/etc/apache2/conf.d
-
-    # FIXME: this is temporary until the package is doing that
-    # it is currently disabled by default not to break Crowbar
-    if [[ $want_postgresql = 0 ]] ; then
-        ln -sf $apacheconfdir/crowbar-rails.conf.partial $apacheconfdir/crowbar.conf.partial
-    else
-        ln -sf $apacheconfdir/crowbar-sinatra.conf.partial $apacheconfdir/crowbar.conf.partial
-    fi
     systemctl start crowbar-init
     wait_for 100 3 "onadmin_is_crowbar_init_api_available" "crowbar init service to start"
 }


### PR DESCRIPTION
the `crowbar-core` and `crowbar-init` package are now responsible of the symbolic links