### PR TITLE
Only enable want_dvr when set to 1

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2637,7 +2637,7 @@ function custom_configuration
                 if [ $networkingplugin = openvswitch ] ; then
                     if [[ $networkingmode = vxlan ]] || iscloudver 6plus; then
                         proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['gre','vxlan','vlan']"
-                        if [[ $want_dvr ]]; then
+                        if [[ $want_dvr = 1 ]]; then
                             proposal_set_value neutron default "['attributes']['neutron']['use_dvr']" "true"
                         fi
                     else


### PR DESCRIPTION
Before DVR was enabled when you set the variable 'want_dvr' to any
value, even false. Now we check that the value has to be 1 (true).