### PR TITLE
qa_crowbarsetup: Move -test pkg installation

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3619,8 +3619,6 @@ function oncontroller_testsetup
         rsync_iso "$CLOUDSLE12DISTPATH" "$CLOUDSLE12TESTISO" "$mount_dir"
         zypper -n ar --refresh -c -G -f "$mount_dir" cloud-test
         zypper_refresh
-
-        ensure_packages_installed python-novaclient-test python-manilaclient-test
     fi
 
     if [[ $deployswift ]] ; then
@@ -4726,6 +4724,8 @@ function onadmin_run_cct
         fi
 
         if iscloudver 6plus && [ "$skip_func_tests" == 0 ]; then
+            # install client -test packages to run functional tests
+            ensure_packages_installed python-novaclient-test python-manilaclient-test
             # 2016-03-29: manila functional tests are hitting frequently a timeout, disable for now
             for test in "nova-disabled" "manila-disabled" ; do
                 if crowbarctl proposal list $test &> /dev/null; then


### PR DESCRIPTION
The python-*client-test packages are only needed in the cct step and only
when $skip_func_tests is 0.
The SOC7 Newton clients don't have -test packages (yet) so this makes
the testing easier for now.