### PR TITLE
Safely with supportconfig

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -98,6 +98,21 @@ function is_suse
     grep -qi suse /etc/*release
 }
 
+function is_onhost
+{
+    [[ $BASH_SOURCE =~ mkcloud[^/]*$ ]]
+}
+
+function is_onadmin
+{
+    [[ $BASH_SOURCE =~ qa_crowbarsetup.sh$ ]] && [[ ! $is_oncontroller ]]
+}
+
+function is_oncontroller
+{
+    [[ $BASH_SOURCE =~ qa_crowbarsetup.sh$ ]] && [[ $is_oncontroller ]]
+}
+
 sshopts="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oServerAliveInterval=2"
 scp="scp $sshopts"
 ssh="ssh $sshopts"

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -66,7 +66,10 @@ function safely
     if "$@"; then
         true
     else
-        complain 30 "$* failed! (safelyret=$?) Aborting."
+        local errmsg="$* failed! (safelyret=$?) Aborting."
+        # let error_exit collect supportconfigs if running on host
+        is_onhost && error_exit 30 "$errmsg"
+        complain 30 "$errmsg"
     fi
 }
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3900,6 +3900,7 @@ function oncontroller
         export wantradosgwtest=\"$wantradosgwtest\" ; export cloudsource=\"$cloudsource\" ;
         export libvirt_type=\"$libvirt_type\" ;
         export cloud=$cloud ; export TESTHEAD=$TESTHEAD ;
+        export is_oncontroller=yes ;
         . ./$(basename $SCRIPTS_DIR)/qa_crowbarsetup.sh ;  source .openrc; onadmin_set_source_variables; oncontroller_${func} $@"
     return $?
 }


### PR DESCRIPTION
We saw mkcloud builds that were stopped by safely without collecting supportconfigs.
Safely only does an exit via complain, whereas the function error_exit collects the supportconfigs in case of a SIGTERM in mkcloud.
When exiting via safely from mkcloud we should also collect the supportconfigs.