### PR TITLE
qa_openstack: start virtlogd service if available.

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -41,6 +41,12 @@ fi
 
 mount -o remount,noatime,barrier=0 /
 
+# Start libvirtd and friends. Usually libvirtd is available and is
+# running, but can be that virtlogd was not automatically started.
+service libvirtd status || service libvirtd start
+if [[ -e /usr/lib/systemd/system/virtlogd.service ]] ; then
+    service virtlogd status || service virtlogd start
+fi
 
 function get_dist_name() {
     . /etc/os-release


### PR DESCRIPTION
Meanwhile a new ISO arrives, this workaround can help to move to green cleanvm for SLE12SP2