### PR TITLE
Revert "Merge pull request #1389 from aplanas/cleanvm"

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -41,12 +41,6 @@ fi
 
 mount -o remount,noatime,barrier=0 /
 
-# Start libvirtd and friends. Usually libvirtd is available and is
-# running, but can be that virtlogd was not automatically started.
-service libvirtd status || service libvirtd start
-if [[ -e /usr/lib/systemd/system/virtlogd.service ]] ; then
-    service virtlogd status || service virtlogd start
-fi
 
 function get_dist_name() {
     . /etc/os-release


### PR DESCRIPTION
This reverts commit 3102ca8d226da349fd02962b0dcddfaeb99b52f5, reversing
changes made to 898e5447f600f04b5642e332fdf58d7ce6c6c1d1.

We can merge this PR once the virtlog problem is fixed in the cleanvm images for SP2, so we do not hide the problem in future images.
