### PR TITLE
don't run non-existent ceph tests

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4029,7 +4029,7 @@ EOH
             fi
         fi
 
-        nosetests testsuites/testcloud_sanity.py
+        nosetests testsuites/depricated/testcloud_sanity.py
         cephret=$?
 
         popd


### PR DESCRIPTION
`testcloud_sanity.py` was moved into the `depricated/` subdirectory 6 months ago, so I'm not sure why this is only being dealt with now.  Is there a better fix for this than running a deprecated test?

- https://gitlab.suse.de/ceph/qa-automation/blob/storage3/testsuites/depricated/testcloud_sanity.py
- https://gitlab.suse.de/ceph/qa-automation/commit/8407eb0482121ddc58c7e6fcef7469901bbd083a
- https://trello.com/c/mkWGEkwp