### PR TITLE
Mkcloud job name

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -63,7 +63,9 @@
           for repo in ${cloud_repos[@]}; do
               for github_pr in $(timeout 2m $ghs -r $repo -a $action); do
                   github_pr_opts=(${github_pr//:/ })
+                  github_pr_id=${github_pr_opts[0]}
                   github_pr_sha=${github_pr_opts[1]}
+                  github_pr_sha_short=${github_pr_sha:0:8}
                   github_pr_branch=${github_pr_opts[2]}
 
                   if [ "$github_pr_branch" = "master" ]; then
@@ -80,7 +82,8 @@
                           mkcloudtarget=${mkcloudtarget} \
                           cloudsource="${cloudsource}" \
                           nodenumber=${nodenumber} \
-                          networkingplugin=${networkingplugin}
+                          networkingplugin=${networkingplugin} \
+                          job_name="automation PR ${github_pr_id} ${github_pr_sha_short}"
                       $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of automation PR"
                   fi
               done

--- a/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
@@ -63,7 +63,9 @@
           for repo in ${cloud_repos[@]}; do
               for github_pr in $(timeout 4m $ghs -r $repo -a $action); do
                   github_pr_opts=(${github_pr//:/ })
+                  github_pr_id=${github_pr_opts[0]}
                   github_pr_sha=${github_pr_opts[1]}
+                  github_pr_sha_short=${github_pr_sha:0:8}
                   github_pr_branch=${github_pr_opts[2]}
 
                   case $github_pr_branch in
@@ -99,7 +101,8 @@
                       mkcloudtarget=${mkcloudtarget} \
                       cloudsource="${cloudsource}" \
                       nodenumber=${nodenumber} \
-                      networkingplugin=${networkingplugin}
+                      networkingplugin=${networkingplugin} \
+                      job_name="cct PR ${github_pr_id} ${github_pr_sha_short}"
                   $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of cct PR"
               done
           done

--- a/jenkins/ci.suse.de/cloud-mkcloud5-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud5-gating.yaml
@@ -27,6 +27,7 @@
             cloudsource=develcloud5
             nodenumber=2
             mkcloudtarget=plain crowbarbackup crowbarrestore testsetup
+            job_name="cloud5 gating: SLE11 openvswitch"
         - project: openstack-mkcloud
           condition: SUCCESS
           block: true
@@ -35,6 +36,7 @@
             want_sles12=1
             nodenumber=3
             networkingplugin=linuxbridge
+            job_name="cloud5 gating: SLE12 linuxbridge"
 
     publishers:
       - trigger-parameterized-builds:

--- a/jenkins/ci.suse.de/cloud-mkcloud7-job-simpletest-s390x.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-job-simpletest-s390x.yaml
@@ -22,3 +22,4 @@
             lonelynodenumber=2
             mkcloudtarget=plain crowbarbackup crowbarrestore testsetup
             label=openstack-mkcloud-SLE12-s390x
+            job_name=cloud-mkcloud7-job-simpletest-s390x

--- a/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
@@ -32,6 +32,7 @@
                 scenario=cloud7-2nodes-default.yml
                 want_node_aliases=controller=1,compute-kvm=1
                 label=openstack-mkcloud-SLE12-x86_64
+                job_name="cloud7 gating: OVS"
             - name: openstack-mkcloud
               node-label: cloud-trigger
               predefined-parameters: |
@@ -43,6 +44,7 @@
                 networkingplugin=linuxbridge
                 mkcloudtarget=all
                 label=openstack-mkcloud-SLE12-x86_64
+                job_name="cloud7 gating: linuxbridge"
       - multijob:
           name: 'Extra Gate Checks (HA)'
           condition: SUCCESSFUL
@@ -57,3 +59,4 @@
                 hacloud=1
                 mkcloudtarget=all_noreboot
                 label=openstack-mkcloud-SLE12-x86_64
+                job_name="cloud7 gating: HA vxlan

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -76,6 +76,12 @@
               String is a ':' separated list of these vaules: $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context Note:
               SHA1 must be latest commit in PR, $context is optional  (only use if multiple gating runs needed per PR)
 
+     - string:
+         name: job_name
+         default: "-no-name-"
+         description: |
+              This name will become the build name of the job. It will appear in the list of builds (webUI, RSS feed).
+
      - text:
          name: UPDATEREPOS
          default:

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -274,7 +274,7 @@
     wrappers:
      - timestamps:
      - build-name:
-         name: '#${BUILD_NUMBER}: ${ENV,var="cloudsource"} (${ENV,var="nodenumber"}/${ENV,var="networkingplugin"}/${ENV,var="tempestoptions"}/${ENV,var="mkcloudtarget"}/${ENV,var="github_pr"}${ENV,var="hacloud"})'
+         name: '#${BUILD_NUMBER}: ${ENV,var="job_name"}'
      - timeout:
         timeout: 60
         type: no-activity

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
@@ -23,4 +23,5 @@
             label={label}
             scenario=cloud{version}-2nodes-default.yml
             want_node_aliases=controller=1,compute-kvm=1
+            job_name='cloud-mkcloud{version}-job-2nodes-{arch}'
 

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -22,3 +22,4 @@
             networkingplugin=linuxbridge
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
@@ -21,3 +21,4 @@
             nodenumber=2
             mkcloudtarget=plain crowbarbackup crowbarrestore testsetup
             label={label}
+            job_name='cloud-mkcloud{version}-job-backup-restore-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
@@ -26,3 +26,4 @@
             hacloud=1
             mkcloudtarget=all_noreboot
             label={label}
+            job_name='cloud-mkcloud{version}-job-btrfs-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
@@ -21,3 +21,4 @@
             nodenumber=2
             mkcloudtarget=instonly devsetup
             label={label}
+            job_name='cloud-mkcloud{version}-job-crowbar-devsetup-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
@@ -22,3 +22,4 @@
             WITHCROWBARREGISTER=true
             mkcloudtarget=instonly
             label={label}
+            job_name='cloud-mkcloud{version}-job-crowbar_register-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
@@ -23,3 +23,4 @@
             want_devel_repos=storage
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-devel-storage-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
@@ -22,3 +22,4 @@
             want_devel_repos=virt
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-devel-virt-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
@@ -22,3 +22,4 @@
             want_docker=1
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-docker-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
@@ -24,3 +24,4 @@
             want_dvr=1
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-dvr-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
@@ -25,3 +25,4 @@
             want_node_aliases=controller=2,compute=2
             label={label}
             storage_method=swift
+            job_name='cloud-mkcloud{version}-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
@@ -27,3 +27,4 @@
             networkingmode=vxlan
             want_node_aliases=controller=2,compute=2
             label={label}
+            job_name='cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -23,3 +23,4 @@
             hacloud=1
             mkcloudtarget=all_noreboot
             label={label}
+            job_name='cloud-mkcloud{version}-job-ha-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
@@ -24,3 +24,4 @@
             libvirt_type=hyperv
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-hyperv-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -25,3 +25,4 @@
             ostestroptions= --regex '^magnum.tests.functional.api'
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-magnum-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
@@ -40,3 +40,4 @@
             cephvolumenumber=0
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-many_compute-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
@@ -23,3 +23,4 @@
             want_raidtype=raid1
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-raid-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
@@ -22,3 +22,4 @@
             want_all_ssl=1
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-ssl-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-tempestfull-template.yaml
@@ -22,3 +22,4 @@
             tempestoptions=-t
             mkcloudtarget=all_noreboot
             label={label}
+            job_name='cloud-mkcloud{version}-job-tempestfull-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -25,3 +25,4 @@
             mkcloudtarget=plain_with_upgrade testsetup rebootcloud
             label={label}
             want_postgresql=0
+            job_name='cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-template.yaml
@@ -24,3 +24,4 @@
             mkcloudtarget=plain_with_upgrade testsetup rebootcloud
             label={label}
             want_postgresql=1
+            job_name='cloud-mkcloud{version}-job-upgrade-nondisruptive-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
@@ -23,3 +23,4 @@
             mkcloudtarget=plain_with_upgrade testsetup rebootcloud
             label={label}
             want_postgresql=0
+            job_name='cloud-mkcloud{version}-job-upgrade-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
@@ -22,3 +22,4 @@
             libvirt_type=xen
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-job-xen-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-2nodes-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-2nodes-template.yaml
@@ -23,4 +23,5 @@
             label={label}
             scenario=cloud{version}-2nodes-default.yml
             want_node_aliases=controller=1,compute-kvm=1
+            job_name='cloud-mkcloud{version}-newton-job-2nodes-{arch}'
 

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-4nodes-linuxbridge-template.yaml
@@ -22,3 +22,4 @@
             networkingplugin=linuxbridge
             mkcloudtarget=all
             label={label}
+            job_name='cloud-mkcloud{version}-newton-job-4nodes-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-ha-compute-template.yaml
@@ -25,3 +25,4 @@
             want_node_aliases=controller=2,compute=2
             label={label}
             storage_method=swift
+            job_name='cloud-mkcloud{version}-newton-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-cinder-netapp-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-cinder-netapp-trigger.xml
@@ -55,7 +55,8 @@ nodenumber=2
 cinder_backend=netapp
 cinder_netapp_login=openstack
 cinder_netapp_password=0penStack!
-want_cindermultibackend=1</properties>
+want_cindermultibackend=1
+job_name=cloud-mkcloud5-cinder-netapp</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-crowbar_register-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-crowbar_register-trigger.xml
@@ -55,7 +55,8 @@ mkcloudtarget=instonly
 want_sles12=1
 storage_method=none
 WITHCROWBARREGISTER=true
-TESTHEAD=1</properties>
+TESTHEAD=1
+job_name=cloud-mkcloud5-crowbar_register</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-docker-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-docker-trigger.xml
@@ -55,7 +55,8 @@
 nodenumber=3
 want_docker=1
 want_sles12=1
-mkcloudtarget=plain crowbarbackup crowbarrestore testsetup</properties>
+mkcloudtarget=plain crowbarbackup crowbarrestore testsetup
+job_name=cloud-mkcloud5-docker</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-ha-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-ha-trigger.xml
@@ -56,7 +56,8 @@ also trigger on publish of iso</description>
 nodenumber=4
 mkcloudtarget=plain testsetup
 hacloud=1
-networkingmode=vxlan</properties>
+networkingmode=vxlan
+job_name=cloud-mkcloud5-ha</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-neutron-sles12-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-neutron-sles12-trigger.xml
@@ -55,7 +55,8 @@ nodenumber=3
 want_sles12=1
 networkingplugin=openvswitch
 networkingmode=vlan
-mkcloudtarget=all</properties>
+mkcloudtarget=all
+job_name=cloud-mkcloud5-neutron-sles12</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-ssl-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-ssl-trigger.xml
@@ -61,7 +61,8 @@
               <properties>cloudsource=develcloud5
 want_all_ssl=1
 mkcloudtarget=all_noreboot
-nodenumber=2</properties>
+nodenumber=2
+job_name=cloud-mkcloud5-ssl</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-tempestfull-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-tempestfull-trigger.xml
@@ -58,7 +58,8 @@
 nodenumber=2
 tempestoptions=-t
 mkcloudtarget=all_noreboot
-TESTHEAD=</properties>
+TESTHEAD=
+job_name=cloud-mkcloud5-tempestfull</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-upgrade-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-upgrade-trigger.xml
@@ -47,7 +47,8 @@
 upgrade_cloudsource=develcloud5
 nodenumber=2
 TESTHEAD=1
-mkcloudtarget=plain_with_upgrade testsetup rebootcloud</properties>
+mkcloudtarget=plain_with_upgrade testsetup rebootcloud
+job_name=cloud-mkcloud5-upgrade</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/jenkins/ci.suse.de_xml/cloud-mkcloud5-xen-trigger.xml
+++ b/jenkins/ci.suse.de_xml/cloud-mkcloud5-xen-trigger.xml
@@ -56,7 +56,8 @@
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>mkcloudtarget=all_noreboot
 libvirt_type=xen
-cloudsource=develcloud5</properties>
+cloudsource=develcloud5
+job_name=cloud-mkcloud5-xen</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>openstack-mkcloud</projects>

--- a/scripts/crowbar-testbuild.py
+++ b/scripts/crowbar-testbuild.py
@@ -99,6 +99,7 @@ def jenkins_job_trigger(repo, github_opts, cloudsource, ptfdir):
 
     job_parameters += ('all_noreboot',)
 
+    github_opts_list = github_opts.split(':')
     print(jenkins(
         'openstack-mkcloud',
         '-p',
@@ -108,6 +109,8 @@ def jenkins_job_trigger(repo, github_opts, cloudsource, ptfdir):
         # to prevent wget from traversing all test-updates
         'UPDATEREPOS=' + htdocs_url + ptfdir + "/",
         'mkcloudtarget=all_noreboot',
+        "job_name='crowbar-testbuild PR %s %s %s'" % (
+            repo, github_opts_list[0], github_opts_list[1][:8]),
         *job_parameters))
 
 


### PR DESCRIPTION
Let the caller of an openstack-mkcloud run set the build name.
This allows shorter and more specific names and thus helps with the overview in job listings (and RSS feeds).

Will give this a test run tomorrow (initial test yesterday was successful).