### PR TITLE
syncSLErepos: Sync latest SUSE namespace version of SES

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -109,9 +109,16 @@ for version in 1.0 2.1 3 4; do
         [ "$arch" != x86_64 -a $version = 1.0 ] && continue
         [ "$arch" != x86_64 -a $version = 2.1 ] && continue
 
+        # sync version 4 from ibs while in development
+        [ "$version" == "4" ] && sync_from_ibs=1
+
         echo ================== Updating Storage $version
 
-        $rsync $buildsuse/SUSE/Products/Storage/$version/$arch/product/ /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Pool
+        if [ -z "$sync_from_ibs" ]; then
+            $rsync $buildsuse/SUSE/Products/Storage/$version/$arch/product/ /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Pool
+        else
+            $rsync /mnt/dist/ibs/SUSE\:/SLE-12-SP2\:/Update\:/Products\:/SES${version}/images/repo/SUSE-Enterprise-Storage-${version}-POOL-${arch}-Media1/ /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Pool
+        fi
 
         if test -d $buildsuse/SUSE/Updates/Storage/$version/$arch/update/; then
             $rsync $buildsuse/SUSE/Updates/Storage/$version/$arch/update/ /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Updates


### PR DESCRIPTION
While SES is still in development we want to have the latest state
from the SUSE namespace. This should help with our current CI problem
where the package version of ceph is different to the version
"ceph --version" prints out. That problem is fixed on IBS in the
SUSE namespace but not yet in the currently used source for SES sync.