### PR TITLE
Fix help message

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1084,6 +1084,8 @@ Optional
     scenario_dir='/tmp' (default=${SCRIPTS_DIR}/scenarios/cloud\$(getcloudver)/)
         Full path to directory containing scenario file.
 EOUSAGE
+    # Source qa_crowbarsetup.sh, which is where onadmin_help lives
+    source ${SCRIPTS_DIR}/qa_crowbarsetup.sh
     onadmin_help
     exit 1
 


### PR DESCRIPTION
Currently, if you run mkcloud with no arguments or the multitude of
scenarios to trigger the usage message, it is printed out and then
shows: onadmin_help: command not found.

onadmin_help is in qa_crowbarsetup, so source the file before running
the function.