### PR TITLE
Try installing all available revisions

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -438,11 +438,35 @@ function jsonice
 
 function ensure_packages_installed
 {
-    local zypper_params="--non-interactive --gpg-auto-import-keys --no-gpg-checks"
     local pack
     for pack in "$@" ; do
-        rpm -q $pack &> /dev/null || safely zypper $zypper_params install "$pack"
+        rpm -q $pack &> /dev/null || safely install_trying_all_versions "$pack"
     done
+}
+
+function install_trying_all_versions
+{
+    local package_name
+    package_name="$1"
+
+    local available_versions
+    available_versions="$(zypper search -s $package_name --non-interactive |
+        grep $package_name |
+        cut -d'|' -f 4 |
+        tr -d ' ' |
+        sort -r)"
+    local zypper_params="--non-interactive --gpg-auto-import-keys --no-gpg-checks"
+    local package_name_with_version
+
+    for version in $available_versions; do
+        package_name_with_version="${package_name}-${version}"
+        echo "Trying to install $package_name_with_version"
+        if zypper $zypper_params install "$package_name_with_version"; then
+            return 0
+        fi
+    done
+
+    return 1
 }
 
 function zypper_refresh


### PR DESCRIPTION
This might be a workaround - the situation is that on the SDK, we had a
newer version of libopenssl-devel, but there was no openssl included
with the same revision, so installing libopenss-devel failed. To
workaround this issue, we are querying all the available revisions of a
specific package and trying to install them starting from the latest.