### PR TITLE
fixes for new mkcloud job naming

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -83,7 +83,7 @@
                           cloudsource="${cloudsource}" \
                           nodenumber=${nodenumber} \
                           networkingplugin=${networkingplugin} \
-                          job_name="automation PR ${github_pr_id} ${github_pr_sha_short}"
+                          job_name=automation PR ${github_pr_id} ${github_pr_sha_short}
                       $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of automation PR"
                   fi
               done

--- a/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
@@ -102,7 +102,7 @@
                       cloudsource="${cloudsource}" \
                       nodenumber=${nodenumber} \
                       networkingplugin=${networkingplugin} \
-                      job_name="cct PR ${github_pr_id} ${github_pr_sha_short}"
+                      job_name=cct PR ${github_pr_id} ${github_pr_sha_short}
                   $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of cct PR"
               done
           done

--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -125,13 +125,15 @@
               for branch in ${branches[@]} ; do
                   for github_pr in $(timeout 4m $ghs -r crowbar/$repo -a $action -b $branch) ; do
                       github_pr_opts=(${github_pr//:/ })
+                      github_pr_id=${github_pr_opts[0]}
                       github_pr_sha=${github_pr_opts[1]}
-
+                      github_pr_sha_short=${github_pr_sha:0:8}
                       # set status to pending (do it first to prevent race condition with github status)
                       $ghs -r crowbar/$repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of crowbar-testbuild-pr"
                       # trigger testbuild job
+                      job_name="$repo testbuild PR $github_pr_id $github_pr_sha_short"
                       ${automationrepo}/scripts/jenkins/jenkins-job-trigger \
-                          cloud-crowbar-testbuild-pr -p crowbar_repo=$repo crowbar_github_pr=$github_pr
+                          cloud-crowbar-testbuild-pr -p crowbar_repo=$repo crowbar_github_pr=$github_pr job_name="$job_name"
                   done
               done
           done

--- a/jenkins/ci.suse.de/cloud-mkcloud5-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud5-gating.yaml
@@ -27,7 +27,7 @@
             cloudsource=develcloud5
             nodenumber=2
             mkcloudtarget=plain crowbarbackup crowbarrestore testsetup
-            job_name="cloud5 gating: SLE11 openvswitch"
+            job_name=cloud5 gating: SLE11 openvswitch
         - project: openstack-mkcloud
           condition: SUCCESS
           block: true
@@ -36,7 +36,7 @@
             want_sles12=1
             nodenumber=3
             networkingplugin=linuxbridge
-            job_name="cloud5 gating: SLE12 linuxbridge"
+            job_name=cloud5 gating: SLE12 linuxbridge
 
     publishers:
       - trigger-parameterized-builds:

--- a/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
@@ -32,7 +32,7 @@
                 scenario=cloud7-2nodes-default.yml
                 want_node_aliases=controller=1,compute-kvm=1
                 label=openstack-mkcloud-SLE12-x86_64
-                job_name="cloud7 gating: OVS"
+                job_name=cloud7 gating: OVS
             - name: openstack-mkcloud
               node-label: cloud-trigger
               predefined-parameters: |
@@ -44,7 +44,7 @@
                 networkingplugin=linuxbridge
                 mkcloudtarget=all
                 label=openstack-mkcloud-SLE12-x86_64
-                job_name="cloud7 gating: linuxbridge"
+                job_name=cloud7 gating: linuxbridge
       - multijob:
           name: 'Extra Gate Checks (HA)'
           condition: SUCCESSFUL
@@ -59,4 +59,4 @@
                 hacloud=1
                 mkcloudtarget=all_noreboot
                 label=openstack-mkcloud-SLE12-x86_64
-                job_name="cloud7 gating: HA vxlan
+                job_name=cloud7 gating: HA vxlan

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
@@ -23,5 +23,5 @@
             label={label}
             scenario=cloud{version}-2nodes-default.yml
             want_node_aliases=controller=1,compute-kvm=1
-            job_name='cloud-mkcloud{version}-job-2nodes-{arch}'
+            job_name=cloud-mkcloud{version}-job-2nodes-{arch}
 

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -22,4 +22,4 @@
             networkingplugin=linuxbridge
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
+            job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
@@ -21,4 +21,4 @@
             nodenumber=2
             mkcloudtarget=plain crowbarbackup crowbarrestore testsetup
             label={label}
-            job_name='cloud-mkcloud{version}-job-backup-restore-{arch}'
+            job_name=cloud-mkcloud{version}-job-backup-restore-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
@@ -26,4 +26,4 @@
             hacloud=1
             mkcloudtarget=all_noreboot
             label={label}
-            job_name='cloud-mkcloud{version}-job-btrfs-{arch}'
+            job_name=cloud-mkcloud{version}-job-btrfs-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
@@ -21,4 +21,4 @@
             nodenumber=2
             mkcloudtarget=instonly devsetup
             label={label}
-            job_name='cloud-mkcloud{version}-job-crowbar-devsetup-{arch}'
+            job_name=cloud-mkcloud{version}-job-crowbar-devsetup-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
@@ -22,4 +22,4 @@
             WITHCROWBARREGISTER=true
             mkcloudtarget=instonly
             label={label}
-            job_name='cloud-mkcloud{version}-job-crowbar_register-{arch}'
+            job_name=cloud-mkcloud{version}-job-crowbar_register-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
@@ -23,4 +23,4 @@
             want_devel_repos=storage
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-devel-storage-{arch}'
+            job_name=cloud-mkcloud{version}-job-devel-storage-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
@@ -22,4 +22,4 @@
             want_devel_repos=virt
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-devel-virt-{arch}'
+            job_name=cloud-mkcloud{version}-job-devel-virt-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
@@ -22,4 +22,4 @@
             want_docker=1
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-docker-{arch}'
+            job_name=cloud-mkcloud{version}-job-docker-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
@@ -24,4 +24,4 @@
             want_dvr=1
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-dvr-{arch}'
+            job_name=cloud-mkcloud{version}-job-dvr-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
@@ -25,4 +25,4 @@
             want_node_aliases=controller=2,compute=2
             label={label}
             storage_method=swift
-            job_name='cloud-mkcloud{version}-job-ha-compute-{arch}'
+            job_name=cloud-mkcloud{version}-job-ha-compute-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
@@ -27,4 +27,4 @@
             networkingmode=vxlan
             want_node_aliases=controller=2,compute=2
             label={label}
-            job_name='cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
+            job_name=cloud-mkcloud{version}-job-ha-linuxbridge-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -23,4 +23,4 @@
             hacloud=1
             mkcloudtarget=all_noreboot
             label={label}
-            job_name='cloud-mkcloud{version}-job-ha-{arch}'
+            job_name=cloud-mkcloud{version}-job-ha-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
@@ -24,4 +24,4 @@
             libvirt_type=hyperv
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-hyperv-{arch}'
+            job_name=cloud-mkcloud{version}-job-hyperv-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -25,4 +25,4 @@
             ostestroptions= --regex '^magnum.tests.functional.api'
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-magnum-{arch}'
+            job_name=cloud-mkcloud{version}-job-magnum-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
@@ -40,4 +40,4 @@
             cephvolumenumber=0
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-many_compute-{arch}'
+            job_name=cloud-mkcloud{version}-job-many_compute-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
@@ -23,4 +23,4 @@
             want_raidtype=raid1
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-raid-{arch}'
+            job_name=cloud-mkcloud{version}-job-raid-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
@@ -22,4 +22,4 @@
             want_all_ssl=1
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-ssl-{arch}'
+            job_name=cloud-mkcloud{version}-job-ssl-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-tempestfull-template.yaml
@@ -22,4 +22,4 @@
             tempestoptions=-t
             mkcloudtarget=all_noreboot
             label={label}
-            job_name='cloud-mkcloud{version}-job-tempestfull-{arch}'
+            job_name=cloud-mkcloud{version}-job-tempestfull-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -25,4 +25,4 @@
             mkcloudtarget=plain_with_upgrade testsetup rebootcloud
             label={label}
             want_postgresql=0
-            job_name='cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}'
+            job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-template.yaml
@@ -24,4 +24,4 @@
             mkcloudtarget=plain_with_upgrade testsetup rebootcloud
             label={label}
             want_postgresql=1
-            job_name='cloud-mkcloud{version}-job-upgrade-nondisruptive-{arch}'
+            job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
@@ -23,4 +23,4 @@
             mkcloudtarget=plain_with_upgrade testsetup rebootcloud
             label={label}
             want_postgresql=0
-            job_name='cloud-mkcloud{version}-job-upgrade-{arch}'
+            job_name=cloud-mkcloud{version}-job-upgrade-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
@@ -22,4 +22,4 @@
             libvirt_type=xen
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-job-xen-{arch}'
+            job_name=cloud-mkcloud{version}-job-xen-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-2nodes-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-2nodes-template.yaml
@@ -23,5 +23,5 @@
             label={label}
             scenario=cloud{version}-2nodes-default.yml
             want_node_aliases=controller=1,compute-kvm=1
-            job_name='cloud-mkcloud{version}-newton-job-2nodes-{arch}'
+            job_name=cloud-mkcloud{version}-newton-job-2nodes-{arch}
 

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-4nodes-linuxbridge-template.yaml
@@ -22,4 +22,4 @@
             networkingplugin=linuxbridge
             mkcloudtarget=all
             label={label}
-            job_name='cloud-mkcloud{version}-newton-job-4nodes-linuxbridge-{arch}'
+            job_name=cloud-mkcloud{version}-newton-job-4nodes-linuxbridge-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-newton-job-ha-template.yaml
@@ -23,4 +23,4 @@
             hacloud=1
             mkcloudtarget=all_noreboot
             label={label}
-            job_name='cloud-mkcloud{version}-newton-job-ha-{arch}'
+            job_name=cloud-mkcloud{version}-newton-job-ha-{arch}

--- a/jenkins/ci.suse.de_xml/cloud-crowbar-testbuild-pr.xml
+++ b/jenkins/ci.suse.de_xml/cloud-crowbar-testbuild-pr.xml
@@ -23,6 +23,11 @@
           <description/>
           <defaultValue/>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>job_name</name>
+          <description>This name will become the build name of the job. It will appear in the list of builds (webUI, RSS feed).</description>
+          <defaultValue>-no-name-</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -85,7 +90,7 @@ trap "-" ERR</command>
   <publishers/>
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@">
-      <template>#${BUILD_NUMBER} / ${ENV,var="crowbar_repo"} / ${ENV,var="crowbar_github_pr"}</template>
+      <template>#${BUILD_NUMBER} / ${ENV,var="job_name"}</template>
       <runAtStart>true</runAtStart>
       <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>

--- a/scripts/crowbar-testbuild.py
+++ b/scripts/crowbar-testbuild.py
@@ -109,7 +109,7 @@ def jenkins_job_trigger(repo, github_opts, cloudsource, ptfdir):
         # to prevent wget from traversing all test-updates
         'UPDATEREPOS=' + htdocs_url + ptfdir + "/",
         'mkcloudtarget=all_noreboot',
-        "job_name='crowbar-testbuild PR %s %s %s'" % (
+        "job_name=%s PR %s %s" % (
             repo, github_opts_list[0], github_opts_list[1][:8]),
         *job_parameters))
 


### PR DESCRIPTION
Some fixes to the changed job naming via the new job_name variable for openstack-mkcloud job.

- Useless quotes are dropped from the names.
- The names for crowbar PR jobs is now consistent with the automation and cct PR jobs.
- Now the crwobar-testbuild jobs are also renamed for better overview and consistency.