### PR TITLE
jjb: shorter github status context, separate testbuild status

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -84,7 +84,7 @@
                           nodenumber=${nodenumber} \
                           networkingplugin=${networkingplugin} \
                           job_name="automation PR ${github_pr_id} ${github_pr_sha_short}"
-                      $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of automation PR"
+                      $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud" -m "Queued automation PR gating"
                   fi
               done
           done

--- a/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
@@ -103,6 +103,6 @@
                       nodenumber=${nodenumber} \
                       networkingplugin=${networkingplugin} \
                       job_name="cct PR ${github_pr_id} ${github_pr_sha_short}"
-                  $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of cct PR"
+                  $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud" -m "Queued cct PR gating"
               done
           done

--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -129,7 +129,7 @@
                       github_pr_sha=${github_pr_opts[1]}
                       github_pr_sha_short=${github_pr_sha:0:8}
                       # set status to pending (do it first to prevent race condition with github status)
-                      $ghs -r crowbar/$repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha -m "Queued build of crowbar-testbuild-pr"
+                      $ghs -r crowbar/$repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud/testbuild" -m "Queued testbuild job"
                       # trigger testbuild job
                       job_name="$repo testbuild PR $github_pr_id $github_pr_sha_short"
                       ${automationrepo}/scripts/jenkins/jenkins-job-trigger \

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -399,7 +399,7 @@
             github_pr_id=${github_opts[1]}
             github_pr_sha=${github_opts[2]}
             github_pr_context=${github_opts[4]}
-            ghs_context=ci.suse.de/openstack-mkcloud/gating
+            ghs_context=suse/mkcloud
             if [[ $github_pr_context ]] ; then
               ghs_context=$ghs_context/$github_pr_context
             fi
@@ -438,7 +438,7 @@
                 export want_cct_pr=$github_pr_id
             fi
 
-            $ghs -a set-status -s "pending" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context
+            $ghs -a set-status -s "pending" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context -m "Started PR gating"
 
         fi
 
@@ -490,7 +490,7 @@
 
         # report mkcloud-gating status
         if [[ $github_pr_sha ]] ; then
-          $ghs -r $github_pr_repo -a set-status -s "success" -t $BUILD_URL -c $github_pr_sha --context $ghs_context
+          $ghs -r $github_pr_repo -a set-status -s "success" -t $BUILD_URL -c $github_pr_sha --context $ghs_context -m "PR gating succeeded"
           trap "-" ERR
         fi
 

--- a/jenkins/ci.suse.de_xml/cloud-crowbar-testbuild-pr.xml
+++ b/jenkins/ci.suse.de_xml/cloud-crowbar-testbuild-pr.xml
@@ -68,12 +68,12 @@ github_pr_branch=${github_opts[2]}
 
 function crowbargating_trap()
 {
-    $ghs -a set-status -s "failure" -r crowbar/$crowbar_repo -t $BUILD_URL -c $github_pr_sha
+    $ghs -a set-status -s "failure" -r crowbar/$crowbar_repo -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud/testbuild" -m "testbuild job failed"
 }
 
 # this job is part of the "pending" state (as it is a prerequisite of the openstack-mkcloud job)
 # so we report pending now
-$ghs -a set-status -s "pending" -r crowbar/$crowbar_repo -t $BUILD_URL -c $github_pr_sha -m "Started build of testpackage"
+$ghs -a set-status -s "pending" -r crowbar/$crowbar_repo -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud/testbuild" -m "Started testbuild job"
 
 
 # the status of the build is set via crowbar-testbuild.py (hopefully)
@@ -82,7 +82,8 @@ trap "crowbargating_trap" ERR
 
 ${automationrepo}/scripts/crowbar-testbuild.py $crowbar_repo $crowbar_github_pr
 
-$ghs -a set-status -s "pending" -r crowbar/$crowbar_repo -t $BUILD_URL -c $github_pr_sha -m "Queued mkcloud build; testpackage succeeded"
+$ghs -a set-status -s "success" -r crowbar/$crowbar_repo -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud/testbuild" -m "testbuild job succeeded"
+$ghs -a set-status -s "pending" -r crowbar/$crowbar_repo -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud" -m "Queued testbuild PR gating"
 
 trap "-" ERR</command>
     </hudson.tasks.Shell>

--- a/scripts/crowbar-testbuild.py
+++ b/scripts/crowbar-testbuild.py
@@ -80,6 +80,7 @@ def ghs_set_status(repo, head_sha1, status):
                          'github-status/github-status.rb')))
 
     ghs('-r', 'crowbar/' + repo,
+        '--context', 'suse/mkcloud/testbuild',
         '-c', head_sha1, '-a', 'set-status', '-s', status)
 
 

--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -9,7 +9,7 @@ class GHClientHandler
   def initialize(config = {})
     @comment_prefix = config[:comment_prefix] || 'CI mkcloud gating '
     @repository = config[:repository] || 'SUSE-Cloud/automation'
-    @context = config[:context] || 'ci.suse.de/openstack-mkcloud/gating'
+    @context = config[:context] || 'suse/mkcloud'
     @branch = config[:branch] || ''
     @client = Octokit::Client.new(:netrc => true)
     @client.auto_paginate = true


### PR DESCRIPTION
The status message of the github status in our PRs was always
truncated. In order to make more room for the message we shorten
the context string:
* ci.suse.de/openstack-mkcloud/gating => suse/mkcloud

Additionally the messages are made consistent for all similar jobs.

Furthermore the testbuild jobs (preliminary job for a PR gating) now
have their own status to better reflect that two steps are needed and
to show both states and have links to both CI jobs.
A testbuild job now needs these status results:
* suse/mkcloud/testbuild  _(building the PR RPM package)_
* suse/mkcloud _(the PR gating job)_


**Note**
This PR is only here to document the change. It will be merged without +1s as it only can be done when all our jenkins jobs can be stopped. This timeslot is now (almost everybody travelling).
This change was discussed previously in the automation team. An email to the list will follow.