### PR TITLE
Forward architectures environment

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -9,6 +9,7 @@ distsuseip=$(dig -t A +short $distsuse)
 : ${libvirt_type:=kvm}
 : ${networkingplugin:=openvswitch}
 : ${arch:=$(uname -m)}
+: ${architectures:='aarch64 x86_64 s390x'}
 
 function max
 {

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -227,6 +227,7 @@ function sshrun
         export cct_tests=$cct_tests ;
         export scenario=$scenario ;
         export host_mtu=$host_mtu ;
+        export architectures='$architectures';
 
         export nova_shared_instance_storage=$nova_shared_instance_storage ;
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -24,7 +24,6 @@ if [[ $debug_qa_crowbarsetup = 1 ]] ; then
 fi
 
 # defaults
-: ${architectures:='aarch64 x86_64 s390x'}
 : ${cinder_backend:=''}
 : ${cinder_netapp_storage_protocol:=iscsi}
 : ${cinder_netapp_login:=openstack}


### PR DESCRIPTION
This way people can do:

export architectures="x86_64"

in their mkcloud, and controller will not try to establish a repository
for other architectures.