### PR TITLE
quote clouddescription when passing to admin server

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -237,7 +237,7 @@ function sshrun
         export TESTHEAD=$TESTHEAD ;
         export NOINSTALLCLOUDPATTERN=$NOINSTALLCLOUDPATTERN ;
 
-        export clouddescription=$clouddescription;
+        export clouddescription='$clouddescription';
         export JENKINS_BUILD_URL=$BUILD_URL;
         export JENKINS_NODE_NAME=$NODE_NAME;
         export JENKINS_EXECUTOR_NUMBER=$EXECUTOR_NUMBER;


### PR DESCRIPTION
The `clouddescription` value can be set by the Jenkins `mkcloud` job to things like

    Jenkins Build: 39680 / cloud-mkcloud7-job-docker-x86_64

which contains spaces.  So we need to quote it when writing `mkcloud.config`, otherwise we only get the first word in `/etc/motd` on the admin server.

Finally fixes #759!