### PR TITLE
unsource qa_crowbarsetup

### DIFF
--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -1,0 +1,41 @@
+# this file contains help and usage functions of qa_crowbarsetup
+# which are called from mkcloud help as well
+
+function qacrowbarsetup_help
+{
+    cat <<EOUSAGE
+    want_neutronsles12=1 (default 0)
+        if there is a SLE12 node, deploy neutron-network role into the SLE12 node
+    want_mtu_size=<size> (default='')
+        Option to set variable MTU size or select Jumbo Frames for Admin and Storage nodes. 1500 is used if not set.
+    want_raidtype (default='raid1')
+        The type of RAID to create.
+    want_node_aliases=list of aliases to assign to nodes
+        Takes all provided aliases and assign them to available nodes successively.
+        Note that this doesn't take care about node assignment itself.
+        Examples:
+            want_node_aliases='controller=1,ceph=2,compute=1'
+              assigns the aliases to 4 nodes as controller, ceph1, ceph2, compute
+            want_node_aliases='data=1,services=2,storage=2'
+              assigns the aliases to 5 nodes as data, service1, service2, storage1, storage2
+    want_node_os=list of OSs to assign to nodes
+        Takes all provided OS values and assign them to available nodes successively.
+        Example:
+            want_node_os=suse-12.1=3,suse-12.0=3,hyperv-6.3=1
+              assigns SLES12SP1 to first 3 nodes, SLES12 to next 3 nodes, HyperV to last one
+    want_node_roles=list of intended roles to assign to nodes
+        Takes all provided intended role values and assign them to available nodes successively.
+        Possible role values: controller, compute, storage, network.
+        Example:
+            want_node_roles=controller=1,compute=2,storage=3
+    want_test_updates=0 | 1  (default=1 if TESTHEAD is set, 0 otherwise)
+        add test update repositories
+    want_sbd=1 (default 0)
+        Setup SBD over iSCSI for cluster nodes, with iSCSI target on admin node. Only usable for HA configuration.
+    want_devel_repos=list of Devel Projects to use for other products
+        Adds Devel Projects for other products on deployed nodes
+        Example:
+            want_devel_repos=storage,virt
+        Valid values: ha, storage, virt
+EOUSAGE
+}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -41,7 +41,7 @@ fi
 scripts_lib_dir=${SCRIPTS_DIR}/lib
 # include separate bash libs
 # NOTE that this is a temporary solution during refactoring of mkcloud
-common_scripts="mkcloud-common.sh mkcloud-$mkclouddriver.sh"
+common_scripts="mkcloud-common.sh mkcloud-$mkclouddriver.sh qa_crowbarsetup-help.sh"
 for script in $common_scripts; do
     source ${scripts_lib_dir}/$script
 done
@@ -1089,7 +1089,7 @@ Optional
     scenario_dir='/tmp' (default=${SCRIPTS_DIR}/scenarios/cloud\$(getcloudver)/)
         Full path to directory containing scenario file.
 EOUSAGE
-    onadmin_help
+    qacrowbarsetup_help
     exit 1
 
 # UNDOCUMENTED OPTIONS:

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1089,8 +1089,6 @@ Optional
     scenario_dir='/tmp' (default=${SCRIPTS_DIR}/scenarios/cloud\$(getcloudver)/)
         Full path to directory containing scenario file.
 EOUSAGE
-    # Source qa_crowbarsetup.sh, which is where onadmin_help lives
-    source ${SCRIPTS_DIR}/qa_crowbarsetup.sh
     onadmin_help
     exit 1
 

--- a/scripts/mkcloud-test.sh
+++ b/scripts/mkcloud-test.sh
@@ -6,4 +6,5 @@ it_gives_help() {
     results=`! ./mkcloud help`
     [[ "$results" =~ "Usage:" ]]
     [[ "$results" =~ "networkingplugin" ]]
+    [[ "$results" =~ "want_raidtype" ]]
 }

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -7,7 +7,7 @@ shopt -s extglob
 
 : ${SCRIPTS_DIR:=$(dirname $(readlink -e $BASH_SOURCE))}
 scripts_lib_dir=${SCRIPTS_DIR}/lib
-common_scripts="mkcloud-common.sh"
+common_scripts="mkcloud-common.sh qa_crowbarsetup-help.sh"
 for script in $common_scripts; do
     source ${scripts_lib_dir}/$script
 done
@@ -112,41 +112,10 @@ function nova_role_prefix
 
 function onadmin_help
 {
-    cat <<EOUSAGE
-    want_neutronsles12=1 (default 0)
-        if there is a SLE12 node, deploy neutron-network role into the SLE12 node
-    want_mtu_size=<size> (default='')
-        Option to set variable MTU size or select Jumbo Frames for Admin and Storage nodes. 1500 is used if not set.
-    want_raidtype (default='raid1')
-        The type of RAID to create.
-    want_node_aliases=list of aliases to assign to nodes
-        Takes all provided aliases and assign them to available nodes successively.
-        Note that this doesn't take care about node assignment itself.
-        Examples:
-            want_node_aliases='controller=1,ceph=2,compute=1'
-              assigns the aliases to 4 nodes as controller, ceph1, ceph2, compute
-            want_node_aliases='data=1,services=2,storage=2'
-              assigns the aliases to 5 nodes as data, service1, service2, storage1, storage2
-    want_node_os=list of OSs to assign to nodes
-        Takes all provided OS values and assign them to available nodes successively.
-        Example:
-            want_node_os=suse-12.1=3,suse-12.0=3,hyperv-6.3=1
-              assigns SLES12SP1 to first 3 nodes, SLES12 to next 3 nodes, HyperV to last one
-    want_node_roles=list of intended roles to assign to nodes
-        Takes all provided intended role values and assign them to available nodes successively.
-        Possible role values: controller, compute, storage, network.
-        Example:
-            want_node_roles=controller=1,compute=2,storage=3
-    want_test_updates=0 | 1  (default=1 if TESTHEAD is set, 0 otherwise)
-        add test update repositories
-    want_sbd=1 (default 0)
-        Setup SBD over iSCSI for cluster nodes, with iSCSI target on admin node. Only usable for HA configuration.
-    want_devel_repos=list of Devel Projects to use for other products
-        Adds Devel Projects for other products on deployed nodes
-        Example:
-            want_devel_repos=storage,virt
-        Valid values: ha, storage, virt
-EOUSAGE
+    # The help moved to lib/qa_crowbarsetup-help.sh
+    # because it needs to be usable from mkcloud as well.
+    # This function is here only for backwards compatibility.
+    qacrowbarsetup_help
 }
 
 # run hook code before the actual script does its function

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -12,6 +12,9 @@ for script in $common_scripts; do
     source ${scripts_lib_dir}/$script
 done
 
+# not being sourced from mkcloud is a feature
+is_onhost && complain 9 "qa_crowbarsetup.sh should not be sourced within mkcloud. Shared functions are in files in scripts/lib/: eg. mkcloud-common.sh or qa_crowbarsetup-help.sh."
+
 mkcconf=mkcloud.config
 if [ -z "$testfunc" ] && [ -e $mkcconf ]; then
     source $mkcconf


### PR DESCRIPTION
Move qa_crowbarsetup help to common file.
Renaming `onadmin_help` to `qacrowbarsetup_help` which is a correct name (because the `onadmin_` prefix means that a function runs **on** the admin node).
    
The goal is to untie mkcloud and qa_crowbarsetup.
So we removed the sourcing of qa_crowbarsetup a few weeks ago (this is a feature).

The idea behind this is, that mkcloud can change more radical than qa_crowbarsetup. The latter will most likely remain a collection of shell functions. But mkcloud will need to change sooner or later into a OOP style (this will not be bash). Changes like this contradict this plan. Breakages should not be fixed by sourcing qa_crowbarsetup.sh again.

This PR contains the revert of commit dae0ddd21698e274175fee60c31d8ae8a24d5600