### PR TITLE
qa_crowbarsetup: Do not deploy calamari on SOC7

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2526,6 +2526,12 @@ function custom_configuration
         ;;
         ceph)
             proposal_set_value ceph default "['attributes']['ceph']['disk_mode']" "'all'"
+            # don't deploy calamari by default on SOC7. calamari needs a postgres DB on localhost
+            # and get's confused if it is deployed on the controller where a postgres DB is already running
+            # see https://bugzilla.suse.com/show_bug.cgi?id=1008331
+            if iscloudver 7plus ; then
+                proposal_set_value ceph default "['deployment']['ceph']['elements']['ceph-calamari']" "[]"
+            fi
         ;;
         magnum)
             proposal_set_value magnum default "['attributes']['magnum']['trustee']['domain_name']" "'magnum'"


### PR DESCRIPTION
The deployment fails sometimes when calamari is deployed on the controller
because calamari deploys (and needs) a postgres DB on localhost but
on the controller is already a postgres DB running.