### PR TITLE
add missing parameter to compute-config script

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -341,7 +341,7 @@ function libvirt_do_setuplonelynodes()
         safely ${scripts_lib_dir}/libvirt/compute-config $cloud $i $mac 0\
             "$cephvolumenumber" "$drbdvolume" $compute_node_memory\
             $controller_node_memory $libvirt_type $vcpus $emulator $vdisk_dir\
-            1 1 > /tmp/$cloud-node$i.xml
+            1 1 "$firmware_type" > /tmp/$cloud-node$i.xml
 
         local lonely_disk
         lonely_disk="$vdisk_dir/${cloud}.node$i"


### PR DESCRIPTION
this fixes "compute-config: error: too few arguments"

this has been overseen in https://github.com/SUSE-Cloud/automation/pull/1141

for reference: https://ci.suse.de/job/openstack-mkcloud/39982