### PR TITLE
mkcloud: drop duplicate wait for loop

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -342,7 +342,6 @@ function setupadmin
     wait_for 300 1 "ping -q -c 1 -w 1 $adminip >/dev/null" 'crowbar admin VM'
     wait_for_crowbar_ssh
 
-    wait_for 20 2 "nc -z $adminip 22" 'sshd to start'
     echo "Injecting public key into admin node..."
     local keyfile
     for keyfile in ~/.ssh/*.pub ; do


### PR DESCRIPTION
The waiting for ssh on admin node is done by a dedicated
function that is called above. So drop duplication.