### PR TITLE
qa_crowbarsetup: write motd early, append info later

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -141,6 +141,11 @@ exec </dev/null
 function show_environment
 {
     end_time=`date`
+    echo
+    echo "Crowbar /etc/motd"
+    echo "---------------------"
+    $ssh root@$adminip "cat /etc/motd"
+    echo
     echo "Environment Details"
     echo "-------------------------------"
     if $(which git >&/dev/null); then

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -355,6 +355,7 @@ function setupadmin
     if [[ $user_keyfile ]]; then
         cat $user_keyfile | sshrun "cat >> ~/.ssh/authorized_keys"
     fi
+    onadmin write_cloud_info
     echo "you can now proceed with installing crowbar"
     # prevent jumbo frames from going out
     if [[ $want_mtu_size -gt 1500 ]] || [[ $host_mtu -lt 1500 ]]; then

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1013,7 +1013,17 @@ function onadmin_add_cloud_repo
     fi
 
     (
-    echo "This cloud was installed on `cat ~/cloud` from: `cat /etc/cloudversion`"
+    echo -n "This cloud was installed from: "
+    cat /etc/cloudversion
+    echo
+    ) >> /etc/motd
+}
+
+function onadmin_write_cloud_info
+{
+    (
+    echo -n "This cloud was installed on: "
+    cat ~/cloud
     echo
     if [[ $JENKINS_BUILD_URL ]] ; then
         echo "Installed via Jenkins"


### PR DESCRIPTION
As pointed out by @aspiers  in https://github.com/SUSE-Cloud/automation/issues/759
the /etc/motd file on the admin node is written too late. Failed deployments before motd is written are missing details about the cloud setup.
So we now write the most of motd when the admin node is setup.
The remaining info is appended (if missing) later in the function `onadmin_add_cloud_repo` (same place as before).