### PR TITLE
mkcloud: fix is_onhost detection

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -103,7 +103,9 @@ function is_suse
 
 function is_onhost
 {
-    [[ $BASH_SOURCE =~ mkcloud[^/]*$ ]]
+    # match for the mkcloud script name in the BASH_SOURCE stack
+    # note: the path may differ, so only match a leading slash
+    [[ " ${BASH_SOURCE[@]} " =~ "/mkcloud " ]]
 }
 
 function is_onadmin


### PR DESCRIPTION
A pointed out in https://github.com/SUSE-Cloud/automation/pull/1384#issuecomment-255878398 the is_onhost detection was wrong.
The entire BASH_SOURCE stack needs to be checked instead of matching
all the common files.

This commit is extracted from PR #1415 as it needs to be fixed for other cases as well.