### PR TITLE
Check crowbarctl upgrade repocheck return code

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4525,7 +4525,7 @@ function onadmin_prepare_crowbar_upgrade
         # move nodes to upgrade mode
         safely crowbar_api_request POST $crowbar_api /installer/upgrade/prepare.json
     else
-        if crowbarctl upgrade repocheck crowbar --format plain | grep "missing" ; then
+        if safely crowbarctl upgrade repocheck crowbar --format plain | grep "missing" ; then
             complain 11 "Some repository is missing on admin server. Cannot upgrade."
         fi
         # FIXME: crowbarctl command can time out easily


### PR DESCRIPTION
It may happen that 'crowbarctl upgrade repocheck crowbar' fails but we
don't catch that error. Added an explicit check for the return value so
later on we can check the command output.