### PR TITLE
For non-disruptive upgrade, run only steps that could pass

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -22,7 +22,7 @@
             nodenumber=5
             hacloud=1
             want_nondisruptiveupgrade=1
-            mkcloudtarget=plain_with_upgrade testsetup rebootcloud
+            mkcloudtarget=plain_with_upgrade
             label={label}
             want_postgresql=0
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-template.yaml
@@ -21,7 +21,7 @@
             upgrade_cloudsource=develcloud{version}
             nodenumber=2
             want_nondisruptiveupgrade=1
-            mkcloudtarget=plain_with_upgrade testsetup rebootcloud
+            mkcloudtarget=plain_with_upgrade
             label={label}
             want_postgresql=1
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-{arch}


### PR DESCRIPTION
Executing cloudupgrade step should only upgrade controller nodes so far.
No reason to run testsetup when we are not upgrading all nodes yet.