### PR TITLE
Do not install SLES12SP1 nodes with Cloud7

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
@@ -19,9 +19,7 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber=5
-            want_sles12sp2=1
             want_rootfs=btrfs
-            want_node_os=suse-12.2=3,suse-12.1=2
             networkingmode=vxlan
             hacloud=1
             mkcloudtarget=all_noreboot


### PR DESCRIPTION
We do not need them for Ceph any more.

This should fix btrfs job failures, I think