### PR TITLE
syncSLErepos: fixes and better readablility for cornercase

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -109,16 +109,16 @@ for version in 1.0 2.1 3 4; do
         [ "$arch" != x86_64 -a $version = 1.0 ] && continue
         [ "$arch" != x86_64 -a $version = 2.1 ] && continue
 
-        # sync version 4 from ibs while in development
-        [ "$version" == "4" ] && sync_from_ibs=1
-
         echo ================== Updating Storage $version
 
-        if [ -z "$sync_from_ibs" ]; then
-            $rsync $buildsuse/SUSE/Products/Storage/$version/$arch/product/ /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Pool
+        # sync version 4 from ibs while in development
+        local poolsource=
+        if [[ $version == 4 ]]; then
+            poolsource=/mnt/dist/ibs/SUSE\:/SLE-12-SP2\:/Update\:/Products\:/SES${version}/images/repo/SUSE-Enterprise-Storage-${version}-POOL-${arch}-Media1/
         else
-            $rsync /mnt/dist/ibs/SUSE\:/SLE-12-SP2\:/Update\:/Products\:/SES${version}/images/repo/SUSE-Enterprise-Storage-${version}-POOL-${arch}-Media1/ /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Pool
+            poolsource=$buildsuse/SUSE/Products/Storage/$version/$arch/product/
         fi
+        $rsync $poolsource /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Pool
 
         if test -d $buildsuse/SUSE/Updates/Storage/$version/$arch/update/; then
             $rsync $buildsuse/SUSE/Updates/Storage/$version/$arch/update/ /srv/nfs/repos/$arch/SUSE-Enterprise-Storage-$version-Updates

--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -70,7 +70,7 @@ for servicepack in 0 1 2; do
         if [ -z "$sync_from_ibs" ]; then
             $rsync --link-dest /srv/nfs/suse-${chef_version}${install_subdir}/install/suse/ $buildsuse/SUSE/Products/SLE-SERVER/$version/$arch/product/ /srv/nfs/repos/$arch/SLES$repo_version-Pool/
         else
-            $rsync --link-dest /srv/nfs/suse-${chef_version}${install_subdir}/install/suse/ /mnt/dist/ibs/SUSE\:/SLE-$version\:/GA/images/repo/SLE-$version-Server-POOL-$arch-Build*-Media1/ /srv/nfs/repos/$arch/SLES$repo_version-Pool/
+            $rsync --link-dest /srv/nfs/suse-${chef_version}${install_subdir}/install/suse/ /mnt/dist/ibs/SUSE\:/SLE-$version\:/GA/images/repo/SLE-$version-Server-POOL-$arch-Media1/ /srv/nfs/repos/$arch/SLES$repo_version-Pool/
         fi
         # SLES updates
         $rsync $buildsuse/SUSE/Updates/SLE-SERVER/$version/$arch/update/ /srv/nfs/repos/$arch/SLES$repo_version-Updates/
@@ -86,7 +86,7 @@ for servicepack in 0 1 2; do
             if [ -z "$sync_from_ibs" ]; then
                 $rsync $buildsuse/SUSE/Products/SLE-HA/$version/$arch/product/ /srv/nfs/repos/$arch/SLE$repo_version-HA-Pool/
             else
-                $rsync /mnt/dist/ibs/SUSE\:/SLE-$version\:/GA/images/repo/SLE-$version-HA-POOL-$arch-Build*-Media1/ /srv/nfs/repos/$arch/SLE$repo_version-HA-Pool/
+                $rsync /mnt/dist/ibs/SUSE\:/SLE-$version\:/GA/images/repo/SLE-$version-HA-POOL-$arch-Media1/ /srv/nfs/repos/$arch/SLE$repo_version-HA-Pool/
             fi
             # HA updates
             $rsync $buildsuse/SUSE/Updates/SLE-HA/$version/$arch/update/ /srv/nfs/repos/$arch/SLE$repo_version-HA-Updates/


### PR DESCRIPTION
Use if block only to set the differing paths.
Drop `sync_from_ibs` variable that would survive loops.