### PR TITLE
Update automation sle11

### DIFF
--- a/scripts/jenkins/update_automation
+++ b/scripts/jenkins/update_automation
@@ -31,7 +31,7 @@ function do_git
 {
     rpm -q git-core || zypper --non-interactive in git-core || return 24
 
-    if [ -d $a_dir ] ; then
+    if [ -d $a_dir/.git ] ; then
         pushd $a_dir > /dev/null
             git clean -f
             git checkout $branch
@@ -39,6 +39,7 @@ function do_git
             git reset --hard origin/$branch
         popd > /dev/null
     else
+        rm -rf ~/$a_dir
         pushd $p_dir > /dev/null
             git clone ${automation_repo}
         popd > /dev/null

--- a/scripts/jenkins/update_automation
+++ b/scripts/jenkins/update_automation
@@ -42,7 +42,7 @@ function do_git
         pushd $p_dir > /dev/null
             git clone ${automation_repo}
         popd > /dev/null
-        ( cd $a_dir && git checkout $branch )
+        ( cd $a_dir && ( git checkout $branch || git checkout -b $branch origin/$branch ))
     fi
 }
 


### PR DESCRIPTION
more secure checks for git repo and SLE11 support

The old git version we ship on SLES11 does not automatically setup the branches upon first checkout. So we need to use checkout -b in this case.

If the target directory was there but empty it was still falsly recognized as git repo.
So we now remove the target directory before cloning to it, it might already be there.
