### PR TITLE
Save cloudsource variable to avoid override

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -798,6 +798,11 @@ function onhost_reset_admin
     safely bootstrapcrowbar
 }
 
+function save_cloudsource
+{
+    echo $cloudsource > /etc/cloudsource
+}
+
 function crowbarupgrade_5plus
 {
     if iscloudver 6plus ; then
@@ -806,6 +811,7 @@ function crowbarupgrade_5plus
         onadmin prepare_crowbar_upgrade
         onadmin upgrade_admin_server
         export cloudsource=$upgrade_cloudsource
+        onadmin save_cloudsource
         wait_for 200 3 "! nc -z $adminip 22" 'crowbar to go down after upgrade'
         wait_for_crowbar_ssh
         onadmin check_admin_server_upgraded
@@ -816,6 +822,7 @@ function crowbarupgrade_5plus
         onadmin prepare_crowbar_upgrade
         crowbarbackup "with_upgrade"
         export cloudsource=$upgrade_cloudsource
+        onadmin save_cloudsource
         crowbarrestore "with_upgrade"
     fi
 }


### PR DESCRIPTION
The cloudsource variable is changed during the upgrade process. It is
updated from the upgrade_cloudsource variable. That update is later
overriden during the call to set_proposalvars, where cloudsource is read
from disk (/etc/cloudsource). In those places where we change
cloudsource now we also write it to disk.