### PR TITLE
Removed all references to upgrade_cloudsource

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -215,7 +215,6 @@ function sshrun
         export cloudfqdn=$cloudfqdn ;
         export cloudsource=$cloudsource ;
         export mkclouddriver=$mkclouddriver ;
-        export upgrade_cloudsource=$upgrade_cloudsource ;
         export adminip=$adminip ;
         export hacloud=$hacloud ;
         export libvirt_type=$libvirt_type ;

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -807,12 +807,12 @@ function crowbarupgrade_5plus
 {
     if iscloudver 6plus ; then
         onadmin upgrade_prechecks
+        export cloudsource=$upgrade_cloudsource
         onadmin prepare_crowbar_upgrade
         onadmin prepare_cloudupgrade_repos_6_to_7
         onadmin upgrade_admin_backup
         onadmin upgrade_admin_repocheck
         onadmin upgrade_admin_server
-        export cloudsource=$upgrade_cloudsource
         wait_for 200 3 "! nc -w 1 -z $adminip 22" 'crowbar to go down after upgrade'
         wait_for_crowbar_ssh
         onadmin check_admin_server_upgraded

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -220,12 +220,6 @@ function add_mount
     fi
 }
 
-function isupgradecloudver
-{
-    local cloudsource=$upgrade_cloudsource
-    iscloudver "$@"
-}
-
 function issusenode
 {
     local machine=$1
@@ -4329,12 +4323,6 @@ function onadmin_rebootneutron
 # This will adapt Cloud6 admin server repositories to Cloud7 ones
 function onadmin_prepare_cloudupgrade_repos_6_to_7
 {
-    test -z "$upgrade_cloudsource" && {
-        complain 15 "upgrade_cloudsource is not set"
-    }
-
-    export cloudsource=$upgrade_cloudsource
-
     export_tftpboot_repos_dir
 
     # change CLOUDSLE11DISTISO/CLOUDSLE11DISTPATH according to the new cloudsource
@@ -4380,12 +4368,6 @@ function onadmin_prepare_cloudupgrade
 
     wait_for_if_running chef-client
 
-    test -z "$upgrade_cloudsource" && {
-        complain 15 "upgrade_cloudsource is not set"
-    }
-
-    export cloudsource=$upgrade_cloudsource
-
     # Update new repo paths
     export_tftpboot_repos_dir
 
@@ -4415,7 +4397,6 @@ function onadmin_cloudupgrade_1st
         echo "SUSE-Cloud-5-Pool SUSE-Cloud-5-Updates" > /etc/zypp/repos.d/ignore-repos
     fi
 
-    export cloudsource=$upgrade_cloudsource
     do_set_repos_skip_checks
 
     # Disable all openstack proposals stop service on the client


### PR DESCRIPTION
The idea is for qa_crowbarsetup.sh not to deal with upgrade_cloudsource
at all. It will just deal with cloudsource. Updating cloudsource from
upgrade_cloudsource will happen in mkcloud only.