### PR TITLE
jjb: use testbuild context when listing open crowbar PRs

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -123,7 +123,7 @@
               esac
 
               for branch in ${branches[@]} ; do
-                  for github_pr in $(timeout 4m $ghs -r crowbar/$repo -a $action -b $branch) ; do
+                  for github_pr in $(timeout 4m $ghs -r crowbar/$repo -a $action -b $branch --context "suse/mkcloud/testbuild") ; do
                       github_pr_opts=(${github_pr//:/ })
                       github_pr_id=${github_pr_opts[0]}
                       github_pr_sha=${github_pr_opts[1]}


### PR DESCRIPTION
Evaluating the wrong status lists this PR again on the next trigger run, as the PR job has not finished meanwhile.
Due to this we will collect too many status report for a sha1 (commit) and the status setting breaks.