### PR TITLE
Raise mkcloud timeout to 6h

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -480,7 +480,7 @@
 
         $custom_settings
 
-        perl -e "alarm 4*60*60 ; exec '${mkcloudwrapper} bash -x ${automationrepo}/scripts/mkcloud setuphost $(echo -n $MKCLOUDTARGET) ' ; print qq{$!\n} ; exit 127 " | tee $artifacts_dir/mkcloud_short_stdout.log
+        perl -e "alarm 6*60*60 ; exec '${mkcloudwrapper} bash -x ${automationrepo}/scripts/mkcloud setuphost $(echo -n $MKCLOUDTARGET) ' ; print qq{$!\n} ; exit 127 " | tee $artifacts_dir/mkcloud_short_stdout.log
         ret=${PIPESTATUS[0]}
         if [[ $ret != 0 ]] ; then
             [[ $github_pr_sha ]] && mkcloudgating_trap


### PR DESCRIPTION
A full tempest run on our rotten hardware takes 4h 41h, so there
is no way to finish successfully in 4h.