### PR TITLE
jenkins: openstack-diskimage-builder: Build Leap 42.2 images

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
+++ b/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
@@ -22,6 +22,7 @@
           type: user-defined
           name: opensuse_release
           values:
+            - 42.2
             - 42.1
             - 13.1
       - axis:


### PR DESCRIPTION
Add option to build Leap 42.2 images