### PR TITLE
Set the cloudsource to upgrade_cloudsource if it is present

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1467,6 +1467,10 @@ function onadmin_activate_repositories
 
 function onadmin_bootstrapcrowbar
 {
+    if [[ $upgrademode = "with_upgrade" ]] ; then
+        export cloudsource=$upgrade_cloudsource
+    fi
+
     local upgrademode=$1
     # temporarily make it possible to not use postgres until we switched to the new upgrade process
     # otherwise we would break the upgrade gating


### PR DESCRIPTION
When bootstrapcrowbar is called from the upgrade path
in needs to adapt the cloudsource to work accordingly

This is meant as a hotfix alternative to https://github.com/SUSE-Cloud/automation/pull/1434