### PR TITLE
jenkins/mkcloud: ignore hacloud value on aarch64

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -302,6 +302,7 @@
         export want_neutronsles12=1
         export want_mtu_size=8900
         [[ $libvirt_type = hyperv ]] && want_mtu_size=1500 # windows-PXE-bootloader seems to not like jumbo-packets
+        [[ $hacloud ]] && [[ $(uname -m) = aarch64 ]] && echo "WARNING: there are no HA repos for aarch64" && hacloud=
         export rally_server=backup.cloudadm.qa.suse.de
         # to not fail when two concurrent zypper runs happen:
         export ZYPP_LOCK_TIMEOUT=120


### PR DESCRIPTION
to unbreak cloud-mkcloud7-job-btrfs-aarch64

The alternative would be to not set hacloud=1 in aarch64 job triggers