### PR TITLE
Install interactive patches only for the upgrade case

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -807,6 +807,7 @@ function onhost_reset_admin
 function crowbarupgrade_5plus
 {
     if iscloudver 6plus ; then
+        onadmin zypper_patch_all
         onadmin upgrade_prechecks
         onadmin prepare_crowbar_upgrade
         onadmin prepare_cloudupgrade_repos_6_to_7

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4169,6 +4169,13 @@ function zypper_patch
     wait_for 30 3 ' zypper --non-interactive up --repo cloud-ptf ; [[ $? != 4 ]] ' "successful zypper run" "exit 9"
 }
 
+function onadmin_zypper_patch_all
+{
+    wait_for 30 3 ' zypper --non-interactive --gpg-auto-import-keys --no-gpg-checks ref ; [[ $? != 4 ]] ' "successful zypper run" "exit 9"
+    wait_for 30 3 ' zypper --non-interactive patch --with-interactive ; ret=$?; if [ $ret == 103 ]; then zypper --non-interactive patch --with-interactive ; ret=$?; fi; [[ $ret != 4 ]] ' "successful zypper run" "exit 9"
+    wait_for 30 3 ' zypper --non-interactive up --repo cloud-ptf ; [[ $? != 4 ]] ' "successful zypper run" "exit 9"
+}
+
 function onadmin_runupdate
 {
     onadmin_repocleanup

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4165,7 +4165,7 @@ function onadmin_addupdaterepo
 function zypper_patch
 {
     wait_for 30 3 ' zypper --non-interactive --gpg-auto-import-keys --no-gpg-checks ref ; [[ $? != 4 ]] ' "successful zypper run" "exit 9"
-    wait_for 30 3 ' zypper --non-interactive patch --with-interactive ; ret=$?; if [ $ret == 103 ]; then zypper --non-interactive patch --with-interactive ; ret=$?; fi; [[ $ret != 4 ]] ' "successful zypper run" "exit 9"
+    wait_for 30 3 ' zypper --non-interactive patch ; ret=$?; if [ $ret == 103 ]; then zypper --non-interactive patch ; ret=$?; fi; [[ $ret != 4 ]] ' "successful zypper run" "exit 9"
     wait_for 30 3 ' zypper --non-interactive up --repo cloud-ptf ; [[ $? != 4 ]] ' "successful zypper run" "exit 9"
 }
 


### PR DESCRIPTION
As alternative to 2nd commit, we could just ignore pending interactive patches in the upgrade prechecks call, as already suggested by @bmwiedemann 
But I do not know why this can be correct, what if there's an interactive patch that is required for the upgrade to run correctly?