### PR TITLE
Fix trackupstream for openstack-zaqar

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -86,12 +86,12 @@
             "openstack-murano",
             "openstack-horizon-plugin-sahara-ui",
             "openstack-horizon-plugin-trove-ui",
+            "openstack-zaqar",
             ].contains(component) ||
             [ "Cloud:OpenStack:Newton:Staging", "Cloud:OpenStack:Mitaka:Staging", "Cloud:OpenStack:Liberty:Staging" ].contains(project) &&
             [
               "python-heat-cfntools",
               "openstack-rally",
-              "openstack-zaqar",
             ].contains(component)
             )
       sequential: true


### PR DESCRIPTION
zaqar exists in Newton already, move it to the right exception
list