### PR TITLE
mkcloud: limit netcat waiting

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -332,7 +332,7 @@ function onhost_prepareadmin
 
 function wait_for_crowbar_ssh
 {
-    wait_for 150 1 "nc -z $adminip 22" 'admin node to start ssh daemon'
+    wait_for 150 1 "nc -w 1 -z $adminip 22" 'admin node to start ssh daemon'
 }
 
 function wait_for_crowbar_ntpd
@@ -721,7 +721,7 @@ function rebootcrowbar
     # reboot the crowbar instance
     #  and test if everything is up and running afterwards
     sshrun "reboot"
-    wait_for 50 3 "! nc -z $adminip 22" 'crowbar to go down'
+    wait_for 50 3 "! nc -w 1 -z $adminip 22" 'crowbar to go down'
     wait_for_crowbar_ssh
     echo "waiting another 180 seconds for services"
     sleep 180
@@ -814,7 +814,7 @@ function crowbarupgrade_5plus
         onadmin upgrade_admin_repocheck
         onadmin upgrade_admin_server
         export cloudsource=$upgrade_cloudsource
-        wait_for 200 3 "! nc -z $adminip 22" 'crowbar to go down after upgrade'
+        wait_for 200 3 "! nc -w 1 -z $adminip 22" 'crowbar to go down after upgrade'
         wait_for_crowbar_ssh
         onadmin check_admin_server_upgraded
         # use crowbar-init to bootstrap crowbar

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3528,7 +3528,7 @@ function oncontroller_manila_generic_driver_setup()
         [ $? != 0 ] && complain 44 "adding a floating ip to the manila service VM failed"
     fi
     # check that the service VM is pingable. otherwise manila tempest tests will fail later
-    wait_for 300 1 "nc -z $manila_tenant_vm_ip 22" \
+    wait_for 300 1 "nc -w 1 -z $manila_tenant_vm_ip 22" \
         "manila service VM booted and ssh port open" \
         "echo \"ERROR: manila service VM not listening on ssh port. manila tests will fail!\""
 }


### PR DESCRIPTION
https://ci.suse.de/view/Cloud/view/Worker/job/openstack-mkcloud/42030/console
timed out after 60 minutes of inactivity

11:04:56   waiting 300 cycles of 1 seconds = 300 seconds
12:04:56 ............................
  Build timed out (after 60 minutes). Marking the build as aborted.

28 netcats in an hour makes an average of 2 minutes per netcat