### PR TITLE
Fix job_names for suse jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
@@ -32,7 +32,7 @@
                 scenario=cloud7-2nodes-default.yml
                 want_node_aliases=controller=1,compute-kvm=1
                 label=openstack-mkcloud-SLE12-x86_64
-                job_name=cloud7 gating: OVS
+                job_name=susecloud7: OVS
             - name: openstack-mkcloud
               node-label: cloud-trigger
               predefined-parameters: |
@@ -44,7 +44,7 @@
                 networkingplugin=linuxbridge
                 mkcloudtarget=all
                 label=openstack-mkcloud-SLE12-x86_64
-                job_name=cloud7 gating: linuxbridge
+                job_name=susecloud7: linuxbridge
       - multijob:
           name: 'Extra Gate Checks (HA)'
           condition: SUCCESSFUL
@@ -59,4 +59,4 @@
                 hacloud=1
                 mkcloudtarget=all_noreboot
                 label=openstack-mkcloud-SLE12-x86_64
-                job_name=cloud7 gating: HA vxlan
+                job_name=susecloud7: HA vxlan


### PR DESCRIPTION
Those are not gating jobs but merely check jobs, indicate
properly that those are running against the media in the SUSE namespace