### PR TITLE
mkcloud: dont block on missing admin node

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -144,7 +144,7 @@ function show_environment
     echo
     echo "Crowbar /etc/motd"
     echo "---------------------"
-    $ssh root@$adminip "cat /etc/motd"
+    nc -z -w 1 $adminip 22 && $ssh root@$adminip "cat /etc/motd"
     echo
     echo "Environment Details"
     echo "-------------------------------"


### PR DESCRIPTION
when using mkcloud to just call cleanup
it blocks at the end when trying to fetch motd
from the now killed admin node