### PR TITLE
make github-status usable by other teams

### DIFF
--- a/scripts/github-status/.gitignore
+++ b/scripts/github-status/.gitignore
@@ -1,0 +1,5 @@
+.bundle/
+doc/
+Gemfile.lock
+vendor/
+.yardoc/

--- a/scripts/github-status/.yardopts
+++ b/scripts/github-status/.yardopts
@@ -1,0 +1,1 @@
+--private github-status.rb

--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -118,13 +118,10 @@ class GHClientHandler
     pulls_applicable
   end
 
-  def print_pr_sha_info(pull)
-    if pull.is_a? Array
-      pull.each do |p|
-        print_pr_sha_info(p)
-      end
-    else
-      puts "#{pull.number}:#{pull.head.sha}:#{pull.base.ref}" if pull
+  # @param pulls [PR,Array<PR>]
+  def print_pr_sha_info(pulls)
+    Array(pulls).each do |pull|
+      puts "#{pull.number}:#{pull.head.sha}:#{pull.base.ref}"
     end
   end
 

--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -10,7 +10,6 @@ class GHClientHandler
 
   # @param  config [Hash]
   # @option config [String] :comment_prefix will start every GH comment
-  #    FIXME: must include a trailing space
   # @option config [String] :repository GH "owner/repo"
   # @option config [String] :context GH status context string
   # @option config [String] :branch ("") filter PRs by branch name
@@ -80,6 +79,11 @@ class GHClientHandler
     get_pr_latest_sha(pr) == sha
   end
 
+  # Get pull requests for *repository* that have a matching build *status*
+  # and match the *branch* (if set).
+  # @param state [String] "open" or "closed"
+  # @param status [Array<String>]
+  #   any of "" (not set), "pending", "success", "error", "failure"
   def get_all_pull_requests(state, status = [])
     pulls = @client.pull_requests(@repository, :state => state)
     pulls.select do |p|
@@ -88,6 +92,8 @@ class GHClientHandler
     end
   end
 
+  # Get pull requests; limit to those made by whitelisted people
+  # @see get_all_pull_requests
   def get_own_pull_requests(state, status = [])
     # filter for our own PRs, as we do not want to build anybodys PR
     pulls = get_all_pull_requests(state, status)
@@ -101,6 +107,10 @@ class GHClientHandler
     end
   end
 
+  # Get pull requests made by whitelisted people.
+  # Of these, return the applicable ones (touching specific files)
+  # AND set the status of the others to "success"
+  # @see get_own_pull_requests
   def get_pull_requests(state, status = [])
     pulls = get_own_pull_requests(state, status)
     # filter applicable PRs, non applicable PRs do not touch files affecting mkcloud runs

--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -184,11 +184,15 @@ options = {}
 optparse = OptionParser.new do |opts|
   opts.banner = "Query github for pull request status"
 
+  opts.separator ""
+  opts.separator "Required option:"
   actions = ACTIONS.join ', '
   opts.on('-a', '--action ACTION', "Action to perform (#{actions})") do |a|
     options[:action] = a
   end
 
+  opts.separator ""
+  opts.separator "Common options:"
   opts.on('-p', '--pullrequest PRID', 'Github Pull Request ID') do |pr|
     options[:pr] = pr
   end
@@ -205,6 +209,8 @@ optparse = OptionParser.new do |opts|
     options[:sha] = sha
   end
 
+  opts.separator ""
+  opts.separator "Options for set-status:"
   opts.on('-t', '--targeturl URL', 'Target URL of a CI Build') do |url|
     options[:target_url] = url
   end
@@ -217,10 +223,14 @@ optparse = OptionParser.new do |opts|
     options[:message] = msg
   end
 
+  opts.separator ""
+  opts.separator "Options for list-...-prs:"
   opts.on('-b', '--branch BRANCHNAME', 'Filters pull requests by target branch name.') do |br|
     options[:branch] = br
   end
 
+  opts.separator ""
+  opts.separator "Options for get-pr-info:"
   opts.on('-k', '--key KEY',
           'Dot-separated attribute path to extract from PR JSON, ' \
           'e.g. base.head.owner.  Optional, only for use with ' \
@@ -228,6 +238,7 @@ optparse = OptionParser.new do |opts|
     options[:key] = key
   end
 
+  opts.separator ""
   opts.on('-h', '--help', 'Show usage') do |h|
     puts opts
     exit

--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -4,8 +4,15 @@ require 'octokit'
 require 'optparse'
 require 'json'
 
+# GitHub client handler
 class GHClientHandler
 
+  # @param  config [Hash]
+  # @option config [String] :comment_prefix will start every GH comment
+  #    FIXME: must include a trailing space
+  # @option config [String] :repository GH "owner/repo"
+  # @option config [String] :context GH status context string
+  # @option config [String] :branch ("") filter PRs by branch name
   def initialize(config = {})
     @comment_prefix = config[:comment_prefix] || 'CI mkcloud gating '
     @repository = config[:repository] || 'SUSE-Cloud/automation'
@@ -150,6 +157,7 @@ if $DEBUG
 end
 
 ACTIONS = %w(
+  list-open-prs
   list-unseen-prs
   list-rebuild-prs
   list-forcerebuild-prs

--- a/scripts/github-status/github-status.rb
+++ b/scripts/github-status/github-status.rb
@@ -137,6 +137,18 @@ class GHClientHandler
 
 end
 
+# To see API traffic:
+# RUBYOPT=-d github-status.rb ...
+if $DEBUG
+  require 'faraday'
+  stack = Faraday::RackBuilder.new do |builder|
+    builder.response :logger
+    builder.use Octokit::Response::RaiseError
+    builder.adapter Faraday.default_adapter
+  end
+  Octokit.middleware = stack
+end
+
 ACTIONS = %w(
   list-unseen-prs
   list-rebuild-prs

--- a/scripts/github-status/github-status.yaml
+++ b/scripts/github-status/github-status.yaml
@@ -1,0 +1,6 @@
+user_whitelist:
+- "SUSE-Cloud"
+team_whitelist:
+- 1541628 # SUSE-Cloud/developers
+- 291046  # crowbar/Owners
+- 159206  # SUSE-Cloud/Owners


### PR DESCRIPTION
I have been trying to connect GitHub and Jenkins for the YaST team repos. @jdsn helpfully pointed me to this and other tools.

This PR intends to extract the SUSE-Cloud specific bits to options on the command line or in a  configuration file.

I have left the "applicable" filter (according to files touched by a PR) untouched as it does not block me from using the script for other projects, nor do I have use for it.

(YaST team Scrum card: <https://trello.com/c/QEpsRJn9>)