### PR TITLE
Move QA4 to the new vlan range

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -255,11 +255,11 @@ function setcloudnetvars
             nodenumbertotal=7
             net=${netp}.66
             net_public=$net
-            vlan_public=715
-            #vlan_admin=714
-            vlan_fixed=717
-            vlan_storage=716
-            vlan_sdn=$vlan_storage
+            #vlan_admin=754
+            vlan_public=755
+            vlan_storage=756
+            vlan_fixed=758
+            vlan_sdn=757
             want_ipmi=true
         ;;
         p2)


### PR DESCRIPTION
As part of the hardware relocation the vlan ranges need to be adjusted.
QA now has a range of 3x 16 vlans starting from vlan 800. We'll start
by moving qa4 to the new range of VLAN 832-847.