### PR TITLE
add mkchp.cloud.suse.de

### DIFF
--- a/hostscripts/soc-ci/soc-ci
+++ b/hostscripts/soc-ci/soc-ci
@@ -34,7 +34,7 @@ from six.moves import input
 # path to the user configuration file
 USER_CONFIG_PATH = os.path.expanduser('~/.soc-ci.ini')
 # possible mkcX hosts
-CI_WORKERS = list('abcdefghijklmn')
+CI_WORKERS = list('abcdefghijklmnp')
 
 
 def _config_credentials_get():


### PR DESCRIPTION
This mkcloud host is active now.