### PR TITLE
soc-ci: add artifacts download and workers pool overview

### DIFF
--- a/hostscripts/soc-ci/README.soc-ci.md
+++ b/hostscripts/soc-ci/README.soc-ci.md
@@ -62,6 +62,22 @@ supportconfigs available in /home/tom/.soc-ci/artifacts/os-mkcloud/42432
 ```
 For the automatic supportconfig extraction, you need [unpack-supportconfig](https://build.opensuse.org/package/show/home:aspiers/supportconfig-utils).
 
+* I want to see all my reserved workers:
+```
+$ soc-ci workers-pool-list
+### mkcha.cloud.suse.de ###
+### mkchb.cloud.suse.de ###
+### mkchc.cloud.suse.de ###
+### mkchd.cloud.suse.de ###
+1.tbechtold
+### mkche.cloud.suse.de ###
+2.tbechtold.2016-11-25
+### mkchf.cloud.suse.de ###
+### mkchg.cloud.suse.de ###
+### mkchh.cloud.suse.de ###
+```
+
+To list all available reservations, use ```soc-ci workers-pool-list --all```.
 ## Requirements
 
 You need a couple of python packages:

--- a/hostscripts/soc-ci/README.soc-ci.md
+++ b/hostscripts/soc-ci/README.soc-ci.md
@@ -53,6 +53,15 @@ Finished: FAILURE
 
 ```
 
+* I have this mkcloud job and want to get the artifacts (which usually
+contain the supportconfig tarballs):
+```
+$ soc-ci os-mkcloud-artifacts 42432
+Artifacts downloaded to /home/tom/.soc-ci/artifacts/os-mkcloud/42432
+supportconfigs available in /home/tom/.soc-ci/artifacts/os-mkcloud/42432
+```
+For the automatic supportconfig extraction, you need [unpack-supportconfig](https://build.opensuse.org/package/show/home:aspiers/supportconfig-utils).
+
 ## Requirements
 
 You need a couple of python packages:
@@ -61,9 +70,19 @@ You need a couple of python packages:
 $ zypper in python-paramiko python-jenkinsapi python-six
 ```
 
+For the automatic supportconfig extraction, you need ```unpack-supportconfig``` from the [supportconfig-utils](https://build.opensuse.org/package/show/home:aspiers/supportconfig-utils)
+package.
+
+
 ## Configuration
 
 When using it the first time, `soc-ci` will ask for the needed
 parameters and store them in `~/.soc-ci.ini`.  The username and
 password are your normal Jenkin credentials, and the URL is
 https://ci.suse.de/.
+
+There are some optional parameters with default if the parameters are not in the
+config:
+
+* ```artifacts_dir```
+The directory path where to store the Jenkins artifacts.

--- a/hostscripts/soc-ci/soc-ci
+++ b/hostscripts/soc-ci/soc-ci
@@ -24,6 +24,8 @@ import os
 import re
 import subprocess
 import sys
+import threading
+from socket import timeout
 
 from jenkinsapi.jenkins import Jenkins
 
@@ -191,13 +193,28 @@ def os_mkcloud_artifacts(args):
     sys.exit(0)
 
 
-def ci_worker_pool_list(args):
+def _get_worker_pool_list(worker, data_dict, data_lock):
+    """write a worker pool list output to the data_dict"""
     client = _ssh_get_client()
-    client.connect('mkch%s.cloud.suse.de' % args.worker,
-                   username='root', password='linux')
-    stdin, stdout, stderr = client.exec_command('ls /root/pool/')
-    print(stdout.read())
-    sys.exit(stdout.channel.recv_exit_status())
+    try:
+        client.connect('mkch%s.cloud.suse.de' % worker,
+                       username='root', password='linux', timeout=3)
+    except timeout:
+        pass
+    else:
+        stdin, stdout, stderr = client.exec_command('ls /root/pool/')
+        if data_lock:
+            with data_lock:
+                data_dict[worker] = stdout.read().strip().split()
+        else:
+            data_dict[worker] = stdout.read().strip().split()
+
+
+def ci_worker_pool_list(args):
+    data = dict()
+    _get_worker_pool_list(args.worker, data, None)
+    print('\n'.join(data[args.worker]))
+    sys.exit(0)
 
 
 def ci_worker_pool_reserve(args):
@@ -223,6 +240,27 @@ def ci_worker_pool_release(args):
                                                  args.slot))
     print(stdout.read())
     sys.exit(stdout.channel.recv_exit_status())
+
+
+def ci_workers_pool_list(args):
+    conf = _config_get()
+    data = dict()
+    data_lock = threading.Lock()
+    threads = []
+    for worker in CI_WORKERS:
+        t = threading.Thread(target=_get_worker_pool_list,
+                             args=(worker, data, data_lock))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+
+    for worker in sorted(data.keys()):
+        print('### mkch%s.cloud.suse.de ###' % worker)
+        for pool in data[worker]:
+            if args.all or pool.find('.%s' % conf['nick']) != -1:
+                print(pool)
+    sys.exit(0)
 
 
 def parse_args():
@@ -260,7 +298,7 @@ def parse_args():
 
     # worker pool list
     parser_worker_pool_list = subparsers.add_parser(
-        'worker-pool-list', help='List CI worker pool')
+        'worker-pool-list', help='List CI worker pool for a single worker')
     parser_worker_pool_list.add_argument('worker', type=str,
                                          choices=CI_WORKERS)
     parser_worker_pool_list.set_defaults(func=ci_worker_pool_list)
@@ -280,6 +318,14 @@ def parse_args():
                                             choices=CI_WORKERS)
     parser_worker_pool_release.add_argument('slot', type=int)
     parser_worker_pool_release.set_defaults(func=ci_worker_pool_release)
+
+    # workers pool list - list *all* workers pool
+    parser_workers_pool_list = subparsers.add_parser(
+        'workers-pool-list', help='List CI workers pool for all workers')
+    parser_workers_pool_list.add_argument('--all',
+                                          action='store_true',
+                                          help='Show all reservations.')
+    parser_workers_pool_list.set_defaults(func=ci_workers_pool_list)
 
     return parser.parse_args()
 

--- a/hostscripts/soc-ci/soc-ci
+++ b/hostscripts/soc-ci/soc-ci
@@ -17,10 +17,12 @@
 from __future__ import print_function
 
 import argparse
-
+import contextlib
 import getpass
+import itertools
 import os
 import re
+import subprocess
 import sys
 
 from jenkinsapi.jenkins import Jenkins
@@ -61,10 +63,30 @@ def _config_get():
         with os.fdopen(os.open(
                 USER_CONFIG_PATH, os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
             conf.write(f)
+
+    # some optional configuration options
+    if not conf.has_option(section_name, "artifacts_dir"):
+        conf.set(section_name, "artifacts_dir",
+                 os.path.expanduser('~/.soc-ci/artifacts/'))
+
+    # create things where needed
+    if not os.path.exists(conf.get(section_name, "artifacts_dir")):
+        os.makedirs(conf.get(section_name, "artifacts_dir"))
+
     return dict(conf.items(section_name))
 
 
 ###############################################################################
+@contextlib.contextmanager
+def changedir(newdir):
+    olddir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(olddir)
+
+
 def _ssh_get_client():
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -126,6 +148,49 @@ def os_mkcloud_available(args):
         sys.exit('no idea where openstack-mkcloud job %s runs' % args.job_id)
 
 
+def _unpack_supportconfigs(cwd):
+    sucessful = True
+    with changedir(cwd):
+        for (dirpath, dirnames, filenames) in os.walk('.'):
+            for f in itertools.ifilter(lambda x: x.endswith('tbz'), filenames):
+                with open('/dev/null', 'w') as devnull:
+                    try:
+                        subprocess.check_call(
+                            'unpack-supportconfig %s' % f,
+                            stdout=devnull, stderr=devnull, shell=True)
+                    except subprocess.CalledProcessError as e:
+                        print('Something failed while trying to unpack the '
+                              'supportconfigs: %s' % (str(e)))
+                        sucessful = False
+    return sucessful
+
+
+def os_mkcloud_artifacts(args):
+    """download artifacts for the given job"""
+    conf = _config_get()
+    server = Jenkins(conf['url'],
+                     username=conf['user'],
+                     password=conf['password'])
+    job = server['openstack-mkcloud']
+
+    build = job.get_build(args.job_id)
+    dest_dir = os.path.join(conf['artifacts_dir'], 'os-mkcloud',
+                            '%s' % args.job_id)
+    if os.path.exists(dest_dir):
+        if not args.force:
+            print('Artifacts already available under %s' % dest_dir)
+            sys.exit(0)
+    else:
+        os.makedirs(dest_dir)
+
+    for filename, artifact in build.get_artifact_dict().items():
+        artifact.save_to_dir(dest_dir)
+    print('Artifacts downloaded to %s' % dest_dir)
+    if _unpack_supportconfigs(dest_dir):
+        print('supportconfigs available in %s' % dest_dir)
+    sys.exit(0)
+
+
 def ci_worker_pool_list(args):
     client = _ssh_get_client()
     client.connect('mkch%s.cloud.suse.de' % args.worker,
@@ -183,6 +248,15 @@ def parse_args():
         'available?')
     parser_os_mkcloud_available.add_argument('job_id', metavar='ID', type=int)
     parser_os_mkcloud_available.set_defaults(func=os_mkcloud_available)
+
+    # download openstack-mkcloud job artifacts
+    parser_os_mkcloud_artifacts = subparsers.add_parser(
+        'os-mkcloud-artifacts', help='openstack-mkcloud: download artifacts')
+    parser_os_mkcloud_artifacts.add_argument('job_id', metavar='ID', type=int)
+    parser_os_mkcloud_artifacts.add_argument('--force', action='store_true',
+                                             help='Force download even if'
+                                             'artifacts already exist')
+    parser_os_mkcloud_artifacts.set_defaults(func=os_mkcloud_artifacts)
 
     # worker pool list
     parser_worker_pool_list = subparsers.add_parser(


### PR DESCRIPTION
We are usually interessted in the supportconfigs when a
openstack-mkcloud job fails. So add the possibility to
download the Jenkins artifacts (which include the supportconfigs).