### PR TITLE
Add ZYPP_LOCK_TIMEOUT variable

### DIFF
--- a/scripts/iscsictl.py
+++ b/scripts/iscsictl.py
@@ -197,7 +197,8 @@ class ISCSI(object):
 
     def zypper(self, package):
         self.ssh.zypper('--non-interactive', 'install',
-                        '--no-recommends', package)
+                        '--no-recommends', package,
+                        _env={'ZYPP_LOCK_TIMEOUT': 120})
 
     def append_cfg(self, fname, lines):
         """Append only new lines in a configuration file."""


### PR DESCRIPTION
We need to provide the system variable 'ZYPP_LOCK_TIMEOUT' to iscsictl.py script to avoid situations like 'System management is locked by the application with pid 3730 (zypper)' in jenkins. 
