### PR TITLE
jenkins: openstack-diskimage-builder: Disable cloud images for Leap 42.2

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
+++ b/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
@@ -24,6 +24,7 @@
           values:
             - 42.2
             - 42.1
+            - 13.2
             - 13.1
       - axis:
           type: user-defined
@@ -38,6 +39,9 @@
             - cloud-cleanvm
 
     execution-strategy:
+      combination-filter: |
+        # There are no pre-built cloud images for opensuse-13.2
+        !(suse_element=="opensuse" && opensuse_release=="13.2")
       # We can only use one VM at a time, so serialize all jobs
       sequential: true
 


### PR DESCRIPTION
openSUSE Leap 42.2 does not provide pre-built cloud images so disable
this combination. Moreover, add 13.2 to the list of distributions but
do not use the 'opensuse' element because openSUSE 13.2 does not provide
a pre-built cloud image either.