### PR TITLE
qa_openstack: Deploy more services

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -244,6 +244,9 @@ sed -i -e "s/with_tempest=no/with_tempest=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_horizon=no/with_horizon=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_magnum=no/with_magnum=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_barbican=no/with_barbican=yes/" /etc/openstackquickstartrc
+sed -i -e "s/with_sahara=no/with_sahara=yes/" /etc/openstackquickstartrc
+sed -i -e "s/with_designate=no/with_designate=yes/" /etc/openstackquickstartrc
+sed -i -e "s/with_gnocchi=no/with_gnocchi=yes/" /etc/openstackquickstartrc
 sed -i -e "s/node_is_compute=.*/node_is_compute=yes/" /etc/openstackquickstartrc
 sed -i -e s/br0/brclean/ /etc/openstackquickstartrc
 unset http_proxy


### PR DESCRIPTION
When running qa_openstack, also deploy Sahara, Designate and
Gnocchi.

Note: All theses services are not yet fully configured and started
in openstack-quickstart. But this commit still helps with manual testing
because the database and endpoints are created and with that it is easier
to continue with enablement in cleanvm.