### PR TITLE
Switch to "standard" repository name

### DIFF
--- a/hostscripts/rpm-packaging/createproject.py
+++ b/hostscripts/rpm-packaging/createproject.py
@@ -102,8 +102,8 @@ Project used: %(ZUUL_PROJECT)s
 
 def upload_meta_enable_repository(project, linkproject):
     repository = """
-  <repository name="SLE_12_SP1" %(repoflags)s>
-    <path project="%(linkproject)s" repository="SLE_12_SP1"/>
+  <repository name="standard" %(repoflags)s>
+    <path project="%(linkproject)s" repository="standard"/>
     <arch>x86_64</arch>
   </repository>
 """ % ({'linkproject': linkproject,

--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
@@ -52,7 +52,7 @@
                   unset failed
                   unset kickscheduler
                   unset succeeded
-                  res=`osc results --csv -w -r SLE_12_SP1`
+                  res=`osc results --csv -w -r standard`
                   if [ $? -ne 0 ]; then
                       sleep 5
                       continue


### PR DESCRIPTION
This allows us to use a different base distribution for
each code stream and consequently allows switching Ocata
to SP2