### PR TITLE
jenkins: openstack-diskimage-builder: Fix combination-filter

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
+++ b/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
@@ -39,9 +39,8 @@
             - cloud-cleanvm
 
     execution-strategy:
-      combination-filter: |
-        # There are no pre-built cloud images for opensuse-13.2
-        !(suse_element=="opensuse" && opensuse_release=="13.2")
+      # There are no pre-built cloud images for opensuse-13.2
+      combination-filter: !(suse_element=="opensuse" && opensuse_release=="13.2")
       # We can only use one VM at a time, so serialize all jobs
       sequential: true
 


### PR DESCRIPTION
Commit 4b31a6280b7a("jenkins: openstack-diskimage-builder: Add openSUSE
13.2 distribution") added support for openSUSE 13.2 but it also
introduced a broken combination filter because of the inline comment.
The inline comment became part of the combination filter which led to
a non-working filter in the end so we move it elsewhere.