### PR TITLE
qa_crowbarsetup: Allow extra repo for testing

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -202,6 +202,15 @@ $zypper -n in wget
 # Everything below here is fatal
 set -e
 
+if [ -n "$QUICKSTART_DEBUG" ]; then
+    # when debugging, allow using a high-prio repo
+    if [ -n "$cloudsource_extra" ]; then
+        $zypper ar $cloudsource_extra cloudextra
+        $zypper mr --priority 5 cloudextra
+        echo "WARN: using extra repo $cloudsource_extra"
+    fi
+fi
+
 # start with patterns
 $zypper -n install -t pattern cloud_controller cloud_compute cloud_network
 $zypper -n install --force openstack-quickstart openstack-tempest-test


### PR DESCRIPTION
When setting $QUICKSTART_DEBUG and the new env var
$cloudsource_extra to a zypper repo, packages from this
repo will be used.
This is useful when testing locally with some packages which
are not yet merged.