### PR TITLE
jenkins: Fix openstack-diskimage-builder job syntax

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
+++ b/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
@@ -40,7 +40,8 @@
 
     execution-strategy:
       # There are no pre-built cloud images for opensuse-13.2
-      combination-filter: !(suse_element=="opensuse" && opensuse_release=="13.2")
+      combination-filter: |
+        !(suse_element=="opensuse" && opensuse_release=="13.2")
       # We can only use one VM at a time, so serialize all jobs
       sequential: true
 


### PR DESCRIPTION
The wrong syntax was introduced with 4fd4254e89c775 .
This fixes:

yaml.scanner.ScannerError: while scanning a tag
  in "suse-cloud/automation/jenkins/ci.opensuse.org/\
  openstack-diskimage-builder.yaml", line 43, column 27
expected ' ', but found '"'
  in "suse-cloud/automation/jenkins/ci.opensuse.org/\
  openstack-diskimage-builder.yaml", line 43, column 43