### PR TITLE
upgrade: on cloud 6 crowbarctl needs to run in experimental mode

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -89,6 +89,8 @@ export want_postgresql=${want_postgresql:-1}
 [ -z "$want_test_updates" -a -n "$TESTHEAD" ] && export want_test_updates=1
 [ "$libvirt_type" = hyperv ] && export wanthyperv=1
 [ "$libvirt_type" = xen ] && export wantxenpv=1 # xenhvm is broken anyway
+# FIXME: delete this after cloud 7 is released
+iscloudver 6 && export CROWBAR_EXPERIMENTAL=true
 
 [ -e /etc/profile.d/crowbar.sh ] && . /etc/profile.d/crowbar.sh
 


### PR DESCRIPTION
otherwise the upgrade subcommand won't be available until release
of cloud7