### PR TITLE
Update QA scenario with 3 clusters: put network API on cluster:services

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -176,7 +176,7 @@ proposals:
   deployment:
     elements:
       neutron-server:
-      - cluster:network
+      - cluster:services
       neutron-network:
       - cluster:network
 

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -203,7 +203,7 @@ proposals:
   deployment:
     elements:
       neutron-server:
-      - cluster:network
+      - cluster:services
       neutron-network:
       - cluster:network
 


### PR DESCRIPTION
The convention is the neutron API sits in `cluster:services`, not in `cluster:network`.