### PR TITLE
Increase the timeout for admin server upgrade

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -815,7 +815,7 @@ function crowbarupgrade_5plus
         onadmin upgrade_admin_backup
         onadmin upgrade_admin_repocheck
         onadmin upgrade_admin_server
-        wait_for 200 3 "! nc -w 1 -z $adminip 22" 'crowbar to go down after upgrade'
+        wait_for 400 3 "! nc -w 1 -z $adminip 22" 'crowbar to go down after upgrade'
         wait_for_crowbar_ssh
         onadmin check_admin_server_upgraded
         # use crowbar-init to bootstrap crowbar


### PR DESCRIPTION
Here is the log from the build when the action timed out, although the upgrade itself actually ended correctly:

http://pastebin.nue.suse.com/17660/src