### PR TITLE
upgrade: don't try to activate the repos during the upgrade

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -820,7 +820,6 @@ function crowbarupgrade_5plus
         onadmin check_admin_server_upgraded
         # use crowbar-init to bootstrap crowbar
         want_postgresql=1 onadmin bootstrapcrowbar "with_upgrade"
-        onadmin activate_repositories
     else
         onadmin prepare_crowbar_upgrade
         crowbarbackup "with_upgrade"


### PR DESCRIPTION
the api is restricted and noderepocheck is taking care about that