### PR TITLE
Revert "Make Milestone6 deployable again"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1483,13 +1483,7 @@ function onadmin_bootstrapcrowbar
         if [[ $upgrademode = "with_upgrade" ]] ; then
             safely crowbarctl upgrade database new
         else
-            if iscloudver 7M6minus ; then
-                safely crowbar_api_request POST $crowbar_init_api /database/new \
-                    '--data username=crowbar&password=crowbar' "$crowbar_api_v2_header"
-                safely crowbar_api_request POST $crowbar_init_api /init "" "$crowbar_api_v2_header"
-            else
-                safely crowbarctl database create
-            fi
+            safely crowbarctl database create
         fi
     fi
 }


### PR DESCRIPTION
This reverts commit a6b54e62d7b4165dad5572bd164e2ef6ca7a0ec1.

gating of https://github.com/crowbar/crowbar-core/pull/899 runs the M6 code (for some reason) which is not necessary, and fails because of that

latest changes of `crowbarctl` should be in the product by now so I guess we don't need this anymore