### PR TITLE
Jenkins: keep 7 days of backlog

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
@@ -14,8 +14,8 @@
                 - simple: true
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - shell: |

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 3 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 2 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 3 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 2 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 22 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H H * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 23 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 23 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H H */2 * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H H */2 * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H H * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 20 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 21 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 21 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -6,8 +6,8 @@
       - timed: '11 2 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H H * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H H * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H H * * 6'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
 
     builders:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 20 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
@@ -6,8 +6,8 @@
       - timed: '29 1 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-uefi-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-uefi-template.yaml
@@ -6,8 +6,8 @@
       - timed: '29 1 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -7,8 +7,8 @@
       - timed: '32 22 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -6,8 +6,8 @@
       - timed: '32 22 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
@@ -6,8 +6,8 @@
       - timed: '32 22 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
@@ -6,8 +6,8 @@
       - timed: '32 22 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
@@ -6,8 +6,8 @@
       - timed: 'H 6 * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - trigger-builds:


### PR DESCRIPTION
Since we currently trigger those jobs once per media, and we have a lot
more than one media per day (more like 6+ medias per day), the backlog
wasn't really enough anymore. keep one week of backlog.