### PR TITLE
Flush arp table entry for floating ip

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3260,6 +3260,8 @@ function addfloatingip
     nova floating-ip-create | tee floating-ip-create.out
     floatingip=$(perl -ne "if(/\d+\.\d+\.\d+\.\d+/){print \$&}" floating-ip-create.out)
     nova add-floating-ip "$instanceid" "$floatingip"
+    # flush arp tables in case this floating ip was recently used for something else
+    arp -d "$floatingip"
 }
 
 # by setting --dns-nameserver for subnet, docker instance gets this as


### PR DESCRIPTION
In case the ip was recently used (e.g. by tempest), flush the arp
table to make sure we learn the new mac