### PR TITLE
jenkins: openstack-diskimage-builder: Drop openSUSE 13.1

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
+++ b/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
@@ -25,7 +25,6 @@
             - 42.2
             - 42.1
             - 13.2
-            - 13.1
       - axis:
           type: user-defined
           name: suse_element


### PR DESCRIPTION
openSUSE 13.1 has reached EOL so there is not much point in testing
it anymore.