### PR TITLE
adding support for lxc to enable dirmaint and privileged commands

### DIFF
--- a/scripts/lib/mkcloud-dirmaint.sh
+++ b/scripts/lib/mkcloud-dirmaint.sh
@@ -262,7 +262,7 @@ EOF
     # FIXME: this is CKD (3390) only, also fixed size of 10015 cylinders
     # FIXME: for FBA, the type would be 9336, and counting would be 512 byte
     # blocks.
-    disksize=$(byte_to_units 3390 8512349400) # this is just the 10015 cylinders
+    disksize=$(byte_to_unit 3390 8512349400) # this is just the 10015 cylinders
     $lxc -c "dirm for $admuser amdisk 0100 3390 autog $disksize CLD9 mr"
     # other modifications also would work with similar commands
     # now deploy the standard image to the boot disk:

--- a/scripts/lib/mkcloud-dirmaint.sh
+++ b/scripts/lib/mkcloud-dirmaint.sh
@@ -3,6 +3,8 @@
 # For more information,
 # see http://www.vm.ibm.com/related/dirmaint/overview.html
 
+. ~/.lxccfg
+
 function dirmaint_do_setuphost()
 {
     vmcp q cplevel || complain 191 "Something is wrong with the CP link"
@@ -19,34 +21,57 @@ function dirmaint_do_sanity_checks()
     fi
 }
 
+function dirmaint_user_deleted()
+{
+    vmcp q $1 2> /dev/null | grep HCPCQV003E >& /dev/null
+    return $?
+}
+
 function dirmaint_do_shutdowncloud()
 {
     for i in $(nodes ids all); do
-        vmcp sig shut $(printf "${cloud}n%02d" $i)
+        # skip user, if it is logged off or if it does not exist
+        vmcp q $(printf "${cloud}n%02d" $i) 2> /dev/null |\
+            grep -e "HCPCQU045E" -e "HCPCQV003E" >& /dev/null && continue
+        sigcmd="cp sig shut $(printf "${cloud}n%02d" $i) within 60"
+        forcecmd="cp force $(printf "${cloud}n%02d" $i)"
+        $lxc -c "$sigcmd" || lxc -c "$forcecmd"
     done
-    vmcp sig shut ${cloud}adm
-    wait_for 60 1 "! vmcp q ${cloud}adm" "admin node ${cloud}adm to log off"
+    # if a guest is logged on, query to the name has status 0
+    vmcp q ${cloud}adm >& /dev/null && $lxc -c "cp force ${cloud}adm IMMED"
+    vmcp q ${cloud}adm >& /dev/null && wait_for 60 1 "! vmcp q ${cloud}adm" "admin node ${cloud}adm to log off"
+    # finally remove cloud administration guest from directory:
+    $lxc -c "dirm for ${cloud}adm purge"
+    # wait until the directory entry is deleted
+    # to improve performance, we might want to remove the disk from the admin node first and purge then.
+    wait_for 120 1 "dirmaint_user_deleted ${cloud}adm" "admin node ${cloud}adm to be purged (disk deletion)"
 }
 
 function dirmaint_do_cleanup()
 {
+    local vdev="0a${cloudidx}0"
+    echo "cleaning up for locally linked minidisk $vdev"
+    # cleanup if copy of image to admin node or dasdfmt aborted failed
+    cat /proc/dasd/devices | grep "0.0.$vdev"  && chccwdev -d 0.0.$vdev
+    vmcp q v $vdev >& /dev/null && vmcp detach $vdev
+    # now we can proceed to try and cleanup the rest
     dirmaint_do_shutdowncloud
 
     killproc -p /var/run/mkcloud/dnsmasq-$cloud.pid /usr/sbin/dnsmasq
     rm -f /var/run/mkcloud/dnsmasq-$cloud.pid /etc/dnsmasq-$cloud.conf
 
     ndev=1${cloudidx}00
-    devname=$(cat /sys/bus/ccwgroup/drivers/qeth/0.0.${ndev}/if_name)
+    if [ -f /sys/bus/ccwgroup/drivers/qeth/0.0.${ndev}/if_name ]; then
+        devname=$(cat /sys/bus/ccwgroup/drivers/qeth/0.0.${ndev}/if_name)
 
-    # take network down for this cloud
-    ip link set $devname down
-    echo 0 > /sys/bus/ccwgroup/drivers/qeth/0.0.${ndev}/online
-    vmcp uncouple ${ndev}
-    vmcp detach nic ${ndev}
-    vmcp set nic ${ndev} macid system
-
+        # take network down for this cloud
+        ip link set $devname down
+        # use system script to take down the device
+        qeth_configure -l 0.0.1${cloudidx}00 0.0.1${cloudidx}01 0.0.1${cloudidx}02 0
+        $lxc -c "cp for lnxadmin cmd detach nic ${ndev}"
+    fi
     # and finally delete the vswitch
-    vmcp detach vswitch ${cloud}
+    $lxc -c "cp q vswitch ${cloud}" >& /dev/null && $lxc -c "cp detach vswitch ${cloud}"
 
     echo "Cleanup done"
 }
@@ -54,22 +79,19 @@ function dirmaint_do_cleanup()
 function dirmaint_do_prepare()
 {
     onhost_add_etchosts_entries
-    onhost_prepareadmin
 
     if ! vmcp q vswitch ${cloud}; then
         # create new vswitch for cloud networks
-        vmcp define vswitch ${cloud} qdio local nouplink ethernet vlan unaware
-
+        $lxc -c "cp define vswitch ${cloud} qdio local nouplink ethernet vlan unaware"
         # create nic on the host, and plug it into that switch
         ndev=1${cloudidx}00
-        vmcp set nic ${ndev} macid 0${cloudidx}7777
-        vmcp define nic ${ndev} type qdio
-        vmcp set vswitch ${cloud} grant mkcldhst
-        vmcp couple ${ndev} to system ${cloud}
+        $lxc -c "cp for lnxadmin cmd define nic ${ndev} type qdio"
+        $lxc -c "cp for lnxadmin cmd set nic ${ndev} macid 0${cloudidx}7700"
+        $lxc -c "cp set vswitch ${cloud} grant lnxadmin"
+        $lxc -c "cp for lnxadmin cmd couple ${ndev} to system ${cloud}"
 
-        # bring nic up
-        echo "0.0.1${cloudidx}00,0.0.1${cloudidx}01,0.0.1${cloudidx}02" > /sys/bus/ccwgroup/drivers/qeth/group
-        echo 1 > /sys/bus/ccwgroup/drivers/qeth/0.0.${ndev}/online
+        # use system script to bring up the device
+	qeth_configure -l 0.0.1${cloudidx}00 0.0.1${cloudidx}01 0.0.1${cloudidx}02 1
         devname=$(cat /sys/bus/ccwgroup/drivers/qeth/0.0.${ndev}/if_name)
 
         ip addr add $admingw/24 dev $devname
@@ -78,6 +100,11 @@ function dirmaint_do_prepare()
 
 
     # setup dnsmasq
+    # get MACPREFIX for this z/VM:
+    macprefix=$(vmcp q vmlan | grep "USER Prefix" | awk '{ print $6 }')
+    macprefix=$(sed -e 's/.\{2\}/&:/g;s/.$//' <<<$macprefix)
+    macprefix=${macprefix,,}
+    echo "Setting MACPREFIX to: $macprefix"
     mkdir -p /var/run/mkcloud
     cat <<EOF > /etc/dnsmasq-$cloud.conf
 strict-order
@@ -100,30 +127,44 @@ function _dirmaint_link_and_write_disk()
     local ruser=$1
     local image=$2
 
-    vmcp q $ruser && complain 193 "$ruser is not logged off"
-
-    # FIXME kill the machine
-    # vmcp force $ruser || :
-    # FIXME
+    # test if user exists and is logged off.
+    vmcp q $ruser 2>/dev/null | grep HCPCQU045E || \
+        complain 193 "$ruser is not logged off or does not exist."
 
     # Derive the link target from $cloudidx to avoid races when doing
     # for multiple mkcloud runs in parallel
     local vdev="0a${cloudidx}0"
     local ccw="0.0.$vdev"
 
-    safely vmcp link to $ruser 0100 as $vdev mw pass=linux
-
+    # added OPTION LNKNOPAS to the local machine. Thus no password needed
+    safely vmcp link to $ruser 0100 as $vdev mr
+    # enable the disk on the admin node
     chccwdev -e $ccw
     wait_for 10 1 "[ -r /dev/disk/by-path/ccw-$ccw ]" "disk to show up"
 
     # low level format
+    echo "Performing low level format of $ccw"
     lsdasd $ccw -l | grep -q "status:.*active" || {
-        dasdfmt -b 4096 -y /dev/disk/by-path/ccw-$ccw
+        dasdfmt -b 4096 -y -m 500 /dev/disk/by-path/ccw-$ccw
     }
 
-    echo "Cloning $role node vdisk from $image ..."
+    # For the following I would recommend a slightly different procedure. I
+    # don't know if this is doable in openstack:
+    # I would add a number of disks to the admin machine that serve as
+    # container for images. Instead of /tmp/$image, there would be a certain
+    # disk with $ccw that contains the image. The actual cloning would then be
+    # done with a command like the following:
+    # lxc -h s390cld015 -u ladmin -P lin390 -c "dirm for $ruser clonedisk 0100 lnxadmin $ccw"
+    # note, that the disk must be detached from lnxadmin after the image has
+    # been copied there. The big advantage would be, that dirmaint would use
+    # flashcopy if available.
+    # After the copy, you would wait until the disk is not linked
+    # anymore with a command like:
+    # lxc -h s390cld015 -u ladmin -P lin390 -c "cp q l $ccw"
+    echo "Cloning $role node vdisk from /tmp/$image to /dev/disk/by-path/ccw-$ccw..."
     safely qemu-img convert -t none -O raw -S 0 -p /tmp/$image /dev/disk/by-path/ccw-$ccw
-
+    # make sure the data is not in cache anymore...
+    sync
     chccwdev -d $ccw
     wait_for 10 1 "[ ! -r /dev/disk/by-path/ccw-$ccw ]" "disk to disappear"
 
@@ -147,17 +188,52 @@ function dirmaint_do_onhost_deploy_image()
 
 function dirmaint_do_setupadmin()
 {
-    # FIXME
-    echo "NEED TO SETUP ADMIN PROTOTYPE"
+    echo "Setting up admin user"
 
     local admuser=${cloud}adm
     local cloudbr=${cloud}
+    # default directory entry for this user:
+    cat <<EOF > $HOME/${admuser^^}.DIRECT
+USER $admuser cldpaswd 2G 4G G
+  INCLUDE LNXDFLT
+  COMMAND SET SECUSER OPERATOR
+  IPL 100 PARM AUTOCR
+  OPTION LNKNOPAS
+  NICDEF 1000 TYPE QDIO LAN SYSTEM $cloudbr MACID 0${cloudidx}7700
+EOF
 
-    vmcp q $admuser && complain 192 "$admuser is not logged off"
+    # now, lets add this user to the directory:
+    $lxc -c "dirm add $admuser"
+    # the user does not have a disk yet, we might want to add one at virtual
+    # address 100:
+    # FIXME: this is CKD (3390) only, also fixed size of 10015 cylinders
+    # FIXME: for FBA, the type would be 9336, and counting would be 512 byte
+    # blocks.
+    $lxc -c "dirm for $admuser amdisk 0100 3390 autog 10015 CLD9 mr"
+    # other modifications also would work with similar commands
+    # now deploy the standard image to the boot disk:
+    dirmaint_do_onhost_deploy_image admin SLES12-SP2-ECKD.qcow2 0100
 
-    vmcp s vswitch $cloudbr gra $admuser
-    vmcp s vswitch $cloudbr gra $admuser prom
-    vmcp xautolog $admuser sync || exit $?
+    # I don't see how the following can happen, but it doesn't hurt anyways
+    vmcp q $admuser 2> /dev/null && complain 192 "$admuser is not logged off"
+
+    # grant access rights to the vswitch:
+    $lxc -c "cp set vswitch $cloudbr gra $admuser"
+    $lxc -c "cp set vswitch $cloudbr gra $admuser prom"
+    # start the node
+    $lxc -c "cp xautolog $admuser sync" || exit $?
+}
+
+function dirmaint_add_node()
+{
+	# assuming that there has been added a CLDPROT PROTODIR entry to
+	# dirmaint that sets common defaults.
+	# The prototype contains default disk and network. If different defaults
+	# are desired, we can also add several prototypes or finalize a user
+	# later on.
+	local node=$1
+	# FIXME: I guess, for production, we would use AUTOONLY as password.
+	$lxc -c "cms dirm add $node like CLDPROT PW lin390"
 }
 
 function dirmaint_do_setuplonelynodes()
@@ -171,12 +247,17 @@ function dirmaint_do_setuplonelynodes()
         lonely_node=$(printf "${cloud}n%02d" $i)
 
         # FIXME push user directory entry
+		dirmaint_add_node $lonely_node
+		# while this is not a bad thing as it is, we could improve the
+		# situation by preparing a number of disks that hold default images.
+		# in that case, dirmaint could be used to clone the respective disk.
         _dirmaint_link_and_write_disk $lonely_node SLES12-SP2-ECKD.qcow2
 
-        safely vmcp s vswitch $cloudbr gra $lonely_node
-        safely vmcp s vswitch $cloudbr gra $lonely_node prom
-
-        safely vmcp xautolog $lonely_node sync
+        # grant access rights to the vswitch:
+        safely $lxc -c "cp set vswitch $cloudbr gra $lonely_node"
+        safely $lxc -c "cp set vswitch $cloudbr gra $lonely_node prom"
+        # start the node
+        safely $lxc -c "vmcp xautolog $lonely_node sync"
     done
 }
 


### PR DESCRIPTION
This is a first functional complete version. It utilizes lxc to run privileged and CMS commands. This version has been tested and seems to work ok.
.lxccfg just contains a line like this:
export lxc='/root/bin/lxc.perl -h s390cld015 -u ladmin -P <password>
Documentation and code for lxc is available from 
http://www.vm.ibm.com/download/packages/descript.cgi?LXC
