### PR TITLE
Allow vendor change on nodes when upgrading packages from develcloud6

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -809,6 +809,9 @@ function crowbarupgrade_5plus
     if iscloudver 6plus ; then
         onadmin zypper_patch_all
         onadmin upgrade_prechecks
+        if [[ $cloudsource = develcloud6 ]] || [[ $upgrade_cloudsource = develcloud7 ]]; then
+            onadmin allow_vendor_change_at_nodes
+        fi
         export cloudsource=$upgrade_cloudsource
         onadmin prepare_crowbar_upgrade
         onadmin prepare_cloudupgrade_repos_6_to_7

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4722,6 +4722,14 @@ function onadmin_crowbarrestore
     fi
 }
 
+
+function onadmin_allow_vendor_change_at_nodes
+{
+    for machine in $(get_all_nodes); do
+        ssh $machine "zypper -n in -y crudini; crudini --set /etc/zypp/zypp.conf main solver.allowVendorChange true"
+    done
+}
+
 function onadmin_crowbar_nodeupgrade
 {
     if iscloudver 6plus ; then


### PR DESCRIPTION
Note that i'm executing it before I change the cloudsource. We wouldn't be able to check it later