### PR TITLE
Change manila backend to cephfs

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -1,5 +1,5 @@
 ---
-# 2c - 8 nodes: HA 1 x 2 SBD, KVM x 2, ESXi x 2
+# 2c - 7 nodes: HA 1 x 2 SBD, KVM x 2, ESXi x 2
 proposals:
 - barclamp: pacemaker
   name: services
@@ -82,6 +82,8 @@ proposals:
       - @@ceph3@@
       ceph-radosgw:
       - @@ceph1@@
+      ceph-mds:
+      - @@compute2@@ 
 
 - barclamp: glance
   attributes:
@@ -175,18 +177,15 @@ proposals:
 
 - barclamp: manila
   attributes:
-    default_share_type: default
+    default_share_type: ceph
     shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_password: linux
-        share_volume_fstype: ext3
-        path_to_private_key: ""
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: ##tenant_net_name_or_ip##
+    - backend_driver: cephfs
+      backend_name: cephfs-backend
+      cephfs:
+        use_crowbar: true
+        cephfs_conf_path: "/etc/ceph/ceph.conf"
+        cephfs_auth_id: manila
+        cephfs_cluster_name: ceph
   deployment:
     elements:
       manila-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -1,5 +1,5 @@
 ---
-# 2c - 8 nodes: HA 1 x 2 SBD, KVM x 2, ESXi x 2
+# 2c - 7 nodes: HA 1 x 2 SBD, KVM x 2, ESXi x 2
 proposals:
 - barclamp: pacemaker
   name: services
@@ -96,6 +96,8 @@ proposals:
       - @@ceph3@@
       ceph-radosgw:
       - @@ceph1@@
+      ceph-mds:
+      - @@compute2@@
 
 - barclamp: glance
   attributes:
@@ -214,18 +216,15 @@ proposals:
 
 - barclamp: manila
   attributes:
-    default_share_type: default
+    default_share_type: ceph
     shares:
-    - backend_driver: generic
-      backend_name: backend1
-      generic:
-        service_instance_user: root
-        service_instance_password: linux
-        share_volume_fstype: ext3
-        path_to_private_key: ""
-        service_instance_name_or_id: ##manila_instance_name_or_id##
-        service_net_name_or_ip: ##service_net_name_or_ip##
-        tenant_net_name_or_ip: ##tenant_net_name_or_ip##
+    - backend_driver: cephfs
+      backend_name: cephfs-backend
+      cephfs:
+        use_crowbar: true
+        cephfs_conf_path: "/etc/ceph/ceph.conf"
+        cephfs_auth_id: manila
+        cephfs_cluster_name: ceph
   deployment:
     elements:
       manila-server:


### PR DESCRIPTION
This PR is changing manila backend from default one to cephfs for non-ssl and ssl-insecure scenarios.
Tested here: https://ci.suse.de/view/Cloud/view/QA/job/cloud-mkphyscloud-qa-scenario-2c/277/