### PR TITLE
Add 1 minute delay for synchronization

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -200,6 +200,8 @@
 
           echo "mkphyscloud ret=$ret (before scenario and configuration)"
 
+          sleep 60
+
           if [ $ret == "0" ]; then
             # ----- Prepare the SBD setup:
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -200,8 +200,6 @@
 
           echo "mkphyscloud ret=$ret (before scenario and configuration)"
 
-          sleep 60
-
           if [ $ret == "0" ]; then
             # ----- Prepare the SBD setup:
 
@@ -259,6 +257,14 @@
 
             scp /tmp/sbd_prepare_$admin root@$admin:sbd_prepare
 
+            # Check if zypper is used by other application
+            ssh root@$admin '
+              source scripts/qa_crowbarsetup.sh;
+              for node in $(crowbar machines aliases | grep -E "controller|data|network" | grep -oE "^.*[[:space:]]"); do
+                wait_for 20 10 "ssh $node \"zypper refresh\" "
+              done
+            '
+
             ssh root@$admin  "
             export cloud=$cloud ;
             export TESTHEAD=$TESTHEAD ;
@@ -271,7 +277,7 @@
             export scenario=scenario.yml "'
 
             source scripts/qa_crowbarsetup.sh
-            source ./sbd_prepare
+            ./sbd_prepare
 
             timeout --signal=ALRM 60m bash -x -c "source scripts/qa_crowbarsetup.sh ; onadmin_runlist batch;"
             ' || ret=$?

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
@@ -195,8 +195,6 @@
 
           echo "mkphyscloud ret=$ret (before scenario)"
 
-          sleep 60
-
           if [ "$ret" = "0" ]; then
             # ----- Prepare the SBD setup:
             cat > /tmp/sbd_prepare_$admin <<EOSCRIPT
@@ -225,9 +223,19 @@
           EOSCRIPT
             chmod +x /tmp/sbd_prepare_$admin
             scp /tmp/sbd_prepare_$admin root@$admin:sbd_prepare
+
+            # Check if zypper is used by other application
+            ssh root@$admin '
+              source scripts/qa_crowbarsetup.sh;
+              for node in $(crowbar machines aliases | grep "controller" | grep -oE "^.*[[:space:]]"); do
+                wait_for 20 10 "ssh $node \"zypper refresh\"" "zypper to be available on $node"
+              done
+            '
+
             ssh root@$admin './sbd_prepare
             ' || ret=$?
           fi
+
           if [ "$ret" = "0" ]; then
             ssh root@$admin "
             export cloud=$cloud ;

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
@@ -195,6 +195,8 @@
 
           echo "mkphyscloud ret=$ret (before scenario)"
 
+          sleep 60
+
           if [ "$ret" = "0" ]; then
             # ----- Prepare the SBD setup:
             cat > /tmp/sbd_prepare_$admin <<EOSCRIPT

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
@@ -181,6 +181,7 @@
 
           echo "mkphyscloud ret=$ret (before scenario)"
 
+          sleep 60
 
           if [ "$ret" = "0" ]; then
             # ----- Prepare the SBD setup:

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
@@ -181,8 +181,6 @@
 
           echo "mkphyscloud ret=$ret (before scenario)"
 
-          sleep 60
-
           if [ "$ret" = "0" ]; then
             # ----- Prepare the SBD setup:
             cat > /tmp/sbd_prepare_$admin <<EOSCRIPT
@@ -209,6 +207,15 @@
 
             chmod +x /tmp/sbd_prepare_$admin
             scp /tmp/sbd_prepare_$admin root@$admin:sbd_prepare
+
+            # Check if zypper is used by other application
+            ssh root@$admin '
+              source scripts/qa_crowbarsetup.sh;
+              for node in $(crowbar machines aliases | grep "controller" | grep -oE "^.*[[:space:]]"); do
+                wait_for 20 10 "ssh $node \"zypper refresh\"" "zypper to be available on $node"
+              done
+            '
+
             ssh root@$admin './sbd_prepare
             ' || ret=$?
           fi

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
@@ -183,21 +183,19 @@
 
           echo "mkphyscloud ret=$ret (before scenario)"
 
-          sleep 60
-
           if [ "$ret" = "0" ]; then
             # ----- Prepare the SBD setup:
             cat > /tmp/sbd_prepare_$admin <<EOSCRIPT
               # preparation of iSCSI
               export ZYPP_LOCK_TIMEOUT=120
               zypper --gpg-auto-import-keys -p http://download.opensuse.org/repositories/devel:/languages:/python/SLE_12_SP2/ --non-interactive install python-sh
-              
+
               chmod +x scripts/iscsictl.py
 
               ./scripts/iscsictl.py --service target --host \$(hostname) --no-key
               ./scripts/iscsictl.py --service initiator --target_host \$(hostname) --host controller1 --no-key
               ./scripts/iscsictl.py --service initiator --target_host \$(hostname) --host controller2 --no-key
-              
+
               # preparation of SBD
               SBD_DEV1=\$(ssh controller1 echo '/dev/disk/by-id/scsi-\$(lsscsi -i | grep LIO | tr -s " " |cut -d " " -f7)')
               SBD_DEV2=\$(ssh controller2 echo '/dev/disk/by-id/scsi-\$(lsscsi -i | grep LIO | tr -s " " |cut -d " " -f7)')
@@ -214,6 +212,15 @@
 
             chmod +x /tmp/sbd_prepare_$admin
             scp /tmp/sbd_prepare_$admin root@$admin:sbd_prepare
+
+            # Check if zypper is used by other application
+            ssh root@$admin '
+              source scripts/qa_crowbarsetup.sh;
+              for node in $(crowbar machines aliases | grep "controller" | grep -oE "^.*[[:space:]]"); do
+                wait_for 20 10 "ssh $node \"zypper refresh\"" "zypper to be available on $node"
+              done
+            '
+
             ssh root@$admin './sbd_prepare
             ' || ret=$?
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
@@ -183,6 +183,8 @@
 
           echo "mkphyscloud ret=$ret (before scenario)"
 
+          sleep 60
+
           if [ "$ret" = "0" ]; then
             # ----- Prepare the SBD setup:
             cat > /tmp/sbd_prepare_$admin <<EOSCRIPT


### PR DESCRIPTION
We need to add 1 minute delay for SBD (2a, 2b, 2c, 9) scenarios to avoid the situation where nodes are not ready yet for SBD setup. 