### PR TITLE
automation: chage the security group used for tests

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3799,10 +3799,12 @@ function oncontroller_testsetup
     nova flavor-create m1.smaller 11 512 8 1
     nova delete testvm  || :
     nova keypair-add --pub-key /root/.ssh/id_rsa.pub testkey
-    nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0
-    nova secgroup-add-rule default tcp 1 65535 0.0.0.0/0
-    nova secgroup-add-rule default udp 1 65535 0.0.0.0/0
-    timeout 10m nova boot --poll --image $image_name --flavor $flavor --key-name testkey testvm | tee boot.out
+    nova secgroup-delete testvm || :
+    nova secgroup-create testvm testvm
+    nova secgroup-add-rule testvm icmp -1 -1 0.0.0.0/0
+    nova secgroup-add-rule testvm tcp 1 65535 0.0.0.0/0
+    nova secgroup-add-rule testvm udp 1 65535 0.0.0.0/0
+    timeout 10m nova boot --poll --image $image_name --flavor $flavor --key-name testkey --security-group testvm testvm | tee boot.out
     ret=${PIPESTATUS[0]}
     [ $ret != 0 ] && complain 43 "nova boot failed"
     instanceid=`perl -ne "m/ id [ |]*([0-9a-f-]+)/ && print \\$1" boot.out`


### PR DESCRIPTION
Due to probably existing security group rules in place
lets use a proper security group different from default
to run the testvm tests


*May not fix anything, but seems to affect some CI jobs failures: https://ci.suse.de/job/openstack-mkcloud/46856/console