### PR TITLE
Switch to parallel full tempest runs

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
@@ -19,7 +19,7 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber=2
-            tempestoptions=-t
+            tempestoptions=
             mkcloudtarget=all_noreboot
             label={label}
             job_name=cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
@@ -20,7 +20,7 @@
             cloudsource=develcloud{version}
             nodenumber=4
             networkingplugin=linuxbridge
-            tempestoptions=-t
+            tempestoptions=
             mkcloudtarget=all_noreboot
             label={label}
             job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}


### PR DESCRIPTION
This saves roughly 20% execution time of the testsetup
step and puts more stress on the system, which is good.