### PR TITLE
Change order of run step expansion

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1278,7 +1278,7 @@ function expand_steps
 
                 case "$cmd" in
                     _new_admin)
-                        runcmds="$runcmds cleanup prepare setupadmin addupdaterepo runupdate prepareinstcrowbar bootstrapcrowbar instcrowbar"
+                        runcmds="$runcmds cleanup prepare setupadmin addupdaterepo prepareinstcrowbar runupdate bootstrapcrowbar instcrowbar"
                     ;;
                     _compute)
                         runcmds="$runcmds setupnodes instnodes setup_aliases proposal"


### PR DESCRIPTION
We want to run `prepareinstcrowbar` before `runupdate` so we call
`onadmin_setup_local_zypper_repositories` to change all repos to the
correct `clouddata` URI.