### PR TITLE
Recreate repository signature during addupdaterepo

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4211,6 +4211,7 @@ function onadmin_addupdaterepo
         onadmin_setup_local_zypper_repositories
         ensure_packages_installed createrepo
         createrepo -o $UPR $UPR || exit 8
+        gpg --detach-sign --armor --yes $UPR/repodata/repomd.xml
     fi
     zypper modifyrepo -e cloud-ptf >/dev/null 2>&1 ||\
         safely zypper ar $UPR cloud-ptf


### PR DESCRIPTION
Without this change, I get the following error while refreshing repository data
`zypper ref`
`Signature verification failed for file 'repomd.xml' from repository 'PTF'.`
`Warning: This might be caused by a malicious change in the file!`
`Continuing might be risky. Continue anyway? [yes/no] (no): `

BR,
Jakub