### PR TITLE
keep tempestoptions non-empty

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -9,6 +9,7 @@
     version: 6
     previous_version: 5
     arch: x86_64
+    tempestoptions: -s -t
     label: openstack-mkcloud-SLE12-x86_64
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -25,13 +25,20 @@
         - 'cloud-mkcloud{version}-job-magnum-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
-        - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
-        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-disruptive-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
         - 'cloud-mkcloud{version}-job-xen-{arch}'
-
+- project:
+    name: cloud-mkcloud7-tempestfull-x86_64
+    version: 7
+    previous_version: 6
+    arch: x86_64
+    label: openstack-mkcloud-SLE12-x86_64
+    tempestoptions: --parallel
+    jobs:
+        - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
+        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
 - project:
     name: cloud-mkcloud7-sles12sp2-x86_64
     version: 7

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
@@ -19,7 +19,7 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber=2
-            tempestoptions=
+            tempestoptions={tempestoptions}
             mkcloudtarget=all_noreboot
             label={label}
             job_name=cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
@@ -20,7 +20,7 @@
             cloudsource=develcloud{version}
             nodenumber=4
             networkingplugin=linuxbridge
-            tempestoptions=
+            tempestoptions={tempestoptions}
             mkcloudtarget=all_noreboot
             label={label}
             job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}


### PR DESCRIPTION
Unfortunately mkcloud substitutes smoke parameters when tempestoptions
is empty. so set some explicit other value to prevent that from
happening