### PR TITLE
fix expansion of tempest options

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3341,8 +3341,8 @@ function oncontroller_run_tempest
         local opts=$tempestoptions
         if iscloudver 7plus; then
             ### backward compatibility, remove
-            opts=${opts/-s/--smoke}
-            opts=${opts/-t/--serial}
+            opts=$( echo "$opts" | sed 's/-s\( \|$\)/--smoke\1/'  )
+            opts=$( echo "$opts" | sed 's/-t\( \|$\)/--serial\1/' )
             tempest run $opts 2>&1 | tee tempest.log
             tempestret=${PIPESTATUS[0]}
         else


### PR DESCRIPTION
Avoid accidentally expanding substrings of longer options.  For example, don't expand `--smoke` to `--smokemoke`.

UPDATE: Apparently this is a duplicate of #1575.