### PR TITLE
Lower replicas setting for low-nodecount deployments

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2724,7 +2724,10 @@ function custom_configuration
             fi
         ;;
         swift)
-            [[ $nodenumber -lt 3 ]] && proposal_set_value swift default "['attributes']['swift']['zones']" "1"
+            [[ $nodenumber -lt 3 ]] && {
+                proposal_set_value swift default "['attributes']['swift']['zones']" "1"
+                proposal_set_value swift default "['attributes']['swift']['replicas']" "1"
+            }
             proposal_set_value swift default "['attributes']['swift']['allow_versions']" "true"
             proposal_set_value swift default "['attributes']['swift']['keystone_delay_auth_decision']" "true"
             proposal_set_value swift default "['attributes']['swift']['middlewares']['crossdomain']['enabled']" "true"


### PR DESCRIPTION
Swift in Liberty or newer started refusing devicecount < $((zones*replicas)),
which is totally sensible, but wasn't ensured by the test environment