### PR TITLE
Change tempestoptions default to the long options variant

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -21,8 +21,6 @@
         - 'cloud-mkcloud{version}-job-hyperv-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
-        - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
-        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-{arch}'
         - 'cloud-mkcloud{version}-job-xen-{arch}'
 - project:
@@ -36,3 +34,13 @@
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
         - 'cloud-mkcloud{version}-job-ha-{arch}'
+- project:
+    name: cloud-mkcloud6-tempestfull-x86_64
+    version: 6
+    previous_version: 5
+    arch: x86_64
+    tempestoptions: -t
+    label: openstack-mkcloud-SLE12-x86_64
+    jobs:
+        - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
+        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -39,6 +39,16 @@
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
 - project:
+    name: cloud-mkcloud7-tempestfull-x86_64
+    version: 7
+    previous_version: 6
+    arch: x86_64
+    tempestoptions: --parallel
+    label: openstack-mkcloud-SLE12-x86_64
+    jobs:
+         - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
+         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
+- project:
     name: cloud-mkcloud7-sles12sp2-x86_64
     version: 7
     arch: x86_64

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -116,10 +116,10 @@
 
      - string:
          name: tempestoptions
-         default: -t -s
+         default:
          description: |
-           Additional options to pass to the "run_tempest.sh -N " step.
-           Use just \"-t\" for a full tempest run.
+           Additional options to pass to the "tempest run " step. The default is cloudversion
+           specific but will default to a smoke run.
 
      - string:
          name: want_horizon_integration_test

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -701,7 +701,7 @@ function testtype
 {
     # If `tempestoptions` contains '-s' or '--smoke' parameter, is a
     # smoke test.  If there is '--load-list 2015.03.required.txt' is a
-    # defcore test.  A full test is supossed by default.
+    # defcore test.  A full test is assumed by default.
     local type="full"
     if [[ $tempestoptions ]] ; then
         if [[ $tempestoptions =~ -s ]] ; then

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -73,7 +73,11 @@ upgrade_progress_file=/var/lib/crowbar/upgrade/6-to-7-progress.yml
 declare -a unclustered_nodes
 
 export nodenumber=${nodenumber:-2}
-export tempestoptions=${tempestoptions:--t -s}
+if iscloudver 7plus; then
+    export tempestoptions=${tempestoptions:---smoke}
+else
+    export tempestoptions=${tempestoptions:--t -s}
+fi
 export want_sles12
 [[ $want_sles12 = 0 ]] && want_sles12=
 export nodes=
@@ -3341,12 +3345,8 @@ function oncontroller_run_tempest
 
     if iscloudver 6plus; then
         tempest cleanup --init-saved-state
-        local opts=$tempestoptions
         if iscloudver 7plus; then
-            ### backward compatibility, remove
-            opts=${opts/-s/--smoke}
-            opts=${opts/-t/--serial}
-            tempest run $opts 2>&1 | tee tempest.log
+            tempest run $tempestoptions 2>&1 | tee tempest.log
             tempestret=${PIPESTATUS[0]}
         else
             ./run_tempest.sh -N $tempestoptions 2>&1 | tee tempest.log


### PR DESCRIPTION
This is more readable and hopefully allows us to remove some ugly
backpatching once cloud6 is out of maintenance.