### PR TITLE
Revert "Skip radosgw tests since its broken (bsc#1017837)"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4096,11 +4096,7 @@ function onadmin_testsetup
         echo "ceph radosgw:" $cephradosgws
         if [ -n "$cephradosgws" ] ; then
             wantcephtestsuite=1
-            # RadosGW in SES4 is broken, so skipping it for now
-            # https://bugzilla.suse.com/show_bug.cgi?id=1017837
-            if iscloudver 6minus; then
-                wantradosgwtest=1
-            fi
+            wantradosgwtest=1
         fi
     fi
 


### PR DESCRIPTION
Lets see if crowbar/crowbar-ceph#83 and crowbar/crowbar-openstack#743
finally resolve this failure

This reverts commit 77eb877a9f466296e6e12a7c27d679efdca16a53.