### PR TITLE
jenkins: Fix ceph proposal on qa mkphyscloud scenario (bsc#1018869)

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -69,6 +69,7 @@ proposals:
 - barclamp: ceph
   attributes:
     disk_mode: first
+    client_network: admin
   deployment:
     elements:
       ceph-calamari: []

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
@@ -69,6 +69,7 @@ proposals:
 - barclamp: ceph
   attributes:
     disk_mode: first
+    client_network: admin
   deployment:
     elements:
       ceph-calamari: []


### PR DESCRIPTION
Due to ceph-mon listening on the admin ip network
and the ceph cookbook looking for other nodes on the
public network, ceph-mon was unable to form a quorum
on this scenarios