### PR TITLE
Add error code to error message

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -59,7 +59,7 @@ function wait_for_if_running
 function complain
 {
     local ex=$1; shift
-    printf "Error: %s\n" "$@" >&2
+    printf "Error ($ex): %s\n" "$@" >&2
     [[ $ex = - ]] || exit $ex
 }
 


### PR DESCRIPTION
For debugging mkcloud failures it might be helpful to have the error
code number (which is hopefully unique) in the error message.