### PR TITLE
jtsync: include new status in notification

### DIFF
--- a/scripts/jtsync/jtsync.rb
+++ b/scripts/jtsync/jtsync.rb
@@ -135,12 +135,13 @@ def board
   @trello_board ||= Trello::Board.find(TRELLO_BOARD)
 end
 
-def notify_card_members(card)
+def notify_card_members(card, new_status)
   members = card.members.map do |m|
     "@" + Trello::Member.find(m.id).username
   end
 
-  comment = card.add_comment("#{members.join(" ")}: card status changed")
+  msg = "#{members.join(" ")}: card status changed to #{new_status}"
+  comment = card.add_comment(msg)
   comment_id = JSON.parse(comment)["id"]
 
   card.comments.select do |c|
@@ -191,7 +192,7 @@ begin
 
   # only notify members if the status changes from failed to success or
   # vice versa.
-  notify_card_members(card) if old_status != job.status
+  notify_card_members(card, job.status) if old_status != job.status
 
 rescue RuntimeError => err
   puts("Running jtsync failed: #{err}")


### PR DESCRIPTION
~~**Currently untested, mainly because I haven't yet tried to figure out how to test it**~~

It's much more helpful if the new status is immediately visible via a notification (which can appear in many forms, e.g. via an email from Trello, or as an notification from the Android app), rather than having to load the Trello app or website in order to see the new status.