### PR TITLE
aodh: enable aodh deployment by default

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -258,6 +258,11 @@
          default:
          description: set to 1 to deploy murano
 
+     - string:
+         name: want_aodh
+         default: '1'
+         description: set to 0 to not deploy aodh
+
      - text:
          name: custom_settings
          default:

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1079,8 +1079,8 @@ Optional
         It's not deployed by default. Set to 1 to deploy murano.
     want_trove=0 (default=1)
         Deployed by default. Set to 0 to prevent trove from being deployed.
-    want_aodh=0 (default=0)
-        It's not deployed by default. Set to 1 to deploy aodh.
+    want_aodh=1 (default=1)
+        Deployed by default. Set to 0 to prevent aodh from being deployed.
     want_postgresql=0 (default=1)
         Use PostgreSQL instead of SQLite as a Crowbar database
     want_horizon_integration_test=1 (default='')

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -40,7 +40,7 @@ fi
 : ${want_murano:=0}
 : ${want_tempest:=1}
 : ${want_trove:=1}
-: ${want_aodh:=0}
+: ${want_aodh:=1}
 : ${want_s390:=''}
 : ${want_horizon_integration_test:=''}
 


### PR DESCRIPTION
Aodh has now its own barclamp. Its time to enable its deployment in the CI and by mkcloud by default