### PR TITLE
ci: reduce PR polling interval to 5min

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -17,7 +17,7 @@
               forceall: trigger rebuild for all open PRs
 
     triggers:
-      - timed: 'H/30 * * * *'
+      - timed: 'H/5 * * * *'
 
     logrotate:
       numToKeep: 300

--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -17,7 +17,7 @@
               forceall: trigger rebuild for all open PRs
 
     triggers:
-      - timed: 'H/30 * * * *'
+      - timed: 'H/5 * * * *'
 
     logrotate:
       numToKeep: 48


### PR DESCRIPTION
As we meanwhile have a filter to skip PRs that do not affect
an mkcloud run it is safe to reduce the polling interval for
open PRs. We reduce to 5 minutes for now and monitor.

Btw. this is already deployed (to test this) on jenkins for these jobs.