### PR TITLE
Change number of replicas to equal to 2

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -68,6 +68,7 @@ proposals:
       - cluster:services
 - barclamp: swift
   attributes:
+    replicas: 2
     cluster_hash: 181d283256
     keystone_delay_auth_decision: true
     allow_versions: true

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
@@ -73,6 +73,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     keystone_delay_auth_decision: true
     allow_versions: true
     middlewares:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -124,6 +124,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     keystone_delay_auth_decision: true
     allow_versions: true
     middlewares:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -76,6 +76,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     keystone_delay_auth_decision: true
     allow_versions: true
     middlewares:


### PR DESCRIPTION
Replicas should be equal to the number of nodes in swift-storage
This fixed the swift failures in qa scenarios.
Also it is in line with the dev scenario changes: https://github.com/SUSE-Cloud/automation/commit/1c2231e511fa65a8e9c2a52b8c9689b51fdbf2b7