### PR TITLE
Change vlan number to 99

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -117,7 +117,7 @@ proposals:
     - linuxbridge
     ml2_type_drivers:
     - vlan
-    num_vlans: 10
+    num_vlans: 99
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
   deployment:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
@@ -128,7 +128,7 @@ proposals:
     - linuxbridge
     ml2_type_drivers:
     - vlan
-    num_vlans: 10
+    num_vlans: 99
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
   deployment:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -181,7 +181,7 @@ proposals:
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
     use_lbaas: false
-    num_vlans: 10
+    num_vlans: 99
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -144,7 +144,7 @@ proposals:
     - vlan
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
-    num_vlans: 10
+    num_vlans: 99
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -83,7 +83,7 @@ proposals:
       ceph-radosgw:
       - @@ceph1@@
       ceph-mds:
-      - @@compute2@@ 
+      - @@compute2@@
 
 - barclamp: glance
   attributes:
@@ -121,7 +121,7 @@ proposals:
     - vlan
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
-    num_vlans: 10
+    num_vlans: 99
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3.yaml
@@ -107,7 +107,7 @@ proposals:
     - gre
     - vxlan
     - vlan
-    num_vlans: 10
+    num_vlans: 99
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
@@ -118,7 +118,7 @@ proposals:
     - vxlan
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
-    num_vlans: 10
+    num_vlans: 99
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -136,7 +136,7 @@ proposals:
     - linuxbridge
     ml2_type_drivers:
     - vlan
-    num_vlans: 10
+    num_vlans: 99
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
     ssl:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -148,7 +148,7 @@ proposals:
     - linuxbridge
     ml2_type_drivers:
     - vlan
-    num_vlans: 10
+    num_vlans: 99
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
     ssl:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -202,7 +202,7 @@ proposals:
     - vlan
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
-    num_vlans: 10
+    num_vlans: 99
     ssl:
       generate_certs: true
       insecure: true

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -157,7 +157,7 @@ proposals:
     - vlan
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
-    num_vlans: 10
+    num_vlans: 99
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -145,7 +145,7 @@ proposals:
     - vlan
     ml2_type_drivers_default_provider_network: vlan
     ml2_type_drivers_default_tenant_network: vlan
-    num_vlans: 10
+    num_vlans: 99
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-3.yaml
@@ -123,7 +123,7 @@ proposals:
     - gre
     - vxlan
     - vlan
-    num_vlans: 10
+    num_vlans: 99
     ssl:
       generate_certs: true
       insecure: true

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -136,7 +136,7 @@ proposals:
     - ##networkingplugin##
     ml2_type_drivers:
     - ##networkingmode##
-    num_vlans: 10
+    num_vlans: 99
     ml2_type_drivers_default_provider_network: ##networkingmode##
     ml2_type_drivers_default_tenant_network: ##networkingmode##
     ssl:


### PR DESCRIPTION
There are now 100 vlans that can be used after move to the new vlan range: https://gitlab.suse.de/qa/cloud-doc/blob/master/infra/nuremberg.md

so ranges:

qa2 1200-1299
qa3 1300-1399
qa4 1400-1499