### PR TITLE
Change number of replicas to equal to 2 for ssl

### DIFF
--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -73,6 +73,7 @@ proposals:
       - cluster:services
 - barclamp: swift
   attributes:
+    replicas: 2
     ssl:
       enabled: true
       generate_certs: true

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -79,6 +79,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     ssl:
       enabled: true
       generate_certs: true

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -129,6 +129,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     keystone_delay_auth_decision: true
     allow_versions: true
     middlewares:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -81,6 +81,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     keystone_delay_auth_decision: true
     allow_versions: true
     middlewares:


### PR DESCRIPTION
Change number of replicas to equal to 2 for ssl-insecure scenarios too

Replicas should be equal to the number of nodes in swift-storage
This fixed the swift failures in qa scenarios.
Also it is in line with the dev scenario changes: 1c2231e