### PR TITLE
mkcloud: libvirt nodesetup restructuring and cleanup

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -480,7 +480,7 @@ function iscloudver
     return $?
 }
 
-get_nodenumbercontroller()
+function get_nodenumbercontroller
 {
     local nodenumbercontroller=1
     if [[ $clusterconfig == *services* ]]; then

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -528,11 +528,7 @@ function setupironicnodes
 # register lonely_node against crowbar
 function crowbar_register
 {
-    local i
-    for i in $(nodes ids lonely) ; do
-        local mac=$(macfunc $i)
-        sshrun "lonelymac=$mac adminip=$adminip onadmin_crowbar_register"
-    done
+    onadmin crowbar_register $(nodes ids lonely)
 }
 
 # setup an NFS server on the first lonely node

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -508,21 +508,25 @@ function restorecloudfromsnapshot
     createcloudsnapshot
 }
 
-# bring up lonely_node(s) in the admin network
-function setuplonelynodes
+function setupspecialnodesobsolete
 {
-    ${mkclouddriver}_do_setuplonelynodes
+    local msg="This function/step is obsolete. All nodes are setup in the setupnodes function. This function will be removed soon."
+    # adding nodes to an existing cloud was an accidental feature, with the current assumptions about node counting this is broken already
+    # the feature to add any kind of node at any point in time will be added with a refactoring of the node management
+
+    echo "Error: $msg"
+    # this echo will soon become a complain
+    #complain 2 "$msg"
 }
 
-# bring up ironic nodes in the ironic network
+function setuplonelynodes
+{
+    setupspecialnodesobsolete
+}
+
 function setupironicnodes
 {
-    if [[ $(nodes number ironic) -lt 1 ]] ; then
-        complain 80 "Please set nodenumberironicnode."
-        return
-    fi
-
-    ${mkclouddriver}_do_setupironicnodes
+    setupspecialnodesobsolete
 }
 
 # register lonely_node against crowbar
@@ -620,61 +624,17 @@ function restartcloud
     wait_for_crowbar_ssh
 }
 
-# bring up VMs that will take cloud controller/compute/storage roles
+# start VMs
+#  - for normal, lonely, ironic nodes
+#  - for cloud controller/compute/storage roles or test nodes (lonely, ironic)
 function setupnodes
 {
     onadmin wait_tftpd || return $?
     setuppublicnet
-    local i
-    for i in $(nodes ids normal) ; do
-        local macaddress=$(macfunc $i)
 
-        # transport drdb volume information to admin node (needed for proposal of data cluster)
-        drbd_serial=""
-        if [ $drbd_hdd_size != 0 ]; then
-            if [ $i -le 2 ] ; then
-                drbd_serial="$cloud-node$i-drbd"
-                # libvirt does not accept anything other than [:alnum:]_-
-                # for serial strings:
-                drbd_serial=${drbd_serial//[^A-Za-z0-9-_]/_}
-                drbdnode_mac_vol="${drbdnode_mac_vol}+${macaddress}#${drbd_serial}"
-                drbdnode_mac_vol="${drbdnode_mac_vol#+}"
-            fi
-        fi
-        local mac_params=""
-        for nicnumber in $(seq 1 $nics) ; do
-            mac_params+=" --macaddress $(macfunc $i $nicnumber)";
-        done
-        local ironic_params=""
-        [[ $want_ironic ]] && ironic_params="--ironicnic $ironicnic"
-
-        ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
-                        $mac_params \
-                        $ironic_params \
-                        --cephvolumenumber $cephvolumenumber \
-                        --drbdserial "$drbd_serial"\
-                        --computenodememory $compute_node_memory \
-                        --controllernodememory $controller_node_memory \
-                        --libvirttype $libvirt_type \
-                        --vcpus $vcpus \
-                        --emulator $(get_emulator) \
-                        --vdiskdir $vdisk_dir \
-                        --bootorder 3 \
-                        --numcontrollers $(get_nodenumbercontroller) \
-                        --firmwaretype "$firmware_type" \
-                        --controller-raid-volumes $controller_raid_volumes > /tmp/$cloud-node$i.xml
-
-        libvirt_vm_start /tmp/$cloud-node$i.xml
-    done
-
-    echo "========================================================"
-    echo " Note: If you interrupt mkcloud now and want to proceed"
-    echo "       later, make sure to run the following command:"
-    echo
-    echo " export drbdnode_mac_vol=\"${drbdnode_mac_vol}\""
-    echo
-    echo "========================================================"
-    sleep 10
+    ${mkclouddriver}_do_setupnodes normal $(nodes ids normal)
+    ${mkclouddriver}_do_setupnodes lonely $(nodes ids lonely)
+    ${mkclouddriver}_do_setupnodes ironic $(nodes ids ironic)
 
     # mkch_physwol can be set by the user to a space-separated list of MAC-addrs
     # of pysical nodes to wake up using WoL

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1999,8 +1999,11 @@ function onadmin_allocate
         curl http://$reposerver_fqdn/git/automation/scripts/qa1_nodes_reboot | bash
     fi
 
-    [[ $nodenumber -gt 0 ]] && wait_for 50 10 'test $(get_all_discovered_nodes | wc -l) -ge 1' "first node to be discovered"
-    wait_for 100 10 '[[ $(get_all_discovered_nodes | wc -l) -ge $nodenumber ]]' "all nodes to be discovered"
+
+    ## normal nodes (more types to follow)
+    ##
+    [[ $(nodes number normal) -gt 0 ]] && wait_for 50 10 'test $(get_all_discovered_nodes | wc -l) -ge 1' "first node to be discovered"
+    wait_for 100 10 '[[ $(get_all_discovered_nodes | wc -l) -ge $(nodes number normal) ]]' "all nodes to be discovered"
     local n
     for n in `get_all_discovered_nodes` ; do
         wait_for 100 2 "knife node show -a state $n | grep -q 'discovered\|ready'" \

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -12,7 +12,7 @@ fi
 
 : ${SCRIPTS_DIR:=$(dirname $(readlink -e $BASH_SOURCE))}
 scripts_lib_dir=${SCRIPTS_DIR}/lib
-common_scripts="mkcloud-common.sh qa_crowbarsetup-help.sh"
+common_scripts="mkcloud-common.sh mkcloud-${mkclouddriver}.sh qa_crowbarsetup-help.sh"
 for script in $common_scripts; do
     source ${scripts_lib_dir}/$script
 done

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2228,6 +2228,11 @@ function onadmin_get_ip_from_dhcp
         END{ if (res=="") exit 1; print res }' $leasefile
 }
 
+function get_ip_address_by_node_name
+{
+    knife node show "$1" -a crowbar.network.admin.address | awk '{print $2}'
+}
+
 function lonely_node_sshkey
 {
     local lonely_ip=$1

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5,6 +5,11 @@
 
 shopt -s extglob
 
+mkcconf=mkcloud.config
+if [ -z "$testfunc" ] && [ -e $mkcconf ]; then
+    source $mkcconf
+fi
+
 : ${SCRIPTS_DIR:=$(dirname $(readlink -e $BASH_SOURCE))}
 scripts_lib_dir=${SCRIPTS_DIR}/lib
 common_scripts="mkcloud-common.sh qa_crowbarsetup-help.sh"
@@ -14,11 +19,6 @@ done
 
 # not being sourced from mkcloud is a feature
 is_onhost && complain 9 "qa_crowbarsetup.sh should not be sourced within mkcloud. Shared functions are in files in scripts/lib/: eg. mkcloud-common.sh or qa_crowbarsetup-help.sh."
-
-mkcconf=mkcloud.config
-if [ -z "$testfunc" ] && [ -e $mkcconf ]; then
-    source $mkcconf
-fi
 
 # this needs to be after mkcloud.config got sourced
 if [[ $debug_qa_crowbarsetup = 1 ]] ; then


### PR DESCRIPTION
The new function to create libvirt configs is now being used for regular nodes as well as lonely nodes.
Background is 
- support DRBD volumes on nodes 1 and 2 even if they are lonely nodes - this is required for an HA setup consisting of lonely nodes only
- remove code duplication
- easier introduction of new node types (will follow soon) without having to duplicate code