### PR TITLE
revert mkcloud: workaround vlan/virtio checksum offloading bug

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -537,7 +537,6 @@ function mkvlan
     vconfig set_name_type DEV_PLUS_VID_NO_PAD
     vconfig add $cloudbr $DEFVLAN
     ifconfig $cloudbr.$DEFVLAN $IP/24
-    ethtool -K $cloudbr tx off
 }
 
 function setuppublicnet


### PR DESCRIPTION
revert 2029b683
https://bugzilla.novell.com/show_bug.cgi?id=884706
as it is probably fixed by now