### PR TITLE
upgrade: reenable ceilometer; drob obsolete parameter

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -25,6 +25,4 @@
             want_nodesupgrade=1
             mkcloudtarget=plain_with_upgrade
             label={label}
-            want_postgresql=0
-            want_ceilometer_proposal=0
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -822,7 +822,7 @@ function crowbarupgrade_5plus
         wait_for_crowbar_ssh
         onadmin check_admin_server_upgraded
         # use crowbar-init to bootstrap crowbar
-        want_postgresql=1 onadmin bootstrapcrowbar "with_upgrade"
+        onadmin bootstrapcrowbar "with_upgrade"
     else
         onadmin prepare_crowbar_upgrade
         crowbarbackup "with_upgrade"


### PR DESCRIPTION
1. ceilometer works again, after removing aodh to separate barclamp

2. want_postgresql=1 is default value for some time already