### PR TITLE
jenkins: Readd crowbar to cloud-trackupstream

### DIFF
--- a/jenkins/ci.suse.de/cloud-trackupstream.yaml
+++ b/jenkins/ci.suse.de/cloud-trackupstream.yaml
@@ -14,6 +14,7 @@
           type: user-defined
           name: component
           values:
+            - crowbar
             - crowbar-ui
             - crowbar-core
             - crowbar-openstack


### PR DESCRIPTION
Crowbar got removed by accident during the conversion to jjb.