### PR TITLE
jtsync: Handle matrix jobs correctly

### DIFF
--- a/scripts/jtsync/jtsync.rb
+++ b/scripts/jtsync/jtsync.rb
@@ -30,18 +30,20 @@ module Job
   class Mapping
     attr_reader :name
     attr_reader :project
-    attr_reader :retcode
+    attr_reader :type
 
 
-    def initialize(name, project, retcode)
-      @name = name
-      @project = project
-      @retcode = retcode
+    def initialize(job, return_code)
+      @name = job.name
+      @project = job.project
+      @type = job.type
+      @job = job
+      @code = return_code
     end
 
     def status
-      raise "Unknown returncode \"#{retcode}\"" unless STATUS_MAPPING.key? retcode
-      STATUS_MAPPING[retcode]
+      raise "Unknown returncode \"#{@code}\"" unless STATUS_MAPPING.key? @code
+      STATUS_MAPPING[@code]
     end
   end
 
@@ -68,6 +70,10 @@ module Job
     def list_name
       "Cloud #{version}"
     end
+
+    def build_nr
+      @job.build_nr.to_i
+    end
   end
 
   class OpenSuseMatrix < Mapping
@@ -78,6 +84,10 @@ module Job
 
     def list_name
       "OpenStack"
+    end
+
+    def build_nr
+      @job.build_nr.to_i
     end
   end
 
@@ -91,9 +101,9 @@ module Job
     }
   }.freeze
 
-  def self.for(service, jobtype, name, project, status)
-    raise "No mapping provided for #{service}/#{jobtype}" unless MAPPING[service].key? jobtype
-    MAPPING[service][jobtype].new(name, project, status)
+  def self.for(job, status)
+    raise "No mapping provided for #{service}/#{jobtype}" unless MAPPING[job.service].key? job.type
+    MAPPING[job.service][job.type].new(job, status)
   end
 end
 
@@ -121,10 +131,12 @@ def parse_job_from_cli
       job.service = service
     end
 
-    opt.on("--matrix NAME,PROJECT", Array, "Set status of a matrix job") do |settings|
+    opt.on("--matrix NAME,PROJECT,BUILDNR", Array, "Set status of a matrix job") do |settings|
+      raise "Invalid matrix job!" if settings.length != 3
       job.type = :matrix
       job.project = settings[1]
       job.name = settings[0]
+      job.build_nr = settings[2]
     end
 
     opt.on("--job NAME", "Set status of a normal job") do |name|
@@ -135,7 +147,7 @@ def parse_job_from_cli
   opts.order!
   raise "Either job or matrix is required" if job.type.nil?
 
-  [board_id, Job.for(job.service, job.type, job.name, job.project, ARGV.pop)]
+  [board_id, Job.for(job, ARGV.pop)]
 end
 
 def board(board_id)
@@ -182,6 +194,39 @@ def find_card_for(board_id, job)
   card
 end
 
+def fetch_build_nr(card)
+  card.desc.split("\n").each do |line|
+    matched = line.match(/^CurrentBuild: (\d+)$/)
+
+    next if matched == nil || matched.length != 2
+    return matched[1].to_i
+  end
+  nil
+end
+
+
+def need_update?(job, card)
+  return true if job.type == :normal
+
+  number = fetch_build_nr(card)
+  #1 build nr is not the same / not set => set new number and update card
+  if number == nil || number != job.build_nr
+    if number == nil
+      card.desc += "\nCurrentBuild: #{job.build_nr}"
+    else
+      card.desc = card.desc.gsub(/^CurrentBuild: (\d+)$/, "CurrentBuild: #{job.build_nr}")
+    end
+    card.save
+    return true
+  end
+
+  #2 build nr is the same and status is failed => update the card
+  return true if number == job.build_nr && job.status == "failed"
+
+  # otherwise => no update
+  false
+end
+
 #
 # run the script
 #
@@ -195,12 +240,16 @@ begin
   end
 
   card = find_card_for(board_id, job)
-  old_status = update_card_label(board_id, card, job)
 
-  # only notify members if the status changes from failed to success or
-  # vice versa.
-  notify_card_members(card, job.status) if old_status != job.status
+  # When job is a matrix job check the buildnumber in the description
+  # in form of CurrentBuild: <build_nr>
+  if need_update?(job, card)
+      old_status = update_card_label(board_id, card, job)
 
+      # only notify members if the status changes from failed to success or
+      # vice versa.
+      notify_card_members(card, job.status) if old_status != job.status
+  end
 rescue RuntimeError => err
   puts("Running jtsync failed: #{err}")
 rescue Netrc::Error => err

--- a/scripts/jtsync/test_jtsync.sh
+++ b/scripts/jtsync/test_jtsync.sh
@@ -21,38 +21,52 @@ echo "returncode: $?"
 read -p "Press any key to continue... " -n1 -s
 echo ""
 
-echo "test: matrix job (cloud) to success"
-${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix crowbar-trackupstream,Devel:Cloud:7:Staging 0
-echo "returncode: $?"
-read -p "Press any key to continue... " -n1 -s
-echo ""
-
-echo "test: matrix job (cloud) to failed"
-${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix crowbar-trackupstream,Devel:Cloud:7:Staging 1
-echo "returncode: $?"
-read -p "Press any key to continue... " -n1 -s
-echo ""
-
-echo "test: matrix job (openstack)"
-${RUBY} jtsync.rb --board ${TEST_BOARD} --ci opensuse --matrix openstack-cleanvm,Juno 0
-echo "returncode: $?"
-read -p "Press any key to continue... " -n1 -s
-echo ""
-
 echo "test: search non existing job"
-${RUBY} jtsync.rb --board ${TEST_BOARD} --ci opensuse --matrix openstack-cleannothing,Juno 0
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci opensuse --matrix openstack-cleannothing,Juno,12 0
 echo "returncode: $?"
 read -p "Press any key to continue... " -n1 -s
 echo ""
 
 echo "test: invalid returncode"
-${RUBY} jtsync.rb --board ${TEST_BOARD} --ci opensuse --matrix openstack-cleanvm,Juno a
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci opensuse --matrix openstack-cleanvm,Juno,13 a
 echo "returncode: $?"
 read -p "Press any key to continue... " -n1 -s
 echo ""
 
 echo "test: invalid ci type"
-${RUBY} ./jtsync.rb --board ${TEST_BOARD}--ci foobar --matrix openstack-cleanvm,Juno 0
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci foobar --matrix openstack-cleanvm,Juno 0
 echo "returncode: $?"
+read -p "Press any key to continue... " -n1 -s
+echo ""
+
+BUILDNR=$(( ( RANDOM % 10000 )  + 1 ))
+echo "Buildnr is ${BUILDNR}"
+echo "Start new matrix run"
+echo "cloud-trackupstream (${BUILDNR}) run successful"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-trackupstream,Devel:Cloud:7:Staging,${BUILDNR} 0
+echo "returncode: $?"
+
+echo "cloud-trackupstream (${BUILDNR}) run failed"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-trackupstream,Devel:Cloud:7:Staging,${BUILDNR} 1
+echo "returncode: $?"
+
+echo "cloud-trackupstream (${BUILDNR}) run successful"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-trackupstream,Devel:Cloud:7:Staging,${BUILDNR} 0
+echo "returncode: $?"
+
+echo ""
+echo "State should be failed"
+read -p "Press any key to continue... " -n1 -s
+echo ""
+
+BUILDNR_NEXT=$(( BUILDNR + 1 ))
+echo "Buildnr is now ${BUILDNR_NEXT}"
+echo "Start new matrix run to with already set buildnr"
+echo "cloud-trackupstream (${BUILDNR_NEXT}) run successful"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-trackupstream,Devel:Cloud:7:Staging,${BUILDNR_NEXT} 0
+echo "returncode: $?"
+
+echo ""
+echo "State should be successful and Buildnr should change from ${BUILDNR} to ${BUILDNR_NEXT}"
 read -p "Press any key to continue... " -n1 -s
 echo ""


### PR DESCRIPTION
Add new logic for matrix jobs:
  Instead of setting the card on each status change the card is only set
  if a new build started or the build changes from successful to
  failed.