### PR TITLE
automation: Fix ceph hostname resolution for tests

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3261,12 +3261,14 @@ function get_ceph_nodes
     if [[ $deployceph ]]; then
         cephmons=`crowbar ceph proposal show default | rubyjsonparse "puts j['deployment']['ceph']['elements']['ceph-mon']"`
         for machine in $cephmons; do
-            net_name="`crowbar machines show $machine | rubyjsonparse "puts j['ceph']['client_network']"`"
-            if [[ $net_name -eq "admin" ]]
+            temp_output="`crowbar machines show $machine`"
+            net_name="`echo $temp_output | rubyjsonparse "puts j['ceph']['client_network']"`"
+            hostname="`echo $temp_output | rubyjsonparse "puts j['hostname']"`"
+            if [[ $net_name == "admin" ]]
             then
-                cephmons_names+="$machine "
+                cephmons_names+="$hostname "
             else
-                cephmons_names+="$net_name.$machine "
+                cephmons_names+="$net_name.$hostname "
             fi
         done
         cephosds=`crowbar ceph proposal show default | rubyjsonparse "puts j['deployment']['ceph']['elements']['ceph-osd']"`


### PR DESCRIPTION
Fix the hostname resolution to be in sync with the testing framework.

We were returning the wrong hostnames for the ceph tests after merging https://github.com/SUSE-Cloud/automation/pull/1610

This patch fixes it by using the simple hostname + network name if needed as to be in sync with https://github.com/crowbar/crowbar-ceph/pull/84

Also fix: Using `-eq` for string comparision always returns 0:

```
$ test='a'          
$ echo $test        
a
$ [[ $test -eq "a" ]]
$ echo $?            
0
$ [[ $test -eq "b" ]]
$ echo $?            
0
$ [[ $test == "b" ]] 
$ echo $?           
1

```