### PR TITLE
mkcloud: add support for storage type nodes

### DIFF
--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -13,15 +13,13 @@ def main():
                         (when this script is called within a loop, this \
                         is usually an incremented number)")
     parser.add_argument("macaddress", help="MAC Address")
-    parser.add_argument("controller_raid_volumes", type=int,
-                        help="Number of disks for RAID on controller node")
+    parser.add_argument("raid_volumes", type=int,
+                        help="Number of disks for RAID on node")
     parser.add_argument("cephvolumenumber", type=int,
                         help="Number of Ceph Volumes")
     parser.add_argument("drbdserial", help="DRBD Volume Serial")
-    parser.add_argument("computenodememory", type=int,
-                        help="Compute Node Memory (kB)")
-    parser.add_argument("controllernodememory", type=int,
-                        help="Controller Node Memory (kB)")
+    parser.add_argument("nodememory", type=int,
+                        help="Node Memory (kB)")
     parser.add_argument("libvirttype", help="Libvirt Type (e.g. kvm)")
     parser.add_argument("vcpus", type=int, help="Number of VCPUs")
     parser.add_argument("emulator", help="QEMU to use",
@@ -29,8 +27,6 @@ def main():
     parser.add_argument("vdiskdir",
                         help="Virtual Disk Directory (e.g /dev/cloud)")
     parser.add_argument("bootorder", type=int, help="Boot Order (e.g. 2)")
-    parser.add_argument("numcontrollers", type=int, default=1,
-                        help="Number of controller nodes")
     parser.add_argument("firmwaretype", default="bios",
                         help="Boot firmware type for the node")
     args = parser.parse_args()

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -212,17 +212,10 @@ def compute_config(args, cpu_flags=cpuflags()):
         configopts['memballoon'] = "    <memballoon model='none' />"
         target_address = ""
 
-    controller_raid_volumes = args.controller_raid_volumes
-    if args.nodecounter > args.numcontrollers:
-        controller_raid_volumes = 0
-        nodememory = args.computenodememory
-    else:
-        nodememory = args.controllernodememory
-
     raidvolume = ""
     # a valid serial is defined in libvirt-1.2.18/src/qemu/qemu_command.c:
     serialcloud = re.sub("[^A-Za-z0-9-_]", "_", args.cloud)
-    for i in range(1, controller_raid_volumes):
+    for i in range(1, args.raid_volumes):
         raid_template = string.Template(
             readfile(os.path.join(TEMPLATE_DIR, "extra-volume.xml")))
         raidvolume += "\n" + raid_template.substitute(merge_dicts({
@@ -275,7 +268,7 @@ def compute_config(args, cpu_flags=cpuflags()):
     values = dict(
         cloud=args.cloud,
         nodecounter=args.nodecounter,
-        nodememory=nodememory,
+        nodememory=args.nodememory,
         vcpus=args.vcpus,
         march=get_machine_arch(),
         machine=get_default_machine(args.emulator),

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -17,6 +17,24 @@ function max
     echo $(( $1 > $2 ? $1 : $2 ))
 }
 
+function node_role
+{
+    local i=$1
+    local nodenumbercontroller=1
+    if [[ $clusterconfig == *services* ]]; then
+        nodenumbercontroller=`echo ${clusterconfig}\
+            | sed -e "s/^.*services[^:]*=\([[:digit:]]\+\).*/\1/"`
+    fi
+
+    if [ $i -gt $(($nodenumbercontroller+$nodenumberstorage)) ]; then
+        echo "compute"
+    elif [ $i -gt $nodenumbercontroller ]; then
+        echo "storage"
+    else
+        echo "controller"
+    fi
+}
+
 function wait_for
 {
     local timecount=${1:-300}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -57,6 +57,7 @@ setcloudnetvars $virtualcloud
 nodenumbercomputedefault=2
 [[ $hacloud ]] && nodenumbercomputedefault=1
 : ${nodenumber:=$nodenumbercomputedefault}
+: ${nodenumberstorage:=0}
 : ${nodenumbercompute:=$nodenumbercomputedefault}
 # expect to have this many physical machines attached via $mkch_physcloudif
 # these replace virtual machines, so we start less VMs
@@ -83,6 +84,7 @@ needcvol=1
 : ${admin_node_memory:=4194304}
 : ${controller_node_memory:=6291456}
 iscloudver 7plus && controller_node_memory=$(max $controller_node_memory 12582912)
+: ${storage_node_memory:=2621440}
 : ${compute_node_memory:=2621440}
 [[ "$libvirt_type" = "hyperv" ]] && \
     compute_node_memory=$(max $compute_node_memory ${hyperv_node_memory:-3000000})
@@ -91,9 +93,11 @@ iscloudver 7plus && controller_node_memory=$(max $controller_node_memory 1258291
 # hdd size defaults (unless defined otherwise)
 : ${adminnode_hdd_size:=15}
 : ${controller_hdd_size:=20}
+: ${storage_hdd_size:=20}
 : ${computenode_hdd_size:=20}
 : ${cephvolume_hdd_size:=21}
 : ${controller_ceph_hdd_size:=25}
+: ${storage_ceph_hdd_size:=25}
 : ${lonelynode_hdd_size:=20}
 if [[ $hacloud ]]; then
     : ${drbd_hdd_size:=15}
@@ -574,12 +578,6 @@ function setupnodes
 {
     onadmin wait_tftpd || return $?
 
-    local nodenumbercontroller=1
-    if [[ $clusterconfig == *services* ]]; then
-        nodenumbercontroller=`echo ${clusterconfig}\
-            | sed -e "s/^.*services[^:]*=\([[:digit:]]\+\).*/\1/"`
-    fi
-
     setuppublicnet
     local i
     for i in $(nodes ids normal) ; do
@@ -598,11 +596,27 @@ function setupnodes
             fi
         fi
 
+        local noderole=$(node_role $i)
+        local raidvolumes=0
+        local nodememory
+        case $noderole in
+            controller)
+                raidvolumes=$controller_raid_volumes
+                nodememory=$controller_node_memory
+                ;;
+            storage)
+                nodememory=$storage_node_memory
+                ;;
+            compute)
+                nodememory=$compute_node_memory
+                ;;
+        esac
+
         ${scripts_lib_dir}/libvirt/compute-config $cloud $i $macaddress\
-            $controller_raid_volumes $cephvolumenumber "$drbd_serial"\
-            $compute_node_memory $controller_node_memory $libvirt_type $vcpus\
-            $emulator $vdisk_dir 3 \
-            $nodenumbercontroller "$firmware_type" > /tmp/$cloud-node$i.xml
+            $raidvolumes $cephvolumenumber "$drbd_serial"\
+            $nodememory \
+            $libvirt_type $vcpus $emulator $vdisk_dir 3 \
+            "$firmware_type" > /tmp/$cloud-node$i.xml
         ${scripts_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
     done
 


### PR DESCRIPTION
This change adds a 3rd type named storage for cloud nodes
in addition to compute and controller nodes that can be tuned
with different configuration settings