### PR TITLE
Remove testsetup from job that does not upgrade nodes

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
@@ -22,6 +22,6 @@
             nodenumber=4
             hacloud=1
             storage_method=swift
-            mkcloudtarget=plain_with_upgrade_test testsetup
+            mkcloudtarget=plain_with_upgrade_test
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}


### PR DESCRIPTION
Wit this job, just admin server is installed, and nodes
do not even have Cloud7 repositories set up.