### PR TITLE
Modify QA tempest tests jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-full.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-full.yaml
@@ -59,12 +59,16 @@
             source scripts/qa_crowbarsetup.sh;
 
             if [ "$testsetup" == true ] ; then
+              sed -i "s/want_tempest=1/want_tempest=0/" mkcloud.config
               bash -x -c "source scripts/qa_crowbarsetup.sh; onadmin_testsetup"
               result=$?
+
+              if [[ $result -gt 0 ]]; then
+                exit $result
+              fi
             fi
 
             get_novacontroller;
-            oncontroller oncontroller_run_tempest;
-            result=${result: $?}
-            exit $result;
+            oncontroller run_tempest;
+            exit $?;
           '

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-smoke.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-smoke.yaml
@@ -57,22 +57,27 @@
           cloud=qa$hw_number;
 
           ssh root@$admin "
-            export tempestoptions=\"-t -s\";
+            export tempestoptions=\"--smoke\";
             export cloud=$cloud;
             export testsetup=$testsetup;
             export TESTHEAD=$TESTHEAD;
           " '
             hostname -f;
+            sed -i "s/tempestoptions.*/tempestoptions=--smoke/" mkcloud.config
             source mkcloud.config;
             source scripts/qa_crowbarsetup.sh;
 
             if [ "$testsetup" == true ] ; then
+              sed -i "s/want_tempest.*/want_tempest=0/" mkcloud.config
               bash -x -c "source scripts/qa_crowbarsetup.sh; onadmin_testsetup"
               result=$?
+
+              if [[ $result -gt 0 ]]; then
+                exit $result
+              fi
             fi
 
             get_novacontroller;
             oncontroller run_tempest;
-            result=${result: $?}
-            exit $result;
+            exit $?;
           '


### PR DESCRIPTION
This change separates `testsetup` from triggering  tempest tests to avoid test run duplication.