### PR TITLE
Correct check for finish of the upgrade

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4883,7 +4883,7 @@ function onadmin_allow_vendor_change_at_nodes
 
 function crowbar_nodeupgrade_finished
 {
-    if grep current_step $upgrade_progress_file | grep -v nodes ; then
+    if [ ! -e /var/lib/crowbar/upgrade/6-to-7-upgrade-running ] ; then
         echo "'nodes' step finished successfuly"
         return 0
     fi


### PR DESCRIPTION
I thought we have problems with timeout, but actually the check for end of 'nodes' step is wrong.

The new behavior was introduced by

https://github.com/crowbar/crowbar-core/pull/1037
https://github.com/crowbar/crowbar-core/pull/1043