### PR TITLE
libvirt: Do not use "unsafe" mode for drbd disks (bsc#1003626)

### DIFF
--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -230,6 +230,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                 serialcloud,
                 args.nodecounter,
                 i),
+            'cache_mode': 'unsafe',
             'source_dev': "{0}/{1}.node{2}-raid{3}".format(
                 args.vdiskdir,
                 args.cloud,
@@ -249,6 +250,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                     serialcloud,
                     args.nodecounter,
                     i),
+                'cache_mode': 'unsafe',
                 'source_dev': "{0}/{1}.node{2}-ceph{3}".format(
                     args.vdiskdir,
                     args.cloud,
@@ -264,6 +266,7 @@ def compute_config(args, cpu_flags=cpuflags()):
             readfile(os.path.join(TEMPLATE_DIR, "extra-volume.xml")))
         drbdvolume = drbd_template.substitute(merge_dicts({
             'volume_serial': args.drbdserial,
+            'cache_mode': 'none',
             'source_dev': "{0}/{1}.node{2}-drbd".format(
                 args.vdiskdir,
                 args.cloud,

--- a/scripts/lib/libvirt/templates/extra-volume.xml
+++ b/scripts/lib/libvirt/templates/extra-volume.xml
@@ -1,6 +1,6 @@
     <disk type='block' device='disk'>
       <serial>$volume_serial</serial>
-      <driver name='qemu' type='raw' cache='unsafe'/>
+      <driver name='qemu' type='raw' cache='$cache_mode'/>
       <source dev='$source_dev'/>
       <target dev='$target_dev' bus='$target_bus'/>
       $target_address


### PR DESCRIPTION
This is causing failures in our CI, and since drbd disks are not super
critical in terms of speed, we can move to "none" instead.

https://bugzilla.suse.com/show_bug.cgi?id=1003626