### PR TITLE
qa_crowbarsetup: Set storage_protocol for manila in tempest

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2837,6 +2837,7 @@ function custom_configuration
                     proposal_set_value tempest default "['attributes']['tempest']['manila']['run_consistency_group_tests']" "false"
                     proposal_set_value tempest default "['attributes']['tempest']['manila']['run_snapshot_tests']" "false"
                     proposal_set_value tempest default "['attributes']['tempest']['manila']['enable_protocols']" "'cephfs'"
+                    proposal_set_value tempest default "['attributes']['tempest']['manila']['storage_protocol']" "'CEPHFS'"
                 else
                     # generic driver
                     proposal_set_value tempest default "['attributes']['tempest']['manila']['image_password']" "'linux'"


### PR DESCRIPTION
That is needed when we deploy with Ceph as backend. Otherwise some
tempest tests fail with:

Failed to schedule create_share: No valid host was found.