### PR TITLE
Enable jtsync for cloud-mediacheck and cloud-trackupstream

### DIFF
--- a/jenkins/ci.suse.de/cloud-mediacheck.yaml
+++ b/jenkins/ci.suse.de/cloud-mediacheck.yaml
@@ -41,6 +41,15 @@
         (["Devel:Cloud:5", "Devel:Cloud:5/SLE_12", "Devel:Cloud:6", "Devel:Cloud:6/SLE_12_SP1", "Devel:Cloud:7/SLE_12_SP2" ].contains(project) || subproject == ":")
     builders:
       - shell: |
+          export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
+          function jtsync_trap() {
+            $jtsync --ci suse --matrix ${JOB_BASE_NAME},${project},${BUILD_NUMBER} 1
+          }
+
+          # only enable jtsync when build is not manually triggered
+          if [[ "${ROOT_BUILD_CAUSE}" != "MANUALTRIGGER" ]]; then
+            trap jtsync_trap EXIT ERR
+          fi
           if [[ ! -d /mounts/dist ]] ; then
               zypper -n install git-core rsync make autofs nfs-client ypbind kernel-default -kernel-default-base curl wget libsolv-tools bsdtar
               echo -e 'ypserver 10.160.0.10\nypserver 10.160.0.1\nypserver 10.160.0.150' > /etc/yp.conf
@@ -94,3 +103,9 @@
 
           # Cleanup
           rm -r cloud/scripts/release-mgmt/*.iso
+
+          # only enable jtsync when build is not manually triggered
+          if [[ "${ROOT_BUILD_CAUSE}" != "MANUALTRIGGER" ]]; then
+            trap - EXIT ERR
+            $jtsync --ci suse --matrix ${JOB_BASE_NAME},${project},${BUILD_NUMBER} $RETVAL
+          fi

--- a/jenkins/ci.suse.de/cloud-trackupstream.yaml
+++ b/jenkins/ci.suse.de/cloud-trackupstream.yaml
@@ -139,6 +139,15 @@
           export automationrepo=~/github.com/SUSE-Cloud/automation
           export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
 
+          function jtsync_trap() {
+            $jtsync --ci suse --matrix ${JOB_BASE_NAME},${project},${BUILD_NUMBER} 1
+          }
+
+          # only enable jtsync when build is not manually triggered
+          if [[ "${ROOT_BUILD_CAUSE}" != "MANUALTRIGGER" ]]; then
+            trap jtsync_trap EXIT ERR
+          fi
+
           # automation bootstrapping
           if ! [ -e ${automationrepo}/scripts/jenkins/update_automation ] ; then
               rm -rf ${automationrepo}
@@ -211,5 +220,10 @@
 
           /root/github.com/SUSE-Cloud/automation/scripts/jenkins/track-upstream-and-package.pl
           ret=$?
-          $jtsync --ci suse --matrix cloud-trackupstream,${project} $ret || :
+
+          # only enable jtsync when build is not manually triggered
+          if [[ "${ROOT_BUILD_CAUSE}" != "MANUALTRIGGER" ]]; then
+            trap - EXIT ERR
+            $jtsync --ci suse --matrix ${JOB_BASE_NAME},${project},${BUILD_NUMBER} $ret
+          fi
           exit $ret


### PR DESCRIPTION
This enables jtsync for cloud-mediacheck and cloud-trackupstream.
Note: This will only set the status if the build was not triggered manually.

__This pr depends on features of https://github.com/SUSE-Cloud/automation/pull/1616 do not merge before__