### PR TITLE
Fix netmask in nova_fixed for non-production

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1407,7 +1407,7 @@ EOF
         -e "s/ [47]00/ $vlan_sdn/g" \
         $netfile
 
-    if [[ $cloud =~ p ]] ; then
+    if [[ $cloud =~ ^p ]] ; then
         # production cloud has a /22 network
         /opt/dell/bin/json-edit -a attributes.network.networks.nova_fixed.netmask -v 255.255.252.0 $netfile
     fi


### PR DESCRIPTION
Production clouds start with `p` and have a larger subnet at their
disposal. The current test for production cloud is overly broad and
captures clouds such as `vp5` which have smaller networks.