### PR TITLE
Skip the check for custom vendor data if they are not present

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3884,7 +3884,11 @@ function oncontroller_testsetup
         complain 95 could not reach internet
     fi
 
-    if iscloudver 7plus ; then
+    # The custom-key value is only set during initial deployment of Cloud7 directly from this script
+    # So it is not present when the cloud is upgraded from Cloud6 and we need to skip this test.
+    if iscloudver 7plus && crowbar nova proposal show default | rubyjsonparse \
+        "exit false if j['attributes']['nova']['metadata']['vendordata']['json'] == '{}'"
+    then
         wait_for 40 5 "timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $ssh_target curl -s http://169.254.169.254/openstack/latest/vendor_data.json|grep -q custom-key" "Custom vendordata not accessable from VM"
     fi
 


### PR DESCRIPTION
The custom-key value is only set during initial deployment of Cloud7,
so it is not present when the cloud is upgraded from Cloud6.

An alternative to https://github.com/SUSE-Cloud/automation/pull/1647