### PR TITLE
switch scenario 2a/2c to default keystone token provider (fernet) and

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -115,8 +115,6 @@ proposals:
 
 - barclamp: keystone
   attributes:
-    signing:
-      token_format: UUID
   deployment:
     elements:
       keystone-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -68,7 +68,7 @@ proposals:
 - barclamp: keystone
   attributes:
     signing:
-      token_format: UUID
+      token_format: uuid
   deployment:
     elements:
       keystone-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -59,8 +59,6 @@ proposals:
 
 - barclamp: keystone
   attributes:
-    signing:
-      token_format: UUID
   deployment:
     elements:
       keystone-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
@@ -60,7 +60,7 @@ proposals:
 - barclamp: keystone
   attributes:
     signing:
-      token_format: UUID
+      token_format: uuid
   deployment:
     elements:
       keystone-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -120,8 +120,6 @@ proposals:
       insecure: true
     api:
       protocol: https
-    signing:
-      token_format: UUID
   deployment:
     elements:
       keystone-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -73,7 +73,7 @@ proposals:
     api:
       protocol: https
     signing:
-      token_format: UUID
+      token_format: uuid
   deployment:
     elements:
       keystone-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -65,8 +65,6 @@ proposals:
     api:
       # FIXME: disabled due to issues in trove (https://bugs.launchpad.net/trove/+bug/1535895) and radosgw (https://bugzilla.suse.com/show_bug.cgi?id=962672)
       #protocol: https
-    signing:
-      token_format: UUID
   deployment:
     elements:
       keystone-server:


### PR DESCRIPTION
fix 2b

We recently renamed UUID to uuid