### PR TITLE
Change tempest full to parallel run

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-full.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-full.yaml
@@ -49,7 +49,7 @@
           cloud=qa$hw_number;
 
           ssh root@$admin "
-            export tempestoptions=\"-t\";
+            export tempestoptions=\"--parallel\";
             export cloud=$cloud;
             export testsetup=$testsetup;
             export TESTHEAD=$TESTHEAD;


### PR DESCRIPTION
Substitute -t (serial) option with --parallel to speed up tempest full
Even though parallel is the default i left it to be more explicit.
