### PR TITLE
Defcore job rework

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-defcore.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-defcore.yaml
@@ -2,7 +2,7 @@
     name: cloud-mkphyscloud-qa-test-tempest-defcore
     node: cloud-mkphyscloud-gate-qa
     description: |
-      Runs tempest defcore tests on a specified QA hardware.
+      Uploads tempest full results using refstack client.
       Useful only for cloud that was built by mkcloud.
       Mandatory parameter: hw_number
 
@@ -37,11 +37,6 @@
           name: scenario_build_number
           description: Optional; scenario build number that triggered this job
 
-      - bool:
-          name: testsetup
-          default: false
-          description: Run tempest with testsetup() in qa_crowbarsetup.sh script
-
     builders:
       - shell: |
           #!/bin/bash
@@ -49,7 +44,6 @@
           cloud=qa$hw_number;
 
           ssh root@$admin "
-            export tempestoptions=\"--serial --no-virtual-env -- --load-list defcore.txt\";
             export cloud=$cloud;
             export testsetup=$testsetup;
             export TESTHEAD=$TESTHEAD;
@@ -58,10 +52,7 @@
             source mkcloud.config;
             source scripts/qa_crowbarsetup.sh;
 
-            if [ "$testsetup" == true ] ; then
-               onadmin_testsetup;
-            else
-               get_novacontroller;
-               oncontroller oncontroller_run_tempest;
-            fi
+            get_novacontroller;
+            oncontroller upload_defcore;
+            exit $?;
           '

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-defcore.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-defcore.yaml
@@ -52,7 +52,5 @@
             source mkcloud.config;
             source scripts/qa_crowbarsetup.sh;
 
-            get_novacontroller;
-            oncontroller upload_defcore;
-            exit $?;
+            onadmin_upload_defcore;
           '

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3424,6 +3424,16 @@ function oncontroller_run_tempest
     return $tempestret
 }
 
+function oncontroller_upload_defcore
+{
+    pushd /var/lib/openstack-tempest-test
+    source /root/.openrc
+    testr last --subunit | subunit-2to1 > tempest.subunit.log
+    git clone https://github.com/openstack/refstack-client
+    yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL tempest.subunit.log
+    popd
+}
+
 function oncontroller_run_integration_test()
 {
     # Install Mozilla Firefox < 47 to work with Selenium.

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3429,9 +3429,15 @@ function oncontroller_upload_defcore
     pushd /var/lib/openstack-tempest-test
     source /root/.openrc
     testr last --subunit | subunit-2to1 > tempest.subunit.log
-    git clone https://github.com/openstack/refstack-client
+    safely git clone https://github.com/openstack/refstack-client
     yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL tempest.subunit.log
     popd
+}
+
+function onadmin_upload_defcore
+{
+    get_novacontroller
+    oncontroller upload_defcore
 }
 
 function oncontroller_run_integration_test()


### PR DESCRIPTION
The job should be run after the tempest full and upload the results with the refstack client.
But for now just a job, without a trigger in tempest full.