### PR TITLE
Test coverage the easy way: use crowbarctl for rebooting nodes

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4436,7 +4436,11 @@ function power_cycle_and_wait
 {
     local machine=$1
 
-    ssh $machine "reboot"
+    if iscloudver 6plus; then
+        crowbarctl node reboot $machine
+    else
+        ssh $machine "reboot"
+    fi
 
     # "crowbar machines list" returns FQDNs but "crowbar node_state status"
     # only hostnames. Get hostname part of FQDN


### PR DESCRIPTION
We'd like to test our code, so better use it instead of
directly rebooting nodes.