### PR TITLE
routed.cloud: use internal clouddata name

### DIFF
--- a/scripts/mkcloudhost/routed.cloud
+++ b/scripts/mkcloudhost/routed.cloud
@@ -7,6 +7,8 @@ if [ "$n" -lt 1 -o "$n" -gt 32 ] ; then
   exit 1
 fi
 
+: ${clouddatadns:=clouddata.cloud.suse.de}
+export clouddatadns
 export net_admin=$(cloudadminnet $n)
 export net_public=$(routedcloudpublicnet $n)
 export adminnetmask=255.255.255.0


### PR DESCRIPTION
when running inside R&D
because it has more direct routing