### PR TITLE
mkcloud-common: add want_timescaling

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -30,6 +30,7 @@ function wait_for
     local error_cmd=${5:-'exit 11'}
 
     local original_xstatus=${-//[^x]/}
+    timesleep=$((timesleep*${want_timescaling:-1}))
     set +x
     echo "Waiting for: $waitfor"
     echo "  until this condition is true: $condition"

--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -30,6 +30,8 @@ function qacrowbarsetup_help
             want_node_roles=controller=1,compute=2,storage=3
     want_test_updates=0 | 1  (default=1 if TESTHEAD is set, 0 otherwise)
         add test update repositories
+    want_timescaling=2 (default 1)
+        increase all wait_for sleeps by this factor
     want_sbd=1 (default 0)
         Setup SBD over iSCSI for cluster nodes, with iSCSI target on admin node. Only usable for HA configuration.
     want_devel_repos=list of Devel Projects to use for other products


### PR DESCRIPTION
to allow increasing all wait_for sleeps
because some (virtualized) mkcloud hosts are a lot slower
and this can make them pass