### PR TITLE
Change number of replicas to 2 in swift config 

### DIFF
--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a.yaml
@@ -88,6 +88,7 @@ proposals:
       - cluster:services
 - barclamp: cinder
   attributes:
+    replicas: 2
     volumes:
     - backend_driver: raw
       backend_name: default

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b.yaml
@@ -86,6 +86,7 @@ proposals:
 
 - barclamp: glance
   attributes:
+    replicas: 2
     default_store: swift
   deployment:
     elements:

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2a.yaml
@@ -124,6 +124,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     keystone_delay_auth_decision: true
     allow_versions: true
   deployment:

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-2b.yaml
@@ -75,8 +75,10 @@ proposals:
       - cluster:services
 
 - barclamp: swift
-  keystone_delay_auth_decision: true
-  allow_versions: true
+  attributes:
+    keystone_delay_auth_decision: true
+    allow_versions: true
+    replicas: 2
   deployment:
     elements:
       swift-dispersion:

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -73,6 +73,7 @@ proposals:
       - cluster:services
 - barclamp: swift
   attributes:
+    replicas: 2
     ssl:
       enabled: true
       generate_certs: true

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -79,6 +79,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     ssl:
       enabled: true
       generate_certs: true

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -129,6 +129,7 @@ proposals:
 
 - barclamp: swift
   attributes:
+    replicas: 2
     keystone_delay_auth_decision: true
     allow_versions: true
     ssl:

--- a/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud6/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -80,9 +80,10 @@ proposals:
       - cluster:services
 
 - barclamp: swift
-  keystone_delay_auth_decision: true
-  allow_versions: true
   attributes:
+    keystone_delay_auth_decision: true
+    allow_versions: true
+    replicas: 2
     ssl:
       enabled: true
       generate_certs: true


### PR DESCRIPTION
Needed due compatibility with cloud 7 in upgrade process