### PR TITLE
Use correct replicas configuration in swift for QA scenarios

### DIFF
--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1a.yaml
@@ -69,6 +69,7 @@ proposals:
 - barclamp: swift
   attributes:
     cluster_hash: 181d283256
+    replicas: 2
   deployment:
     elements:
       swift-dispersion: []
@@ -88,7 +89,6 @@ proposals:
       - cluster:services
 - barclamp: cinder
   attributes:
-    replicas: 2
     volumes:
     - backend_driver: raw
       backend_name: default

--- a/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud6/qa/no-ssl/qa-scenario-1b.yaml
@@ -72,6 +72,8 @@ proposals:
       - cluster:services
 
 - barclamp: swift
+  attributes:
+    replicas: 2
   deployment:
     elements:
       swift-dispersion:
@@ -86,7 +88,6 @@ proposals:
 
 - barclamp: glance
   attributes:
-    replicas: 2
     default_store: swift
   deployment:
     elements:


### PR DESCRIPTION
The replicas attributes were put into incorrect barclamp sections by mistake in [previous PR](https://github.com/SUSE-Cloud/automation/pull/1715).