### PR TITLE
Add magnum_trusts parameter to `mkcloud`

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1129,6 +1129,9 @@ Optional
         It's not deployed by default. Set to 1 to deploy magnum.
     want_monasca=1 (default=0)
       Set to 1 to deploy monasca (Cloud7+ only)
+    want_magnum_trusts (default=0)
+        Set to 1 to pass trust ID into magnum clusters' instances. Insecure but
+        required for some functional tests.
     want_barbican=0 (default=1)
         Deployed by default. Set to 0 to prevent barbican from being deployed.
     want_sahara=0 (default=1)

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -36,6 +36,7 @@ fi
 : ${want_multidnstest:=1}
 : ${want_magnum:=0}
 : ${want_monasca:=0}
+: ${want_magnum_trusts:=0}
 : ${want_barbican:=1}
 : ${want_sahara:=1}
 : ${want_murano:=0}
@@ -2720,6 +2721,9 @@ function custom_configuration
             fi
         ;;
         magnum)
+            if [ $want_magnum_trusts = 1 ]; then
+                proposal_set_value magnum default "['attributes']['magnum']['trustee']['cluster_user_trust']" "true"
+            fi
             proposal_set_value magnum default "['attributes']['magnum']['trustee']['domain_name']" "'magnum'"
             proposal_set_value magnum default "['attributes']['magnum']['trustee']['domain_admin_name']" "'magnum_domain_admin'"
 


### PR DESCRIPTION
This setting sets [trust/cluster_user_trust] to True in magnum.conf. Enabling this is not required right now, so it defaults to `False`. Should we ever want to run more than `functional-api` we will need to add an `magnum_trusts=1` to the parameters in `templates/cloud-mkcloud-job-magnum-template.yaml`.

Note: this requires https://github.com/crowbar/crowbar-openstack/pull/853 to work, hence the "Do not merge, yet" label.