### PR TITLE
qa_crowbarsetup: only enable ssl if available

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2240,6 +2240,11 @@ function enable_ssl_generic
     echo "Enabling SSL for $service"
     local p="proposal_set_value $service default"
     local a="['attributes']['$service']"
+    local pfile=`get_proposal_filename "$service" default`
+    if ! grep -q generate_certs $pfile ; then
+        echo "Cannot enable ssl for $service - not supported in this cloud version"
+        return
+    fi
     case $service in
         swift)
             $p "$a['ssl']['enabled']" true


### PR DESCRIPTION
this avoids issues such as
https://github.com/SUSE-Cloud/automation/pull/1729
breaking deployment of GM7 that does not include
the required crowbar-openstack code