### PR TITLE
Cloud 7 updates repo is needed when doing Cloud6->7 upgrade

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4742,6 +4742,7 @@ function onadmin_prepare_cloudupgrade_repos_6_to_7
 
     # recreate the SUSE-Cloud Repo with the latest iso
     onadmin_prepare_cloud_repos
+    addcloud7maintupdates
     onadmin_add_cloud_repo
 
     # create skeleton for PTF repositories


### PR DESCRIPTION
This was removed by https://github.com/SUSE-Cloud/automation/pull/1736