### PR TITLE
rename HCP to SAP

### DIFF
--- a/jenkins/ci.suse.de/cloud-trackupstream.yaml
+++ b/jenkins/ci.suse.de/cloud-trackupstream.yaml
@@ -64,7 +64,7 @@
           values:
             - Devel:Cloud:5:Staging
             - Devel:Cloud:6:Staging
-            - Devel:Cloud:6:HCP:Staging
+            - Devel:Cloud:6:SAP:Staging
             - Devel:Cloud:7:Staging
       - axis:
           type: slave
@@ -113,7 +113,7 @@
           ||
           (
             [
-              "Devel:Cloud:6:HCP:Staging"
+              "Devel:Cloud:6:SAP:Staging"
             ].contains(project) &&
             [
               "crowbar-ui",

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1091,8 +1091,8 @@ Optional
     want_keystone_token_type='uuid' | 'fernet' (default='')
         Choose Keystone token provider type, possible values are "uuid" or "fernet".
         Default value will be applied from Keystone barclamp proposal.
-    want_hcp='' | 1  (default='')
-        Set up a HCP cloud.
+    want_sap='' | 1  (default='')
+        Set up a cloud based on the SAP fork.
     install_chef_suse_override='path/to/script'
         Optional path to an alternate version of install-chef-suse.sh on the mkcloud hostto use
         instead of the one from the packages.  This will be scp'd to the admin node before use.

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -448,12 +448,12 @@ function add_sdk_repo
     esac
 }
 
-function add_hcp_repo
+function add_sap_repo
 {
     local stage=
     [[ $TESTHEAD ]] && stage=":/Staging"
     # priority required to overwrite the default cloud6 packages
-    zypper ar -p 92 -f http://$susedownload/ibs/Devel:/Cloud:/6:/HCP${stage}/SLE_12_SP1/ dc6hpc
+    zypper ar -p 92 -f http://$susedownload/ibs/Devel:/Cloud:/6:/SAP${stage}/SLE_12_SP1/ dc6sap
 }
 
 function add_ha_repo
@@ -1399,7 +1399,7 @@ EOF
         fi
     fi
 
-    [[ $want_hcp = 1 ]] && add_hcp_repo
+    [[ $want_sap = 1 ]] && add_sap_repo
 
     if [ -n "$deployceph" ] && iscloudver 5plus; then
         add_suse_storage_repo


### PR DESCRIPTION
The term HCP should no longer be used. Instead we rename it to SAP who is working on this fork.

This PR depends on PR #1740 but could be merged any time.