### PR TITLE
qa_crowbarsetup: Do not deploy calamari on SOC6

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2604,7 +2604,7 @@ function custom_configuration
             # don't deploy calamari by default on SOC7. calamari needs a postgres DB on localhost
             # and get's confused if it is deployed on the controller where a postgres DB is already running
             # see https://bugzilla.suse.com/show_bug.cgi?id=1008331
-            if iscloudver 7plus ; then
+            if iscloudver 6plus ; then
                 proposal_set_value ceph default "['deployment']['ceph']['elements']['ceph-calamari']" "[]"
             fi
         ;;


### PR DESCRIPTION
I need #1417 for cloud 6 also, we hit https://bugzilla.suse.com/show_bug.cgi?id=1008331 a lot in maintenance