### PR TITLE
Make node setup params optional

### DIFF
--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -12,27 +12,33 @@ def main():
                         help="Node Counter \
                         (when this script is called within a loop, this \
                         is usually an incremented number)")
-    parser.add_argument("macaddress", help="MAC Address")
-    parser.add_argument("controller_raid_volumes", type=int,
-                        help="Number of disks for RAID on controller node")
-    parser.add_argument("cephvolumenumber", type=int,
-                        help="Number of Ceph Volumes")
-    parser.add_argument("drbdserial", help="DRBD Volume Serial")
-    parser.add_argument("computenodememory", type=int,
-                        help="Compute Node Memory (kB)")
-    parser.add_argument("controllernodememory", type=int,
-                        help="Controller Node Memory (kB)")
-    parser.add_argument("libvirttype", help="Libvirt Type (e.g. kvm)")
-    parser.add_argument("vcpus", type=int, help="Number of VCPUs")
-    parser.add_argument("emulator", help="QEMU to use",
+    parser.add_argument("--macaddress", help="MAC Address")
+    parser.add_argument("--controller-raid-volumes", type=int, default=0,
+                        help="Number of disks for RAID on controller node. "
+                        "Default: %(default)s")
+    parser.add_argument("--cephvolumenumber", type=int, default=0,
+                        help="Number of Ceph Volumes. Default: %(default)s")
+    parser.add_argument("--drbdserial", help="DRBD Volume Serial")
+    parser.add_argument("--computenodememory", type=int, default=2097152,
+                        help="Compute Node Memory (kB). Default: %(default)s")
+    parser.add_argument("--controllernodememory", type=int, default=6291456,
+                        help="Controller Node Memory (kB). "
+                        "Default: %(default)s")
+    parser.add_argument("--libvirttype", default="kvm",
+                        help="Libvirt Type (e.g. kvm). Default: %(default)s")
+    parser.add_argument("--vcpus", type=int, default=1, help="Number of VCPUs. "
+                        "Default: %(default)s")
+    parser.add_argument("--emulator", help="QEMU to use. Default: %(default)s",
                         default="/usr/bin/qemu-system-%s" % os.uname()[4])
-    parser.add_argument("vdiskdir",
-                        help="Virtual Disk Directory (e.g /dev/cloud)")
-    parser.add_argument("bootorder", type=int, help="Boot Order (e.g. 2)")
-    parser.add_argument("numcontrollers", type=int, default=1,
-                        help="Number of controller nodes")
-    parser.add_argument("firmwaretype", default="bios",
-                        help="Boot firmware type for the node")
+    parser.add_argument("--vdiskdir", default="/var/lib/libvirt/",
+                        help="Virtual Disk Directory (e.g /dev/cloud). "
+                        "Default: %(default)s")
+    parser.add_argument("--bootorder", type=int, help="Boot Order (e.g. 2)")
+    parser.add_argument("--numcontrollers", type=int, default=1,
+                        help="Number of controller nodes. Default: %(default)s")
+    parser.add_argument("--firmwaretype", default="bios",
+                        help="Boot firmware type for the node. "
+                        "Default: %(default)s")
     args = parser.parse_args()
 
     print(libvirt_setup.compute_config(args, libvirt_setup.cpuflags()))

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -361,10 +361,19 @@ function libvirt_do_setuplonelynodes()
         local mac=$(macfunc $i)
         local lonely_node
         lonely_node=$cloud-node$i
-        safely ${scripts_lib_dir}/libvirt/compute-config $cloud $i $mac 0\
-            "$cephvolumenumber" "$drbdvolume" $compute_node_memory\
-            $controller_node_memory $libvirt_type $vcpus $(get_emulator) $vdisk_dir\
-            1 1 "$firmware_type" > /tmp/$cloud-node$i.xml
+        safely ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
+               --macaddress $mac \
+               --cephvolumenumber "$cephvolumenumber" \
+               --drbdserial "$drbdvolume" \
+               --computenodememory $compute_node_memory\
+               --controllernodememory $controller_node_memory \
+               --libvirttype $libvirt_type \
+               --vcpus $vcpus \
+               --emulator $(get_emulator) \
+               --vdiskdir $vdisk_dir \
+               --bootorder 1 \
+               --numcontrollers 1 \
+               --firmwaretype "$firmware_type" > /tmp/$cloud-node$i.xml
 
         local lonely_disk
         lonely_disk="$vdisk_dir/${cloud}.node$i"

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -583,11 +583,20 @@ function setupnodes
             fi
         fi
 
-        ${scripts_lib_dir}/libvirt/compute-config $cloud $i $macaddress\
-            $controller_raid_volumes $cephvolumenumber "$drbd_serial"\
-            $compute_node_memory $controller_node_memory $libvirt_type $vcpus\
-            $(get_emulator) $vdisk_dir 3 \
-            $nodenumbercontroller "$firmware_type" > /tmp/$cloud-node$i.xml
+        ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
+                        --macaddress $macaddress \
+                        --cephvolumenumber $cephvolumenumber \
+                        --drbdserial "$drbd_serial"\
+                        --computenodememory $compute_node_memory \
+                        --controllernodememory $controller_node_memory \
+                        --libvirttype $libvirt_type \
+                        --vcpus $vcpus \
+                        --emulator $(get_emulator) \
+                        --vdiskdir $vdisk_dir \
+                        --bootorder 3 \
+                        --numcontrollers $nodenumbercontroller \
+                        --firmwaretype "$firmware_type" \
+                        --controller-raid-volumes $controller_raid_volumes > /tmp/$cloud-node$i.xml
         ${scripts_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
     done
 


### PR DESCRIPTION
When using the script manually to setup a compute/controller node,
make most of the needed parameters optional. This simplifies the call
and also makes it more exclicit which parameter is for what.
Having all parameters as positionals is ugly.