### PR TITLE
Allow multiple nics for controller and compute nodes

### DIFF
--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -12,7 +12,7 @@ def main():
                         help="Node Counter \
                         (when this script is called within a loop, this \
                         is usually an incremented number)")
-    parser.add_argument("--macaddress", help="MAC Address")
+    parser.add_argument("--macaddress", help="MAC Address(es)", action="append")
     parser.add_argument("--controller-raid-volumes", type=int, default=0,
                         help="Number of disks for RAID on controller node. "
                         "Default: %(default)s")

--- a/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
@@ -36,7 +36,7 @@
       <target dev='cloud-a'/>
       <source network='cloud-admin'/>
       <model type='virtio'/>
-      <address type='pci' slot='0x03'/>
+      <address type='pci' slot='0x3'/>
     </interface>
     <serial type='pty'>
       <target port='0'/>

--- a/scripts/lib/libvirt/fixtures/cloud-admin.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin.xml
@@ -36,7 +36,7 @@
       <target dev='cloud-a'/>
       <source network='cloud-admin'/>
       <model type='virtio'/>
-      <address type='pci' slot='0x03'/>
+      <address type='pci' slot='0x3'/>
     </interface>
     <serial type='pty'>
       <target port='0'/>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -58,14 +58,15 @@
     </disk>
 
 
-    <interface type='network'>
-      <mac address='52:54:01:77:77:01'/>
-      <target dev='cloud-1'/>
-      <source network='cloud-admin'/>
-      <model type='virtio'/>
-      <address type='pci' slot='0x03'/>
-      <boot order='2'/>
-    </interface>
+<interface type='network'>
+  <mac address='52:54:01:77:77:01'/>
+  <target dev='cloud-1-0'/>
+  <source network='cloud-admin'/>
+  <model type='virtio'/>
+  <address type='pci' slot='0x3'/>
+  <boot order='2'/>
+</interface>
+
     <serial type='pty'>
       <target port='0'/>
     </serial>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -42,14 +42,15 @@
     </disk>
 
 
-    <interface type='network'>
-      <mac address='52:54:01:77:77:01'/>
-      <target dev='cloud-1'/>
-      <source network='cloud-admin'/>
-      <model type='virtio'/>
-      <address type='pci' slot='0x03'/>
-      <boot order='2'/>
-    </interface>
+<interface type='network'>
+  <mac address='52:54:01:77:77:01'/>
+  <target dev='cloud-1-0'/>
+  <source network='cloud-admin'/>
+  <model type='virtio'/>
+  <address type='pci' slot='0x3'/>
+  <boot order='2'/>
+</interface>
+
     <serial type='pty'>
       <target port='0'/>
     </serial>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -42,14 +42,15 @@
     </disk>
 
 
-    <interface type='network'>
-      <mac address='52:54:01:77:77:01'/>
-      <target dev='cloud-1'/>
-      <source network='cloud-admin'/>
-      <model type='e1000'/>
-      <address type='pci' slot='0x03'/>
-      <boot order='2'/>
-    </interface>
+<interface type='network'>
+  <mac address='52:54:01:77:77:01'/>
+  <target dev='cloud-1-0'/>
+  <source network='cloud-admin'/>
+  <model type='e1000'/>
+  <address type='pci' slot='0x3'/>
+  <boot order='2'/>
+</interface>
+
     <serial type='pty'>
       <target port='0'/>
     </serial>

--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -42,14 +42,15 @@
     </disk>
 
 
-    <interface type='network'>
-      <mac address='52:54:01:77:77:01'/>
-      <target dev='cloud-1'/>
-      <source network='cloud-admin'/>
-      <model type='virtio'/>
-      <address type='pci' slot='0x03'/>
-      <boot order='2'/>
-    </interface>
+<interface type='network'>
+  <mac address='52:54:01:77:77:01'/>
+  <target dev='cloud-1-0'/>
+  <source network='cloud-admin'/>
+  <model type='virtio'/>
+  <address type='pci' slot='0x3'/>
+  <boot order='2'/>
+</interface>
+
     <serial type='pty'>
       <target port='0'/>
     </serial>

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -25,14 +25,7 @@ $cpuflags
 $raidvolume
 $cephvolume
 $drbdvolume
-    <interface type='network'>
-      <mac address='$macaddress'/>
-      <target dev='$cloud-$nodecounter'/>
-      <source network='$cloud-admin'/>
-      <model type='$nicmodel'/>
-      $mainnicaddress
-      <boot order='2'/>
-    </interface>
+$nics
 $serialdevice
     <console type='pty'>
       <target type='$consoletype' port='0'/>

--- a/scripts/lib/libvirt/templates/net-interface.xml
+++ b/scripts/lib/libvirt/templates/net-interface.xml
@@ -1,0 +1,8 @@
+<interface type='network'>
+  <mac address='$macaddress'/>
+  <target dev='$cloud-$nodecounter-$nicindex'/>
+  <source network='$cloud-admin'/>
+  <model type='$nicmodel'/>
+  $mainnicaddress
+  <boot order='$bootorder'/>
+</interface>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -88,7 +88,7 @@ def filter_vm_xml(xmlstr):
 def default_test_args(args):
     args.cloud = "cloud"
     args.nodecounter = 1
-    args.macaddress = "52:54:01:77:77:01"
+    args.macaddress = ["52:54:01:77:77:01"]
     args.controller_raid_volumes = 0
     args.cephvolumenumber = 1
     args.computenodememory = 2097152

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -183,7 +183,7 @@ function nodes
 : ${macprefix:=52:54:77}
 function macfunc
 {
-    ${mkclouddriver}_do_macfunc $1
+    ${mkclouddriver}_do_macfunc $@
 }
 
 function mac_to_nodename

--- a/scripts/lib/mkcloud-dirmaint.sh
+++ b/scripts/lib/mkcloud-dirmaint.sh
@@ -182,5 +182,7 @@ function dirmaint_do_setuplonelynodes()
 
 function dirmaint_do_macfunc()
 {
-    printf "$macprefix:0${cloudidx}:77:%02x" $1
+    local nodenumber=$1
+    local nicnumber=${2:-"1"}
+    printf "$macprefix:0${cloudidx}:%02x:%02x" $nicnumber $nodenumber
 }

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -397,5 +397,7 @@ function libvirt_do_shutdowncloud()
 
 function libvirt_do_macfunc
 {
-    printf "$macprefix:77:77:%02x" $1
+    local nodenumber=$1
+    local nicnumber=${2:-"1"}
+    printf "$macprefix:77:%02x:%02x" $nicnumber $nodenumber
 }

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -70,6 +70,7 @@ nodenumbercomputedefault=2
 : ${cephvolumenumber:=1}
 : ${controller_raid_volumes:=0}
 : ${vcpus:=2}
+: ${nics:=1}
 : ${adminvcpus:=2}
 cpuflags=''
 working_dir_orig=`pwd`
@@ -582,9 +583,12 @@ function setupnodes
                 drbdnode_mac_vol="${drbdnode_mac_vol#+}"
             fi
         fi
-
+        local mac_params=""
+        for nicnumber in $(seq 1 $nics) ; do
+            mac_params+=" --macaddress $(macfunc $i $nicnumber)";
+        done
         ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
-                        --macaddress $macaddress \
+                        $mac_params \
                         --cephvolumenumber $cephvolumenumber \
                         --drbdserial "$drbd_serial"\
                         --computenodememory $compute_node_memory \
@@ -1027,6 +1031,8 @@ Optional
         of $nodenumber - $nodenumbercompute are used as HA cluster nodes
     vcpus=1         (default $vcpus)
         set the number of CPU cores per compute node
+    nics=1         (default $nics)
+        set the number of network interfaces per cloud node
     adminvcpus=1    (default $adminvcpus)
         set the number of CPU cores for admin node
     admin_node_memory (default 4194304)


### PR DESCRIPTION
This is useful to test real world setups where nodes do have multiple
nics.
Setting the new variable $nics (defaults to 1) generates $nics network
interfaces per node.