### PR TITLE
soc-ci: Remove j host

### DIFF
--- a/hostscripts/soc-ci/soc-ci
+++ b/hostscripts/soc-ci/soc-ci
@@ -37,8 +37,8 @@ from six.moves import input
 
 # path to the user configuration file
 USER_CONFIG_PATH = os.path.expanduser('~/.soc-ci.ini')
-# possible mkcX hosts
-CI_WORKERS = list('abcdefghijklmnp')
+# possible mkcX hosts (there is no 'j' host)
+CI_WORKERS = list('abcdefghiklmnp')
 
 
 def _config_credentials_get():


### PR DESCRIPTION
There is no mkchj host available so do not try to connect to it.