### PR TITLE
Extend 2c scenario

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
@@ -12,11 +12,13 @@
         - DRBD
         - ceph (3 nodes)
         - 2 kvm compute nodes
+        - Neutron: linuxbridge or OVS
 
       It will wipe all QA2 machines!
 
     wrappers:
-      - mkphyscloud-qa-common-wrappers
+        - build-name:
+            name: '#${BUILD_NUMBER} ${ENV,var="cloudsource"} - qa${ENV,var="hw_number"} ${ENV,var="networkingplugin"}:${ENV,var="networkingmode"}'
     publishers:
       - mkphyscloud-qa-common-publishers
 
@@ -99,7 +101,18 @@
           name: clusterconfig
           default: services=2
           description: HA configuration for clusters. Make sense only if hacloud=1
-
+      
+      - string:
+          name: networkingplugin
+          default: linuxbridge
+          description: |
+              networking plugin to be used by Neutron. Available options are: openvswitch:gre, vlan, vxlan / linuxbridge:vlan
+       
+      - string:
+          name: networkingmode
+          default: vlan
+          description: networking mode to be used by Neutron. Available options are gre, vlan, vxlan
+      
       - string:
           name: nodenumber
           default: "7"
@@ -168,9 +181,14 @@
           export want_node_aliases=controller=2,compute=2,ceph=3 ;
           export want_node_roles=controller=2,compute=2,storage=3 ;
           export want_ceph=1 ;
+          export networkingplugin=$networkingplugin ;
+          export networkingmode=$networkingmode ;
           export cephvolumenumber=1 ;
           export scenario=\"/root/scenario.yml\" ;
           export commands=\"$commands\" "'
+
+          sed -i -e "s,##networkingplugin##,$networkingplugin," scenario.yml
+          sed -i -e "s,##networkingmode##,$networkingmode," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -114,11 +114,11 @@ proposals:
 - barclamp: neutron
   attributes:
     ml2_mechanism_drivers:
-    - linuxbridge
+    - ##networkingplugin##
     ml2_type_drivers:
-    - vlan
-    ml2_type_drivers_default_provider_network: vlan
-    ml2_type_drivers_default_tenant_network: vlan
+    - ##networkingmode##
+    ml2_type_drivers_default_provider_network: ##networkingmode##
+    ml2_type_drivers_default_tenant_network: ##networkingmode##
     num_vlans: 99
   deployment:
     elements:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -138,11 +138,11 @@ proposals:
 - barclamp: neutron
   attributes:
     ml2_mechanism_drivers:
-    - linuxbridge
+    - ##networkingplugin##
     ml2_type_drivers:
-    - vlan
-    ml2_type_drivers_default_provider_network: vlan
-    ml2_type_drivers_default_tenant_network: vlan
+    - ##networkingmode##
+    ml2_type_drivers_default_provider_network: ##networkingmode##
+    ml2_type_drivers_default_tenant_network: ##networkingmode##
     num_vlans: 99
   deployment:
     elements:


### PR DESCRIPTION
 Extend all 2c scenario to use both linuxbridge and ovs with vlan + vxlan neutron drivers.