### PR TITLE
Make use of Jenkins Log Parser plugin

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -517,8 +517,4 @@
          only-if-success: false
          fingerprint: false
          default-excludes: true
-      - email:
-         notify-every-unstable-build: true
-         recipients: null
-         send-to-individuals: false
     triggers: []

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -390,7 +390,6 @@
         # fetch the latest automation updates
         ${automationrepo}/scripts/jenkins/update_automation #NO PARAMETERS HERE ANY MORE!!!
 
-
         function mkcloudgating_trap()
         {
             $ghs -a set-status -s "failure" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context
@@ -445,6 +444,8 @@
             $ghs -a set-status -s "pending" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context -m "Started PR gating"
 
         fi
+
+        cp ${automationrepo}/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt log-parser-plugin-rules.txt
 
         echo "########################################################################"
         env
@@ -511,6 +512,12 @@
         fi
 
     publishers:
+      - logparser:
+          use-project-rules: true
+          parse-rules: log-parser-plugin-rules.txt
+          unstable-on-warning: true
+          fail-on-error: false
+          show-graphs: true
       - archive:
          artifacts: .artifacts/**
          allow-empty: false

--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -1,0 +1,8 @@
+start /^(===+> MKCLOUD STEP START: |MKCLOUD step: )/
+start /^Starting proposal/
+
+info /^\+ onadmin /
+info /^Waiting for /
+
+error /Error/
+error /$h1!!/


### PR DESCRIPTION
Take advantage of the Jenkins Log Parser plugin:

- https://wiki.jenkins-ci.org/display/JENKINS/Log+Parser+Plugin

This requires a patch to jenkins-job-builder in order for the per-project rules to be correctly activated during upload of the job to Jenkins:

- https://review.openstack.org/#/c/445509/

(However, it should not break anything if the patch is not applied.)

Once correctly configured, when viewing a job in the web UI, you can click on "Parsed Console Output" to see a nice analysis of the errors and warnings, broken down by mkcloud section.  Note that #1755 has already been merged to help clean up this UI.

Also remove the email publisher which breaks with the latest `jjb`.