### PR TITLE
temporarily disable aarch jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -65,7 +65,7 @@
 
 - project:
     name: cloud-mkcloud7-aarch64
-    disabled: false
+    disabled: true
     version: 7
     previous_version: 6
     arch: aarch64


### PR DESCRIPTION
The aarch workers are not available currently and the jenkins queue is filling up with aarch jobs - so disabling them temporarily.

The refactoring commits allow to disable any of the projects we have, to address issues with workers as well as bottlenecks in computation resources.
