### PR TITLE
Job enablement refactoring

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -6,6 +6,7 @@
         - 'cloud-mkcloud{version}-gating'
 - project:
     name: cloud-mkcloud6-x86_64
+    disabled: false
     version: 6
     previous_version: 5
     arch: x86_64
@@ -25,6 +26,7 @@
         - 'cloud-mkcloud{version}-job-xen-{arch}'
 - project:
     name: cloud-mkcloud6-ha-x86_64
+    disabled: false
     version: 6
     previous_version: 5
     arch: x86_64
@@ -36,6 +38,7 @@
         - 'cloud-mkcloud{version}-job-ha-{arch}'
 - project:
     name: cloud-mkcloud6-tempestfull-x86_64
+    disabled: false
     version: 6
     previous_version: 5
     arch: x86_64

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -7,6 +7,7 @@
         - 'cloud-mkcloud{version}-gating'
 - project:
     name: cloud-mkcloud7-x86_64
+    disabled: false
     version: 7
     previous_version: 6
     arch: x86_64
@@ -27,6 +28,7 @@
         - 'cloud-mkcloud{version}-job-xen-{arch}'
 - project:
     name: cloud-mkcloud7-ha-x86_64
+    disabled: false
     version: 7
     previous_version: 6
     arch: x86_64
@@ -42,6 +44,7 @@
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
 - project:
     name: cloud-mkcloud7-tempestfull-x86_64
+    disabled: false
     version: 7
     previous_version: 6
     arch: x86_64
@@ -52,6 +55,7 @@
          - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
 - project:
     name: cloud-mkcloud7-sles12sp2-x86_64
+    disabled: false
     version: 7
     arch: x86_64
     label: openstack-mkcloud-SLE12-SP2-x86_64
@@ -61,6 +65,7 @@
 
 - project:
     name: cloud-mkcloud7-aarch64
+    disabled: false
     version: 7
     previous_version: 6
     arch: aarch64
@@ -95,6 +100,7 @@
           #
 - project:
     name: cloud-mkcloud7-s390x
+    disabled: false
     version: 7
     previous_version: 6
     arch: s390x

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -80,24 +80,25 @@
         - 'cloud-mkcloud{version}-job-raid-{arch}'
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
 
-# mkcloud fixes missing for using generic nodenumber jobs on s390x
-          #- project:
-          #    name: cloud-mkcloud7-s390x
-          #    version: 7
-          #    previous_version: 6
-          #    arch: s390x
-          #    label: openstack-mkcloud-SLE12-{arch}
-          #    jobs:
-          #        - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
-          #        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
-          #        - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
-          #        - 'cloud-mkcloud{version}-job-dvr-{arch}'
-          #        - 'cloud-mkcloud{version}-job-ha-{arch}'
-          #        - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
-          #        - 'cloud-mkcloud{version}-job-raid-{arch}'
-          #        - 'cloud-mkcloud{version}-job-ssl-{arch}'
-          #        - 'cloud-mkcloud{version}-job-tempestfull-{arch}'
-          #
+- project:
+    name: cloud-mkcloud7-s390x-all
+    disabled: true
+    version: 7
+    previous_version: 6
+    arch: s390x
+    label: openstack-mkcloud-SLE12-{arch}
+    tempestoptions: --smoke
+    jobs:
+        - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
+        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
+        - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
+        - 'cloud-mkcloud{version}-job-dvr-{arch}'
+        - 'cloud-mkcloud{version}-job-ha-{arch}'
+        - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
+        - 'cloud-mkcloud{version}-job-raid-{arch}'
+        - 'cloud-mkcloud{version}-job-ssl-{arch}'
+        - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
+
 - project:
     name: cloud-mkcloud7-s390x
     disabled: false

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-tempestfull-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 3 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-2nodes-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 2 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 3 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 2 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-backup-restore-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-backup-restore-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 22 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-btrfs-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-btrfs-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H H * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar-devsetup-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-crowbar-devsetup-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 23 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-crowbar_register-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 23 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-storage-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-devel-storage-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H H */2 * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-devel-virt-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-devel-virt-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H H */2 * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-docker-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-docker-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H H * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-dvr-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 20 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-ha-compute-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 21 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 21 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-ha-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '11 2 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-hyperv-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-hyperv-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H H * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-magnum-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H H * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-many_compute-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-many_compute-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H H * * 6'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-raid-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 20 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ssl-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-ssl-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '29 1 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-uefi-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-uefi-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-uefi-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '29 1 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-upgrade-disruptive-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '32 22 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-dvr-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-dvr-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-dvr-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '32 22 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '32 22 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '32 22 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-upgrade-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: '32 22 * * *'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-xen-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'cloud-mkcloud{version}-job-xen-{arch}'
     node: cloud-trigger
+    disabled: {disabled}
 
     triggers:
       - timed: 'H 6 * * *'


### PR DESCRIPTION
allow to disable projects with a quick switch in jjb

Templates set the variable disabled=true to disable an entire project. The jobs are still there and deployed.

This helps when resouces are low or the workers of an additional arch are not available - they can be disabled now with a small change to the project configuration in jjb.

