### PR TITLE
Drop openSUSE 13.2

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
+++ b/jenkins/ci.opensuse.org/openstack-diskimage-builder.yaml
@@ -24,7 +24,6 @@
           values:
             - 42.2
             - 42.1
-            - 13.2
       - axis:
           type: user-defined
           name: suse_element
@@ -38,9 +37,6 @@
             - cloud-cleanvm
 
     execution-strategy:
-      # There are no pre-built cloud images for opensuse-13.2
-      combination-filter: |
-        !(suse_element=="opensuse" && opensuse_release=="13.2")
       # We can only use one VM at a time, so serialize all jobs
       sequential: true
 

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -35,7 +35,6 @@
             - SLE_12
             - SLE_12_SP1
             - SLE_12_SP2
-            - openSUSE_13.2
             - openSUSE_Leap_42.1
             - openSUSE_Leap_42.2
       - axis:
@@ -45,13 +44,13 @@
             - cloud-trackupstream
     execution-strategy:
       combination-filter: |
-       !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_11_SP3", "SLE_12", "openSUSE_13.2", "openSUSE_Leap_42.1", "SLE_12_SP1"].contains(repository) ||
+       !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_11_SP3", "SLE_12", "openSUSE_Leap_42.1", "SLE_12_SP1"].contains(repository) ||
          ["Cloud:OpenStack:Factory"].contains(project) && ["SLE_11_SP3", "SLE_12", "SLE_12_SP1", "SLE_12_SP2", "openSUSE_Leap_42.1", "openSUSE_Leap_42.2"].contains(repository) ||
          ["Cloud:OpenStack:Juno", "Cloud:OpenStack:Juno:Staging"].contains(project) && ["SLE_12_SP1", "SLE_12_SP2", "openSUSE_Leap_42.1", "openSUSE_Leap_42.2"].contains(repository)  ||
          ["Cloud:OpenStack:Liberty", "Cloud:OpenStack:Liberty:Staging"].contains(project) && ["SLE_11_SP3", "SLE_12_SP2", "openSUSE_Leap_42.2"].contains(repository) ||
-         ["Cloud:OpenStack:Mitaka", "Cloud:OpenStack:Mitaka:Staging"].contains(project) && ["openSUSE_13.2", "SLE_12", "SLE_11_SP3", "openSUSE_Leap_42.2"].contains(repository) ||
-         ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_13.2", "SLE_12", "SLE_12_SP1", "SLE_11_SP3"].contains(repository) ||
-         ["Cloud:OpenStack:Ocata", "Cloud:OpenStack:Ocata:Staging"].contains(project) && ["openSUSE_13.2", "SLE_12", "SLE_12_SP1", "openSUSE_Leap_42.1", "SLE_11_SP3"].contains(repository) ||
+         ["Cloud:OpenStack:Mitaka", "Cloud:OpenStack:Mitaka:Staging"].contains(project) && ["SLE_12", "SLE_11_SP3", "openSUSE_Leap_42.2"].contains(repository) ||
+         ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["SLE_12", "SLE_12_SP1", "SLE_11_SP3"].contains(repository) ||
+         ["Cloud:OpenStack:Ocata", "Cloud:OpenStack:Ocata:Staging"].contains(project) && ["SLE_12", "SLE_12_SP1", "openSUSE_Leap_42.1", "SLE_11_SP3"].contains(repository) ||
          ["Cloud:Tools"].contains(project) && ["SLE_11_SP3", "SLE_12"].contains(repository)
        )
       sequential: true


### PR DESCRIPTION
openSUSE 13.2 is no longer maintained, see
https://en.opensuse.org/Lifetime#Discontinued_distributions