### PR TITLE
Allow to setup an independent nfsserver for cinder

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1248,7 +1248,7 @@ function sanity_checks
     fi
 
     case $cinder_backend in
-        ''|netapp|local|raw|rbd)
+        ''|netapp|local|nfs|raw|rbd)
             ;;
         *)
             complain 101 "$cinder_backend as the cinder backend is currently not supported."

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -479,6 +479,14 @@ function crowbar_register
     done
 }
 
+# setup an NFS server on the first lonely node
+function lonelynode_nfs_server
+{
+    local nfsserver=($(nodes ids lonely))
+    local mac=$(macfunc $nfsserver)
+    onadmin setup_nfs_server $mac
+}
+
 function prepareinstcrowbar
 {
     echo "connecting to crowbar admin server at $adminip"
@@ -1282,6 +1290,7 @@ allcmds="$step_aliases _test_setuphost \
     crowbarbackup crowbarrestore shutdowncloud restartcloud qa_test help \
     rebootneutron cloudupgrade \
     setuplonelynodes crowbar_register createadminsnapshot \
+    lonelynode_nfs_server \
     restoreadminfromsnapshot createcloudsnapshot restorecloudfromsnapshot \
     cct steps batch setup_aliases onadmin onhost devsetup plain_with_upgrade_test \
     testpreupgrade testpostupgrade"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2909,6 +2909,10 @@ function custom_configuration
                 netapp)
                     cinder_netapp_proposal_configuration "0"
                     ;;
+                nfs)
+                    proposal_set_value cinder default "['attributes']['cinder']['volumes'][0]['backend_name']" "'backend_nfs'"
+                    proposal_set_value cinder default "['attributes']['cinder']['volumes'][0]['nfs']['nfs_shares']" "'nfsserver:/srv/nfs/cinder'"
+                    ;;
             esac
 
             # add a second backend to enable multi-backend, if not already present

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2513,7 +2513,6 @@ function custom_configuration
             [ "$want_multidnstest" = 1 ] || return 0
             local cmachines=$(get_all_suse_nodes | head -n 3)
             local dnsnodes=`echo \"$cmachines\" | sed 's/ /", "/g'`
-            proposal_set_value dns default "['attributes']['dns']['records']" "{}"
             proposal_set_value dns default "['attributes']['dns']['records']['multi-dns']" "{}"
             # We could do the usual "if iscloudver 6plus ; then", but this
             # would break mkcloud when installing Cloud 6 without updates


### PR DESCRIPTION
When testing the upgrade from 6 to 7 we need to use a cinder backend that doesn't use storage that is located on any of the cloud nodes (or the admin node) to have it available during the whole upgrade process. This PR adds the ability to have mkcloud setup a "lonelynode" with an NFS server running that is exporting /srv/nfs/cinder.