### PR TITLE
Revert "mkcloud: fix cloudbrlimit due to merge of PR #1750"

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -115,8 +115,8 @@ next_pv_device=
 pv_cur_device_no=0
 
 : ${cloudbr:=${cloud}br}
-# IFNAMSIZ - 1 - 4 (vlan suffix likely length) - 2 (for interface number from PR #1750)
-cloudbrlimit=9
+# IFNAMSIZ - 1 - 4 (vlan suffix likely length)
+cloudbrlimit=11
 [[ ${#cloudbr} -gt $cloudbrlimit ]] && complain 100 "cloudbr name is too long (> $cloudbrlimit); \$cloud must be shorter"
 
 #if localreposdir_src string is available, the local repositories are used for setup


### PR DESCRIPTION
This reverts commit 2e75e274af462518277ac32f7e31d2d413806649.