### PR TITLE
fixes for cinder tests

### DIFF
--- a/scripts/heat/ping_template.sh
+++ b/scripts/heat/ping_template.sh
@@ -47,14 +47,22 @@ chmod +x /usr/bin/ping_forever_neighbour
 cat >> /usr/bin/cinder_test << EOF
   #!/bin/sh
 
+  trap "" 1
+
+  if [ `id -u` -ne 0 ]; then
+    echo "please run as root"
+    exit 1
+  fi
+
   device="/dev/vdb"
   while [ ! -e \$device ]; do
       echo "waiting for \$device to be ready"
+      echo 1 > /sys/bus/pci/rescan
       sleep 10
   done
 
-  sudo mkfs -t ext4 -L cinder_volume \$device
-  sudo mount \$device /mnt
+  mkfs -t ext4 -L cinder_volume \$device
+  mount \$device /mnt
 
   while [ 1 = 1 ]; do
       date +%s >> /mnt/cinder_test.out


### PR DESCRIPTION
The cinder test script was ending abruptly for no reason. A trap capture has been put in place to prevent that behavior, the same way the other scripts do.

Additionally a mechanism to allow for recovery when the cinder volume is not attached on time has been added.

The use of `sudo` to write the output file has been added mainly to support debugging on cloud7, since on cloud6 that wasn't necessary.