### PR TITLE
Extend 1a scenario

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -10,11 +10,12 @@
         - HA with IPMI (3 controllers)
         - shared device for DB and rabbit
         - swift
+        - Neutron: linuxbridge or OVS
 
       It will wipe all machines in the selected cloud!
 
     wrappers:
-      - mkphyscloud-qa-common-wrappers
+      - mkphyscloud-qa-build-name-wrapper 
     publishers:
       - mkphyscloud-qa-common-publishers
 
@@ -52,7 +53,18 @@
           name: branch
           default: master
           description: Mandatory, automation repo branch
+      
+      - string:
+          name: networkingplugin
+          default: linuxbridge
+          description: |
+               networking plugin to be used by Neutron. Available options are: openvswitch:gre, vlan, vxlan / linuxbridge:vlan
 
+      - string: 
+          name: networkingmode
+          default: vlan
+          description: networking mode to be used by Neutron. Available options are gre, vlan, vxlan
+          
       - string:
           name: tempest
           default: smoke
@@ -92,36 +104,45 @@
       - string:
           name: cloudsource
           default: develcloud$cloud_version
+
       - string:
           name: upgrade_cloudsource
           default: develcloud$(($cloud_version + 1))
+
       - string:
           name: TESTHEAD
           default: "1"
           description: if non-empty, test latest version from Devel:Cloud Stagin
+
       - string:
           name: hacloud
           default: "1"
           description: By default we do not want HA configured and installed
+
       - string:
           name: clusterconfig
           default: services=3
           description: HA configuration for clusters. Make sense only if hacloud=1
+
       - string:
           name: nodenumber
           default: "7"
           description: Number of nodes to use; is scenario specific
+
       - string:
           name: want_ipmi
           default: "true"
+
       - string:
           name: commands
           default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
           description: All the steps that needs to be completed to have cloud installed
+
       - text:
           name: UPDATEREPOS
           default:
           description: Update repositories (one URL per line)
+
       - bool:
           name: UPDATEBEFOREINSTALL
           default: false
@@ -179,12 +200,16 @@
           export clusterconfig=$clusterconfig ;
           export shared_storage_ip=$shared_storage_ip
           export want_node_aliases=controller=3,compute-kvm=2,storage-swift=2 ;
+          export networkingplugin=$networkingplugin ;
+          export networkingmode=$networkingmode ;
           export scenario=\"/root/scenario.yml\" ;
           export commands=\"$commands\" "'
 
           sed -i -e "s,##shared_nfs_for_database##,$shared_storage_ip:/var/$cloud/ha-database," scenario.yml
           sed -i -e "s,##shared_nfs_for_rabbitmq##,$shared_storage_ip:/var/$cloud/ha-rabbitmq," scenario.yml
           sed -i -e "s,##cinder-storage-shares##,$shared_storage_ip:/var/$cloud/cinder-storage," scenario.yml
+          sed -i -e "s,##networkingplugin##,$networkingplugin," scenario.yml
+          sed -i -e "s,##networkingmode##,$networkingmode," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -115,12 +115,12 @@ proposals:
 - barclamp: neutron
   attributes:
     ml2_mechanism_drivers:
-    - linuxbridge
+    - ##networkingplugin##
     ml2_type_drivers:
-    - vlan
+    - ##networkingmode##
     num_vlans: 99
-    ml2_type_drivers_default_provider_network: vlan
-    ml2_type_drivers_default_tenant_network: vlan
+    ml2_type_drivers_default_provider_network: ##networkingmode##
+    ml2_type_drivers_default_tenant_network: ##networkingmode##
   deployment:
     elements:
       neutron-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -134,12 +134,12 @@ proposals:
 - barclamp: neutron
   attributes:
     ml2_mechanism_drivers:
-    - linuxbridge
+    - ##networkingplugin##
     ml2_type_drivers:
-    - vlan
+    - ##networkingmode##
     num_vlans: 99
-    ml2_type_drivers_default_provider_network: vlan
-    ml2_type_drivers_default_tenant_network: vlan
+    ml2_type_drivers_default_provider_network: ##networkingmode##
+    ml2_type_drivers_default_tenant_network: ##networkingmode##
     ssl:
       generate_certs: true
       insecure: true


### PR DESCRIPTION
Extend 1a scenario to use both linuxbridge and ovs with vlan + vxlan neutron drivers.