### PR TITLE
Extend 9 scenario

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
@@ -12,11 +12,12 @@
         - HA with SBD (2 nodes)
         - ceph (3 nodes)
         - 2 kvm compute nodes
+        - Neutron: linuxbridge and OVS
 
       It will wipe all QA2 machines!
 
     wrappers:
-      - mkphyscloud-qa-common-wrappers
+      - mkphyscloud-qa-build-name-wrapper      
     publishers:
       - mkphyscloud-qa-common-publishers
 
@@ -50,6 +51,17 @@
           default: master
           description: Mandatory, automation repo branch
       
+      - string:
+          name: networkingplugin
+          default: openvswitch
+          description: |
+              networking plugin to be used by Neutron. Available options are: openvswitch:gre, vlan, vxlan / linuxbridge:vlan
+
+      - string:
+          name: networkingmode
+          default: vxlan
+          description: Networking mode to be used by Neutron. Available options are gre, vlan, vxlan
+
       - string:
           name: tempest
           default: smoke
@@ -172,8 +184,13 @@
           export networkingplugin=openvswitch ;
           export networkingmode=vlan ;
           export cephvolumenumber=1 ;
+          export networkingplugin=$networkingplugin ;
+          export networkingmode=$networkingmode ;
           export scenario=\"/root/scenario.yml\" ;
           export commands=\"$commands\" "'
+
+          sed -i -e "s,##networkingplugin##,$networkingplugin," scenario.yml
+          sed -i -e "s,##networkingmode##,$networkingmode," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
@@ -113,13 +113,11 @@ proposals:
     use_dvr: true
     use_l2pop: true
     ml2_mechanism_drivers:
-    - openvswitch
+    - ##networkingplugin##
     ml2_type_drivers:
-    - gre
-    - vlan
-    - vxlan
-    ml2_type_drivers_default_provider_network: vxlan
-    ml2_type_drivers_default_tenant_network: vxlan
+    - ##networkingmode##
+    ml2_type_drivers_default_provider_network: ##networkingmode##
+    ml2_type_drivers_default_tenant_network: ##networkingmode##
     num_vlans: 99
   deployment:
     elements:


### PR DESCRIPTION
Extend 9 scenario to use both linuxbridge and ovs with vlan + vxlan neutron drivers.