### PR TITLE
Add a new wrapper for build names

### DIFF
--- a/jenkins/ci.suse.de/macros.yaml
+++ b/jenkins/ci.suse.de/macros.yaml
@@ -6,6 +6,13 @@
           name: '#${BUILD_NUMBER}: ${ENV,var="cloudsource"}'
       - timestamps
 
+- wrapper:
+    name: mkphyscloud-qa-build-name-wrapper
+    wrappers: 
+      - build-name:
+          name: '#${BUILD_NUMBER} ${ENV,var="cloudsource"} - qa${ENV,var="hw_number"} ${ENV,var="networkingplugin"}:${ENV,var="networkingmode"}'
+      - timestamps
+
 - publisher:
     name: mkphyscloud-qa-common-publishers
     publishers:


### PR DESCRIPTION
We're planning to use a new wrapper for build names, so ` #478 develcloud6` will become `#478 develcloud6 - qa3 linuxbridge:vlan`