### PR TITLE
Use ldappool with keystone LDAP backend

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2555,7 +2555,7 @@ function custom_configuration
                     $p "['attributes']['keystone']['identity']['driver']" "'keystone.identity.backends.hybrid.Identity'"
                     $p "['attributes']['keystone']['assignment']['driver']" "'keystone.assignment.backends.hybrid.Assignment'"
                 fi
-                $p "$l['url']" "'ldap://ldap.suse.de'"
+                $p "$l['url']" "'ldaps://ldap.suse.de'"
                 $p "$l['suffix']" "'dc=suse,dc=de'"
                 $p "$l['user_tree_dn']" "'ou=accounts,dc=suse,dc=de'"
                 $p "$l['user_objectclass']" "'posixAccount'"
@@ -2567,10 +2567,10 @@ function custom_configuration
                 $p "$l['group_name_attribute']" "'cn'"
                 $p "$l['group_member_attribute']" "'memberUid'"
                 $p "$l['group_members_are_ids']" "true"
-                $p "$l['use_tls']" "true"
+                $p "$l['use_tls']" "false"
                 $p "$l['tls_cacertdir']" "'/etc/ssl/certs'"
                 $p "$l['tls_req_cert']" "'demand'"
-                $p "$l['use_pool']" "false" # ldappool does not work with tls https://review.openstack.org/#/c/443264/
+                $p "$l['use_pool']" "true"
             fi
             if [[ $want_keystone_v3 ]] ; then
                 proposal_set_value keystone default "['attributes']['keystone']['api']['version']" "'3'"


### PR DESCRIPTION
ldappool significantly speeds up LDAP requests[1] so it's a good idea to use
it. We weren't using it before because there was a bug making it incompatible
with the use_ssl parameter[2]. The bug has been fixed but not released, but we
can use LDAPS rather than StartTLS and avoid the problem entirely.

[1] https://www.mattfischer.com/blog/?p=624
[2] https://review.openstack.org/#/c/443264/