### PR TITLE
Make "nfs" a valid cinder_backend choice for the mkcloud job

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -166,6 +166,7 @@
            - raw
            - rbd
            - netapp
+           - nfs
      - bool:
          name: want_cindermultibackend
          default: false
@@ -336,6 +337,8 @@
 
         if [[ $cinder_backend = " " ]] ; then
           cinder_backend=""
+        elif [[ $cinder_backend = "nfs" ]] ; then
+          export nodenumberlonelynode=1
         fi
 
 

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-dvr-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-dvr-template.yaml
@@ -23,8 +23,9 @@
             nodenumber=5
             hacloud=1
             storage_method=swift
+            cinder_backend=nfs
             want_nodesupgrade=1
-            mkcloudtarget=plain_with_upgrade_test testsetup
+            mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server proposal testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
             label={label}
             want_ceilometer_proposal=0
             want_dvr=1

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -23,8 +23,9 @@
             nodenumber=5
             hacloud=1
             storage_method=swift
+            cinder_backend=nfs
             want_nodesupgrade=1
             want_ping_running_instances=1
-            mkcloudtarget=plain_with_upgrade_test testsetup
+            mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server proposal testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}


### PR DESCRIPTION
With https://github.com/SUSE-Cloud/automation/pull/1766 we're able to deploy cinder using the nfs backend. This adapts the mkcloud job to utilize that in the jenkins jobs.