### PR TITLE
jenkins: allow trigger jobs to run on other cloud trigger nodes

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -28,7 +28,7 @@
           ## THIS IS A TRIGGER JOB ONLY - NO WORKER CODE IN HERE - DO NOT DARE TO ADD SOME
           ## TRIGGER JOBS ARE MOVED TO A DEDICATED TRIGGER NODE
           ## THIS JOB IS ABOUT PRs FOR THE AUTOMATION REPO
-          [[ $NODE_NAME != 'cloud-trigger' ]] && exit 99
+          [[ $NODE_NAME =~ cloud.?trigger ]] || exit 99
           ##
 
           set -x

--- a/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-cct-pr-trigger.yaml
@@ -28,7 +28,7 @@
           ## THIS IS A TRIGGER JOB ONLY - NO WORKER CODE IN HERE - DO NOT DARE TO ADD SOME
           ## TRIGGER JOBS ARE MOVED TO A DEDICATED TRIGGER NODE
           ## THIS JOB IS ABOUT PRs FOR THE CCT REPO
-          [[ $NODE_NAME != 'cloud-trigger' ]] && exit 99
+          [[ $NODE_NAME =~ cloud.?trigger ]] || exit 99
           ##
 
           set -x

--- a/jenkins/ci.suse.de/cloud-crowbar-sap-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-sap-testbuild-pr-trigger.yaml
@@ -29,7 +29,7 @@
           ## THIS IS A TRIGGER JOB ONLY - NO WORKER CODE IN HERE - DO NOT DARE TO ADD SOME
           ## TRIGGER JOBS ARE MOVED TO A DEDICATED TRIGGER NODE
           ## THIS JOB IS ABOUT PRs FOR THE CCT REPO
-          [[ $NODE_NAME != 'cloud-trigger' ]] && exit 99
+          [[ $NODE_NAME =~ cloud.?trigger ]] || exit 99
           ##
 
           set -x

--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -28,7 +28,7 @@
           ## THIS IS A TRIGGER JOB ONLY - NO WORKER CODE IN HERE - DO NOT DARE TO ADD SOME
           ## TRIGGER JOBS ARE MOVED TO A DEDICATED TRIGGER NODE
           ## THIS JOB IS ABOUT PRs FOR THE CCT REPO
-          [[ $NODE_NAME != 'cloud-trigger' ]] && exit 99
+          [[ $NODE_NAME =~ cloud.?trigger ]] || exit 99
           ##
 
           set -x

--- a/jenkins/ci.suse.de/cloud-update-ci.yaml
+++ b/jenkins/ci.suse.de/cloud-update-ci.yaml
@@ -25,7 +25,7 @@
       - shell: |
           ## THIS JOB ONLY UPDATES JENKINS JOBS - NO WORKER CODE IN HERE - DO NOT DARE TO ADD SOME
           ## THUS RUNNING ON THE DEDICATED TRIGGER NODE
-          [[ $NODE_NAME != 'cloud-trigger' ]] && exit 99
+          [[ $NODE_NAME =~ cloud.?trigger ]] || exit 99
           ##
 
           set -x


### PR DESCRIPTION
to allow having more than one, allowing for easy maintenance

When this is merged and deployed, we can enable again
https://ci.suse.de/computer/cloud-swarm-p1cloudtrigger/