### PR TITLE
make Jenkins Log Parser plugin check for warnings

### DIFF
--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -4,5 +4,9 @@ start /^Starting proposal/
 info /^\+ onadmin /
 info /^Waiting for /
 
+ok /Warning: Turning on '--gpg-auto-import-keys'/
+ok /Warning: Permanently added .* to the list of known hosts/
+warning /(?i)warning/
+
 error /Error/
 error /$h1!!/


### PR DESCRIPTION
We exclude some warnings which we know are fine in an mkcloud context.