### PR TITLE
stop Log Parser Plugin marking builds unstable on warning

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -524,7 +524,7 @@
       - logparser:
           use-project-rules: true
           parse-rules: log-parser-plugin-rules.txt
-          unstable-on-warning: true
+          unstable-on-warning: false
           fail-on-error: false
           show-graphs: true
       - archive:


### PR DESCRIPTION
When the Log Parser Plugin sees warnings, it marks the build as unstable which causes yellow icons instead of green.  That doesn't really help us, especially considering that `openstack-mkcloud` will never stabilise (because it's covering an enormous range of scenarios of vastly different degrees of stability) so disable it.