### PR TITLE
tidy up openstack-mkcloud YAML

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -9,300 +9,300 @@
       on mkcloudresultcheck@mkcloudresultcheck.cloud.suse.de every 15 minutes
 
     logrotate:
-        numToKeep: 2000
-        daysToKeep: 300
+      numToKeep: 2000
+      daysToKeep: 300
 
     properties:
       - authorization:
           cloud:
-               - job-build
-               - job-cancel
-               - job-configure
-               - job-delete
-               - job-discover
-               - job-read
-               - job-workspace
-               - run-delete
-               - run-update
-               - scm-tag
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-delete
+            - job-discover
+            - job-read
+            - job-workspace
+            - run-delete
+            - run-update
+            - scm-tag
           anonymous:
-               - job-read
+            - job-read
 
     parameters:
 
-    ################################################
-    # CI job run
+      ################################################
+      # CI job run
 
-     - string:
-        name: mkcloudtarget
-        default: all
-        description: Set mkcloudtarget to define the mkcloud command line parameters.
+      - string:
+          name: mkcloudtarget
+          default: all
+          description: Set mkcloudtarget to define the mkcloud command line parameters.
 
-     - string:
-         name: github_pr
-         description: |
-              String is a ':' separated list of these vaules: $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context Note:
-              SHA1 must be latest commit in PR, $context is optional  (only use if multiple gating runs needed per PR)
+      - string:
+          name: github_pr
+          description: |
+            String is a ':' separated list of these values: $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context Note:
+            SHA1 must be latest commit in PR, $context is optional  (only use if multiple gating runs needed per PR)
 
-     - string:
-         name: job_name
-         default: "-no-name-"
-         description: |
-              This name will become the build name of the job. It will appear in the list of builds (webUI, RSS feed).
+      - string:
+          name: job_name
+          default: "-no-name-"
+          description: |
+            This name will become the build name of the job. It will appear in the list of builds (webUI, RSS feed).
 
-     - string:
-         name: scenario
-         default:
-         description: |
-          Defines which scenario file should be used. Only works with cloud5 or newer.
-          Currently only the 'batch' step uses such a file.
+      - string:
+          name: scenario
+          default:
+          description: |
+            Defines which scenario file should be used. Only works with cloud5 or newer.
+            Currently only the 'batch' step uses such a file.
 
-     - label:
-         name: label
-         default: openstack-mkcloud
-         description: |
-          Default: openstack-mkcloud | Possible values:
-          openstack-mkcloud-SLE11 (SLE11 host) |
-          openstack-mkcloud-SLE12 (SLE12 host) | openstack-mkcloud-SLE12-aarch64 (SLE12 aarch64 host)
+      - label:
+          name: label
+          default: openstack-mkcloud
+          description: |
+            Default: openstack-mkcloud | Possible values:
+            openstack-mkcloud-SLE11 (SLE11 host) |
+            openstack-mkcloud-SLE12 (SLE12 host) | openstack-mkcloud-SLE12-aarch64 (SLE12 aarch64 host)
 
-    ################################################
-    # repositories
+      ################################################
+      # repositories
 
-     - string:
-        name: cloudsource
-        default: develcloud7
-        description: |
-             Can be something like develcloud6 (uses Devel:Cloud:*, see TESTHEAD parameter for Staging),  susecloud6 (uses SUSE:*), GM3 (uses the GM ISO)
+      - string:
+          name: cloudsource
+          default: develcloud7
+          description: |
+            Can be something like develcloud6 (uses Devel:Cloud:*, see TESTHEAD parameter for Staging),  susecloud6 (uses SUSE:*), GM3 (uses the GM ISO)
 
-     - text:
-         name: UPDATEREPOS
-         default:
-         description: |
-              Update repositories (one URL per line)
+      - text:
+          name: UPDATEREPOS
+          default:
+          description: |
+               Update repositories (one URL per line)
 
-     - bool:
-         name: UPDATEBEFOREINSTALL
-         default: false
-         description: 'add update repos before crowbar install'
+      - bool:
+          name: UPDATEBEFOREINSTALL
+          default: false
+          description: 'add update repos before crowbar install'
 
-     - string:
-         name: TESTHEAD
-         default : '1'
-         description: |
-              if non-empty, test latest version from Devel:Cloud (:1.0)
+      - string:
+          name: TESTHEAD
+          default: '1'
+          description: |
+               if non-empty, test latest version from Devel:Cloud (:1.0)
 
-     - string:
-         name: want_test_updates
-         default:
-         description: allow disabling of test updates
+      - string:
+          name: want_test_updates
+          default:
+          description: allow disabling of test updates
 
-     - string:
-         name: want_sles12
-         default:
-         description: Set to 1 if sle12 nodes should be installed
+      - string:
+          name: want_sles12
+          default:
+          description: Set to 1 if sle12 nodes should be installed
 
-     - string:
-         name: want_sles12sp2
-         default:
-         description: deploy cloud7 with SP2 instead of SP1
+      - string:
+          name: want_sles12sp2
+          default:
+          description: deploy cloud7 with SP2 instead of SP1
 
-     - string:
-         name: upgrade_cloudsource
-         default:
-         description: In case of using upgrade, upgrade to that cloudsource version
+      - string:
+          name: upgrade_cloudsource
+          default:
+          description: In case of using upgrade, upgrade to that cloudsource version
 
-    ################################################
-    # cloud shape and size
+      ################################################
+      # cloud shape and size
 
-     - choice:
-         name: libvirt_type
-         choices:
-           - kvm
-           - xen
-           - hyperv
+      - choice:
+          name: libvirt_type
+          choices:
+            - kvm
+            - xen
+            - hyperv
 
-     - string:
-         name: nodenumber
-         default: '2'
-         description: number of nodes excl. admin-node minimum 2=controller+compute
+      - string:
+          name: nodenumber
+          default: '2'
+          description: number of nodes excl. admin-node minimum 2=controller+compute
 
-     - string:
-         name: nodenumbercompute
-         default:
-         description: Number of compute nodes
+      - string:
+          name: nodenumbercompute
+          default:
+          description: Number of compute nodes
 
-     - bool:
-         name: WITHCROWBARREGISTER
-         default: false
-         description: boot up one lonely node in the admin network and register it with crowbar_register (image type depends on want_sles12 parameter)
+      - bool:
+          name: WITHCROWBARREGISTER
+          default: false
+          description: boot up one lonely node in the admin network and register it with crowbar_register (image type depends on want_sles12 parameter)
 
-     - string:
-         name: want_node_aliases
-         default:
-         description: |
-           List of aliases to assign to nodes.
-           Takes all provided aliases and assign them to available nodes successively.
-           Examples want_node_aliases='controller=1,ceph=2,compute=1'
-           assigns the aliases to 4 nodes as controller, ceph1, ceph2, compute
-            want_node_aliases='data=1,services=2,storage=2'
-            assigns the aliases to 5 nodes as data, service1, service2,
-            storage1, storage2
+      - string:
+          name: want_node_aliases
+          default:
+          description: |
+            List of aliases to assign to nodes.
+            Takes all provided aliases and assign them to available nodes successively.
+            Examples want_node_aliases='controller=1,ceph=2,compute=1'
+            assigns the aliases to 4 nodes as controller, ceph1, ceph2, compute
+             want_node_aliases='data=1,services=2,storage=2'
+             assigns the aliases to 5 nodes as data, service1, service2,
+             storage1, storage2
 
-     - string:
-         name: hacloud
-         default:
-         description: If hacloud=1 then deploy a 4-node cluster
+      - string:
+          name: hacloud
+          default:
+          description: If hacloud=1 then deploy a 4-node cluster
 
-     - string:
-         name: clusterconfig
-         default:
-         description: the cluster configuration to pass to the mkcloud script
+      - string:
+          name: clusterconfig
+          default:
+          description: the cluster configuration to pass to the mkcloud script
 
-     - string:
-         name: vcpus
-         default: '2'
-         description: number of vcpus for the compute nodes
+      - string:
+          name: vcpus
+          default: '2'
+          description: number of vcpus for the compute nodes
 
-    ################################################
-    # OS deployment
+      ################################################
+      # OS deployment
 
-     - string:
-         name: want_efi
-         default:
-         description: Set to UEFI boot admin node
+      - string:
+          name: want_efi
+          default:
+          description: Set to UEFI boot admin node
 
-     - string:
-         name: want_rootfs
-         default:
-         description: set to btrfs to deploy with btrfs
+      - string:
+          name: want_rootfs
+          default:
+          description: set to btrfs to deploy with btrfs
 
-    ################################################
-    # general OpenStack deployment
+      ################################################
+      # general OpenStack deployment
 
-     - string:
-         name: want_postgresql
-         default:
-         description: set to 1 to deploy with postgresql
+      - string:
+          name: want_postgresql
+          default:
+          description: set to 1 to deploy with postgresql
 
-     - string:
-         name: want_all_ssl
-         default:
-         description: set to 1 to deploy all cloud services with SSL aka HTTPS
+      - string:
+          name: want_all_ssl
+          default:
+          description: set to 1 to deploy all cloud services with SSL aka HTTPS
 
-    ################################################
-    # neutron
+      ################################################
+      # neutron
 
-     - choice:
-         name: networkingplugin
-         choices:
+      - choice:
+          name: networkingplugin
+          choices:
             - openvswitch
             - linuxbridge
 
-     - choice:
-         name: networkingmode
-         choices:
-             - gre
-             - vlan
-             - vxlan
+      - choice:
+          name: networkingmode
+          choices:
+            - gre
+            - vlan
+            - vxlan
 
-    ################################################
-    # storage
+      ################################################
+      # storage
 
-     - choice:
-         name: storage_method
-         description: |
-              Select storage method: default (let mkcloud decide), none (enforce none)
-         choices:
+      - choice:
+          name: storage_method
+          description: |
+            Select storage method: default (let mkcloud decide), none (enforce none)
+          choices:
             - default
             - none
             - swift
             - ceph
 
-     - choice:
-         name: cinder_backend
-         choices:
-           - " "
-           - local
-           - raw
-           - rbd
-           - netapp
-           - nfs
+      - choice:
+          name: cinder_backend
+          choices:
+            - " "
+            - local
+            - raw
+            - rbd
+            - netapp
+            - nfs
 
-     - bool:
-         name: want_cindermultibackend
-         default: false
-         description: enables deployment of more than one cinder backend
+      - bool:
+          name: want_cindermultibackend
+          default: false
+          description: enables deployment of more than one cinder backend
 
-     - string:
-         name: cinder_netapp_login
-         default:
-         description: the password for the user "openstack" as configured on the netapp server
+      - string:
+          name: cinder_netapp_login
+          default:
+          description: the password for the user "openstack" as configured on the netapp server
 
-     - string:
-         name: cinder_netapp_password
-         default:
-         description: the password for the user "openstack" as configured on the netapp server
+      - string:
+          name: cinder_netapp_password
+          default:
+          description: the password for the user "openstack" as configured on the netapp server
 
-    ################################################
-    # tempest
+      ################################################
+      # tempest
 
-     - string:
-         name: want_tempest
-         default:
-         description: can be used for force off(0) or on(1)
+      - string:
+          name: want_tempest
+          default:
+          description: can be used for force off(0) or on(1)
 
-     - string:
-         name: tempestoptions
-         default:
-         description: |
-           Additional options to pass to the "tempest run " step. The default is cloudversion
-           specific but will default to a smoke run.
+      - string:
+          name: tempestoptions
+          default:
+          description: |
+            Additional options to pass to the "tempest run " step. The default is cloudversion
+            specific but will default to a smoke run.
 
-    ################################################
-    # horizon
+      ################################################
+      # horizon
 
-     - string:
-         name: want_horizon_integration_test
-         default:
-         description: |
-             Execute selenium integration tests for Horizon after Tempest. This test is in beta, and
-             a fail will not be considered for now.
+      - string:
+          name: want_horizon_integration_test
+          default:
+          description: |
+              Execute selenium integration tests for Horizon after Tempest. This test is in beta, and
+              a fail will not be considered for now.
 
-    ################################################
-    # extras
+      ################################################
+      # extras
 
-     - string:
-         name: want_docker
-         default:
-         description: set to 1 to deploy with docker
+      - string:
+          name: want_docker
+          default:
+          description: set to 1 to deploy with docker
 
-     - string:
-         name: want_magnum
-         default:
-         description: Deploy with Magnum
+      - string:
+          name: want_magnum
+          default:
+          description: Deploy with Magnum
 
-     - string:
-         name: want_barbican
-         default:
-         description: Deploy with Barbican
+      - string:
+          name: want_barbican
+          default:
+          description: Deploy with Barbican
 
-     - string:
-         name: want_sahara
-         default:
-         description: set to 1 to deploy sahara
+      - string:
+          name: want_sahara
+          default:
+          description: set to 1 to deploy sahara
 
-     - string:
-         name: want_murano
-         default:
-         description: set to 1 to deploy murano
+      - string:
+          name: want_murano
+          default:
+          description: set to 1 to deploy murano
 
-     - string:
-         name: want_aodh
-         default: '1'
-         description: set to 0 to not deploy aodh
+      - string:
+          name: want_aodh
+          default: '1'
+          description: set to 0 to not deploy aodh
 
-    ################################################
-    # misc
+      ################################################
+      # misc
 
      - string:
          name: want_nodesupgrade
@@ -314,256 +314,256 @@
          default:
          description: set to 1 to ping running instances during the upgrade
 
-     - text:
-         name: custom_settings
-         default:
-         description: |
-              This holds shell code and will be executed before calling mkcloud. This should not be used by default or regularly. It is meant to test PRs with special configurations.
+      - text:
+          name: custom_settings
+          default:
+          description: |
+               This holds shell code and will be executed before calling mkcloud. This should not be used by default or regularly. It is meant to test PRs with special configurations.
 
     wrappers:
-     - timestamps:
-     - build-name:
-         name: '#${BUILD_NUMBER}: ${ENV,var="job_name"}'
-     - timeout:
-        timeout: 60
-        type: no-activity
-        abort: true
-        write-description: "Job aborted due to 60 minutes of inactivity."
+      - timestamps:
+      - build-name:
+          name: '#${BUILD_NUMBER}: ${ENV,var="job_name"}'
+      - timeout:
+          timeout: 60
+          type: no-activity
+          abort: true
+          write-description: "Job aborted due to 60 minutes of inactivity."
 
     builders:
-    - shell: |
-        set -x
-        shopt -s extglob
-        # emptying the workspace
-        mkdir -p empty
-        rsync -r --delete empty/ ./
+      - shell: |
+          set -x
+          shopt -s extglob
+          # emptying the workspace
+          mkdir -p empty
+          rsync -r --delete empty/ ./
 
-        export artifacts_dir=$WORKSPACE/.artifacts
-        rm -rf $artifacts_dir
-        mkdir -p $artifacts_dir
-        touch $artifacts_dir/.ignore
-        export log_dir=$artifacts_dir/mkcloud_log
+          export artifacts_dir=$WORKSPACE/.artifacts
+          rm -rf $artifacts_dir
+          mkdir -p $artifacts_dir
+          touch $artifacts_dir/.ignore
+          export log_dir=$artifacts_dir/mkcloud_log
 
-        export automationrepo=~/github.com/SUSE-Cloud/automation
-        jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
-        export debug_qa_crowbarsetup=1
-        export cephvolumenumber=1 # one disk is either cinder raw, ceph-osd or swift storage
-        export debug=0
-        export want_neutronsles12=1
-        export want_mtu_size=8900
-        [[ $libvirt_type = hyperv ]] && want_mtu_size=1500 # windows-PXE-bootloader seems to not like jumbo-packets
-        export rally_server=backup.cloudadm.qa.suse.de
-        # to not fail when two concurrent zypper runs happen:
-        export ZYPP_LOCK_TIMEOUT=120
+          export automationrepo=~/github.com/SUSE-Cloud/automation
+          jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
+          export debug_qa_crowbarsetup=1
+          export cephvolumenumber=1 # one disk is either cinder raw, ceph-osd or swift storage
+          export debug=0
+          export want_neutronsles12=1
+          export want_mtu_size=8900
+          [[ $libvirt_type = hyperv ]] && want_mtu_size=1500 # windows-PXE-bootloader seems to not like jumbo-packets
+          export rally_server=backup.cloudadm.qa.suse.de
+          # to not fail when two concurrent zypper runs happen:
+          export ZYPP_LOCK_TIMEOUT=120
 
-        case $cloudsource in
-            GM4|GM4+up|GM5|GM5+up)
-                echo "Not setting want_ldap=1"
-                ;;
-            develcloud6)
-                if [[ $mkcloudtarget =~ upgrade ]]; then
-                    echo "Unsetting want_ldap for upgrade jobs until hybrid backend is ported to Mitaka"
-                    unset want_ldap
-                fi
-                ;;
-            M*|develcloud7|mitakacloud7|susecloud7)
-                if [[ $mkcloudtarget =~ upgrade ]]; then
-                    echo "Unsetting want_ldap for upgrade jobs until hybrid backend is migrated to domain-specific backends"
-                    unset want_ldap
-                else
-                    [[ $nodenumber == 2 && -z "$scenario" ]] && export want_ldap=1
-                fi
-                ;;
-            *)
-                [[ $nodenumber == 2 && -z "$scenario" ]] && export want_ldap=1
-                ;;
-        esac
-
-
-        if [[ $cinder_backend = " " ]] ; then
-          cinder_backend=""
-        elif [[ $cinder_backend = "nfs" ]] ; then
-          export nodenumberlonelynode=1
-        fi
+          case $cloudsource in
+              GM4|GM4+up|GM5|GM5+up)
+                  echo "Not setting want_ldap=1"
+                  ;;
+              develcloud6)
+                  if [[ $mkcloudtarget =~ upgrade ]]; then
+                      echo "Unsetting want_ldap for upgrade jobs until hybrid backend is ported to Mitaka"
+                      unset want_ldap
+                  fi
+                  ;;
+              M*|develcloud7|mitakacloud7|susecloud7)
+                  if [[ $mkcloudtarget =~ upgrade ]]; then
+                      echo "Unsetting want_ldap for upgrade jobs until hybrid backend is migrated to domain-specific backends"
+                      unset want_ldap
+                  else
+                      [[ $nodenumber == 2 && -z "$scenario" ]] && export want_ldap=1
+                  fi
+                  ;;
+              *)
+                  [[ $nodenumber == 2 && -z "$scenario" ]] && export want_ldap=1
+                  ;;
+          esac
 
 
-        # HAcloud
-        if [[ $hacloud == 1 ]] ; then
-          : ${clusterconfig:=data+services+network=2}
-          export clusterconfig
-          if [[ $nodenumber < 4 ]] ; then
-            export nodenumber=4
+          if [[ $cinder_backend = " " ]] ; then
+            cinder_backend=""
+          elif [[ $cinder_backend = "nfs" ]] ; then
+            export nodenumberlonelynode=1
           fi
 
-          # for now disable ceph deployment in HA mode explicitly
-          # it would need 5 nodes (2 for the cluster + 3 nodes for compute and ceph)
-          #### temorarily allow ceph in HA (test if it works)
-          #export want_ceph=0
-          #export cephvolumenumber=0
-        fi
 
-
-        #storage
-        case "$storage_method" in
-          none)
-            want_ceph=0
-            want_swift=0
-            ;;
-          swift)
-            want_ceph=0
-            want_swift=1
-            ;;
-          ceph)
-            want_ceph=1
-            want_swift=0
-            if [[ $nodenumber < 5 ]] ; then
-              export nodenumber=5
-            fi
-            cephvolumenumber=2
-            ;;
-          *)
-            unset want_ceph
-            unset want_swift
-        esac
-        export want_ceph
-        export want_swift
-
-        if [ ! -z "$UPDATEREPOS" ] ; then
-          # testing update only makes sense with GM and without TESTHEAD
-        #  unset TESTHEAD
-        #  export cloudsource=GM
-          export UPDATEREPOS=${UPDATEREPOS//$'\n'/+}
-        fi
-
-
-        # automation bootstrapping
-        if ! [ -e ${automationrepo}/scripts/jenkins/update_automation ] ; then
-          rm -rf ${automationrepo}
-          curl https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation | bash
-        fi
-        # fetch the latest automation updates
-        ${automationrepo}/scripts/jenkins/update_automation #NO PARAMETERS HERE ANY MORE!!!
-
-        function mkcloudgating_trap()
-        {
-            $ghs -a set-status -s "failure" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context
-        }
-
-        ## mkcloud github PR gating
-        if [[ $github_pr ]] ; then
-            github_opts=(${github_pr//:/ })
-            github_pr_repo=${github_opts[0]}
-            github_pr_id=${github_opts[1]}
-            github_pr_sha=${github_opts[2]}
-            github_pr_context=${github_opts[4]}
-            ghs_context=suse/mkcloud
-            if [[ $github_pr_context ]] ; then
-              ghs_context=$ghs_context/$github_pr_context
+          # HAcloud
+          if [[ $hacloud == 1 ]] ; then
+            : ${clusterconfig:=data+services+network=2}
+            export clusterconfig
+            if [[ $nodenumber < 4 ]] ; then
+              export nodenumber=4
             fi
 
-            echo "testing PR: https://github.com/$github_pr_repo/pull/$github_pr_id"
-            ghs=${automationrepo}/scripts/github-status/github-status.rb
-            zypper -n install "rubygem(netrc)" "rubygem(octokit)"
+            # for now disable ceph deployment in HA mode explicitly
+            # it would need 5 nodes (2 for the cluster + 3 nodes for compute and ceph)
+            #### temorarily allow ceph in HA (test if it works)
+            #export want_ceph=0
+            #export cephvolumenumber=0
+          fi
 
-            if ! $ghs -r $github_pr_repo -a is-latest-sha -p $github_pr_id -c $github_pr_sha ; then
-                $ghs -a set-status -s "error" -t $BUILD_URL -r $github_pr_repo -c $github_pr_sha -m "SHA1 mismatch, newer commit exists" --context $ghs_context
-                exit 1
-            fi
 
-            trap "mkcloudgating_trap" ERR
+          #storage
+          case "$storage_method" in
+            none)
+              want_ceph=0
+              want_swift=0
+              ;;
+            swift)
+              want_ceph=0
+              want_swift=1
+              ;;
+            ceph)
+              want_ceph=1
+              want_swift=0
+              if [[ $nodenumber < 5 ]] ; then
+                export nodenumber=5
+              fi
+              cephvolumenumber=2
+              ;;
+            *)
+              unset want_ceph
+              unset want_swift
+          esac
+          export want_ceph
+          export want_swift
 
-            # Support for automation self-gating
-            if [[ "$github_pr_repo" = "SUSE-Cloud/automation" ]]; then
-                automationrepo_orig=$automationrepo
-                pr_dir=`mktemp -d $WORKSPACE/SUSE-Cloud.automation.XXXXXX`
-                automationrepo=$pr_dir/automation
+          if [ ! -z "$UPDATEREPOS" ] ; then
+            # testing update only makes sense with GM and without TESTHEAD
+          #  unset TESTHEAD
+          #  export cloudsource=GM
+            export UPDATEREPOS=${UPDATEREPOS//$'\n'/+}
+          fi
 
-                mkdir -p $automationrepo
-                rsync -a ${automationrepo_orig%/}/ $automationrepo/
-                pushd $automationrepo
-                ghremote=origin
-                git config --get-all remote.${ghremote}.fetch | grep -q pull || \
-                    git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
-                git fetch $ghremote
-                git checkout -t $ghremote/pr/$github_pr_id
-                echo "we merge to always test what will end up in master"
-                git merge master -m temp-merge-commit
-                # show latest commit in log to see what's really tested
-                git --no-pager show
-                popd
-            elif [[ "$github_pr_repo" = "SUSE-Cloud/cct" ]]; then
-                export want_cct_pr=$github_pr_id
-            fi
 
-            $ghs -a set-status -s "pending" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context -m "Started PR gating"
+          # automation bootstrapping
+          if ! [ -e ${automationrepo}/scripts/jenkins/update_automation ] ; then
+            rm -rf ${automationrepo}
+            curl https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation | bash
+          fi
+          # fetch the latest automation updates
+          ${automationrepo}/scripts/jenkins/update_automation #NO PARAMETERS HERE ANY MORE!!!
 
-        fi
-
-        cp ${automationrepo}/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt log-parser-plugin-rules.txt
-
-        echo "########################################################################"
-        env
-        echo "########################################################################"
-
-        MKCLOUDTARGET=$mkcloudtarget
-        [ $UPDATEBEFOREINSTALL == "true" ] && MKCLOUDTARGET='cleanup prepare setupadmin addupdaterepo instcrowbar setupcompute instcompute proposal testsetup'
-
-        [ $(uname -m) = s390x ] && WITHCROWBARREGISTER=true
-        if [ $WITHCROWBARREGISTER == "true" ] ; then
-          export nodenumberlonelynode=1
-          [ $(uname -m) = s390x ] && {
-              export nodenumberlonelynode=$nodenumber
-              export nodenumber=0
-              export controller_node_memory=8388608
-              export compute_node_memory=6291456
+          function mkcloudgating_trap()
+          {
+              $ghs -a set-status -s "failure" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context
           }
-          MKCLOUDTARGET+=" setuplonelynodes crowbar_register"
-        fi
 
-        [ $(uname -m) = aarch64 ] && {
-            export vcpus=16
-        }
+          ## mkcloud github PR gating
+          if [[ $github_pr ]] ; then
+              github_opts=(${github_pr//:/ })
+              github_pr_repo=${github_opts[0]}
+              github_pr_id=${github_opts[1]}
+              github_pr_sha=${github_opts[2]}
+              github_pr_context=${github_opts[4]}
+              ghs_context=suse/mkcloud
+              if [[ $github_pr_context ]] ; then
+                ghs_context=$ghs_context/$github_pr_context
+              fi
 
-        pushd ~/pool/
-            # free up a pool if more than one is reserved
-            # policy allows only one reservation per host at the moment
-            ls -1 | grep -v "^[0-9]\+$" | sort -R | head -n -1 | while read p ; do mv $p ${p%%.*} ; done
-        popd
+              echo "testing PR: https://github.com/$github_pr_repo/pull/$github_pr_id"
+              ghs=${automationrepo}/scripts/github-status/github-status.rb
+              zypper -n install "rubygem(netrc)" "rubygem(octokit)"
 
-        starttime=`date +%s`
+              if ! $ghs -r $github_pr_repo -a is-latest-sha -p $github_pr_id -c $github_pr_sha ; then
+                  $ghs -a set-status -s "error" -t $BUILD_URL -r $github_pr_repo -c $github_pr_sha -m "SHA1 mismatch, newer commit exists" --context $ghs_context
+                  exit 1
+              fi
 
-        mkcloudwrapper="${automationrepo}/scripts/mkcloudhost/allocpool ${automationrepo}/scripts/mkcloudhost/mkcloude"
-        #FIXME - drop next 3 lines once the change in allocpool is merged
-        if grep -q "exec.*mkcloude" ${automationrepo}/scripts/mkcloudhost/allocpool ; then
-            mkcloudwrapper=${automationrepo}/scripts/mkcloudhost/allocpool
-        fi
+              trap "mkcloudgating_trap" ERR
 
-        # Shut down the cloud to save resources
-        ##MKCLOUDTARGET+=" cleanup"
+              # Support for automation self-gating
+              if [[ "$github_pr_repo" = "SUSE-Cloud/automation" ]]; then
+                  automationrepo_orig=$automationrepo
+                  pr_dir=`mktemp -d $WORKSPACE/SUSE-Cloud.automation.XXXXXX`
+                  automationrepo=$pr_dir/automation
 
-        export clouddescription="Jenkins Build: $BUILD_NUMBER / $JOB_NAME"
+                  mkdir -p $automationrepo
+                  rsync -a ${automationrepo_orig%/}/ $automationrepo/
+                  pushd $automationrepo
+                  ghremote=origin
+                  git config --get-all remote.${ghremote}.fetch | grep -q pull || \
+                      git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
+                  git fetch $ghremote
+                  git checkout -t $ghremote/pr/$github_pr_id
+                  echo "we merge to always test what will end up in master"
+                  git merge master -m temp-merge-commit
+                  # show latest commit in log to see what's really tested
+                  git --no-pager show
+                  popd
+              elif [[ "$github_pr_repo" = "SUSE-Cloud/cct" ]]; then
+                  export want_cct_pr=$github_pr_id
+              fi
 
-        $custom_settings
+              $ghs -a set-status -s "pending" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context -m "Started PR gating"
 
-        perl -e "alarm 6*60*60 ; exec '${mkcloudwrapper} bash -x ${automationrepo}/scripts/mkcloud setuphost $(echo -n $MKCLOUDTARGET) ' ; print qq{$!\n} ; exit 127 " | tee $artifacts_dir/mkcloud_short_stdout.log
-        ret=${PIPESTATUS[0]}
-        if [[ $ret != 0 ]] ; then
-            if [[ $github_pr_sha ]] ; then
-              mkcloudgating_trap
-            else
-              $jtsync --ci suse --job $JOB_NAME 1
-            fi
-            echo "mkcloud ret=$ret"
-            exit $ret # check return code before tee
-        fi
+          fi
 
-        # report mkcloud-gating status or jenkins trello status
-        if [[ $github_pr_sha ]] ; then
-          $ghs -r $github_pr_repo -a set-status -s "success" -t $BUILD_URL -c $github_pr_sha --context $ghs_context -m "PR gating succeeded"
-          trap "-" ERR
-        else
-          $jtsync --ci suse --job $JOB_NAME 0
-        fi
+          cp ${automationrepo}/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt log-parser-plugin-rules.txt
+
+          echo "########################################################################"
+          env
+          echo "########################################################################"
+
+          MKCLOUDTARGET=$mkcloudtarget
+          [ $UPDATEBEFOREINSTALL == "true" ] && MKCLOUDTARGET='cleanup prepare setupadmin addupdaterepo instcrowbar setupcompute instcompute proposal testsetup'
+
+          [ $(uname -m) = s390x ] && WITHCROWBARREGISTER=true
+          if [ $WITHCROWBARREGISTER == "true" ] ; then
+            export nodenumberlonelynode=1
+            [ $(uname -m) = s390x ] && {
+                export nodenumberlonelynode=$nodenumber
+                export nodenumber=0
+                export controller_node_memory=8388608
+                export compute_node_memory=6291456
+            }
+            MKCLOUDTARGET+=" setuplonelynodes crowbar_register"
+          fi
+
+          [ $(uname -m) = aarch64 ] && {
+              export vcpus=16
+          }
+
+          pushd ~/pool/
+              # free up a pool if more than one is reserved
+              # policy allows only one reservation per host at the moment
+              ls -1 | grep -v "^[0-9]\+$" | sort -R | head -n -1 | while read p ; do mv $p ${p%%.*} ; done
+          popd
+
+          starttime=`date +%s`
+
+          mkcloudwrapper="${automationrepo}/scripts/mkcloudhost/allocpool ${automationrepo}/scripts/mkcloudhost/mkcloude"
+          #FIXME - drop next 3 lines once the change in allocpool is merged
+          if grep -q "exec.*mkcloude" ${automationrepo}/scripts/mkcloudhost/allocpool ; then
+              mkcloudwrapper=${automationrepo}/scripts/mkcloudhost/allocpool
+          fi
+
+          # Shut down the cloud to save resources
+          ##MKCLOUDTARGET+=" cleanup"
+
+          export clouddescription="Jenkins Build: $BUILD_NUMBER / $JOB_NAME"
+
+          $custom_settings
+
+          perl -e "alarm 6*60*60 ; exec '${mkcloudwrapper} bash -x ${automationrepo}/scripts/mkcloud setuphost $(echo -n $MKCLOUDTARGET) ' ; print qq{$!\n} ; exit 127 " | tee $artifacts_dir/mkcloud_short_stdout.log
+          ret=${PIPESTATUS[0]}
+          if [[ $ret != 0 ]] ; then
+              if [[ $github_pr_sha ]] ; then
+                mkcloudgating_trap
+              else
+                $jtsync --ci suse --job $JOB_NAME 1
+              fi
+              echo "mkcloud ret=$ret"
+              exit $ret # check return code before tee
+          fi
+
+          # report mkcloud-gating status or jenkins trello status
+          if [[ $github_pr_sha ]] ; then
+            $ghs -r $github_pr_repo -a set-status -s "success" -t $BUILD_URL -c $github_pr_sha --context $ghs_context -m "PR gating succeeded"
+            trap "-" ERR
+          else
+            $jtsync --ci suse --job $JOB_NAME 0
+          fi
 
     publishers:
       - logparser:
@@ -573,9 +573,9 @@
           fail-on-error: false
           show-graphs: true
       - archive:
-         artifacts: .artifacts/**
-         allow-empty: false
-         only-if-success: false
-         fingerprint: false
-         default-excludes: true
+          artifacts: .artifacts/**
+          allow-empty: false
+          only-if-success: false
+          fingerprint: false
+          default-excludes: true
     triggers: []

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -29,46 +29,14 @@
                - job-read
 
     parameters:
-     - string:
-        name: cloudsource
-        default: develcloud7
-        description: |
-             Can be something like develcloud6 (uses Devel:Cloud:*, see TESTHEAD parameter for Staging),  susecloud6 (uses SUSE:*), GM3 (uses the GM ISO)
+
+    ################################################
+    # CI job run
 
      - string:
         name: mkcloudtarget
         default: all
         description: Set mkcloudtarget to define the mkcloud command line parameters.
-
-     - choice:
-         name: libvirt_type
-         choices:
-           - kvm
-           - xen
-           - hyperv
-
-     - choice:
-         name: networkingplugin
-         choices:
-            - openvswitch
-            - linuxbridge
-
-     - choice:
-         name: networkingmode
-         choices:
-             - gre
-             - vlan
-             - vxlan
-
-     - choice:
-         name: storage_method
-         description: |
-              Select storage method: default (let mkcloud decide), none (enforce none)
-         choices:
-            - default
-            - none
-            - swift
-            - ceph
 
      - string:
          name: github_pr
@@ -81,6 +49,30 @@
          default: "-no-name-"
          description: |
               This name will become the build name of the job. It will appear in the list of builds (webUI, RSS feed).
+
+     - string:
+         name: scenario
+         default:
+         description: |
+          Defines which scenario file should be used. Only works with cloud5 or newer.
+          Currently only the 'batch' step uses such a file.
+
+     - label:
+         name: label
+         default: openstack-mkcloud
+         description: |
+          Default: openstack-mkcloud | Possible values:
+          openstack-mkcloud-SLE11 (SLE11 host) |
+          openstack-mkcloud-SLE12 (SLE12 host) | openstack-mkcloud-SLE12-aarch64 (SLE12 aarch64 host)
+
+    ################################################
+    # repositories
+
+     - string:
+        name: cloudsource
+        default: develcloud7
+        description: |
+             Can be something like develcloud6 (uses Devel:Cloud:*, see TESTHEAD parameter for Staging),  susecloud6 (uses SUSE:*), GM3 (uses the GM ISO)
 
      - text:
          name: UPDATEREPOS
@@ -100,33 +92,9 @@
               if non-empty, test latest version from Devel:Cloud (:1.0)
 
      - string:
-         name: nodenumber
-         default: '2'
-         description: number of nodes excl. admin-node minimum 2=controller+compute
-
-     - string:
-         name: nodenumbercompute
+         name: want_test_updates
          default:
-         description: Number of compute nodes
-
-     - string:
-         name: want_tempest
-         default:
-         description: can be used for force off(0) or on(1)
-
-     - string:
-         name: tempestoptions
-         default:
-         description: |
-           Additional options to pass to the "tempest run " step. The default is cloudversion
-           specific but will default to a smoke run.
-
-     - string:
-         name: want_horizon_integration_test
-         default:
-         description: |
-             Execute selenium integration tests for Horizon after Tempest. This test is in beta, and
-             a fail will not be considered for now.
+         description: allow disabling of test updates
 
      - string:
          name: want_sles12
@@ -143,10 +111,25 @@
          default:
          description: In case of using upgrade, upgrade to that cloudsource version
 
+    ################################################
+    # cloud shape and size
+
+     - choice:
+         name: libvirt_type
+         choices:
+           - kvm
+           - xen
+           - hyperv
+
      - string:
-         name: hacloud
+         name: nodenumber
+         default: '2'
+         description: number of nodes excl. admin-node minimum 2=controller+compute
+
+     - string:
+         name: nodenumbercompute
          default:
-         description: If hacloud=1 then deploy a 4-node cluster
+         description: Number of compute nodes
 
      - bool:
          name: WITHCROWBARREGISTER
@@ -154,9 +137,86 @@
          description: boot up one lonely node in the admin network and register it with crowbar_register (image type depends on want_sles12 parameter)
 
      - string:
+         name: want_node_aliases
+         default:
+         description: |
+           List of aliases to assign to nodes.
+           Takes all provided aliases and assign them to available nodes successively.
+           Examples want_node_aliases='controller=1,ceph=2,compute=1'
+           assigns the aliases to 4 nodes as controller, ceph1, ceph2, compute
+            want_node_aliases='data=1,services=2,storage=2'
+            assigns the aliases to 5 nodes as data, service1, service2,
+            storage1, storage2
+
+     - string:
+         name: hacloud
+         default:
+         description: If hacloud=1 then deploy a 4-node cluster
+
+     - string:
+         name: clusterconfig
+         default:
+         description: the cluster configuration to pass to the mkcloud script
+
+     - string:
+         name: vcpus
+         default: '2'
+         description: number of vcpus for the compute nodes
+
+    ################################################
+    # OS deployment
+
+     - string:
+         name: want_efi
+         default:
+         description: Set to UEFI boot admin node
+
+     - string:
+         name: want_rootfs
+         default:
+         description: set to btrfs to deploy with btrfs
+
+    ################################################
+    # general OpenStack deployment
+
+     - string:
+         name: want_postgresql
+         default:
+         description: set to 1 to deploy with postgresql
+
+     - string:
          name: want_all_ssl
          default:
          description: set to 1 to deploy all cloud services with SSL aka HTTPS
+
+    ################################################
+    # neutron
+
+     - choice:
+         name: networkingplugin
+         choices:
+            - openvswitch
+            - linuxbridge
+
+     - choice:
+         name: networkingmode
+         choices:
+             - gre
+             - vlan
+             - vxlan
+
+    ################################################
+    # storage
+
+     - choice:
+         name: storage_method
+         description: |
+              Select storage method: default (let mkcloud decide), none (enforce none)
+         choices:
+            - default
+            - none
+            - swift
+            - ceph
 
      - choice:
          name: cinder_backend
@@ -167,6 +227,7 @@
            - rbd
            - netapp
            - nfs
+
      - bool:
          name: want_cindermultibackend
          default: false
@@ -182,42 +243,38 @@
          default:
          description: the password for the user "openstack" as configured on the netapp server
 
-     - label:
-         name: label
-         default: openstack-mkcloud
-         description: |
-          Default: openstack-mkcloud | Possible values:
-          openstack-mkcloud-SLE11 (SLE11 host) |
-          openstack-mkcloud-SLE12 (SLE12 host) | openstack-mkcloud-SLE12-aarch64 (SLE12 aarch64 host)
+    ################################################
+    # tempest
 
      - string:
-         name: want_node_aliases
+         name: want_tempest
          default:
-         description: |
-           List of aliases to assign to nodes.
-           Takes all provided aliases and assign them to available nodes successively.
-           Examples want_node_aliases='controller=1,ceph=2,compute=1'
-           assigns the aliases to 4 nodes as controller, ceph1, ceph2, compute
-            want_node_aliases='data=1,services=2,storage=2'
-            assigns the aliases to 5 nodes as data, service1, service2,
-            storage1, storage2
+         description: can be used for force off(0) or on(1)
 
      - string:
-         name: scenario
+         name: tempestoptions
          default:
          description: |
-          Defines which scenario file should be used. Only works with cloud5 or newer.
-          Currently only the 'batch' step uses such a file.
+           Additional options to pass to the "tempest run " step. The default is cloudversion
+           specific but will default to a smoke run.
+
+    ################################################
+    # horizon
+
+     - string:
+         name: want_horizon_integration_test
+         default:
+         description: |
+             Execute selenium integration tests for Horizon after Tempest. This test is in beta, and
+             a fail will not be considered for now.
+
+    ################################################
+    # extras
 
      - string:
          name: want_docker
          default:
          description: set to 1 to deploy with docker
-
-     - string:
-         name: want_test_updates
-         default:
-         description: allow disabling of test updates
 
      - string:
          name: want_magnum
@@ -230,29 +287,9 @@
          description: Deploy with Barbican
 
      - string:
-         name: vcpus
-         default: '2'
-         description: number of vcpus for the compute nodes
-
-     - string:
          name: want_sahara
          default:
          description: set to 1 to deploy sahara
-
-     - string:
-         name: want_rootfs
-         default:
-         description: set to btrfs to deploy with btrfs
-
-     - string:
-         name: want_postgresql
-         default:
-         description: set to 1 to deploy with postgresql
-
-     - string:
-         name: want_efi
-         default:
-         description: Set to UEFI boot admin node
 
      - string:
          name: want_murano
@@ -264,6 +301,9 @@
          default: '1'
          description: set to 0 to not deploy aodh
 
+    ################################################
+    # misc
+
      - string:
          name: want_nodesupgrade
          default: '1'
@@ -273,11 +313,6 @@
          name: want_ping_running_instances
          default:
          description: set to 1 to ping running instances during the upgrade
-
-     - string:
-         name: clusterconfig
-         default:
-         description: the cluster configuration to pass to the mkcloud script
 
      - text:
          name: custom_settings

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -2,10 +2,11 @@
     name: openstack-mkcloud
     node: openstack-mkcloud
     concurrent: true
-    description: |
-      <!-- Managed by Jenkins Job Builder -->
-      This job runs https://github.com/SUSE-Cloud/automation/blob/master/scripts/mkcloud results are
-      analyzed by https://github.com/SUSE-Cloud/automation/blob/master/scripts/jenkins/mkcloudresultcheck.pl
+    description: >-
+      This job runs https://github.com/SUSE-Cloud/automation/blob/master/scripts/mkcloud
+
+      Results are analyzed by
+      https://github.com/SUSE-Cloud/automation/blob/master/scripts/jenkins/mkcloudresultcheck.pl
       on mkcloudresultcheck@mkcloudresultcheck.cloud.suse.de every 15 minutes
 
     logrotate:

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -36,34 +36,42 @@
       - string:
           name: mkcloudtarget
           default: all
-          description: Set mkcloudtarget to define the mkcloud command line parameters.
+          description: >-
+            Set mkcloudtarget to define the mkcloud command line parameters.
 
       - string:
           name: github_pr
-          description: |
-            String is a ':' separated list of these values: $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context Note:
-            SHA1 must be latest commit in PR, $context is optional  (only use if multiple gating runs needed per PR)
+          description: >-
+            String is a ':' separated list of these values:
+            $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context
+
+            Note: SHA1 must be latest commit in PR, $context is optional
+            (only use if multiple gating runs needed per PR)
 
       - string:
           name: job_name
           default: "-no-name-"
-          description: |
-            This name will become the build name of the job. It will appear in the list of builds (webUI, RSS feed).
+          description: >-
+            This name will become the build name of the job.
+            It will appear in the list of builds (webUI, RSS feed).
 
       - string:
           name: scenario
           default:
-          description: |
-            Defines which scenario file should be used. Only works with cloud5 or newer.
-            Currently only the 'batch' step uses such a file.
+          description: >-
+            Defines which scenario file should be used. Only works
+            with cloud5 or newer.  Currently only the 'batch' step uses
+            such a file.
 
       - label:
           name: label
           default: openstack-mkcloud
-          description: |
-            Default: openstack-mkcloud | Possible values:
-            openstack-mkcloud-SLE11 (SLE11 host) |
-            openstack-mkcloud-SLE12 (SLE12 host) | openstack-mkcloud-SLE12-aarch64 (SLE12 aarch64 host)
+          description: >-
+            Default: openstack-mkcloud |
+            Possible values:
+            openstack-mkcloud-SLE11 (SLE11 host),
+            openstack-mkcloud-SLE12 (SLE12 host),
+            openstack-mkcloud-SLE12-aarch64 (SLE12 aarch64 host)
 
       ################################################
       # repositories
@@ -71,45 +79,52 @@
       - string:
           name: cloudsource
           default: develcloud7
-          description: |
-            Can be something like develcloud6 (uses Devel:Cloud:*, see TESTHEAD parameter for Staging),  susecloud6 (uses SUSE:*), GM3 (uses the GM ISO)
+          description: >-
+            Can be something like develcloud6 (uses Devel:Cloud:*, see
+            TESTHEAD parameter for Staging), susecloud6 (uses SUSE:*),
+            GM3 (uses the GM ISO)
 
       - text:
           name: UPDATEREPOS
           default:
-          description: |
-               Update repositories (one URL per line)
+          description: >-
+            Update repositories (one URL per line)
 
       - bool:
           name: UPDATEBEFOREINSTALL
           default: false
-          description: 'add update repos before crowbar install'
+          description: >-
+            Add update repos before crowbar install
 
       - string:
           name: TESTHEAD
           default: '1'
-          description: |
-               if non-empty, test latest version from Devel:Cloud (:1.0)
+          description: >-
+            If non-empty, test latest version from Devel:Cloud (:1.0)
 
       - string:
           name: want_test_updates
           default:
-          description: allow disabling of test updates
+          description: >-
+            Allow disabling of test updates
 
       - string:
           name: want_sles12
           default:
-          description: Set to 1 if sle12 nodes should be installed
+          description: >-
+            Set to 1 if sle12 nodes should be installed
 
       - string:
           name: want_sles12sp2
           default:
-          description: deploy cloud7 with SP2 instead of SP1
+          description: >-
+            Deploy cloud7 with SP2 instead of SP1
 
       - string:
           name: upgrade_cloudsource
           default:
-          description: In case of using upgrade, upgrade to that cloudsource version
+          description: >-
+            In case of using upgrade, upgrade to that cloudsource version
 
       ################################################
       # cloud shape and size
@@ -124,7 +139,8 @@
       - string:
           name: nodenumber
           default: '2'
-          description: number of nodes excl. admin-node minimum 2=controller+compute
+          description: >-
+            Number of nodes excluding admin-node.  Minimum is 2 (controller+compute)
 
       - string:
           name: nodenumbercompute
@@ -134,19 +150,25 @@
       - bool:
           name: WITHCROWBARREGISTER
           default: false
-          description: boot up one lonely node in the admin network and register it with crowbar_register (image type depends on want_sles12 parameter)
+          description: >-
+            Boot up one node in the admin network from a preinstalled
+            OS image, and register it with crowbar_register (image type
+            depends on want_sles12 parameter)
 
       - string:
           name: want_node_aliases
           default:
-          description: |
-            List of aliases to assign to nodes.
-            Takes all provided aliases and assign them to available nodes successively.
-            Examples want_node_aliases='controller=1,ceph=2,compute=1'
+          description: >-
+            List of aliases to assign to nodes.  Takes all provided
+            aliases and assign them to available nodes
+            successively. Examples:
+
+            want_node_aliases='controller=1,ceph=2,compute=1'
             assigns the aliases to 4 nodes as controller, ceph1, ceph2, compute
-             want_node_aliases='data=1,services=2,storage=2'
-             assigns the aliases to 5 nodes as data, service1, service2,
-             storage1, storage2
+
+            want_node_aliases='data=1,services=2,storage=2'
+            assigns the aliases to 5 nodes as data, service1, service2,
+            storage1, storage2
 
       - string:
           name: hacloud
@@ -156,12 +178,12 @@
       - string:
           name: clusterconfig
           default:
-          description: the cluster configuration to pass to the mkcloud script
+          description: Cluster configuration to pass to the mkcloud script
 
       - string:
           name: vcpus
           default: '2'
-          description: number of vcpus for the compute nodes
+          description: Number of vcpus for the compute nodes
 
       ################################################
       # OS deployment
@@ -174,7 +196,7 @@
       - string:
           name: want_rootfs
           default:
-          description: set to btrfs to deploy with btrfs
+          description: Set to btrfs to deploy with btrfs
 
       ################################################
       # general OpenStack deployment
@@ -182,12 +204,12 @@
       - string:
           name: want_postgresql
           default:
-          description: set to 1 to deploy with postgresql
+          description: Set to 1 to deploy with postgresql
 
       - string:
           name: want_all_ssl
           default:
-          description: set to 1 to deploy all cloud services with SSL aka HTTPS
+          description: Set to 1 to deploy all cloud services with SSL aka HTTPS
 
       ################################################
       # neutron
@@ -236,12 +258,14 @@
       - string:
           name: cinder_netapp_login
           default:
-          description: the password for the user "openstack" as configured on the netapp server
+          description: >-
+            Password for the user "openstack" as configured on the netapp server
 
       - string:
           name: cinder_netapp_password
           default:
-          description: the password for the user "openstack" as configured on the netapp server
+          description: >-
+            Password for the user "openstack" as configured on the netapp server
 
       ################################################
       # tempest
@@ -254,9 +278,9 @@
       - string:
           name: tempestoptions
           default:
-          description: |
-            Additional options to pass to the "tempest run " step. The default is cloudversion
-            specific but will default to a smoke run.
+          description: >-
+            Additional options to pass to the "tempest run " step. The
+            default is cloudversion specific but will default to a smoke run.
 
       ################################################
       # horizon
@@ -264,9 +288,10 @@
       - string:
           name: want_horizon_integration_test
           default:
-          description: |
-              Execute selenium integration tests for Horizon after Tempest. This test is in beta, and
-              a fail will not be considered for now.
+          description: >-
+            Execute selenium integration tests for Horizon after
+            Tempest. This test is in beta, and a fail will not be
+            considered for now.
 
       ################################################
       # extras
@@ -304,21 +329,23 @@
       ################################################
       # misc
 
-     - string:
-         name: want_nodesupgrade
-         default: '1'
-         description: set to 0 to not upgrade nodes, only admin server
+      - string:
+          name: want_nodesupgrade
+          default: '1'
+          description: set to 0 to not upgrade nodes, only admin server
 
-     - string:
-         name: want_ping_running_instances
-         default:
-         description: set to 1 to ping running instances during the upgrade
+      - string:
+          name: want_ping_running_instances
+          default:
+          description: set to 1 to ping running instances during the upgrade
 
       - text:
           name: custom_settings
           default:
-          description: |
-               This holds shell code and will be executed before calling mkcloud. This should not be used by default or regularly. It is meant to test PRs with special configurations.
+          description: >-
+            This holds shell code and will be executed before calling
+            mkcloud. This should not be used by default or regularly. It
+            is meant to test PRs with special configurations.
 
     wrappers:
       - timestamps:


### PR DESCRIPTION
Try to bring some order back into this insane mess:

- group parameters more logically
- fix indentation
- tidy up some description strings and reduce line lengths

The new job can be previewed at https://ci.suse.de/job/openstack-mkcloud-reordered/build

In the future, hopefully we can use

    https://wiki.jenkins-ci.org/display/JENKINS/Parameter+Separator+Plugin

so clearly delimit each section.  I have also submitted

    https://issues.jenkins-ci.org/browse/JENKINS-43070

with the goal of being able to name each section delimited by a separator.