### PR TITLE
ha: Clean up expected vip failed actions

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -654,6 +654,7 @@ function instnodes
 function proposal
 {
     onadmin proposal
+    onadmin cleanup_crm_resources
     return $?
 }
 


### PR DESCRIPTION
This builds on #1785, since it is not just the upgrade runs that are
having issues but the general hacloud scenario as well.