### PR TITLE
mkcloud/host: allow to run as non-root

### DIFF
--- a/scripts/mkcloudhost/cloudfunc
+++ b/scripts/mkcloudhost/cloudfunc
@@ -1,4 +1,6 @@
-. /root/cloud.d/cloudrc.host
+hostrc=/etc/mkcloud/cloudrc.host
+test -e $hostrc || hostrc=~/cloud.d/cloudrc.host
+. $hostrc
 cloudspernode=32
 
 # note, cloudadminnet must be in the same /23 as cloudpublicnet

--- a/scripts/mkcloudhost/routed.cloud
+++ b/scripts/mkcloudhost/routed.cloud
@@ -1,6 +1,8 @@
 n=$1
 shift
-. /root/cloud.d/cloudfunc
+cloudfunc=~/cloud.d/cloudfunc
+test -e $cloudfunc || cloudfunc=$(dirname $(readlink -e $BASH_SOURCE))/cloudfunc
+. $cloudfunc
 
 if [ "$n" -lt 1 -o "$n" -gt 32 ] ; then
   echo "$n is out of range [1..32]"

--- a/scripts/mkcloudhost/runtestn
+++ b/scripts/mkcloudhost/runtestn
@@ -9,7 +9,9 @@ fi
 
 # workaround libvirtd disappearance:
 pidof libvirtd || /usr/local/sbin/fixlibvirt
-. /root/cloud.d/cloudfunc
+cloudfunc=~/cloud.d/cloudfunc
+test -e $cloudfunc || cloudfunc=$(dirname $(readlink -e $BASH_SOURCE))/cloudfunc
+. $cloudfunc
 
 #export cloudsource=GM2.0
 #export TESTHEAD=1


### PR DESCRIPTION
by dropping /root/cloud.d/
in favour of using cloudfunc from the same dir (usually a git checkout)
and /etc/mkcloud/cloudrc.host
with fallbacks for existing systems