### PR TITLE
jtsync: do not hide backtrace

### DIFF
--- a/scripts/jtsync/jtsync.rb
+++ b/scripts/jtsync/jtsync.rb
@@ -246,5 +246,5 @@ rescue RuntimeError => err
 rescue Netrc::Error => err
   puts("Could not fetch credentials: #{err}")
 rescue => err
-  puts("Script failed err was: #{err}")
+  puts("Script failed err was: #{err} #{err.backtrace}")
 end


### PR DESCRIPTION
to allow easier debugging of problems that are otherwise just reported as
`undefined method '[]' for nil:NilClass`