### PR TITLE
Rename the crm cleanup method

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -655,7 +655,7 @@ function instnodes
 function proposal
 {
     onadmin proposal
-    onadmin cleanup_crm_resources
+    onadmin cleanup_db_mq_vips
     return $?
 }
 
@@ -838,7 +838,7 @@ function crowbarupgrade_5plus
         cloudsource=$upgrade_cloudsource onadmin prepare_cloudupgrade_nodes_repos_6_to_7
         onadmin upgrade_ses_to_4
         onadmin zypper_patch_all
-        onadmin cleanup_crm_resources
+        onadmin cleanup_db_mq_vips
         onadmin upgrade_prechecks
         if [[ $cloudsource = develcloud6 ]] || [[ $upgrade_cloudsource = develcloud7 ]]; then
             onadmin allow_vendor_change_at_nodes

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4877,11 +4877,9 @@ zypper -non-interactive --gpg-auto-import-keys --no-gpg-checks install ses-upgra
     done
 }
 
-# Some resources are known to fail for a short time after Cloud6 deployment
-# because wicked ifreload call.
-# It's safe to clean existing errors now so we have a error-less crm status
-# output before the upgrade.
-function onadmin_cleanup_crm_resources
+# Some resources are known to fail for a short time because of a wicked ifreload call.
+# It's safe to clean existing errors now so we have a error-less crm status output.
+function onadmin_cleanup_db_mq_vips
 {
     for svc in database rabbitmq; do
         local node=$(knife search node "roles:$svc-server AND pacemaker_founder:true" -a name | \


### PR DESCRIPTION
We only want to clean up two specific resources that we expect to have
failed, this is not a general "make all the problems go away" method, so
let's rename it to make it more clear.