### PR TITLE
qa_crowbarsetup: auto-refresh for PTF repos (bsc#1030462)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4656,7 +4656,7 @@ function onadmin_addupdaterepo
     fi
     zypper modifyrepo -e cloud-ptf >/dev/null 2>&1 ||\
         safely zypper ar $UPR cloud-ptf
-    safely zypper mr -p 90 cloud-ptf
+    safely zypper mr -p 90 -r cloud-ptf
 }
 
 function zypper_patch


### PR DESCRIPTION
Enable auto-refresh for the zypper PTF repositories
to avoid using stale repository contents when executing
the update barclamp.