### PR TITLE
cinder's secret_uuid is required for ceph backend

### DIFF
--- a/scripts/scenarios/cloud6/cloud7-upgrade-non-disruptive-ceph.yml
+++ b/scripts/scenarios/cloud6/cloud7-upgrade-non-disruptive-ceph.yml
@@ -93,6 +93,7 @@ proposals:
         admin_keyring: "/etc/ceph/ceph.client.admin.keyring"
         pool: volumes
         user: cinder
+        secret_uuid: ""
   deployment:
     elements:
       cinder-controller:


### PR DESCRIPTION
See https://ci.suse.de/job/openstack-mkcloud/57549/consoleText