### PR TITLE
Raise the number of nodes so that default swift replica count is correct

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -21,6 +21,7 @@
             cloudsource=develcloud{previous_version}
             upgrade_cloudsource=develcloud{version}
             nodenumber=3
+            cephvolumenumber=2
             storage_method=swift
             mkcloudtarget=plain_with_upgrade testsetup
             want_nodesupgrade=1


### PR DESCRIPTION
The job fails because of number of swift replicas is bigger than number of disks
See https://ci.suse.de/job/openstack-mkcloud/57546/consoleText
(which is wrong for Cloud7, but current mkcloud code does not set replica number for Cloud6)
