### PR TITLE
Job that is upgading just admin server should unset nodes variable

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
@@ -24,5 +24,6 @@
             hacloud=1
             storage_method=swift
             mkcloudtarget=plain_with_upgrade
+            want_nodesupgrade=
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}


### PR DESCRIPTION
The default valye of want_nodesupgrade has changed to 1 recently,
so we need to unset it here.

Here was the change: https://github.com/SUSE-Cloud/automation/pull/1799