### PR TITLE
mkcloud: Stop chef-client on nodes after a failure

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -194,6 +194,17 @@ function error_exit
         '
         $scp root@$adminip:/var/log/*tbz $artifacts_dir/
     fi
+
+    # stop chef-client on nodes so the env will not be altered after a failure
+    ssh $sshopts root@$adminip '
+            set -x
+            for node in $(crowbar machines list | grep ^d) ; do
+            (
+                echo "Stopping chef-client on $node"
+                timeout 30 ssh $node rcchef-client stop
+            )
+            done
+        '
     pre_exit_cleanup
     echo $message
     show_environment


### PR DESCRIPTION
If the mkcloud environment runs into a failure, stop the periodic chef-client
run on all nodes.
This is useful to not alter the environment where the failure happens. Sometimes
there is a failure and the periodic chef-client run fixes the failure afterwards
which makes it more difficult to debug problems in the failed environment.