### PR TITLE
Fix false positives in log parser plugin

### DIFF
--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -14,8 +14,13 @@ ok /trap 'error_exit/
 ok /local 'error_cmd=/
 ok /Loading robots.txt; please ignore errors/
 ok /update-alternatives: .*ruby_parse_extract_error/
+
+# https://bugzilla.suse.com/show_bug.cgi?id=1031131
+ok /dracut-install: ERROR: installing .*dracut-fsck-help.txt/
+
 # https://bugzilla.redhat.com/show_bug.cgi?id=1312188
 ok /virtlogd\[\d+\]: End of file while reading data: Input\/output error/
+
 error /(?i)error/
 error /(?i)\bfail(ure)?\b/
 error /(?i)fatal/

--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -19,7 +19,7 @@ ok /update-alternatives: .*ruby_parse_extract_error/
 ok /dracut-install: ERROR: installing .*dracut-fsck-help.txt/
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1312188
-ok /virtlogd\[\d+\]: End of file while reading data: Input\/output error/
+ok /(libvirtd|virtlogd)\[\d+\]: End of file while reading data: Input\/output error/
 
 error /(?i)error/
 error /(?i)\bfail(ure)?\b/

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -620,7 +620,11 @@ function setupnodes
                         --numcontrollers $nodenumbercontroller \
                         --firmwaretype "$firmware_type" \
                         --controller-raid-volumes $controller_raid_volumes > /tmp/$cloud-node$i.xml
-        $sudo ${scripts_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml
+
+        # Hide expected message from libvirt about non-existing domain, since
+        # this creates false positives for anything which scans for errors.
+        $sudo ${scripts_lib_dir}/libvirt/vm-start /tmp/$cloud-node$i.xml \
+              2>&1 | grep -v "libvirt: QEMU Driver error : Domain not found: no domain with matching name"
     done
 
     echo "========================================================"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -750,7 +750,7 @@ function rsync_iso
     mkdir -p /mnt/cloud "$targetdir"
     (
         cd "$targetdir"
-        wget --progress=dot:mega -r -np -nc -A "$distiso" \
+        wget --progress=dot:mega -r -np -nc -e robots=off -A "$distiso" \
             http://$susedownload$distpath/ \
         || complain 71 "iso not found"
         local cloudiso=$(ls */$distpath/*.iso | tail -1)
@@ -4644,6 +4644,7 @@ function onadmin_addupdaterepo
         for repo in ${UPDATEREPOS//+/ } ; do
             safely wget --progress=dot:mega \
                 -r --directory-prefix $UPR \
+                -e robots=off \
                 --no-check-certificate \
                 --no-parent \
                 --no-clobber \


### PR DESCRIPTION
Fix 4 sources of false positives in the `Errors` section of the log parser plugin when parsing output of the `openstack-mkcloud` job.