### PR TITLE
Raise the nodenumber so the default swift replica count is correct

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -21,7 +21,6 @@
             cloudsource=develcloud{previous_version}
             upgrade_cloudsource=develcloud{version}
             nodenumber=4
-            cephvolumenumber=2
             storage_method=swift
             mkcloudtarget=plain_with_upgrade testsetup
             want_nodesupgrade=1

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -20,7 +20,7 @@
             TESTHEAD=1
             cloudsource=develcloud{previous_version}
             upgrade_cloudsource=develcloud{version}
-            nodenumber=3
+            nodenumber=4
             cephvolumenumber=2
             storage_method=swift
             mkcloudtarget=plain_with_upgrade testsetup


### PR DESCRIPTION
It seems that due to a very old version of swift in cloud6
we cannot change the default number of replicas so it will
always default to 3. Using a nodenumber count of 3 makes the
default number of nodes assigned to the swift-storage role to be
2 which doesnt sync with the required number of replicas, causing
the upgrade prechecks to fail.
Setting the nodenumber to 4 makes the default number of swift-storage
nodes to be 3, making the upgrade prechecks pass.