### PR TITLE
Disable cluster resource failcount tests for C6 and older

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3931,7 +3931,7 @@ function oncontroller_testsetup
 {
     . .openrc
     oncontroller_prepare_functional_tests
-    if [[ $hacloud = 1 ]] ; then
+    if iscloudver 7plus && [[ $hacloud = 1 ]] ; then
         crm_mon --failcounts -1 | grep "fail-count=" && complain 55 "Cluster resources' failures detected"
     fi
     # 28 is the overhead of an ICMP(ping) packet


### PR DESCRIPTION
It seems we are consistently failing them on all old products. lets
aim low by first getting it right for C7 and ignore the existing
problems for C5/C6.