### PR TITLE
Fix suspend/resume instances during upgrade

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5349,13 +5349,14 @@ function onadmin_crowbar_nodeupgrade
         fi
 
         if [[ $want_nodesupgrade ]]; then
+            get_novacontroller
             local upgrade_mode="normal"
             if safely crowbarctl upgrade mode | grep -q non_disruptive ; then
                 upgrade_mode="non_disruptive"
             fi
             # suspend all active instances on disruptive upgrade
             if [[ "$upgrade_mode" == "normal" ]]; then
-                oncontroller suspendallinstances
+                safely oncontroller suspendallinstances
             fi
             safely crowbarctl upgrade services
 
@@ -5378,7 +5379,7 @@ function onadmin_crowbar_nodeupgrade
             fi
             # resume all suspended instances after disruptive upgrade
             if [[ "$upgrade_mode" == "normal" ]]; then
-                oncontroller resumeallinstances
+                safely oncontroller resumeallinstances
             fi
         fi
     else


### PR DESCRIPTION
Missing the get_novacontroller function before running
scripts on the controller. Also adds safely to the calls.

PR affected was merged without testing as I didnt set the proper label so this was not working. 

This one is tested and works, sorry for the inconvenience.