### PR TITLE
Wait a bit after ceph upgrade so the health check succeeds

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4922,6 +4922,10 @@ zypper -non-interactive --gpg-auto-import-keys --no-gpg-checks install ses-upgra
     for node in $ceph_mons; do
         ssh $node "ceph osd crush tunables firefly; ceph osd set require_jewel_osds"
     done
+
+    # wait for ceph cluster to recover after the upgrade
+    nodes=($ceph_mons)
+    wait_for 60 5 "ssh ${nodes[0]} ceph health | grep -q HEALTH_OK" "ceph cluster to recover after upgrade"
 }
 
 # Some resources are known to fail for a short time because of a wicked ifreload call.


### PR DESCRIPTION
Cloud upgrade does a ceph health check at the start but ceph
could report some minor health problems initially after it is upgraded.

See this job https://ci.suse.de/job/openstack-mkcloud/58107/consoleText . It fails with ceph not being health but when I ssh and repeat the test, it is already fine.