### PR TITLE
Fix ordering of LDAP proposal value setting

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2634,8 +2634,8 @@ function custom_configuration
                 local l="['attributes']['keystone']['ldap']"
                 if iscloudver 7plus ; then
                     $p "['attributes']['keystone']['domain_specific_drivers']" true
-                    $p "$l['group_members_are_ids']" "true"
                     l="['attributes']['keystone']['domain_specific_config']['ldap_users']['ldap']"
+                    $p "$l['group_members_are_ids']" "true"
                 elif iscloudver 6; then
                     $p "['attributes']['keystone']['identity']['driver']" "'hybrid'"
                     $p "['attributes']['keystone']['assignment']['driver']" "'hybrid'"


### PR DESCRIPTION
The local variable 'l' is set differently for SOC 7, so it needs to be
set before we try to use it. This should correct the LDAP group
membership test issues[1].

[1] https://ci.suse.de/job/openstack-mkcloud/58297/console