### PR TITLE
Set timezone for crowbar admin node

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1543,6 +1543,12 @@ EOF
             echo "/srv/nfs     <%= @admin_subnet %>/<%= @admin_netmask %>(rw,async,no_root_squash,no_subtree_check)" >> $f
         fi
     fi
+
+    # Ensure the admin timezone is the same as the timezone that
+    # autoyast will configure for the deployed nodes
+    timedatectl set-timezone "Etc/UTC"
+    echo 'TIMEZONE="Etc/UTC"' >> /etc/sysconfig/clock
+
     return 0
 }
 


### PR DESCRIPTION
The jenkins build hosts use UTC, and the nodes that crowbar deploys are
configured to use UTC with autoyast, but the crowbar admin node itself
is set to the local timezone, CEST, because there is nothing in crowbar
that sets it otherwise. This makes sense because in our documentation
we start the process off with installing the base operating system
manually, which is where the operator would normally configure the
timezone. Having inconsistent timezones between the nodes causes a lot
of pain when debugging failed jobs because the log files and the output
of 'date' do not sync up. This patch explicitly sets the timezone on
the admin node during the prepareinstcrowbar phase.