### PR TITLE
New upgrade job with LBaaSv2 enabled

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -43,6 +43,7 @@
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-ceph-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-dvr-{arch}'
+        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-lbaasv2-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
 - project:
     name: cloud-mkcloud7-tempestfull-x86_64

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-lbaasv2-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-lbaasv2-template.yaml
@@ -1,0 +1,33 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-lbaasv2-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: 'H H * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{previous_version}
+            upgrade_cloudsource=develcloud{version}
+            nodenumber=4
+            storage_method=swift
+            cinder_backend=nfs
+            hacloud=1
+            want_node_aliases=controller=2,compute=2
+            clusterconfig=data+network+services=2
+            want_ping_running_instances=1
+            mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server batch testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
+            scenario=cloud{version}-upgrade-non-disruptive-lbaasv2.yml
+            label={label}
+            job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-lbaasv2-{arch}

--- a/scripts/scenarios/cloud6/cloud7-upgrade-non-disruptive-lbaasv2.yml
+++ b/scripts/scenarios/cloud6/cloud7-upgrade-non-disruptive-lbaasv2.yml
@@ -1,0 +1,160 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: libvirt
+      libvirt:
+        hypervisor_ip: ##hypervisor_ip##
+      sbd:
+        nodes:
+          @@controller1@@:
+            devices:
+            - ''
+          @@controller2@@:
+            devices:
+            - ''
+      per_node:
+        nodes:
+          @@controller1@@:
+            params: ''
+          @@controller2@@:
+            params: ''
+    drbd:
+      enabled: true
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - @@controller1@@
+      - @@controller2@@
+      hawk-server:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: nfs_client
+  name: services
+  attributes:
+    exports:
+      glance-images:
+        nfs_server: crowbar
+        export: "/var/lib/glance/images"
+        mount_path: "/var/lib/glance/images"
+        mount_options:
+        - ''
+  deployment:
+    elements:
+      nfs-client:
+      - "@@controller1@@"
+      - "@@controller2@@"
+
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+- barclamp: rabbitmq
+  attributes:
+    trove:
+      enabled: true
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+- barclamp: keystone
+  attributes:
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+- barclamp: glance
+  attributes:
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: nfs
+      backend_name: default
+      nfs:
+        nfs_shares: nfsserver:/srv/nfs/cinder
+        nfs_mount_options: ''
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - @@compute1@@
+- barclamp: neutron
+  attributes:
+    ml2_mechanism_drivers:
+      - linuxbridge
+    ml2_type_drivers:
+      - vlan
+    ml2_type_drivers_default_provider_network: vlan
+    ml2_type_drivers_default_tenant_network: vlan
+    use_lbaas: true
+    use_lbaasv2: true
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - @@compute1@@
+      - @@compute2@@
+      nova-compute-qemu: []
+      nova-compute-xen: []
+- barclamp: horizon
+  attributes:
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+- barclamp: heat
+  attributes:
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+- barclamp: ceilometer
+  attributes:
+  deployment:
+    elements:
+      ceilometer-agent:
+      - @@compute1@@
+      - @@compute2@@
+      ceilometer-agent-hyperv: []
+      ceilometer-central:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware: []
+- barclamp: tempest
+  attributes:
+  deployment:
+    elements:
+      tempest:
+      - @@controller1@@


### PR DESCRIPTION
In order to be able to test the LBaaSv2 related parts of the upgrade we
need to deploy cloud 6 with LBaaSv2 enabled (it's still defaulting to v1).

This jobs is using the NFS backend for cinder and switches the neutron
mechansim driver to "linuxbridge".