### PR TITLE
Enable IPv6 RA accept to have virsh net-start succeed again

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -108,8 +108,12 @@ function libvirt_do_setuphost()
         dnsmasq netcat-openbsd ebtables iproute2 sudo kpartx rsync
 
     sed -i 's/net.ipv4.ip_forward = 0/net.ipv4.ip_forward = 1/' /etc/sysctl.conf
-    echo "net.ipv4.conf.all.rp_filter = 0" > /etc/sysctl.d/90-cloudrpfilter.conf
-    echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
+    rm -f /etc/sysctl.d/90-cloudrpfilter.conf
+    # to enable IPv6 forwarding, we also need to enable accepting IPv6 RA
+    local mkcloudconf=/etc/sysctl.d/90-mkcloud.conf
+    echo "net.ipv4.conf.all.rp_filter = 0" > $mkcloudconf
+    echo "net.ipv6.conf.all.accept_ra = 2" >> $mkcloudconf
+    sysctl -p $mkcloudconf
     if [ -n "$needcvol" ] ; then
         safely pvcreate "$cloudpv"
         safely vgcreate "$cloudvg" "$cloudpv"


### PR DESCRIPTION
Recently IPv6 got enabled on the mkchX hosts, causing all jobs to
fail with the error message:

error: internal error: Check the host setup: enabling IPv6 forwarding
with RA routes without accept_ra set to 2 is likely to cause routes
loss.