### PR TITLE
Safer approach to crm resource cleanup

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -670,7 +670,7 @@ function instnodes
 function proposal
 {
     onadmin proposal
-    onadmin cleanup_db_mq_vips
+    onadmin cleanup_crm_errors
     return $?
 }
 


### PR DESCRIPTION
Looks like using crm resource cleanup on postgres/rabbitmq VIPs
causes the underlying resources to be restarted, leading to a temporal
unavailability of the service.
Instead, lets use crm_resource -C which only cleans the error history
and probes the resources, letting them be alive during the recheck.