### PR TITLE
Check for heat api availability before creating the heat stack

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4568,6 +4568,9 @@ function ping_fips
 
 function oncontroller_testpreupgrade
 {
+    # Workaround for onadmin_cleanup_db_mq_vips restarting
+    # the db/rpc servers. Wait until heat stack-list success
+    wait_for 120 5 "heat stack-list" "heat api to be available"
     heat stack-create upgrade_test -f /root/scripts/heat/2-instances-cinder.yaml
     wait_for 15 20 "heat stack-list | grep upgrade_test | grep CREATE_COMPLETE" \
              "heat stack for upgrade tests to complete"


### PR DESCRIPTION
Due to onadmin_cleanup_db_mq_vips seemingly restarting the db/rpc
services on the resource cleanup, the heat-api may be unavailable
for some time after the cleanup.
This introduces a little wait before creating the heat stack to
see if the heat api is up and running correctly