### PR TITLE
Fix wrong call to name method

### DIFF
--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -341,7 +341,7 @@ def domain_cleanup(dom):
 # name, otherwise None.
 def get_domain_by_name(conn, name):
     return next((domain for domain in conn.listAllDomains()
-                 if domain.name == name),
+                 if domain.name() == name),
                 None)
 
 


### PR DESCRIPTION
We are comparing against the name method instead of
calling it, thus get_domain_by_name is always returning nothing.

This may be why the cloud-mkcloudX-job-backup-restore-x86_64 jobs are failing.


```
mkche:~ # python
Python 2.7.13 (default, Jan 11 2017, 10:56:06) [GCC] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import libvirt
>>> l = libvirt.open("qemu:///system")
>>> [d.name for d in l.listAllDomains()]
[<bound method virDomain.name of <libvirt.virDomain object at 0x7f07da604090>>, <bound method virDomain.name of <libvirt.virDomain object at 0x7f07da6040d0>>, <bound method virDomain.name of <libvirt.virDomain object at 0x7f07da604110>>, <bound method virDomain.name of <libvirt.virDomain object at 0x7f07da604150>>, <bound method virDomain.name of <libvirt.virDomain object at 0x7f07da604190>>, <bound method virDomain.name of <libvirt.virDomain object at 0x7f07da6041d0>>, <bound method virDomain.name of <libvirt.virDomain object at 0x7f07da604210>>]
>>> [d.name() for d in l.listAllDomains()]
['ve1-node1', 've2-node2', 've1-admin', 've3-admin', 've2-admin', 've2-node1', 've1-node2']

```