### PR TITLE
default want_mtu_size not passed to qa_crowbarsetup

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -21,6 +21,7 @@ fi
 : ${networkingplugin:=openvswitch}
 : ${architectures:='aarch64 x86_64 s390x'}
 : ${nodenumberlonelynode:=0}
+: ${want_mtu_size:=1500}
 
 function max
 {

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -129,7 +129,6 @@ cloudbrlimit=11
 : ${install_chef_suse_override:=./install-chef-suse.sh}
 : ${cct_tests:="features:base"}
 host_mtu=$(determine_mtu)
-: ${want_mtu_size:=1500}
 : ${cachedir:=/tmp}
 iscloudver 7plus && [[ $arch == x86_64 ]] && \
     [[ -n $want_efi ]] && firmware_type="uefi"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1525,13 +1525,11 @@ EOF
         /opt/dell/bin/json-edit -a attributes.network.networks.public.ranges.host.end -v 10.162.211.191 $netfile
     fi
     # Setup network attributes for custom MTU
-    if [[ $want_mtu_size -ne 1500 ]]; then
-        echo "Setting MTU to custom value of: $want_mtu_size"
-        local lnet
-        for lnet in admin storage os_sdn ; do
-            /opt/dell/bin/json-edit -a attributes.network.networks.$lnet.mtu -r -v $want_mtu_size $netfile
-        done
-    fi
+    echo "Setting MTU to: $want_mtu_size"
+    local lnet
+    for lnet in admin storage os_sdn ; do
+        /opt/dell/bin/json-edit -a attributes.network.networks.$lnet.mtu -r -v $want_mtu_size $netfile
+    done
 
     # to allow integration into external DNS:
     local f=/opt/dell/chef/cookbooks/bind9/templates/default/named.conf.erb


### PR DESCRIPTION
if want_mtu_size is default and not set in env, it gets not passed from mkcloud to qa_crowbarsetup.sh, so we need to check if the variable is set