### PR TITLE
Revert "qa_crowbarsetup: use crowbarctl to commit proposals"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1733,7 +1733,7 @@ EOF
             puts JSON.pretty_generate(j)" > $pfile
         crowbar ntp proposal --file=$pfile edit default
         rm -f $pfile
-        crowbar_proposal_commit ntp
+        crowbar ntp proposal commit default
     fi
 
     for proposal in crowbar provisioner dns; do
@@ -2125,7 +2125,7 @@ function add_dns_record
             j['attributes']['dns']['records']['$name']['values']=['$ip'];
             puts JSON.pretty_generate(j)" > $pfile
     crowbar dns proposal --file=$pfile edit default
-    crowbar_proposal_commit dns
+    crowbar dns proposal commit default
 }
 
 function onadmin_setup_nfs_server
@@ -3170,18 +3170,6 @@ function set_noproxyvar
     no_proxy="${no_proxy%,}";
 }
 
-# commit a proposal, but use crowbarctl from cloud6 on
-function crowbar_proposal_commit
-{
-    local proposal="$1"
-    local proposaltype="${2:-default}"
-    if iscloudver 6plus ; then
-        safely crowbarctl proposal commit "$proposal" "$proposaltype"
-    else
-        safely crowbar "$proposal" proposal commit "$proposaltype"
-    fi
-}
-
 # configure and commit one proposal
 function update_one_proposal
 {
@@ -3194,8 +3182,8 @@ function update_one_proposal
     date
     # hook for changing proposals:
     custom_configuration $proposal $proposaltypemapped
-    crowbar_proposal_commit "$proposal" $proposaltype
 
+    crowbar "$proposal" proposal commit $proposaltype
     local ret=$?
     echo "Commit exit code: $ret"
     if [ "$ret" = "0" ]; then
@@ -5087,7 +5075,7 @@ function onadmin_cloudupgrade_2nd
 
     echo 'y' | suse-cloud-upgrade upgrade ||\
         complain $? "Upgrade failed with $?"
-    crowbar_proposal_commit provisioner
+    crowbar provisioner proposal commit default
 
     # Allow vendor changes for packages as we might be updating an official
     # Cloud release to something form the Devel:Cloud projects. Note: On the
@@ -5109,7 +5097,7 @@ function onadmin_cloudupgrade_clients
     json-edit updater.json -a attributes.updater.zypper.licenses_agree --raw -v "true"
     crowbar updater proposal --file updater.json edit default
     rm updater.json
-    crowbar_proposal_commit updater
+    crowbar updater proposal commit default
 }
 
 function onadmin_cloudupgrade_reboot_and_redeploy_clients
@@ -5149,7 +5137,8 @@ function onadmin_reapply_openstack_proposals
 
         for proposal in $applied_proposals; do
             echo "Commiting proposal $proposal of barclamp ${barclamp}..."
-            crowbar_proposal_commit "$barclamp" "$proposal"
+            crowbar "$barclamp" proposal commit "$proposal" ||\
+                complain 30 "committing barclamp-$barclamp failed"
         done
     done
 }


### PR DESCRIPTION
crowbarctl has a five minutes timeout when committing proposals, and
this change basically kills a good part of our CI because of timeouts.

This reverts commit b333958684cb9e7b4dfc3fc01cc1d77b6e4594a8.