### PR TITLE
Revert crowbarctl usage

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3175,7 +3175,8 @@ function crowbar_proposal_commit
 {
     local proposal="$1"
     local proposaltype="${2:-default}"
-    if iscloudver 6plus ; then
+    # crowbarctl triggers timeouts on deployment (2017-04-05)
+    if false && iscloudver 6plus ; then
         safely crowbarctl proposal commit "$proposal" "$proposaltype"
     else
         safely crowbar "$proposal" proposal commit "$proposaltype"


### PR DESCRIPTION
Now jobs are failing with:

from server (RestClient::Exceptions::ReadTimeout)
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/rest-client-2.0.0/lib/restclient/request.rb:704:in `transmit'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/rest-client-2.0.0/lib/restclient/request.rb:221:in `execute'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/rest-client-2.0.0/lib/restclient/request.rb:52:in `execute'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/rest-client-2.0.0/lib/restclient/resource.rb:67:in `post'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/crowbar-client-3.3.0/lib/crowbar/client/request/base.rb:69:in `process'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/crowbar-client-3.3.0/lib/crowbar/client/command/proposal/commit.rb:36:in `execute'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/crowbar-client-3.3.0/lib/crowbar/client/app/proposal.rb:305:in `commit'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:115:in `invoke'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:235:in `block in subcommand'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/crowbar-client-3.3.0/lib/crowbar/client/util/runner.rb:50:in `execute!'
23:54:32 	from /usr/lib64/ruby/gems/2.1.0/gems/crowbar-client-3.3.0/bin/crowbarctl:34:in `<top (required)>'
23:54:32 	from /usr/bin/crowbarctl:23:in `load'
23:54:32 	from /usr/bin/crowbarctl:23:in `<main>'