### PR TITLE
ignore output of "git show" when testing PRs

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud-log-parser-test.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud-log-parser-test.yaml
@@ -123,8 +123,10 @@
                   git checkout -t $ghremote/pr/$github_pr_id
                   echo "we merge to always test what will end up in master"
                   git merge master -m temp-merge-commit
-                  # show latest commit in log to see what's really tested
-                  git --no-pager show
+                  # Show latest commit in log to see what's really tested.
+                  # Include a unique indent so that the log parser plugin
+                  # can ignore the output and avoid false positives.
+                  git --no-pager show | sed 's/^/|@| /'
                   popd
               elif [[ "$github_pr_repo" = "SUSE-Cloud/cct" ]]; then
                   export want_cct_pr=$github_pr_id

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -531,8 +531,10 @@
                   git checkout -t $ghremote/pr/$github_pr_id
                   echo "we merge to always test what will end up in master"
                   git merge master -m temp-merge-commit
-                  # show latest commit in log to see what's really tested
-                  git --no-pager show
+                  # Show latest commit in log to see what's really tested.
+                  # Include a unique indent so that the log parser plugin
+                  # can ignore the output and avoid false positives.
+                  git --no-pager show | sed 's/^/|@| /'
                   popd
               elif [[ "$github_pr_repo" = "SUSE-Cloud/cct" ]]; then
                   export want_cct_pr=$github_pr_id

--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -7,6 +7,9 @@ info /^Waiting for /
 # Ignore set -x trace output
 ok /^\++\((mkcloud(-common\.sh)?|qa_crowbarsetup\.sh):\d+\) /
 
+# Ignore output of git show when testing PRs
+ok /^\|@\| /
+
 # wait_for() a condition to become true
 ok /^ *until this condition is true: /
 


### PR DESCRIPTION
When openstack-mkcloud is testing PRs, it does a

    git --no-pager show

to show the changes in the PR being tested.  However if the changes, or even the context around the changes, mentions something like `error` or `fail` or `fatal` then the Log Parser plugin will incorrectly flag this as a false positive.  So we indent the `git show` output by a unique prefix and then configure the plugin to ignore anything with that prefix.