### PR TITLE
jenkins/mkcloud: configure user+email

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -529,6 +529,8 @@
                       git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
                   git fetch $ghremote 2>&1 | grep -v '\[new ref\]' || :
                   git checkout -t $ghremote/pr/$github_pr_id
+                  git config user.email cloud-devel+jenkins@suse.de
+                  git config user.name "Jenkins User"
                   echo "we merge to always test what will end up in master"
                   git merge master -m temp-merge-commit
                   # Show latest commit in log to see what's really tested.


### PR DESCRIPTION
so that the git merge will not fail from their absence

change is partially tested (the lines work in bash on another git repo)