### PR TITLE
Revert: add trap

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -136,7 +136,6 @@ iscloudver 7plus && [[ $arch == x86_64 ]] && \
 
 pidfile=mkcloud.pid
 
-trap 'error_exit $? "error caught by trap"' TERM
 exec </dev/null
 
 function show_environment


### PR DESCRIPTION
This reverts commit 8afe815a11258c4ff19a0ff042622c05f17328da.

This trap causes race conditions in jenkins:
- when a job is cancelled mkcloud receives a TERM signal
- the trap catches it and call error_exit
- error_exit collects supportconfig for a few minutes
- meanwhile jenkins already finished and triggered the next job on
  the same host/slot and allocpool does not find a free slot

So in jenkins we never want to collect supportconfig when cancelling
a job. On the otherhand if an mkcloud is terminated manually, the user
can fetch the supportconfigs manually as well.