### PR TITLE
leave the drbd cleanup to recursive_remove_holders

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -300,13 +300,6 @@ function libvirt_do_cleanup()
         $sudo kpartx -dsv /dev/mapper/$vol
     done
 
-    # workaround host grabbing guest devices
-    for vol in postgresql rabbitmq ; do
-        dev=drbd-$vol
-        if $sudo dmsetup info $dev >/dev/null 2>&1; then
-            $sudo lvremove $cloudvg/$dev
-        fi
-    done
     # 2. remove all previous volumes for that cloud; this helps preventing
     # accidental booting and freeing space
     if [ -d $vdisk_dir ]; then


### PR DESCRIPTION
this code was added in commit 6cfe0bee3
and is probably obsolete now with the more general cleanup code
in recursive_remove_holders