### PR TITLE
mkcloud: look for qemu-kvm on SLE12

### DIFF
--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -87,11 +87,12 @@ libvirt_vm_start()
 # run as root
 function libvirt_do_setuphost()
 {
-    local kvmpkg=kvm
+    local kvmpkg=qemu-kvm
     local extra_packages=
     is_debian && extra_packages="chkconfig"
     if is_suse ; then
         extra_packages=python-xml
+        grep -q "SUSE Linux Enterprise Server 11" /etc/os-release && kvmpkg=kvm
         [[ $arch = aarch64 ]] && {
             kvmpkg=qemu-arm
             extra_packages+=" qemu-uefi-aarch64 qemu-ipxe"


### PR DESCRIPTION
because the rpm -q shortcut will not find a 'kvm' package
and then try to install kpartx and fail, because of the lock
for https://bugzilla.suse.com/show_bug.cgi?id=1033541

example failure without this:
https://ci.suse.de/job/openstack-mkcloud/59906/console