### PR TITLE
Add a job for non-disruptive upgrade with compute HA nodes

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-ceph-compute_ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-ceph-compute_ha-template.yaml
@@ -1,0 +1,33 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-ceph-compute_ha-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: '32 22 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{previous_version}
+            upgrade_cloudsource=develcloud{version}
+            nodenumber=7
+            storage_method=ceph
+            hacloud=1
+            want_node_aliases=ceph=3,controller=2,compute=2
+            clusterconfig=data+network+services=2
+            want_nodesupgrade=1
+            want_ping_running_instances=1
+            mkcloudtarget=instonly batch testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
+            scenario=cloud{version}-upgrade-non-disruptive-ceph-compute_ha.yml
+            label={label}
+            job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-ceph-compute_ha-{arch}

--- a/scripts/scenarios/cloud6/cloud7-upgrade-non-disruptive-ceph-compute_ha.yml
+++ b/scripts/scenarios/cloud6/cloud7-upgrade-non-disruptive-ceph-compute_ha.yml
@@ -1,0 +1,160 @@
+---
+proposals:
+- barclamp: ceph
+  attributes:
+    disk_mode: first
+    keystone_instance: default
+  deployment:
+    elements:
+      ceph-calamari: []
+      ceph-mon:
+      - @@ceph1@@
+      ceph-osd:
+      - @@ceph1@@
+      - @@ceph2@@
+      - @@ceph3@@
+      ceph-radosgw: []
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: libvirt
+      libvirt:
+        hypervisor_ip: ##hypervisor_ip##
+      sbd:
+        nodes:
+          @@controller1@@:
+            devices:
+            - ''
+          @@controller2@@:
+            devices:
+            - ''
+      per_node:
+        nodes:
+          @@controller1@@:
+            params: ''
+          @@controller2@@:
+            params: ''
+    drbd:
+      enabled: true
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - @@controller1@@
+      - @@controller2@@
+      hawk-server:
+      - @@controller1@@
+      - @@controller2@@
+      pacemaker-remote:
+      - @@compute1@@
+      - @@compute2@@
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+- barclamp: rabbitmq
+  attributes:
+    trove:
+      enabled: true
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+- barclamp: keystone
+  attributes:
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+- barclamp: glance
+  attributes:
+    default_store: rbd
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: rbd
+      backend_name: default
+      rbd:
+        use_crowbar: true
+        config_file: "/etc/ceph/ceph.conf"
+        admin_keyring: "/etc/ceph/ceph.client.admin.keyring"
+        pool: volumes
+        user: cinder
+        secret_uuid: ""
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - @@controller1@@
+      - @@controller2@@
+      - @@compute1@@
+      - @@compute2@@
+- barclamp: neutron
+  attributes:
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+  deployment:
+    elements:
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - remotes:services
+      nova-compute-qemu: []
+      nova-compute-xen: []
+- barclamp: horizon
+  attributes:
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+- barclamp: heat
+  attributes:
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+- barclamp: ceilometer
+  attributes:
+  deployment:
+    elements:
+      ceilometer-agent:
+      - @@compute1@@
+      - @@compute2@@
+      ceilometer-agent-hyperv: []
+      ceilometer-central:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware: []
+- barclamp: tempest
+  attributes:
+  deployment:
+    elements:
+      tempest:
+      - @@controller1@@


### PR DESCRIPTION
It's almost same as the upgrade-ceph job, only change is that the compute nodes have remote role