### PR TITLE
put controller nodes first

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-ceph-compute_ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-ceph-compute_ha-template.yaml
@@ -23,7 +23,7 @@
             nodenumber=7
             storage_method=ceph
             hacloud=1
-            want_node_aliases=ceph=3,controller=2,compute=2
+            want_node_aliases=controller=2,ceph=3,compute=2
             clusterconfig=data+network+services=2
             want_nodesupgrade=1
             want_ping_running_instances=1

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-ceph-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-ceph-template.yaml
@@ -23,7 +23,7 @@
             nodenumber=7
             storage_method=ceph
             hacloud=1
-            want_node_aliases=ceph=3,controller=2,compute=2
+            want_node_aliases=controller=2,ceph=3,compute=2
             clusterconfig=data+network+services=2
             want_nodesupgrade=1
             want_ping_running_instances=1


### PR DESCRIPTION
The mkcloud deployment starts the first $#services nodes of clusterconfig
(which is two here) with higher memory settings (the controller mem
settings). So we should assign the controller aliases to the first two
nodes.