### PR TITLE
cloud-crowbar-sap-testbuild-pr-trigger: enable job

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar-sap-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-sap-testbuild-pr-trigger.yaml
@@ -1,7 +1,7 @@
 - job:
     name: 'cloud-crowbar-sap-testbuild-pr-trigger'
     node: cloud-trigger
-    disabled: true
+    disabled: false
 
     parameters:
       - choice:


### PR DESCRIPTION
This enables the trigger job, to run all PRs of the sap-oc organization.