### PR TITLE
qa_crowbarsetup.sh: avoid downgrades when preparing the admin node

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1450,7 +1450,8 @@ EOF
 
     # avoid kernel update
     zypper al kernel-default
-    zypper -n dup --no-recommends -r Cloud -r cloudtup || zypper -n dup --no-recommends -r Cloud
+    local zypperdup="zypper -n dup --no-recommends --no-allow-downgrade"
+    $zypperdup -r Cloud -r cloudtup || $zypperdup -r Cloud
     zypper rl kernel-default
 
     # Workaround chef-solr crashes


### PR DESCRIPTION
For maintenance / update testing we'd like to avoid downgrading
to versions that are embedded in the Cloud media. However we still
want to allow upgrading in case we build a media with something newer
for trying out.