### PR TITLE
Fail fast(er) on crm failures

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -675,7 +675,6 @@ function instnodes
 function proposal
 {
     onadmin proposal
-    onadmin cleanup_db_mq_vips
     return $?
 }
 
@@ -858,7 +857,6 @@ function crowbarupgrade_5plus
         cloudsource=$upgrade_cloudsource onadmin prepare_cloudupgrade_nodes_repos_6_to_7
         onadmin upgrade_ses_to_4
         onadmin zypper_patch_all
-        onadmin cleanup_db_mq_vips
         onadmin upgrade_prechecks
         if [[ $cloudsource = develcloud6 ]] || [[ $upgrade_cloudsource = develcloud7 ]]; then
             onadmin allow_vendor_change_at_nodes

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4600,9 +4600,6 @@ function ping_fips
 # Use $heat_stack_params to provide parameters to heat template
 function oncontroller_testpreupgrade
 {
-    # Workaround for onadmin_cleanup_db_mq_vips restarting
-    # the db/rpc servers. Wait until heat stack-list success
-    wait_for 120 5 "heat --insecure stack-list" "heat api to be available"
     heat --insecure stack-create upgrade_test -f /root/scripts/heat/2-instances-cinder.yaml $heat_stack_params
     wait_for 15 20 "heat --insecure stack-list | grep upgrade_test | grep CREATE_COMPLETE" \
              "heat stack for upgrade tests to complete"
@@ -4969,26 +4966,6 @@ zypper -non-interactive --gpg-auto-import-keys --no-gpg-checks install ses-upgra
     # wait for ceph cluster to recover after the upgrade
     nodes=($ceph_mons)
     wait_for 60 5 "ssh ${nodes[0]} ceph health | grep -q HEALTH_OK" "ceph cluster to recover after upgrade"
-}
-
-# Some resources are known to fail for a short time because of a wicked ifreload call:
-# https://bugzilla.suse.com/show_bug.cgi?id=1030822
-# It's safe to clean existing errors now so we have a error-less crm status output.
-function onadmin_cleanup_db_mq_vips
-{
-    for svc in database rabbitmq; do
-        local node=$(knife search node "roles:$svc-server AND pacemaker_founder:true" -a name | \
-            grep ^name: | cut -d : -f 2 | sed 's/\s//g')
-
-        if [ -n "$node" ] ; then
-            # We're looking for resource like vip-admin-database-default-data (where 'data' is cluster name)
-            ssh $node "
-res=\$(crm resource list | grep vip-admin-$svc-default | cut -f 1 | sed 's/\s//g')
-if [ -n \"\$res\" ]; then
-    crm resource cleanup \$res
-fi"
-        fi
-    done
 }
 
 # This will adapt Cloud6 nodes repositories to Cloud7 ones


### PR DESCRIPTION
Currently, we check the crm failure report during the testsetup phase to
make sure that nothing in the deployment caused any resources to hiccup.
This is great for telling us that something went wrong, but because our
logs from supportconfig are truncated, we often can't get enough
information to see what happened on the system at the time the failure
occurred. This patch adds the check during the proposal phase after each
proposal starting with the nova proposal is applied. This way, if an
error occurred during the application of a proposal (whether the error
was caused by the proposal or not) the automation run will terminate and
the supportconfig generated should have relatively recent logs to
examine.  The reason this is only applied for proposals that come after
the nova proposal is that the oncontroller function uses the nova
proposal to determine which node is the controller. If keystone, for
example, causes a failure, we won't know until after the nova proposal
is applied, but we will still have a better chance of getting relevant
logs.