### PR TITLE
Verbose output

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -3,6 +3,11 @@
 # curl http://openqa.suse.de/sle/qatests/qa_openstack.sh | sh -x
 # needs 2.1GB space for /var/lib/{glance,nova}
 
+if [[ $debug_openstack = 1 ]] ; then
+    set -x
+    PS4='+(${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+fi
+
 : ${MODE:=kvm}
 ARCH=$(uname -i)
 : ${repomirror:=http://download.opensuse.org}


### PR DESCRIPTION
Added verbose output for debugging to `qa_openstack.sh`. The output is
disabled by default and is enabled when the `debug_openstack` variable
is set to `1`.