### PR TITLE
Allocate a bigger ("controller") VM for monasca

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -600,6 +600,11 @@ function setupnodes
             | sed -e "s/^.*services[^:]*=\([[:digit:]]\+\).*/\1/"`
     fi
 
+    # Need one more big VM for Monasca
+    if iscloudver 7plus && [[ $want_monasca = 1 ]]; then
+        nodenumbercontroller=$(($nodenumbercontroller+1))
+    fi
+
     setuppublicnet
     local i
     for i in $(nodes ids normal) ; do

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1928,6 +1928,11 @@ function onadmin_allocate
     echo "Setting first node to controller..."
     set_node_role_and_platform ${controllernodes[0]} "controller" $controller_os
 
+    if iscloudver 7plus && [[ $want_monasca = 1 ]]; then
+        echo "Setting 2nd node to monitoring..."
+        set_node_role_and_platform ${controllernodes[1]} "monitoring" $controller_os
+    fi
+
     # setup RAID for controller node
     if [[ $controller_raid_volumes -gt 1 ]] ; then
         set_node_raid ${controllernodes[0]} $want_raidtype $controller_raid_volumes
@@ -3329,6 +3334,10 @@ function deploy_single_proposal
                 return
             fi
             [[ $want_monasca = 1 ]] || return
+            if ! iscloudver 7plus; then
+                echo "monasca is SOC 7+ only. Skipping"
+                return
+            fi
             ;;
         swift)
             [[ $deployswift ]] || return


### PR DESCRIPTION
Monasca needs 10+GB of memory to start up, so we need
to allocate a second controller VM for it to succeed.