### PR TITLE
crowbar-testbuild: support custom osc parameters

### DIFF
--- a/scripts/crowbar-testbuild.yaml
+++ b/scripts/crowbar-testbuild.yaml
@@ -83,7 +83,14 @@ infrastructure:
   osc:
     cmd: /usr/bin/osc
     parameters:
-      - -A
-      - https://api.suse.de
+      _global:
+        - -A
+        - https://api.suse.de
+      co:
+        - -c
+        # - --server-side-source-service-files # for SAP
+      build:
+        - --noverify
+        # - --noservice # for SAP, to skip local service run, if server side source service files is enabled
   jenkins_job_trigger:
     cmd: jenkins/jenkins-job-trigger


### PR DESCRIPTION
The parameters may differ if the build service projects are setup differently (e.g. at sap).

@tpatzig This adds the support to change the parameters for any osc subcommand that might be used in the testbuild script (yes you can create a new section for a subcommand and it will be used). Please have a look and maybe a testrun on your system (hint: see the changed config yaml).