### PR TITLE
jenkins/mkcloud/ha: enable ssl for all services

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -24,6 +24,7 @@
             tempestoptions={tempestoptions}
             storage_method={storage_method_ha}
             hacloud=1
+            want_all_ssl=1
             mkcloudtarget=all_noreboot
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-{arch}


### PR DESCRIPTION
enable ssl for all services
in order to be closer to our required production cloud setup.
    
still missing:
controller_raid_volumes=2
want_ldap=1