### PR TITLE
trackupstream-openstack: Track monasca packages

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -41,12 +41,21 @@
             - openstack-horizon-plugin-neutron-lbaas-ui
             - openstack-horizon-plugin-manila-ui
             - openstack-horizon-plugin-magnum-ui
+            - openstack-horizon-plugin-monasca-ui
             - openstack-horizon-plugin-sahara-ui
             - openstack-horizon-plugin-trove-ui
             - openstack-ironic
             - openstack-keystone
             - openstack-manila
             - openstack-magnum
+            - openstack-monasca-agent
+            - openstack-monasca-api
+            - openstack-monasca-common
+            - openstack-monasca-log-agent
+            - openstack-monasca-log-api
+            - openstack-monasca-notification
+            - openstack-monasca-persister
+            - openstack-monasca-statsd
             - openstack-murano
             - openstack-neutron
             - openstack-neutron-fwaas
@@ -80,6 +89,15 @@
               "openstack-barbican",
               "openstack-horizon-plugin-ironic-ui",
               "openstack-horizon-plugin-magnum-ui",
+              "openstack-horizon-plugin-monasca-ui",
+              "openstack-monasca-agent",
+              "openstack-monasca-api",
+              "openstack-monasca-common",
+              "openstack-monasca-log-agent",
+              "openstack-monasca-log-api",
+              "openstack-monasca-notification",
+              "openstack-monasca-persister",
+              "openstack-monasca-statsd",
               "openstack-octavia",
             ].contains(component) ||
             [ "Cloud:OpenStack:Liberty:Staging", "Cloud:OpenStack:Mitaka:Staging" ].contains(project) &&


### PR DESCRIPTION
Enable tracking for those monasca packages that contain a _service file.