### PR TITLE
trackupstream-openstack: Fix some monasca names

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -50,12 +50,10 @@
             - openstack-magnum
             - openstack-monasca-agent
             - openstack-monasca-api
-            - openstack-monasca-common
             - openstack-monasca-log-agent
             - openstack-monasca-log-api
             - openstack-monasca-notification
             - openstack-monasca-persister
-            - openstack-monasca-statsd
             - openstack-murano
             - openstack-neutron
             - openstack-neutron-fwaas
@@ -75,6 +73,8 @@
             - openstack-utils
             - openstack-zaqar
             - python-heat-cfntools
+            - python-monasca-common
+            - python-monasca-statsd
             - python-networking-cisco
             - python-networking-hyperv
       - axis:
@@ -92,13 +92,13 @@
               "openstack-horizon-plugin-monasca-ui",
               "openstack-monasca-agent",
               "openstack-monasca-api",
-              "openstack-monasca-common",
               "openstack-monasca-log-agent",
               "openstack-monasca-log-api",
               "openstack-monasca-notification",
               "openstack-monasca-persister",
-              "openstack-monasca-statsd",
               "openstack-octavia",
+              "python-monasca-common",
+              "python-monasca-statsd",
             ].contains(component) ||
             [ "Cloud:OpenStack:Liberty:Staging", "Cloud:OpenStack:Mitaka:Staging" ].contains(project) &&
             [


### PR DESCRIPTION
It is python-monasca-common and python-monasca-statsd because both
packages do not contain any services.