### PR TITLE
Do not pass swift storage method to lbaas job

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-lbaasv2-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-lbaasv2-template.yaml
@@ -21,7 +21,7 @@
             cloudsource=develcloud{previous_version}
             upgrade_cloudsource=develcloud{version}
             nodenumber=4
-            storage_method=swift
+            storage_method=none
             cinder_backend=nfs
             hacloud=1
             want_node_aliases=controller=2,compute=2


### PR DESCRIPTION
The job uses scenario which does not deploy swift.
But the storage_method variable sets deployswift to 1 (although no
swift is actually deployed) and this in turn leads testsetup step
to do some swift testing, which obviously fails.


See e.g. swift test failures in this job https://ci.suse.de/job/openstack-mkcloud/60929/consoleText