### PR TITLE
ceph: Fix radosgw port for SSL

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4547,6 +4547,13 @@ function onadmin_testsetup
     if [ "$wantradosgwtest" == 1 ] ; then
         # test S3 access using python API
         radosgw=`echo $cephradosgws | sed "s/ .*//g" | sed "s/\..*//g"`
+        if [ "$want_ceph_ssl" == 1 -o "$want_all_ssl" == 1 ] ; then
+            local radosgwport=8081
+            local is_secure=True
+        else
+            local radosgwport=8080
+            local is_secure=False
+        fi
         ssh $radosgw radosgw-admin user create --uid=rados --display-name=RadosGW --secret="secret" --access-key="access"
 
         # using curl directly is complicated, see http://ceph.com/docs/master/radosgw/s3/authentication/
@@ -4559,8 +4566,8 @@ conn = boto.connect_s3(
         aws_access_key_id = "access",
         aws_secret_access_key = "secret",
         host = "$radosgw",
-        port = 8080,
-        is_secure=False,
+        port = $radosgwport,
+        is_secure=$is_secure,
         calling_format = boto.s3.connection.OrdinaryCallingFormat()
     )
 bucket = conn.create_bucket("test-s3-bucket")


### PR DESCRIPTION
When SSL is turned on, the RadosGW server uses port 8081[1][2] and does
not listen on port 8080. Hard-coding 8080 as the connection port was
causing the RadosGW tests to fail when SSL was turned on[3]. This patch
makes the port number conditional on whether SSL is being used so that
the test bucket can successfully be created even in an SSL environment.

[1] https://github.com/crowbar/crowbar-ceph/blob/d290aaca5cddd4539e512355b26efe9ddbe99397/chef/cookbooks/ceph/recipes/conf.rb#L48
[2] https://github.com/crowbar/crowbar-ceph/blob/2bce1372a2e6aba8570d0f30f3cab88839d09d5c/chef/cookbooks/ceph/attributes/radosgw.rb#L22
[3] https://ci.suse.de/job/openstack-mkcloud/61042/