### PR TITLE
Fix setuphost on a pristine but broken host

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -325,7 +325,7 @@ function onhost_enable_ksm
 
 function setuphost
 {
-    ${mkclouddriver}_do_setuphost
+    SKIPSUPPORTCONFIG=1 ${mkclouddriver}_do_setuphost
 }
 
 function prepare


### PR DESCRIPTION
When there is an error on package installation (because
of some repo being outdated or a libzypp update not yet installed)
mkcloud goes into a long-windling death due to trying to collect
supportconfig from everything below the horizon. Skip that.