### PR TITLE
qa_crowbarsetup: handle service deps later

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -27,9 +27,6 @@ fi
 : ${want_monasca_proposal:=0}
 : ${want_murano_proposal:=0}
 
-# service dependencies
-[[ $want_ceilometer_proposal = 0 ]] && want_aodh_proposal=0
-
 function max
 {
     echo $(( $1 > $2 ? $1 : $2 ))
@@ -116,6 +113,11 @@ function intercept
         echo "When ready exit this shell to continue with $1"
         bash
     fi
+}
+
+function handle_service_dependencies
+{
+    [[ $want_ceilometer_proposal = 0 ]] && want_aodh_proposal=0
 }
 
 function determine_mtu

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5734,3 +5734,4 @@ iscloudver 5plus && ruby=/usr/bin/ruby.ruby2.1
 export_tftpboot_repos_dir
 set_proposalvars
 set_noproxyvar
+handle_service_dependencies || :


### PR DESCRIPTION
this reverts the previous attempt from commit 20681e75a
which did not work, because at the time we source mkcloud-common,
the config from the mkcloud host is not yet sourced
thus we do not yet have the want_ceilometer_proposal value