### PR TITLE
libvirt_setup: make sure RAID disks are before others

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -38,7 +38,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1-raid1'/>
       <target dev='vdb' bus='virtio'/>
-      <address type='pci' slot='0x1a'/>
+      <address type='pci' slot='0x11'/>
     </disk>
 
 
@@ -47,7 +47,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1-ceph1'/>
       <target dev='vdc' bus='virtio'/>
-      <address type='pci' slot='0x11'/>
+      <address type='pci' slot='0x17'/>
     </disk>
 
     <disk type='block' device='disk'>
@@ -55,7 +55,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1-ceph2'/>
       <target dev='vdd' bus='virtio'/>
-      <address type='pci' slot='0x12'/>
+      <address type='pci' slot='0x18'/>
     </disk>
 
 

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -39,7 +39,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1-ceph1'/>
       <target dev='vdb' bus='virtio'/>
-      <address type='pci' slot='0x11'/>
+      <address type='pci' slot='0x17'/>
     </disk>
 
 

--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -39,7 +39,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1-ceph1'/>
       <target dev='vdb' bus='virtio'/>
-      <address type='pci' slot='0x11'/>
+      <address type='pci' slot='0x17'/>
     </disk>
 
 

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -266,7 +266,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                 args.nodecounter,
                 i),
             'target_dev': targetdevprefix + ''.join(alldevices.next()),
-            'target_address': target_address.format('0x1' + hex(i+9)[2:]),
+            'target_address': target_address.format(hex(0x10+i)),
         }, configopts))
 
     cephvolume = ""
@@ -285,7 +285,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                     args.nodecounter,
                     i),
                 'target_dev': targetdevprefix + ''.join(alldevices.next()),
-                'target_address': target_address.format('0x1' + str(i)),
+                'target_address': target_address.format(hex(0x16+i)),
             }, configopts))
 
     drbdvolume = ""


### PR DESCRIPTION
because we use vda+vdb for the RAID
and disk sizes usually do not match up

and get rid of the unreliable string manipulation logic