### PR TITLE
support to add additional updaterepos after deployment

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -273,6 +273,7 @@ function sshrun
         export cinder_netapp_password=$cinder_netapp_password;
 
         export UPDATEREPOS=$UPDATEREPOS ;
+        export UPDATEREPOS_EXTRA=$UPDATEREPOS_EXTRA ;
         export TESTHEAD=$TESTHEAD ;
         export NOINSTALLCLOUDPATTERN=$NOINSTALLCLOUDPATTERN ;
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -272,6 +272,7 @@ function sshrun
         export cinder_netapp_login=$cinder_netapp_login;
         export cinder_netapp_password=$cinder_netapp_password;
 
+        export UPDATEREPOS=$UPDATEREPOS ;
         export TESTHEAD=$TESTHEAD ;
         export NOINSTALLCLOUDPATTERN=$NOINSTALLCLOUDPATTERN ;
 
@@ -1211,7 +1212,7 @@ EOUSAGE
 
 function addupdaterepo
 {
-    sshrun "UPDATEREPOS=$UPDATEREPOS onadmin_addupdaterepo"
+    onadmin addupdaterepo "$@"
     return $?
 }
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4724,6 +4724,7 @@ function onadmin_addupdaterepo
 {
     pre_hook $FUNCNAME
 
+    local repos=$UPDATEREPOS
     local UPR=
     if iscloudver 7plus; then
         UPR=$tftpboot_repos12sp2_dir/PTF
@@ -4734,9 +4735,9 @@ function onadmin_addupdaterepo
     fi
     mkdir -p $UPR
 
-    if [[ $UPDATEREPOS ]]; then
+    if [[ $repos ]]; then
         local repo
-        for repo in ${UPDATEREPOS//+/ } ; do
+        for repo in ${repos//+/ } ; do
             safely wget --progress=dot:mega \
                 -r --directory-prefix $UPR \
                 -e robots=off \

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4725,6 +4725,7 @@ function onadmin_addupdaterepo
     pre_hook $FUNCNAME
 
     local repos=$UPDATEREPOS
+    local extra_repos=${1}
     local UPR=
     if iscloudver 7plus; then
         UPR=$tftpboot_repos12sp2_dir/PTF
@@ -4734,6 +4735,20 @@ function onadmin_addupdaterepo
         UPR=$tftpboot_repos_dir/Cloud-PTF
     fi
     mkdir -p $UPR
+
+    # Extra repos can be fetched on demand to the ptf repo
+    # From the variable $UPDATEREPOS_EXTRA the first 'n' repos are added, where n is the parameter to this function
+    # So addupdaterepo can be called repeatedly. Contents of the extra repos are only added but never removed.
+    case $extra_repos in
+        all|0)
+            repos=$UPDATEREPOS_EXTRA ;;
+        [1-9]*)
+            repos="$(echo $UPDATEREPOS_EXTRA | cut -d+ -f1-${extra_repos//[^0-9]/})" ;;
+        '')
+            echo "Info: No extra repos will be fetched from \$UPDATEREPOS_EXTRA." ;;
+        *)
+            complain 13 "Invalid parameter for addupdaterepo. Valid are integers or the string 'all' (0 == all). The value was: $extra_repos" ;;
+    esac
 
     if [[ $repos ]]; then
         local repo


### PR DESCRIPTION
For various use cases we were asked to support to add updaterepos after the deployment.

This PR adds support for this via the existing addupdaterepos function.
When called without parameter (like in regular deployments) all repos from the variable $UPDATEREPOS are added to the PTF repo.

When called later (or at any time, repeatedly) with a parameter (n, integer > 0) the first n repos from the variable $UPDATEREPOS_EXTRA are added to the PTF repo. The variable is not changed. So the parameter has to increase to successively add content to the PTF repo.

If the parameter is 0 or 'all' then all repos from the variable $UPDATEREPOS_EXTRA are added.

Intended usage e.g.: `mkcloud all addupdaterepo+2 onadmin+zypper_update onadmin+cloudupgrade_clients testsetup`