### PR TITLE
Provide meaningful message when clouddata unreachable

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1253,6 +1253,10 @@ function sanity_checks
         exit 1
     fi
 
+    if [[ -z $clouddata ]] ; then
+        complain 96 "The host $clouddatadns could not be resolved and no alternative has been supplied in \$clouddata"
+    fi
+
     [[ $clouddata =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
         complain 96 "clouddata must be an IPv4 address"
 


### PR DESCRIPTION
When clouddata.nue.suse.com is unreachable, mkcloud complained in a
confusing way about the fact that the clouddata variable was not set.
Provide a more meaningful error message when this happens.