### PR TITLE
mkcloud: fix calling for functions

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1434,10 +1434,12 @@ for cmd in `echo $steplist` ; do
     echo $cmd >> mkcloud.steps.log
     # support calls to functions with parameters
     # this is currently used for the cct function
-    cmd_parameters="${cmd#*+}"
-    cmd=${cmd%%+*}
+    IFS=+
+    cmd_and_parameters=($cmd) # split at + and convert to list
+    unset IFS
+    cmd=${cmd_and_parameters[0]}
     TIMEFORMAT="timing for mkcloud step '$cmd' real=%R user=%U system=%S"
-    time $cmd "${cmd_parameters//+/ }"
+    time "${cmd_and_parameters[@]}"
     ret=$?
     if [ $ret != 0 ] ; then
         set +x


### PR DESCRIPTION
fix calling for functions
that can get optional params,
otherwise it would be called with the function name as only param
instead of no param