### PR TITLE
simpletest-s390x: upgrade nodes via updater barclamp

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7-job-simpletest-s390x.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-job-simpletest-s390x.yaml
@@ -19,7 +19,7 @@
             TESTHEAD=1
             cloudsource=develcloud7
             nodenumber=2
-            mkcloudtarget=cleanup prepare setupadmin addupdaterepo prepareinstcrowbar runupdate bootstrapcrowbar instcrowbar setuplonelynodes crowbar_register proposal crowbarbackup crowbarrestore
+            mkcloudtarget=cleanup prepare setupadmin addupdaterepo prepareinstcrowbar runupdate bootstrapcrowbar instcrowbar setuplonelynodes crowbar_register onadmin+cloudupgrade_clients proposal crowbarbackup crowbarrestore
             label=openstack-mkcloud-SLE12-s390x
             job_name=cloud-mkcloud7-job-simpletest-s390x
             want_ceilometer_proposal=0


### PR DESCRIPTION
SLE12 images needs to be upgraded and recaptured, but meanwhile we need
to upgrade them via the updater barclamp to fix some bugs in the named
service.