### PR TITLE
mark PTF key as workaround for =< cloud7

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4899,7 +4899,10 @@ function onadmin_addupdaterepo
         safely $zypper ar $UPR cloud-ptf
     safely $zypper mr -p 90 -r cloud-ptf
     safely $zypper ref
-    [[ ! -e $UPR/repodata/repomd.xml.key ]] || safely rpmkeys --import $UPR/repodata/repomd.xml.key
+    if iscloudver 7minus ; then
+        # workaround missing in cloud 6 GM and 7 GM: https://github.com/crowbar/crowbar/pull/2320
+        [[ ! -e $UPR/repodata/repomd.xml.key ]] || safely rpmkeys --import $UPR/repodata/repomd.xml.key
+    fi
 }
 
 function zypper_patch


### PR DESCRIPTION
This reverts commit 623e4180f32041b58e1b22b8af8a5ad335e0c880.
It was only a workaround until the fix was ported to all current versions of crowbar. So do not merge this revert earlier.