### PR TITLE
linked to parsed console for failed builds

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -489,7 +489,7 @@
 
           function mkcloudgating_trap()
           {
-              $ghs -a set-status -s "failure" -r $github_pr_repo -t $BUILD_URL -c $github_pr_sha --context $ghs_context
+              $ghs -a set-status -s "failure" -r $github_pr_repo -t ${BUILD_URL}parsed_console/ -c $github_pr_sha --context $ghs_context
           }
 
           ## mkcloud github PR gating


### PR DESCRIPTION
When a build fails, usually the first thing we want to know is why it failed.  The parsed console is the quickest way of finding this out, so jump directly to it instead of requiring an extra click.