### PR TITLE
cleanvm: tunnel through SSH

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -49,12 +49,14 @@
         )
       sequential: true
     builders:
-      - update-automation
       - shell: |
           #!/bin/bash
+          ssh jenkins@ci1-opensuse openstack_project=$openstack_project image=$image '
+          [ -e ~/bin/update_automation ] || wget -O ~/bin/update_automation https://raw.github.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation && chmod a+x ~/bin/update_automation
+          update_automation
           sudo /usr/local/sbin/freshvm cleanvm $image
           sleep 100
-          cloudsource=openstack$(echo $openstack_project | tr '[:upper:]' '[:lower:]')
+          cloudsource=openstack$(echo $openstack_project | tr "[:upper:]" "[:lower:]")
           oshead=1
           set -u
           set +e
@@ -76,6 +78,7 @@
           fi
 
           exit $ret
+          '
       - trigger-builds:
         - project: openstack-submit
           condition: SUCCESS


### PR DESCRIPTION
so that we do not need java-1.8 on the host

for this we have to inline the update-automation macro,
because it also needs to happen on the remote end

First test of a slightly different version is running at
https://ci.opensuse.org/job/openstack-cleanvm/image=SLE_11_SP3,openstack_project=Juno,slave=cloud-cleanvm/2742/console