### PR TITLE
doc: drop obsolete variables from documentation

### DIFF
--- a/docs/basic-mkcloud-config.sh
+++ b/docs/basic-mkcloud-config.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-unset PARALLEL
 unset cloudpv
 unset cloudsource
 unset nodenumber
 unset want_sles12sp1
 
-export PARALLEL=yes
 export cloudpv=/dev/loop0
 export cloudsource=develcloud6
 export nodenumber='2'

--- a/mkcloudruns/mkcloudconfig/SUSECloud.mkcloud
+++ b/mkcloudruns/mkcloudconfig/SUSECloud.mkcloud
@@ -69,7 +69,6 @@ export networkingmode=gre
 export want_dvr=1
 #export host_mtu= # Set given MTU settings...
 
-export PARALLEL=yes
 export cloud_port_offset=$((1000 + 100*$n))
 export net_admin=192.168.$((50+$n*2))
 export net_public=192.168.$((51+$n*2))


### PR DESCRIPTION
PARALLEL is no longer needed and supported