### PR TITLE
ha: Fix check_crm_failcounts function

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4030,7 +4030,7 @@ function oncontroller_check_crm_failcounts
 {
     iscloudver 7plus && [[ $hacloud = 1 ]] && \
         [[ $(crm_mon --failcounts -1 | grep "fail-count=" | wc -l) -gt 0 ]] && \
-        complain 55 "Cluster resources' failures detected"
+        complain 55 "Cluster resources' failures detected" || :
 }
 
 # code run on controller/dashboard node to do basic tests of deployed cloud

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4031,6 +4031,7 @@ function oncontroller_check_crm_failcounts
     if iscloudver 7plus && [[ $hacloud = 1 ]] ; then
         crm_mon --failcounts -1 | grep "fail-count=" && complain 55 "Cluster resources' failures detected"
     fi
+    return 0
 }
 
 # code run on controller/dashboard node to do basic tests of deployed cloud

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4028,10 +4028,9 @@ function nova_services_up
 
 function oncontroller_check_crm_failcounts
 {
-    if iscloudver 7plus && [[ $hacloud = 1 ]] ; then
-        crm_mon --failcounts -1 | grep "fail-count=" && complain 55 "Cluster resources' failures detected"
-    fi
-    return 0
+    iscloudver 7plus && [[ $hacloud = 1 ]] && \
+        [[ $(crm_mon --failcounts -1 | grep "fail-count=" | wc -l) -gt 0 ]] && \
+        complain 55 "Cluster resources' failures detected"
 }
 
 # code run on controller/dashboard node to do basic tests of deployed cloud


### PR DESCRIPTION
This function is run with the "safely" wrapper so that if it fails while
running on a remote host, it causes the run to abort. This is a problem
because the function works by checking the output of grep, which when
finding no matches (which is a success in this case), exits 1. Since the
function apparently fails, the "safely" wrapper causes the run to abort
even though everything is fine. This patch ensures the function returns
a success code if it made it past the "complain", which would cause the
function to exit before making it to the end.