### PR TITLE
syncSLErepos: use delay-updates

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -13,7 +13,7 @@ M=
 DRY=--dry-run
 DRY=
 
-rsync="$E rsync $DRY --bwlimit 10000 --delete-after -avH --no-owner --no-group --exclude=*src.rpm "
+rsync="$E rsync $DRY --bwlimit 10000 --delay-updates --delete-delay -avH --no-owner --no-group --exclude=*src.rpm "
 
 # http://download.suse.de/ibs/Devel:/Cloud:/4/images/*qcow2 -> images/SLES11-SP3-x86_64-cfntools.qcow2
 


### PR DESCRIPTION
to always have a consistent repo synced
and delete-delay instead of delete-after
in order to use the more efficient recursion algorithm