### PR TITLE
Set mtu of public/nova_fixed/nova_floating networks

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1542,7 +1542,7 @@ EOF
     # Setup network attributes for custom MTU
     echo "Setting MTU to: $want_mtu_size"
     local lnet
-    for lnet in admin storage os_sdn ; do
+    for lnet in admin storage os_sdn public nova_floating nova_fixed; do
         /opt/dell/bin/json-edit -a attributes.network.networks.$lnet.mtu -r -v $want_mtu_size $netfile
     done
 


### PR DESCRIPTION
We want to set the MTU of all those networks to the $want_mtu_size var
as we want to allow setting up the custom MTU for all netwroks trougth
the network cookbook.
Not setting it would make the controller tests fail to ping the admin
as the mtu size set for the br-fixed iface would be too low.

Fixes https://github.com/crowbar/crowbar-core/pull/1087 mkcloud runs