### PR TITLE
Print $UPDATEREPOS_EXTRA in show_environment

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -174,6 +174,7 @@ function show_environment
     echo "  nodenumber: $nodenumber"
     echo "     cloudpv: $cloudpv"
     echo " UPDATEREPOS: $UPDATEREPOS"
+    echo " UPDATEREPOS_EXTRA: $UPDATEREPOS_EXTRA"
     echo "    cephvolumenumber: $cephvolumenumber"
     echo " upgrade_cloudsource: $upgrade_cloudsource"
     echo "-------------------------------"


### PR DESCRIPTION
Add $UPDATEREPOS_EXTRA to the environment details printed in
show_environment. This helps with debugging when an mkcloud run fails.