### PR TITLE
Extend the number of supported disks and NICs

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
@@ -37,7 +37,7 @@
       <target dev='cloud-a'/>
       <source network='cloud-admin'/>
       <model type='virtio'/>
-      <address type='pci' slot='0x3'/>
+      <address type='pci' bus='0x01' slot='0x1'/>
     </interface>
     <serial type='pty'>
       <target port='0'/>
@@ -53,7 +53,7 @@
     </video>
 
     <memballoon model='virtio' autodeflate='on'>
-      <address type='pci' slot='0x05'/>
+      <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
 
   </devices>

--- a/scripts/lib/libvirt/fixtures/cloud-admin.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin.xml
@@ -37,7 +37,7 @@
       <target dev='cloud-a'/>
       <source network='cloud-admin'/>
       <model type='virtio'/>
-      <address type='pci' slot='0x3'/>
+      <address type='pci' bus='0x01' slot='0x1'/>
     </interface>
     <serial type='pty'>
       <target port='0'/>
@@ -53,7 +53,7 @@
     </video>
 
     <memballoon model='virtio' autodeflate='on'>
-      <address type='pci' slot='0x05'/>
+      <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
 
   </devices>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -64,7 +64,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='virtio'/>
-  <address type='pci' slot='0x3'/>
+  <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>
 
@@ -82,7 +82,7 @@
     </video>
 
     <memballoon model='virtio' autodeflate='on'>
-      <address type='pci' slot='0x05'/>
+      <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
   </devices>
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -48,7 +48,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='virtio'/>
-  <address type='pci' slot='0x3'/>
+  <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>
 
@@ -66,7 +66,7 @@
     </video>
 
     <memballoon model='virtio' autodeflate='on'>
-      <address type='pci' slot='0x05'/>
+      <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
   </devices>
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -48,7 +48,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='e1000'/>
-  <address type='pci' slot='0x3'/>
+  <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>
 

--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -48,7 +48,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='virtio'/>
-  <address type='pci' slot='0x3'/>
+  <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>
 
@@ -66,7 +66,7 @@
     </video>
 
     <memballoon model='virtio' autodeflate='on'>
-      <address type='pci' slot='0x05'/>
+      <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
   </devices>
 </domain>

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -103,7 +103,7 @@ def get_memballoon_type():
     </memballoon>"""
 
     return """    <memballoon model='virtio' autodeflate='on'>
-      <address type='pci' slot='0x05'/>
+      <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>"""
 
 
@@ -117,7 +117,7 @@ def get_serial_device():
 
 
 def get_mainnic_address(index):
-    mainnicaddress = "<address type='pci' slot='%s'/>" % (hex(index + 0x3))
+    mainnicaddress = "<address type='pci' bus='0x01' slot='%s'/>" % (hex(index + 0x1))
     if 's390x' in get_machine_arch():
         mainnicaddress = "<address type='ccw' cssid='0xfe' ssid='0x0' " \
                                          "devno='%s'/>" % \

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -86,7 +86,7 @@ def get_default_machine(emulator):
     else:
         machine = "pc-i440fx-2.0"
         if os.system("%(emulator)s -machine help | grep -q %(machine)s" % ({
-                         'emulator': emulator, 'machine': machine})) != 0:
+                     'emulator': emulator, 'machine': machine})) != 0:
             return "pc-0.14"
         return machine
 
@@ -117,11 +117,12 @@ def get_serial_device():
 
 
 def get_mainnic_address(index):
-    mainnicaddress = "<address type='pci' bus='0x01' slot='%s'/>" % (hex(index + 0x1))
+    mainnicaddress = "<address type='pci' bus='0x01' slot='%s'/>" % \
+        (hex(index + 0x1))
     if 's390x' in get_machine_arch():
         mainnicaddress = "<address type='ccw' cssid='0xfe' ssid='0x0' " \
-                                         "devno='%s'/>" % \
-                                         (hex(index + 0x1))
+            "devno='%s'/>" % \
+            (hex(index + 0x1))
     return mainnicaddress
 
 
@@ -182,7 +183,7 @@ def net_interfaces_config(args, nicmodel):
             net=get_net_for_nic(args, index),
             macaddress=mac,
             nicmodel=nicmodel,
-            bootorder=bootorderoffset+(index*10),
+            bootorder=bootorderoffset + (index * 10),
             mainnicaddress=mainnicaddress)
         nic_configs.append(
             get_config(values, os.path.join(TEMPLATE_DIR,
@@ -266,12 +267,12 @@ def compute_config(args, cpu_flags=cpuflags()):
                 args.nodecounter,
                 i),
             'target_dev': targetdevprefix + ''.join(alldevices.next()),
-            'target_address': target_address.format(hex(0x10+i)),
+            'target_address': target_address.format(hex(0x10 + i)),
         }, configopts))
 
     cephvolume = ""
     if args.cephvolumenumber and args.cephvolumenumber > 0:
-        for i in range(1, args.cephvolumenumber+1):
+        for i in range(1, args.cephvolumenumber + 1):
             ceph_template = string.Template(
                 readfile(os.path.join(TEMPLATE_DIR, "extra-volume.xml")))
             cephvolume += "\n" + ceph_template.substitute(merge_dicts({
@@ -285,7 +286,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                     args.nodecounter,
                     i),
                 'target_dev': targetdevprefix + ''.join(alldevices.next()),
-                'target_address': target_address.format(hex(0x16+i)),
+                'target_address': target_address.format(hex(0x16 + i)),
             }, configopts))
 
     drbdvolume = ""
@@ -369,7 +370,7 @@ def cleanup_one_node(args):
 def cleanup(args):
     conn = libvirt_connect()
     domains = [i for i in conn.listAllDomains()
-               if i.name().startswith(args.cloud+"-")]
+               if i.name().startswith(args.cloud + "-")]
 
     for dom in domains:
         domain_cleanup(dom)


### PR DESCRIPTION
We have to support a variable number of disks and NICs in order to
accommodate our deployment scenarios and these two device classes
compete over the available PCI slots.

Currently the PCI slot of the memballoon device collides with the
network cards for more than 2 NICs.

We can extend the number of supported PCI devices by using more than one
PCI bus (each PCI bus supports up to 32 devices). This change places all
disks onto `bus=0x00`, all NICs onto `bus=0x01`, and the memballoon
device onto `bus=0x02`.For more than 2 NICs the PCI slot of the memoballoon device collides
with the network cards. This patch moves the slot used up by 16 to
create some buffer between the last NIC and the memoballoon device.