### PR TITLE
mkcloud: Allow custom crowbar networking mode

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -160,6 +160,12 @@
           default:
           description: Number of compute nodes
 
+      - string:
+          name: nics
+          default: '1'
+          description: >-
+            Number of network interfaces for the nodes (admin node has always 1 currently)
+
       - bool:
           name: WITHCROWBARREGISTER
           default: false
@@ -210,6 +216,14 @@
           name: want_rootfs
           default:
           description: Set to btrfs to deploy with btrfs
+
+      ################################################
+      # Crowbar
+
+      - string:
+          name: crowbar_networkingmode
+          default: 'single'
+          description: The Crowbar networking mode.
 
       ################################################
       # general OpenStack deployment

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -77,6 +77,7 @@ nicsdefault=1
 [[ $want_ironic ]] && nicsdefault=2
 : ${nics:=$nicsdefault}
 : ${adminvcpus:=2}
+: ${crowbar_networkingmode:=single}
 cpuflags=''
 working_dir_orig=`pwd`
 : ${artifacts_dir:=$working_dir_orig/.artifacts}
@@ -274,6 +275,8 @@ function sshrun
         export scenario=$scenario ;
         export host_mtu=$host_mtu ;
         export architectures='$architectures';
+
+        export crowbar_networkingmode=$crowbar_networkingmode;
 
         export nova_shared_instance_storage=$nova_shared_instance_storage ;
 
@@ -1092,6 +1095,8 @@ Optional
     nics=1         (default $nics)
         set the number of network interfaces per cloud node
         if Ironic is enabled (want_ironic=1), default is set to 2
+    crowbar_networkingmode=single         (default $crowbar_networkingmode)
+        set the networking mode for Crowbar.
     adminvcpus=1    (default $adminvcpus)
         set the number of CPU cores for admin node
     admin_node_memory (default 4194304)


### PR DESCRIPTION
Introduce a new 'crowbar_networkingmode' variable which defaults to 'single'.
When set to 'team' ('nics' variable must be > 1 then), mkcloud deploys the cloud
with a bonding network setup. This is useful for testing more complex (and more
realistic) scenarios.
Note: The crowbar node itself has no bonding enabled. Our current mkcloud setup
gives the crowbar node only a single nic (even if 'nics' > 1). That's why this
commit adds an extra entry to the conduit_map for the crowbar node.

It can be used to set the Crowbar networking mode which can be 'team' which
does bond multiple interfaces.
This is useful for testing more realistic scenarios where multiple interfaces
are used together.