### PR TITLE
Temporally disable test repo for 4nodes-linuxbrige jobs

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -24,4 +24,6 @@
             tempestoptions={tempestoptions}
             mkcloudtarget=all
             label={label}
+            # Temporal fix meanwhile test repository is fixed for Ceph
+            want_test_updates=0
             job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}


### PR DESCRIPTION
The last Ceph update for SLE12SP1 broke the ceph packages