### PR TITLE
updated ironic job to use batch

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
@@ -19,15 +19,16 @@
           predefined-parameters: |
             TESTHEAD=1
             cloudsource=develcloud{version}
-            nodenumber=5
-            clusterconfig=data+network+services=3
+            nodenumber=3
+            clusterconfig=data+network+services=2
             storage_method=default
             hacloud=1
-            mkcloudtarget=plain_with_ironic
+            mkcloudtarget=instonly batch setupironicnodes
             networkingplugin=openvswitch
             networkingmode=gre
-            want_node_aliases=controller=3,compute=2
+            want_node_aliases=controller=2,compute=1
             label={label}
+            scenario=cloud{version}-ironic-basic-ha.yml
             job_name=cloud-mkcloud{version}-job-ha-ironic-{arch}
             want_ironic=1
-            nodenumberironicnode=1
+            nodenumberironicnode=2

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5711,6 +5711,10 @@ function onadmin_batch
 
     if iscloudver 5plus; then
         sed -i "s/##hypervisor_ip##/$admingw/g" ${scenario}
+
+        sed -i "s/##ironic_net_prefix##/$net_ironic/g" ${scenario}
+        sed -i "s/##ironic_netmask##/$ironicnetmask/g" ${scenario}
+
         if iscloudver 6plus; then
             safely crowbar batch --exclude manila --timeout 2400 build ${scenario}
             if grep -q "barclamp: manila" ${scenario}; then

--- a/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
@@ -1,0 +1,275 @@
+---
+proposals:
+- barclamp: network
+  attributes:
+    conduit_map:
+    - conduit_list:
+        intf0:
+          if_list:
+          - 1g1
+          - 1g2
+        intf1:
+          if_list:
+          - 1g1
+          - 1g2
+        intf2:
+          if_list:
+          - 1g1
+          - 1g2
+        intf3:
+          if_list:
+          - 1g1
+          - 1g2
+      pattern: team/.*/.*
+    - conduit_list:
+        intf0:
+          if_list:
+          - "?1g1"
+        intf1:
+          if_list:
+          - "?1g2"
+        intf2:
+          if_list:
+          - "?1g1"
+        intf3:
+          if_list:
+          - "?1g2"
+      pattern: dual/.*/.*
+    - conduit_list:
+        intf0:
+          if_list:
+          - "?1g1"
+        intf1:
+          if_list:
+          - "?1g1"
+        intf2:
+          if_list:
+          - "?1g1"
+        intf3:
+          if_list:
+          - "?1g2"
+      pattern: single/.*/.*ironic.*
+    - conduit_list:
+        intf0:
+          if_list:
+          - "?1g1"
+        intf1:
+          if_list:
+          - "?1g1"
+        intf2:
+          if_list:
+          - "?1g1"
+        intf3:
+          if_list:
+          - "?1g1"
+      pattern: single/.*/.*
+    - conduit_list:
+        intf0:
+          if_list:
+          - "?1g1"
+        intf1:
+          if_list:
+          - 1g1
+        intf2:
+          if_list:
+          - 1g1
+        intf3:
+          if_list:
+          - 1g1
+      pattern: ".*/.*/.*"
+    - conduit_list:
+        intf0:
+          if_list:
+          - 1g1
+        intf1:
+          if_list:
+          - "?1g1"
+        intf2:
+          if_list:
+          - "?1g1"
+        intf3:
+          if_list:
+          - "?1g1"
+      pattern: mode/1g_adpt_count/role
+    networks:
+      ironic:
+        conduit: intf3
+        vlan: 100
+        use_vlan: false
+        add_bridge: false
+        add_ovs_bridge: false
+        bridge_name: br-ironic
+        subnet: ##ironic_net_prefix##.0
+        netmask: ##ironic_netmask##
+        broadcast: ##ironic_net_prefix##.255
+        router: ##ironic_net_prefix##.1
+        router_pref: 50
+        ranges:
+          admin:
+            start: ##ironic_net_prefix##.10
+            end: ##ironic_net_prefix##.11
+          dhcp:
+            start: ##ironic_net_prefix##.21
+            end: ##ironic_net_prefix##.254
+        mtu: 1500
+  deployment:
+    elements:
+      switch_config:
+      - crowbar.virtual.cloud.suse.de
+      network:
+      - crowbar.virtual.cloud.suse.de
+      - "@@controller1@@"
+      - "@@compute@@"
+      - "@@controller2@@"
+- barclamp: pacemaker
+  name: data
+  attributes:
+    stonith:
+      mode: libvirt
+      libvirt:
+        hypervisor_ip: ##hypervisor_ip##
+    drbd:
+      enabled: true
+      shared_secret: yaYqaPqd3jYz
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      hawk-server:
+      - "@@controller1@@"
+      - "@@controller2@@"
+- barclamp: nfs_client
+  name: data
+  attributes:
+    exports:
+      glance-images:
+        nfs_server: crowbar.virtual.cloud.suse.de
+        export: "/var/lib/glance/images"
+        mount_path: "/var/lib/glance/images"
+        mount_options:
+        - ''
+  deployment:
+    elements:
+      nfs-client:
+      - "@@controller1@@"
+      - "@@controller2@@"
+- barclamp: database
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+  deployment:
+    elements:
+      database-server:
+      - cluster:data
+- barclamp: rabbitmq
+  attributes:
+    ha:
+      storage:
+        mode: drbd
+        drbd:
+          size: 5
+    trove:
+      enabled: true
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:data
+- barclamp: keystone
+  attributes:
+    database_instance: default
+    rabbitmq_instance: default
+    api:
+      region: CustomRegion
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:data
+- barclamp: glance
+  attributes:
+    keystone_instance: default
+    database_instance: default
+    rabbitmq_instance: default
+  deployment:
+    elements:
+      glance-server:
+      - cluster:data
+- barclamp: cinder
+  attributes:
+    rabbitmq_instance: default
+    keystone_instance: default
+    glance_instance: default
+    database_instance: default
+    volumes:
+    - backend_driver: local
+      backend_name: default
+      raw:
+        volume_name: cinder-volumes
+        cinder_raw_method: first
+      local:
+        volume_name: cinder-volumes
+        file_name: "/var/lib/cinder/volume.raw"
+        file_size: 2000
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:data
+      cinder-volume:
+      - "@@compute@@"
+- barclamp: neutron
+  attributes:
+    rabbitmq_instance: default
+    keystone_instance: default
+    ml2_type_drivers:
+    - vxlan
+    - vlan
+    database_instance: default
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:data
+      neutron-network:
+      - cluster:data
+- barclamp: ironic
+  attributes:
+    rabbitmq_instance: default
+    database_instance: default
+    glance_instance: default
+    keystone_instance: default
+    neutron_instance: default
+    enabled_drivers:
+    - pxe_ssh
+    - pxe_ipmitool
+  deployment:
+    elements:
+      ironic-server:
+      - "@@controller1@@"
+- barclamp: nova
+  attributes:
+    database_instance: default
+    rabbitmq_instance: default
+    keystone_instance: default
+    glance_instance: default
+    cinder_instance: default
+    neutron_instance: default
+    itxt_instance: ''
+  deployment:
+    elements:
+      nova-controller:
+      - "@@controller1@@"
+      nova-compute-kvm: []
+      nova-compute-qemu: []
+      nova-compute-xen: []
+      nova-compute-ironic:
+      - "@@compute@@"
+- barclamp: horizon
+  attributes:
+    keystone_instance: default
+    database_instance: default
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:data


### PR DESCRIPTION
Ironic will not work with default proposals as compute service config needs to be different from the one for VMs. Ironic also requires special networking setup (network proposal).
Additionally the job setup was modified to better suit Ironic:
- 1 compute node is enough as nova-compute-ironic is just a proxy
- 2 node HA cluster for controllers
- 2 'baremetal' nodes for ironic instances
- split mkcloud steps as plain_with_ironic was removed

NOTE: this PR requires #1923 for proper ironic node creation