### PR TITLE
Trigger the cloud7-suse job daily

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
@@ -47,6 +47,7 @@
               node-label: cloud-trigger
               predefined-parameters: |
                 TESTHEAD=
+                want_test_updates=1
                 cloudsource=susecloud7
                 nodenumber=5
                 networkingmode=vxlan

--- a/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7-suse.yaml
@@ -4,17 +4,11 @@
     node: cloud-trigger
 
     triggers:
-      - pollurl:
-          cron: 'H/5 * * * *'
-          polling-node: cloud-trigger
-          urls:
-            - url: 'http://clouddata.cloud.suse.de/cgi-bin/grep/download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Cloud7/images/iso/?regexp=x86_64'
-              check-content:
-                - simple: true
+      - timed: 'H H * * *'
 
     logrotate:
-      numToKeep: 7
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 7
 
     builders:
       - multijob:


### PR DESCRIPTION
Currently it was only triggering on a Cloud7 GM media rebuild, which
doesn't make sense because it doesn't happen very often anymore.