### PR TITLE
mkcloud: support update repos during upgrade process

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -288,6 +288,7 @@ function sshrun
         export cinder_netapp_password=$cinder_netapp_password;
 
         export UPDATEREPOS=$UPDATEREPOS ;
+        export UPDATEREPOS_UPGRADE=$UPDATEREPOS_UPGRADE ;
         export UPDATEREPOS_EXTRA=$UPDATEREPOS_EXTRA ;
         export TESTHEAD=$TESTHEAD ;
         export NOINSTALLCLOUDPATTERN=$NOINSTALLCLOUDPATTERN ;
@@ -885,6 +886,7 @@ function crowbarupgrade_5plus
         export cloudsource=$upgrade_cloudsource
         onadmin prepare_crowbar_upgrade
         onadmin prepare_cloudupgrade_admin_repos_6_to_7
+        onadmin addupdaterepo upgrade
         onadmin upgrade_admin_backup
         onadmin upgrade_admin_repocheck
         onadmin upgrade_admin_server

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4759,6 +4759,8 @@ function onadmin_addupdaterepo
     case $extra_repos in
         all|0)
             repos=$UPDATEREPOS_EXTRA ;;
+        upgrade)
+            repos=$UPDATEREPOS_UPGRADE ;;
         [1-9]*)
             repos="$(echo $UPDATEREPOS_EXTRA | cut -d+ -f1-${extra_repos//[^0-9]/})" ;;
         '')


### PR DESCRIPTION
This PR allows to add packages to the PTF repo during the upgrade process.
Until now it was only possible to do it before installation of the initial cloud (UPDATEREPOS variable). The variable UPDATEREPOS_EXTRA offers something similar for
manually triggered runs.

Background:
Some patches for cloud X break the upgrade process from cloud X-1. In order to test these properly the patched package(s) for cloud X need to be added during the upgrade workflow instead of being added before installation of cloud X-1.

This PR allows to define the variable UPDATEREPOS_UPGRADE (its a plus separated list of urls, just like UPDATEREPOS). The content of these repos will be added to the PTF repo during the upgrade process. If it is empty nothing will be added.