### PR TITLE
Make URL to use for internet test configurable

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -590,6 +590,7 @@ fi
 : ${smtserver_fqdn:=$(to_fqdn $smtserver)}
 : ${smturl:=http://$smtserver_fqdn/update/build.suse.de}
 
+: ${test_internet_url:=http://$reposerver_fqdn/test}
 
 if [[ $UID != 0 ]] ; then
     : ${sudo:=sudo}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -297,6 +297,7 @@ function sshrun
         export JENKINS_NODE_NAME=$NODE_NAME;
         export JENKINS_EXECUTOR_NUMBER=$EXECUTOR_NUMBER;
         export JENKINS_WORKSPACE=$WORKSPACE;
+        export test_internet_url=$test_internet_url;
 EOF
     # setting these variables within mkcloud does not make them part of the env, so we need to export them
     export nodenumber nodenumbercompute nodenumberlonelynode clusterconfig

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4223,7 +4223,7 @@ function oncontroller_testsetup
 
     wait_for 40 5 "timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $ssh_target true" "SSH key to be copied to VM"
 
-    if ! ssh $ssh_target curl $reposerver_fqdn/test ; then
+    if ! ssh $ssh_target curl $test_internet_url ; then
         complain 95 could not reach internet
     fi
 


### PR DESCRIPTION
During testsetup, testvm sends a curl request to `$reposerver_fqdn/test`.
This is not ideal for all environments. To fix this, this patch
introduces the variable `$test_internet_url` to make this value
configurable.