### PR TITLE
Delete testvm in testsetup after shutting it down

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4292,6 +4292,7 @@ function oncontroller_testsetup
     nova flavor-delete m1.smaller || :
     nova flavor-create m1.smaller 101 512 8 1
     nova delete testvm  || :
+    wait_for 10 3 "[[ ! \$(nova show $instanceid) ]]" "testvm to be deleted"
     nova keypair-add --pub-key /root/.ssh/id_rsa.pub testkey
     nova secgroup-delete testvm || :
     nova secgroup-create testvm testvm


### PR DESCRIPTION
Not deleting the testvm can lead to problems when the testsetup step is
repeated multiple times. Also, it is better for a test to clean up after
itself than to leave resources around that are no longer needed after
the test has finished.

In our environment the second test setup run failed because the deletion of the nova vm before it's re-creation takes too long.

The following excerpt from the mkcloud log shows the issue: The deletion of testvm gets started, but when the security group for testvm should be deleted it is still in use because the deletion of testvm has not yet finished. Since there are now two security groups with the name 'testvm', they can not be assigned to the VM and the boot fails. Deleting the testvm at the end of the first test setup should fix this issue.

```
+(qa_crowbarsetup.sh:4204) oncontroller_testsetup(): nova delete testvm
Request to delete server testvm has been accepted.
+(qa_crowbarsetup.sh:4205) oncontroller_testsetup(): nova keypair-add --pub-key /root/.ssh/id_rsa.pub testkey
ERROR (Conflict): Key pair 'testkey' already exists. (HTTP 409) (Request-ID: req-d6cfa0f8-6762-4cc4-8213-593164c833e3)
+(qa_crowbarsetup.sh:4206) oncontroller_testsetup(): nova secgroup-delete testvm
ERROR (BadRequest): Security Group 56bcbbae-7432-449b-b3ce-51ee1660c045 in use. (HTTP 400) (Request-ID: req-14dc713c-afa8-4ab1-a0b4-d49360106258)
+(qa_crowbarsetup.sh:4206) oncontroller_testsetup(): :
+(qa_crowbarsetup.sh:4207) oncontroller_testsetup(): nova secgroup-create testvm testvm
+--------------------------------------+--------+-------------+
| Id                                   | Name   | Description |
+--------------------------------------+--------+-------------+
| 04f903c2-c6bc-4064-be18-628b995c4fe6 | testvm | testvm      |
+--------------------------------------+--------+-------------+
+(qa_crowbarsetup.sh:4208) oncontroller_testsetup(): nova secgroup-add-rule testvm icmp -1 -1 0.0.0.0/0
ERROR (NoUniqueMatch): Multiple security group matches found for name 'testvm', use an ID to be more specific.
+(qa_crowbarsetup.sh:4209) oncontroller_testsetup(): nova secgroup-add-rule testvm tcp 1 65535 0.0.0.0/0
ERROR (NoUniqueMatch): Multiple security group matches found for name 'testvm', use an ID to be more specific.
+(qa_crowbarsetup.sh:4210) oncontroller_testsetup(): nova secgroup-add-rule testvm udp 1 65535 0.0.0.0/0
ERROR (NoUniqueMatch): Multiple security group matches found for name 'testvm', use an ID to be more specific.
+(qa_crowbarsetup.sh:4211) oncontroller_testsetup(): timeout 10m nova boot --poll --image jeos --flavor m1.smaller --key-name testkey --security-group testvm testvm
+(qa_crowbarsetup.sh:4211) oncontroller_testsetup(): tee boot.out
ERROR (Conflict): Multiple security_group matches found for name 'testvm', use an ID to be more specific. (HTTP 409) (Request-ID: req-2c0f3a93-1ea4-473e-ac43-8bdc01ed238a)
+(qa_crowbarsetup.sh:4212) oncontroller_testsetup(): ret=1
+(qa_crowbarsetup.sh:4213) oncontroller_testsetup(): '[' 1 '!=' 0 ']'
+(qa_crowbarsetup.sh:4213) oncontroller_testsetup(): complain 43 'nova boot failed'
```