### PR TITLE
Refresh zypper repositories after adding the update repo.

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4891,6 +4891,7 @@ function onadmin_addupdaterepo
     $zypper modifyrepo -e cloud-ptf >/dev/null 2>&1 ||\
         safely $zypper ar $UPR cloud-ptf
     safely $zypper mr -p 90 -r cloud-ptf
+    safely $zypper ref
     [[ ! -e $UPR/repodata/repomd.xml.key ]] || safely rpmkeys --import $UPR/repodata/repomd.xml.key
 }
 


### PR DESCRIPTION
This is needed to import new GPG keys coming from freshly created PTF repo.

~Needs a rebase after https://github.com/SUSE-Cloud/automation/pull/1971~