### PR TITLE
Add timestamp to start/end of each step

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1470,6 +1470,7 @@ for cmd in `echo $steplist` ; do
     echo "============> MKCLOUD STEP START <============"
     # next line is for jenkins log parser:
     echo "MKCLOUD step: $cmd"
+    echo "step started at `date '+%Y-%m-%d %H:%M:%S'`: $cmd"
     echo
     sleep 2
     echo $cmd >> mkcloud.steps.log
@@ -1492,6 +1493,7 @@ for cmd in `echo $steplist` ; do
         error_exit $ret ""
     fi >&2
     echo
+    echo "step finished at `date '+%Y-%m-%d %H:%M:%S'`: $cmd"
     echo "^^^^^^^^^^^^= MKCLOUD STEP DONE: $cmd =^^^^^^^^^^^^"
     echo
 done


### PR DESCRIPTION
Timing information at each mkcloud step helps with debugging, especially when trying to find certain information in logs.