### PR TITLE
Add missing ironicnetmask env variable

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -301,8 +301,8 @@ function sshrun
         export JENKINS_WORKSPACE=$WORKSPACE;
 EOF
     # setting these variables within mkcloud does not make them part of the env, so we need to export them
-    export nodenumber nodenumbercompute nodenumberlonelynode nodenumberironicnode clusterconfig
-    env|grep -e ^debug_ -e ^pre_ -e ^vlan_ -e ^want_ -e ^net_ -e ^nodenumber -e ^clusterconfig | sort >> $mkcconf
+    export nodenumber nodenumbercompute nodenumberlonelynode nodenumberironicnode clusterconfig ironicnetmask
+    env|grep -e ^debug_ -e ^pre_ -e ^vlan_ -e ^want_ -e ^net_ -e ^nodenumber -e ^clusterconfig -e ^ironicnetmask | sort >> $mkcconf
 
     cp -a $mkcconf $artifacts_dir/
     $scp -r $SCRIPTS_DIR $mkcconf root@$adminip:


### PR DESCRIPTION
The ironicnemask variable was not exported to the onadmin envs which
caused the batch templates to not fill properly.