### PR TITLE
Added missing gre ml2 driver in ironic scenario

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
@@ -224,6 +224,7 @@ proposals:
     rabbitmq_instance: default
     keystone_instance: default
     ml2_type_drivers:
+    - gre
     - vxlan
     - vlan
     database_instance: default


### PR DESCRIPTION
For some reason gre got removed from original batch scenario for
ironic job. It failed with default deployment so the missing option
was added.