### PR TITLE
ironic: removed nfs_client from scenario

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
@@ -129,20 +129,6 @@ proposals:
       hawk-server:
       - "@@controller1@@"
       - "@@controller2@@"
-- barclamp: nfs_client
-  name: data
-  attributes:
-    exports:
-      glance-images:
-        export: "/var/lib/glance/images"
-        mount_path: "/var/lib/glance/images"
-        mount_options:
-        - ''
-  deployment:
-    elements:
-      nfs-client:
-      - "@@controller1@@"
-      - "@@controller2@@"
 - barclamp: database
   attributes:
     ha:


### PR DESCRIPTION
The nfs_client is not really needed for basic ironic deployment and a stripped version which was included in the scenario fails validation when deploying.