### PR TITLE
jenkins: Use storage_method=none for raid testing

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-raid-template.yaml
@@ -20,6 +20,7 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber=2
+            storage_method=none
             controller_raid_volumes=2
             want_raidtype=raid1
             mkcloudtarget=all


### PR DESCRIPTION
Since we also use raid for the second node there is no space left for a
swift disk.