### PR TITLE
ironic: set net_ironic depending on used cloud

### DIFF
--- a/scripts/mkcloudhost/cloudfunc
+++ b/scripts/mkcloudhost/cloudfunc
@@ -10,6 +10,12 @@ function cloudadminnet()
     echo -n 192.168.$((255-2*n))
 }
 
+function cloudironicnet()
+{
+    n=$1
+    echo -n 192.168.$((4*n))
+}
+
 function cloudpublicnet()
 {
     n=$1

--- a/scripts/mkcloudhost/hacloud.common
+++ b/scripts/mkcloudhost/hacloud.common
@@ -8,6 +8,7 @@ if [ "$n" -lt 1 -o "$n" -gt 4 ] ; then
 fi
 
 export net_admin=192.168.$n
+export net_ironic=$(cloudironicnet $n)
 export net_public=$(vcloudpublicnet $n)
 export adminnetmask=255.255.255.0
 export virtualcloud=v$(($haoffset + $n))

--- a/scripts/mkcloudhost/routed.cloud
+++ b/scripts/mkcloudhost/routed.cloud
@@ -13,6 +13,7 @@ fi
 : ${nfsserver:=clouddata.cloud.suse.de}
 export reposerver nfsserver
 export net_admin=$(cloudadminnet $n)
+export net_ironic=$(cloudironicnet $n)
 export net_public=$(routedcloudpublicnet $n)
 export adminnetmask=255.255.255.0
 export virtualcloud=$vcloudname$n

--- a/scripts/mkcloudhost/runtestmulticloud
+++ b/scripts/mkcloudhost/runtestmulticloud
@@ -12,6 +12,7 @@ cloudfunc=$(dirname $(readlink -e $BASH_SOURCE))/cloudfunc
 : ${vcloudname:=c}
 
 export net_admin=$(cloudadminnet $n)
+export net_ironic=$(cloudironicnet $n)
 export net_public=$(cloudpublicnet $n)
 export adminnetmask=255.255.254.0
 export virtualcloud=$vcloudname$n

--- a/scripts/mkcloudhost/runtestn
+++ b/scripts/mkcloudhost/runtestn
@@ -21,6 +21,7 @@ test -e $cloudfunc || cloudfunc=$(dirname $(readlink -e $BASH_SOURCE))/cloudfunc
 #export forwardmode="route"
 #export NOQACROWBARDOWNLOAD=1
 export net_admin=$(cloudadminnet $n)
+export net_ironic=$(cloudironicnet $n)
 export net_public=$(cloudpublicnet $n)
 export adminnetmask=255.255.254.0
 export virtualcloud=$vcloudname$n


### PR DESCRIPTION
Without this change all clouds with want_ironic=1 would get the same
subnet assigned for ironic use which causes failures during libvirt
network creation.