### PR TITLE
ironic: Enforce 2 NICs per node

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -164,7 +164,8 @@
           name: nics
           default: '1'
           description: >-
-            Number of network interfaces for the nodes (admin node has always 1 currently)
+            Number of network interfaces for the nodes (admin node has always 1 currently).
+            If Ironic is enabled (want_ironic=1) min value of this parameter is set to 2.
 
       - bool:
           name: WITHCROWBARREGISTER
@@ -459,6 +460,10 @@
             #export cephvolumenumber=0
           fi
 
+          # enforce min 2 nics if deploying with ironic
+          if [[ $want_ironic ]] ; then
+            [[ $nics -lt 2 ]] && nics=2
+          fi
 
           #storage
           case "$storage_method" in


### PR DESCRIPTION
mkcloud properly adds second NIC as default if ironic is enabled but
openstack-mkcloud jenkins template overrides the default with another
default (1 NIC). For proper ironic setup the number of NICs needs to be
enforced to 2.