### PR TITLE
iptables: wait for other process to finish and retry

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -413,11 +413,11 @@ function setupadmin
         IFS=$nfs
         for x in $(iptables -S FORWARD | grep -o --color=never FORWARD.*TCPMSS.*); do
             IFS=$ofs
-            $sudo iptables -D ${x} 2>/dev/null
+            $sudo iptables -w -D ${x} 2>/dev/null
             IFS=$nfs
         done
         IFS=$ofs
-        $sudo iptables -I FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss $mss
+        $sudo iptables -w -I FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss $mss
     fi
 }
 


### PR DESCRIPTION
from iptables manpage:
-w, --wait
Wait for the xtables lock. To prevent multiple instances of the
program from running concurrently, an attempt will be made to obtain an
exclusive lock at launch.  By default, the program will exit if the lock
cannot be obtained.  This option will make the program wait until
the exclusive lock can be obtained.