### PR TITLE
mkcloud: fix crowbarrestore

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -874,6 +874,8 @@ function crowbarrestore
         onhost_reset_admin
     fi
     safely $scp "$btarball" root@$adminip:/tmp/
+    safely prepareinstcrowbar
+    safely bootstrapcrowbar
     safely onadmin crowbarrestore "$@"
 }
 


### PR DESCRIPTION
After the crowbar node has been wiped and reinstalled the cloud repos and product are missing.
So we need to run bootstrapcrowbar and prepareinstcrowbar to allow crowbar to be installed before the backup can be restored.