### PR TITLE
Don't remove patch lines from spec in testbuild

### DIFF
--- a/scripts/crowbar-testbuild.rb
+++ b/scripts/crowbar-testbuild.rb
@@ -170,8 +170,7 @@ class CrowbarTestbuild
     system(
       *[
         "sed", "-i",
-        "-e", "s,Url:.*,%define _default_patch_fuzz 2,",
-        "-e", "s,%patch[0-36-9].*,,", package_spec_file
+        "-e", "s,Url:.*,%define _default_patch_fuzz 2,", package_spec_file
       ]
     )
 


### PR DESCRIPTION
Without this patch, the testbuild CI job may fail the obs validators if
the package has patches to apply[1]. This causes the testbuild job to
fail and hence the mkcloud job to never start. This patch keeps the
patch directives in the spec file so they can be applied and the
validators can pass.

[1] https://ci.suse.de/job/cloud-crowbar-testbuild-pr/4500/console