### PR TITLE
openstack-mkcloud: reduce default nodenumber for ha cloud to 3

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -455,8 +455,8 @@
           if [[ $hacloud == 1 ]] ; then
             : ${clusterconfig:=data+services+network=2}
             export clusterconfig
-            if [[ $nodenumber -lt 4 ]] ; then
-              export nodenumber=4
+            if [[ $nodenumber -lt 3 ]] ; then
+              export nodenumber=3
             fi
 
             # for now disable ceph deployment in HA mode explicitly


### PR DESCRIPTION
Previously the default and minimum nodenumber for an hacloud was 4.
The default cluster only used two nodes though. Having one compute node by default should be sufficient.

In order to free or save resources on our workers we now lower the number of nodes for an hacloud to 3 (2 for the cluster, one compute).

All current hacloud jobs define their required nodenumber explicitly:
`grep -lr hacloud=1 | xargs grep -E "nodenumber=|hacloud="`
So the existing jobs should not be affected by this change.

Thanks @skazi0 for the hint to this.