### PR TITLE
Use direct rebuild mode

### DIFF
--- a/hostscripts/rpm-packaging/createproject.py
+++ b/hostscripts/rpm-packaging/createproject.py
@@ -107,7 +107,7 @@ def upload_meta_enable_repository(project, linkproject):
     <arch>x86_64</arch>
   </repository>
 """ % ({'linkproject': linkproject,
-        'repoflags': 'rebuild="local" block="local" linkedbuild="localdep"'})
+        'repoflags': 'rebuild="direct" block="local" linkedbuild="localdep"'})
 
     upload_meta(project, repository, linkproject)
 


### PR DESCRIPTION
Now that we're freezing the parent project link, we can actually
do a sensible rebuild mode to ensure that all direct rebuilds are
also triggering indirect rebuilds for consistency check.