### PR TITLE
Install packages from cloud-ptf with --no-recommends

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1535,7 +1535,7 @@ EOF
     if [ -z "$NOINSTALLCLOUDPATTERN" ] ; then
         safely $zypper in -l -t pattern cloud_admin
         # make sure to use packages from PTF repo (needs zypper dup)
-        $zypper mr -e cloud-ptf && safely $zypper dup --from cloud-ptf
+        $zypper mr -e cloud-ptf && safely $zypper dup --no-recommends --from cloud-ptf
     fi
 
     cd /tmp


### PR DESCRIPTION
The cloud-ptf repo may not contain all recommended packages required
for installation. Use --no-recommends in zypper dup to prevent errors
when a recommended package is missing in the cloud-ptf repo.