### PR TITLE
Add more Cloud8 jenkins jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -16,6 +16,15 @@
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
+        - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
+        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
+        - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
+        - 'cloud-mkcloud{version}-job-crowbar-devsetup-{arch}'
+        - 'cloud-mkcloud{version}-job-dvr-{arch}'
+        - 'cloud-mkcloud{version}-job-magnum-{arch}'
+        - 'cloud-mkcloud{version}-job-raid-{arch}'
+        - 'cloud-mkcloud{version}-job-ssl-{arch}'
+        - 'cloud-mkcloud{version}-job-xen-{arch}'
 - project:
     name: cloud-mkcloud8-ha-x86_64
     disabled: false


### PR DESCRIPTION
The list of Cloud8 jenkins jobs is not the same as the Cloud7 jenkins
jobs. This commit adds some more jobs to reduce the gap.