### PR TITLE
Remove obsolete want_postgresql

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -236,11 +236,6 @@
       # general OpenStack deployment
 
       - string:
-          name: want_postgresql
-          default:
-          description: Set to 1 to deploy with postgresql
-
-      - string:
           name: want_all_ssl
           default:
           description: Set to 1 to deploy all cloud services with SSL aka HTTPS

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1182,8 +1182,6 @@ Optional
         want_magnum_proposal=1
         want_monasca_proposal=1   (Cloud7+ only)
         want_murano_proposal=1
-    want_postgresql=0 (default=1)
-        Use PostgreSQL instead of SQLite as a Crowbar database
     want_horizon_integration_test=1 (default='')
         Execute selenium integration tests for Horizon after Tempest. This test is in beta, and
         a fail will not be considered for now.

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -83,7 +83,6 @@ export cinder_netapp_login
 export cinder_netapp_password
 export localreposdir_target
 export want_ipmi=${want_ipmi:-false}
-export want_postgresql=${want_postgresql:-1}
 [ -z "$want_test_updates" -a -n "$TESTHEAD" ] && export want_test_updates=1
 [ "$libvirt_type" = hyperv ] && export wanthyperv=1
 [ "$libvirt_type" = xen ] && export wantxenpv=1 # xenhvm is broken anyway
@@ -1676,9 +1675,6 @@ function onadmin_bootstrapcrowbar
     fi
 
     local upgrademode=$1
-    # temporarily make it possible to not use postgres until we switched to the new upgrade process
-    # otherwise we would break the upgrade gating
-    [[ $want_postgresql = 0 ]] && return
     if iscloudver 7plus ; then
         systemctl start crowbar-init
         wait_for 100 3 "onadmin_is_crowbar_init_api_available" "crowbar init service to start"
@@ -1729,7 +1725,7 @@ function crowbar_nodeupgrade_status
 
 function do_installcrowbar_cloud6plus
 {
-    if [[ $want_postgresql = 0 ]] || iscloudver 6minus; then
+    if iscloudver 6minus; then
         service crowbar status || service crowbar stop
         service crowbar start
 


### PR DESCRIPTION
Postgresql is since a long time the only option crowbar supports and
uses.