### PR TITLE
Fix 64f09b2c

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -21,6 +21,7 @@
         - 'cloud-mkcloud{version}-job-hyperv-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
+        - 'cloud-mkcloud{version}-job-upgrade-{arch}'
         - 'cloud-mkcloud{version}-job-xen-{arch}'
 - project:
     name: cloud-mkcloud6-ha-x86_64


### PR DESCRIPTION
The removal of the Cloud 6 upgrade job in
64f09b2ce3c74393fa01efd2a6bb667e65214581 was incorrect. Since the
template was removed from `jenkins/ci.suse.de/cloud-mkcloud6.yaml`, JJB
never disabled the actual job. This commit partially reverts the
previous one.