### PR TITLE
qa_crowbarsetup: avoid setting attribute in SOC6

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3076,7 +3076,7 @@ function custom_configuration
         cinder)
             proposal_set_value cinder default "['attributes']['cinder']['volumes'][0]['${cinder_backend}']" "j['attributes']['cinder']['volume_defaults']['${cinder_backend}']"
             proposal_set_value cinder default "['attributes']['cinder']['volumes'][0]['backend_driver']" "'${cinder_backend}'"
-            if [[ $deployceph && $want_cinder_rbd_flatten_snaps ]] ; then
+            if [[ $deployceph && $want_cinder_rbd_flatten_snaps ]] && iscloudver 7plus ; then
                 proposal_set_value cinder default "['attributes']['cinder']['volumes'][0]['${cinder_backend}']['flatten_volume_from_snapshot']" "true"
             fi
             case "$cinder_backend" in


### PR DESCRIPTION
In SOC6 there is not `flatten_volume_from_snapshot` attribute in
cinder, so we need to check that we are in SOC7 or bigger.