### PR TITLE
ironic: disable storage role

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
@@ -21,7 +21,7 @@
             cloudsource=develcloud{version}
             nodenumber=3
             clusterconfig=data+network+services=2
-            storage_method=default
+            storage_method=none
             hacloud=1
             mkcloudtarget=instonly batch setupironicnodes
             networkingplugin=openvswitch


### PR DESCRIPTION
For basic ironic tests no storage node is needed. It can cause problems
with Cloud8 as storage node would get SP2 which would make it unusable
for other services which require SP3.