### PR TITLE
exposed want_ironic in openstack-mkcloud

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -341,6 +341,11 @@
           description: set to 1 to deploy with docker
 
       - string:
+          name: want_ironic
+          default:
+          description: set to 1 to deploy with ironic
+
+      - string:
           name: want_ceilometer_proposal
           default:
           description: Deploy with Ceilomenter


### PR DESCRIPTION
Without it want_ironic is lost when e.g. rebuilding ironic jobs.