### PR TITLE
At least 3 ceph nodes are needed. With Cloud8 this means SP2 nodes.

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2088,7 +2088,8 @@ function onadmin_allocate
         fi
         if [ -n "$deployceph" ] && iscloudver 7plus ; then
             storage_os="suse-12.2"
-            for n in $(seq 0 1); do
+            # we need 3 ceph nodes: at least 2 for osd (can be mixed with mons) and 1 for mds
+            for n in $(seq 0 2); do
                 echo "Setting node ${nodes[$n]} to Storage... "
                 set_node_role_and_platform ${nodes[$n]} "storage" ${storage_os}
             done


### PR DESCRIPTION
ceph-osd requires at least 2 nodes (these can also have ceph-mon role).
One extra is needed for ceph-mds, which is needed by manila.