### PR TITLE
Give more nodes to SOC8 ha jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -31,6 +31,7 @@
     arch: x86_64
     tempestoptions: -s -t
     label: openstack-mkcloud-ha-x86_64
+    nodenumber_ha: 5
     jobs:
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -35,6 +35,7 @@
     arch: x86_64
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
+    nodenumber_ha: 5
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -33,6 +33,7 @@
     arch: x86_64
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
+    nodenumber_ha: 6
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -19,7 +19,7 @@
           predefined-parameters: |
             TESTHEAD=1
             cloudsource=develcloud{version}
-            nodenumber=5
+            nodenumber={nodenumber_ha}
             networkingmode=vxlan
             tempestoptions={tempestoptions}
             hacloud=1


### PR DESCRIPTION
For HA that is 2 for pacemaker cluster, 3 for ceph and 1 as compute node.
ceph nodes cannot be used for anything else as they have SP2 system.
compute node cannot be in the cluster.