### PR TITLE
Do not use ceph for default Cloud8 HA jobs + add specific HA+ceph job

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -31,6 +31,7 @@
     arch: x86_64
     tempestoptions: -s -t
     label: openstack-mkcloud-ha-x86_64
+    storage_method_ha: ceph
     jobs:
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -35,6 +35,7 @@
     arch: x86_64
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
+    storage_method_ha: ceph
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -33,6 +33,7 @@
     arch: x86_64
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
+    storage_method_ha: swift
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -36,6 +36,7 @@
     storage_method_ha: swift
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
+        - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ceph-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ceph-template.yaml
@@ -1,0 +1,29 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: '11 2 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{version}
+            nodenumber=6
+            networkingmode=vxlan
+            tempestoptions={tempestoptions}
+            storage_method=ceph
+            hacloud=1
+            mkcloudtarget=all_noreboot
+            label={label}
+            job_name=cloud-mkcloud{version}-job-ha-ceph-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -22,6 +22,7 @@
             nodenumber=5
             networkingmode=vxlan
             tempestoptions={tempestoptions}
+            storage_method={storage_method_ha}
             hacloud=1
             mkcloudtarget=all_noreboot
             label={label}


### PR DESCRIPTION
Cloud8 ceph needs some fine tuning regarding nodes and roles allocations
so let's not use it by default.

An alternative to https://github.com/SUSE-Cloud/automation/pull/2026