### PR TITLE
devstack: added explicit exit command at the end

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-devstack.yaml
+++ b/jenkins/ci.opensuse.org/openstack-devstack.yaml
@@ -42,6 +42,6 @@
               du $file
               exit 1
           fi
-
+          exit $ret
     wrappers:
       - timestamps


### PR DESCRIPTION
Without this the job remains stuck.

Actually copied it from cleanvm.yaml