### PR TITLE
openstack-submit: Output error message when a package is not a link

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-submit.yaml
+++ b/jenkins/ci.opensuse.org/openstack-submit.yaml
@@ -54,7 +54,10 @@
           fi
           cd $COMPONENT || exit 1
 
-          grep -q "<linkinfo" .osc/_files || exit 2
+          if ! grep -q "<linkinfo" .osc/_files; then
+              echo "$COMPONENT is not a link; please fix it in $COSS and ensure the checkout of the package in this worker is up-to-date"
+              exit 2
+          fi
 
           if $OSC rdiff $COS $COMPONENT $COSS | grep .  &&  $OSC api /build/$COSS/$OSCBUILDDIST/x86_64/$COMPONENT/_status | grep -q 'code="succeeded"'
           then

--- a/jenkins/ci.opensuse.org/openstack-submit.yaml
+++ b/jenkins/ci.opensuse.org/openstack-submit.yaml
@@ -38,7 +38,7 @@
               submitcmd="$OSC copypac -K -e"
               OSCBUILDDIST=SLE_12_SP2
             ;;
-            *) echo "Please add support for the project: $project"
+            *) echo "Please add support for the project: $openstack_project"
               exit 1
             ;;
           esac


### PR DESCRIPTION
This broke openstack-submit for Cloud:OpenStack:Newton for the past few
weeks, and the error was not trivial to understand just based on the
output of the job.