### PR TITLE
Obsolete nfs_mount_options

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -106,7 +106,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
@@ -112,7 +112,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -161,7 +161,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
   deployment:
     elements:
       cinder-controller:
@@ -172,7 +171,7 @@ proposals:
 - barclamp: neutron
   attributes:
     ml2_mechanism_drivers:
-    - ##networkingplugin## 
+    - ##networkingplugin##
     ml2_type_drivers:
     - ##networkingmode##
     ml2_type_drivers_default_provider_network: ##networkingmode##

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -116,7 +116,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     - backend_driver: vmware
       backend_name: vmware
       vmware:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -120,7 +120,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -127,7 +127,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -175,7 +175,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -130,7 +130,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     - backend_driver: vmware
       backend_name: vmware-backend
       vmware:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1a.yaml
@@ -106,7 +106,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
@@ -112,7 +112,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
@@ -161,7 +161,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
   deployment:
     elements:
       cinder-controller:
@@ -172,7 +171,7 @@ proposals:
 - barclamp: neutron
   attributes:
     ml2_mechanism_drivers:
-    - ##networkingplugin## 
+    - ##networkingplugin##
     ml2_type_drivers:
     - ##networkingmode##
     ml2_type_drivers_default_provider_network: ##networkingmode##

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
@@ -116,7 +116,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     - backend_driver: vmware
       backend_name: vmware
       vmware:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -120,7 +120,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -127,7 +127,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -175,7 +175,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -130,7 +130,6 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
-        nfs_mount_options: nfsvers=3,rw,sync,nofail
     - backend_driver: vmware
       backend_name: vmware-backend
       vmware:


### PR DESCRIPTION
Because of this change: https://github.com/crowbar/crowbar-openstack/pull/972 cinder nfs option is obsolete