### PR TITLE
qa_crowbarsetup: fix deletion of testvm

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4305,8 +4305,11 @@ function oncontroller_testsetup
 
     nova flavor-delete m1.smaller || :
     nova flavor-create m1.smaller 101 512 8 1
-    nova delete testvm  || :
-    wait_for 10 3 "[[ ! \$(nova show $instanceid) ]]" "testvm to be deleted"
+    instanceid=`openstack server show testvm -f value -c id`
+    if [[ $instanceid ]] ; then
+        nova delete $instanceid
+        wait_for 10 3 "[[ ! \$(nova show $instanceid) ]]" "testvm to be deleted"
+    fi
     nova keypair-add --pub-key /root/.ssh/id_rsa.pub testkey
     nova secgroup-delete testvm || :
     nova secgroup-create testvm testvm


### PR DESCRIPTION
This is a fix for f87bca5fe912c2c5ce1eb7180d585674bb6bad81
The $instanceid variable is not set when it was used so the wait_for loop did not wait for anything (it is first defined 10 lines later).

This PR fixes it as it queries the instanceid of a potentially running instance called testvm first and only calls delete on it if an instance exists.

@gonzolino FYI