### PR TITLE
mkcloud: move crowbar_networkingmode into qa_crowbarsetup

### DIFF
--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -4,6 +4,8 @@
 function qacrowbarsetup_help
 {
     cat <<EOUSAGE
+    crowbar_networkingmode=single         (default single)
+        set the networking mode for Crowbar.
     want_neutronsles12=1 (default 0)
         if there is a SLE12 node, deploy neutron-network role into the SLE12 node
     want_mtu_size=<size> (default='')

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -73,7 +73,6 @@ nicsdefault=1
 [[ $want_ironic ]] && nicsdefault=2
 : ${nics:=$nicsdefault}
 : ${adminvcpus:=2}
-: ${crowbar_networkingmode:=single}
 cpuflags=''
 working_dir_orig=`pwd`
 : ${artifacts_dir:=$working_dir_orig/.artifacts}
@@ -1106,8 +1105,6 @@ Optional
     nics=1         (default $nics)
         set the number of network interfaces per cloud node
         if Ironic is enabled (want_ironic=1), default is set to 2
-    crowbar_networkingmode=single         (default $crowbar_networkingmode)
-        set the networking mode for Crowbar.
     adminvcpus=1    (default $adminvcpus)
         set the number of CPU cores for admin node
     admin_node_memory (default 4194304)

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -31,6 +31,7 @@ fi
 : ${cinder_netapp_storage_protocol:=iscsi}
 : ${cinder_netapp_login:=openstack}
 : ${cinder_netapp_password:=''}
+: ${crowbar_networkingmode:=single}
 : ${want_rootpw:=linux}
 : ${want_raidtype:="raid1"}
 : ${want_multidnstest:=1}


### PR DESCRIPTION
as it is not used in mkcloud
to fix mkphyscloud jobs that failed from mode=''