### PR TITLE
trackupstream: stop autoupdating crowbar-hyperv

### DIFF
--- a/jenkins/ci.suse.de/cloud-trackupstream.yaml
+++ b/jenkins/ci.suse.de/cloud-trackupstream.yaml
@@ -20,7 +20,6 @@
             - crowbar-openstack
             - crowbar-ceph
             - crowbar-ha
-            - crowbar-hyperv
             - crowbar-init
             - openstack-dashboard-theme-SUSE
             - release-notes-suse-openstack-cloud


### PR DESCRIPTION
because the huge tarballs cause timeouts in service runs
and we do not update it much anymore.
Last hyper-v related changes were 2016-02-08

timeouts:
https://ci.suse.de/view/Cloud/view/Worker/job/cloud-trackupstream/component=crowbar-hyperv,label=openstack-trackupstream,project=Devel%3ACloud%3A6%3AStaging/