### PR TITLE
Don't wait for neutron if it isn't deployed

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4983,6 +4983,8 @@ function onneutron_wait_for_neutron
 {
     get_neutron_server_node
 
+    [ -z "$NEUTRON_SERVER" ] && return
+
     wait_for 300 3 "ssh $NEUTRON_SERVER 'rcopenstack-neutron status' |grep -q running" "neutron-server service running state"
     wait_for 200 3 " ! ssh $NEUTRON_SERVER '. .openrc && neutron --insecure agent-list -f csv --quote none'|tail -n+2 | grep -q -v ':-)'" "neutron agents up"
 


### PR DESCRIPTION
The wait_for_neutron function does not cope well if the neutron
barclamp is not deployed. Check if $NEUTRON_SERVER is not set and return
in that case.