### PR TITLE
Avoid unary operator expected error when mistyping password

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1253,7 +1253,7 @@ function is_concurrent_run
 
 function sanity_checks
 {
-    if test `$sudo id -u` != 0 ; then
+    if [[ `$sudo id -u` != 0 ]] ; then
         complain 1 "This script needs to be run as root or have sudoers setup" \
             "Please be aware that this script will create a LVM" \
             "and kill all current VMs on this host."


### PR DESCRIPTION
For those who fatfingered the sudo password, there is a
weird error message printed. avoid the error message.