### PR TITLE
Add ocatacloud8 cloudsource

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1040,7 +1040,7 @@ Mandatory
     cloudpv=/dev/vdx (default /dev/vdb)
         Device where a LVM physical volume will be created, all data lost on this device
         Should be at least 80 GB. The volume group will be called 'cloud'.
-    cloudsource=develcloud5/6/7/8 | mitakacloud7 | susecloud8 | GM5 | GM5+up | GM6 | GM6+up | GM7 | GM7+up | M?  (default '')
+    cloudsource=develcloud5/6/7/8 | mitakacloud7 | ocatacloud8 | susecloud8 | GM5 | GM5+up | GM6 | GM6+up | GM7 | GM7+up | M?  (default '')
         NOTE: The latest version always is in development. So do NOT expect it to work out of the box.
         NOTE: If you need a stable/working version use <latest-version>-1.
         defines the installation source of the product
@@ -1048,6 +1048,7 @@ Mandatory
         develcloud6   : product from IBS Devel:Cloud:6
         develcloud7   : product from IBS Devel:Cloud:7
         mitakacloud7  : product from IBS Devel:Cloud:7:Mitaka
+        ocatacloud8   : product from IBS Devel:Cloud:8:Ocata
         develcloud8   : product from IBS Devel:Cloud:8
         susecloud8    : product from IBS SUSE:SLE....
         GM5           : SUSE Cloud Goldmaster 5 without updates

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1323,6 +1323,13 @@ function onadmin_set_source_variables
             CLOUDSLE12TESTISO="CLOUD-8-TESTING-${arch}-Media1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-8-devel"
         ;;
+        ocatacloud8)
+            # This is used by the CloudFoundry team. Do not remove!
+            CLOUDSLE12DISTPATH=/ibs/Devel:/Cloud:/8:/Ocata/images/iso
+            CLOUDSLE12DISTISO="SUSE-OPENSTACK-CLOUD-8-$arch*Media1.iso"
+            CLOUDSLE12TESTISO="CLOUD-8-TESTING-$arch*Media1.iso"
+            CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-8-official"
+        ;;
         susecloud8)
             CLOUDSLE12DISTPATH=/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Cloud8/images/iso/
             CLOUDSLE12DISTISO="SUSE-OPENSTACK-CLOUD-8-$arch*Media1.iso"


### PR DESCRIPTION
While transitioning to Ocata, we want a cloudsource=ocatacloud8 to be able
to test the Ocata setup.
This can later be used by the CloudFoundry team ,too.