### PR TITLE
jenkins: Use crowbar teaming (bonding) mode for some jobs

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
@@ -21,6 +21,8 @@
             cloudsource=develcloud{version}
             nodenumber=4
             networkingplugin=linuxbridge
+            nics=2
+            crowbar_networkingmode=team
             tempestoptions={tempestoptions}
             mkcloudtarget=all_noreboot
             label={label}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -21,6 +21,8 @@
             cloudsource=develcloud{version}
             nodenumber=4
             networkingplugin=linuxbridge
+            nics=2
+            crowbar_networkingmode=team
             tempestoptions={tempestoptions}
             mkcloudtarget=all
             label={label}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -22,6 +22,8 @@
             nodenumber=5
             networkingmode=vxlan
             tempestoptions={tempestoptions}
+            nics=2
+            crowbar_networkingmode=team
             storage_method={storage_method_ha}
             hacloud=1
             mkcloudtarget=all_noreboot


### PR DESCRIPTION
Our gating jobs are not using bonding for nics which is not an
realistic scenario in a real world deployment.
Change that and use bonding for the 4node linuxbridge jobs and for the
gating HA job.