### PR TITLE
Fix renderspec source service handling

### DIFF
--- a/scripts/jenkins/track-upstream-and-package.pl
+++ b/scripts/jenkins/track-upstream-and-package.pl
@@ -283,6 +283,9 @@ sub osc_checkin()
     eval {
       $custom_service=xml_get_text($xmldom, '/services/service[@name="download_files"][1]/param[@name="changesgenerate"][1]');
     };
+    eval {
+      $custom_service=xml_get_text($xmldom, '/services/service[@name="renderspec"][1]/param[@name="output-name"][1]');
+    };
     die $@ unless $custom_service;
   }
   eval {


### PR DESCRIPTION
This fixes:

     Error: Could not find an xml element with the statement

when only "renderspec" is used as source service.