### PR TITLE
qa_crowbarsetup.sh: Set want_cinder_rbd_flatten_snaps to 0

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -38,7 +38,11 @@ fi
 : ${want_tempest:=1}
 : ${want_s390:=''}
 : ${want_horizon_integration_test:=''}
-: ${want_cinder_rbd_flatten_snaps:=1}
+if iscloudver 8plus; then
+    : ${want_cinder_rbd_flatten_snaps:=1}
+else
+    : ${want_cinder_rbd_flatten_snaps:=0}
+fi
 
 if [[ $arch = "s390x" ]] ; then
     want_s390=1


### PR DESCRIPTION
We have to disable want_cinder_rbd_flatten_snaps for Cloud 7
as this feature was not in GM7 and will break GM7 deployments.