### PR TITLE
Drop cloud5 related parts

### DIFF
--- a/docs/mkcloud.md
+++ b/docs/mkcloud.md
@@ -165,7 +165,7 @@ Here's an example script you can execute to create a full cloud:
 export localreposdir_src=/home/tom/devel/repositories/
 
 # setup/create lvm disk
-cloud_lvm_disk=/home/tom/devel/libvirt-images/develcloud5-lvm.raw
+cloud_lvm_disk=/home/tom/devel/libvirt-images/develcloud7-lvm.raw
 if ! [ -f $cloud_lvm_disk ] ; then
     qemu-img create -f raw $cloud_lvm_disk 100G
 fi
@@ -178,7 +178,7 @@ else
 fi
 
 export cloudpv=${loused}
-export cloudsource=develcloud5
+export cloudsource=develcloud7
 export cloud=$cloudsource
 export net_fixed=192.168.150
 export net_public=192.168.151

--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -88,10 +88,9 @@ done
 # Storage
 ##############
 
-for version in 1.0 2.1 4; do
+for version in 2.1 4 5; do
 
     for arch in x86_64 aarch64; do
-        [ "$arch" != x86_64 -a $version = 1.0 ] && continue
         [ "$arch" != x86_64 -a $version = 2.1 ] && continue
 
         echo ================== Updating Storage $version
@@ -134,7 +133,7 @@ function mount_and_rsync {
 # mirror aarch64 SP1 builds
 $rsync /mnt/dist/ibs/Devel:/ARM:/SLE-12-SP1:/Update/images/repo/SLE-12-SP1-Server-POOL-aarch64-*-Media1/ /srv/nfs/repos/aarch64/SLES12-SP1-Pool
 
-for version in 6 7; do
+for version in 6 7 8; do
     # fetch latest code from version in development (not just latest beta)
     sync_from_ibs=
     [ "$version" == "8" ] && sync_from_ibs=1

--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -21,31 +21,17 @@ buildsuse=/mnt/dist/ibs/
 buildncc=$buildsuse
 ibsmaint=$buildsuse/SUSE\:/Maintenance\:/Test\:/
 
-# SLE11 SP3
-echo ================== Updating SLE 11 SP3
-$rsync $buildncc/SUSE/Updates/SLE-SERVER/11-SP3/x86_64/update/ /srv/nfs/repos/SLES11-SP3-Updates/
-$rsync $buildncc/SUSE/Updates/SLE-HAE/11-SP3/x86_64/update/ /srv/nfs/repos/SLE11-HAE-SP3-Updates/
-$rsync $ibsmaint/SLE-SERVER\:/11-SP3\:/x86_64/update/ /srv/nfs/repos/SLES11-SP3-Updates-test/
-$rsync $ibsmaint/SLE-HAE\:/11-SP3\:/x86_64/update/ /srv/nfs/repos/SLE11-HAE-SP3-Updates-test/
-/usr/local/bin/miniuprepo /srv/nfs/repos/SLES11-SP3-Updates/
-
-
 ##############
 # SLE 12
 ##############
 
-for servicepack in 0 1 2 3; do
+for servicepack in 1 2 3; do
     # fetch latest code from service pack in development (not just latest beta)
     sync_from_ibs=
     [ $servicepack -eq 3 ] && sync_from_ibs=1
 
-    if [ $servicepack -eq 0 ]; then
-        version=12
-        repo_version="12-GA"
-    else
-        version="12-SP$servicepack"
-        repo_version="$version"
-    fi
+    version="12-SP$servicepack"
+    repo_version="$version"
     chef_version="12.$servicepack"
 
     for arch in x86_64 s390x aarch64; do
@@ -74,7 +60,6 @@ for servicepack in 0 1 2 3; do
         fi
         # SLES updates
         $rsync $buildsuse/SUSE/Updates/SLE-SERVER/$version/$arch/update/ /srv/nfs/repos/$arch/SLES$repo_version-Updates/
-        [ "$arch" == x86_64 ] && /usr/local/bin/miniuprepo /srv/nfs/repos/$arch/SLES$repo_version-Updates/
         # SLES test updates
         if test -d $ibsmaint/SLE-SERVER\:/$version\:/$arch/update/ ; then
             $rsync $ibsmaint/SLE-SERVER\:/$version\:/$arch/update/ /srv/nfs/repos/$arch/SLES$repo_version-Updates-test/
@@ -145,34 +130,6 @@ function mount_and_rsync {
         $M umount /mnt/cloud
     fi
 }
-
-for version in 5; do
-    echo ================== Updating Cloud $version
-
-    if test -d /mnt/dist/install/SLP/SUSE-Cloud-$version-GM/; then
-        $rsync /mnt/dist/install/SLP/SUSE-Cloud-$version-GM/x86_64/DVD1/ /srv/nfs/repos/SUSE-Cloud-$version-official
-    else
-        mount_and_rsync "/mnt/dist/ibs/SUSE:/SLE-11-SP3:/Update:/Cloud$version:/Test/images/iso/*Media1.iso" SUSE-Cloud-$version-official
-    fi
-    mount_and_rsync "/mnt/dist/ibs/Devel\:/Cloud\:/$version/images/iso/SUSE-CLOUD-$version-x86_64-Build[0-9][0-9][0-9][0-9]-Media1.iso" SUSE-Cloud-$version-devel
-    mount_and_rsync "/mnt/dist/ibs/Devel\:/Cloud\:/$version\:/Staging/images/iso/SUSE-CLOUD-$version-x86_64-Build[0-9][0-9][0-9][0-9]-Media1.iso" SUSE-Cloud-$version-devel-staging
-
-    $rsync $buildncc/SUSE/Updates/SUSE-CLOUD/$version/x86_64/update/ /srv/nfs/repos/SUSE-Cloud-$version-Updates/
-    if test -d $ibsmaint/Cloud\:/$version\:/$arch/update/; then
-        $rsync $ibsmaint/Cloud\:/$version\:/$arch/update/ /srv/nfs/repos/$arch/SUSE-Cloud-$version-Updates-test/
-    fi
-done
-
-mount_and_rsync "/mnt/dist/ibs/Devel:/Cloud:/Shared:/11-SP3:/Update/images/iso/SUSE-CLOUD-*11-SP3-DEPS-x86_64-Build[0-9][0-9][0-9][0-9]-Media.iso" SUSE-Cloud-SLE-11-SP3-deps
-
-echo ================== Updating Cloud 5 for SLE12
-
-$rsync /mnt/dist/install/SLP/SLE-12-Module-Public-Cloud-GM/x86_64/CD1/ /srv/nfs/repos/SUSE-Cloud-5-SLE-12-official
-mount_and_rsync "/mnt/dist/ibs/Devel:/Cloud:/5/images/iso/SUSE-SLE12-CLOUD-5-COMPUTE-x86_64-Build[0-9][0-9][0-9][0-9]-Media1.iso" SUSE-Cloud-5-SLE-12-devel
-mount_and_rsync "/mnt/dist/ibs/Devel:/Cloud:/5:/Staging/images/iso/SUSE-SLE12-CLOUD-5-COMPUTE-x86_64-Build[0-9][0-9][0-9][0-9]-Media1.iso" SUSE-Cloud-5-SLE-12-devel-staging
-$rsync $buildsuse/SUSE/Products/12-Cloud-Compute/5/x86_64/product/ /srv/nfs/repos/SUSE-Cloud-5-SLE-12-Pool/
-$rsync $buildsuse/SUSE/Updates/12-Cloud-Compute/5/x86_64/update/ /srv/nfs/repos/SUSE-Cloud-5-SLE-12-Updates/
-$rsync $ibsmaint/12-Cloud-Compute\:/5\:/x86_64/update/ /srv/nfs/repos/SUSE-Cloud-5-SLE-12-Updates-test/
 
 # mirror aarch64 SP1 builds
 $rsync /mnt/dist/ibs/Devel:/ARM:/SLE-12-SP1:/Update/images/repo/SLE-12-SP1-Server-POOL-aarch64-*-Media1/ /srv/nfs/repos/aarch64/SLES12-SP1-Pool

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -60,9 +60,8 @@
           name: scenario
           default:
           description: >-
-            Defines which scenario file should be used. Only works
-            with cloud5 or newer.  Currently only the 'batch' step uses
-            such a file.
+            Defines which scenario file should be used.
+            Currently only the 'batch' step uses such a file.
 
       - label:
           name: label

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1041,21 +1041,18 @@ Mandatory
     cloudpv=/dev/vdx (default /dev/vdb)
         Device where a LVM physical volume will be created, all data lost on this device
         Should be at least 80 GB. The volume group will be called 'cloud'.
-    cloudsource=develcloud5/6/7/8 | mitakacloud7 | ocatacloud8 | susecloud8 | GM5 | GM5+up | GM6 | GM6+up | GM7 | GM7+up | M?  (default '')
+    cloudsource=develcloud6/7/8 | mitakacloud7 | ocatacloud8 | susecloud8 | GM6 | GM6+up | GM7 | GM7+up | M?  (default '')
         NOTE: The latest version always is in development. So do NOT expect it to work out of the box.
         NOTE: If you need a stable/working version use <latest-version>-1.
         defines the installation source of the product
-        develcloud5   : product from IBS Devel:Cloud:5
         develcloud6   : product from IBS Devel:Cloud:6
         develcloud7   : product from IBS Devel:Cloud:7
         mitakacloud7  : product from IBS Devel:Cloud:7:Mitaka
         ocatacloud8   : product from IBS Devel:Cloud:8:Ocata
         develcloud8   : product from IBS Devel:Cloud:8
         susecloud8    : product from IBS SUSE:SLE....
-        GM5           : SUSE Cloud Goldmaster 5 without updates
         GM6           : SUSE Cloud Goldmaster 6 without updates
         GM7           : SUSE Cloud Goldmaster 7 without updates
-        GM5+up        : SUSE Cloud Goldmaster 5 with released maintenance updates
         GM6+up        : SUSE Cloud Goldmaster 6 with released maintenance updates
         GM7+up        : SUSE Cloud Goldmaster 7 with released maintenance updates
         M?            : uses official Milestone? ISO image (? is a number)
@@ -1193,7 +1190,7 @@ Optional
     cct_tests='test1+test2' (default='features')
         Defines which cct_tests should be run while the cct step.
     scenario='scenario.yaml' (default='')
-        Defines which scenario file should be used. Only works with cloud5 or newer.
+        Defines which scenario file should be used.
         Currently only the step 'batch' uses such a file.
     scenario_dir='/tmp' (default=${SCRIPTS_DIR}/scenarios/cloud\$(getcloudver)/)
         Full path to directory containing scenario file.
@@ -1275,7 +1272,7 @@ function sanity_checks
 
     if [ -z "$cloudsource" ] ; then
         echo "Please set the env variable:"
-        echo "export cloudsource=M?|develcloud5|develcloud6|develcloud7|develcloud8|susecloud8|GM5|GM5+up|GM6|GM6+up|GM7|GM7+up"
+        echo "export cloudsource=M?|develcloud6|develcloud7|develcloud8|susecloud8|GM6|GM6+up|GM7|GM7+up"
         exit 1
     fi
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -435,7 +435,7 @@ function add_ha12sp1_repo
         # Note no zypper alias parameter here since we don't want to
         # zypper addrepo on the admin node.
         add_mount "$repo" \
-            "$nfsserver_ip:$nfsserver_base_path/repos/$repo" \
+            "$nfsserver_ip:$nfsserver_base_path/repos/$arch/$repo" \
             "$tftpboot_repos12sp1_dir/$repo"
     done
 }
@@ -472,7 +472,7 @@ function add_suse_storage_repo
                 # Note no zypper alias parameter here since we don't want
                 # to zypper addrepo on the admin node.
                 add_mount "$repo" \
-                    "$nfsserver_ip:$nfsserver_base_path/repos/$repo" \
+                    "$nfsserver_ip:$nfsserver_base_path/repos/$arch/$repo" \
                     "$tftpboot_repos12sp1_dir/$repo"
             done
         fi


### PR DESCRIPTION
Cloud 5 is EOL, so we can rip out some pieces that are no longer
relevant. With this change cloud5 related deployments are no longer
possible, which allows to simplify other things further.