### PR TITLE
qa_crowbarsetup: fix develcloud7/8 repo setup

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1052,14 +1052,14 @@ function onadmin_prepare_cloud_repos
             addcloud6pool
             addcloud6maintupdates
             ;;
-        develcloud7|GM7)
+        GM7)
             addcloud7pool
             ;;
         GM7+up)
             addcloud7pool
             addcloud7maintupdates
             ;;
-        develcloud8)
+        GM8)
             addcloud8pool
             ;;
     esac


### PR DESCRIPTION
because the Pool repo is supposed to be for gold-master based deployments only