### PR TITLE
Fix zypper rm calls

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1197,7 +1197,7 @@ function onadmin_setup_local_zypper_repositories
     # Delete all repos except PTF repo, because this could
     # be called after the addupdaterepo step.
     $zypper lr -e - | sed -n '/^name=/ {s///; /ptf/! p}' | \
-        xargs -r $zypper rr
+        xargs -r zypper rr
 
     uri_base=$smturl
     # restore needed repos depending on localreposdir_target


### PR DESCRIPTION
xargs will not be able to access functions defined in the bash file,
thus leaving us with these errors:

```
... onadmin_setup_local_zypper_repositories(): xargs -r run_zypper rr
xargs: run_zypper: No such file or directory
```