### PR TITLE
Fix 9p installation

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -152,6 +152,8 @@ function mount_localreposdir_target
     fi
     mkdir -p $localreposdir_target
     if ! grep -q "$localreposdir_target\s\+$localreposdir_target" /etc/fstab ; then
+        echo 'force_drivers+="9pnet_virtio"' > /etc/dracut.conf.d/03-libvirt.conf
+        dracut -f
         echo "$localreposdir_target $localreposdir_target 9p    ro,trans=virtio,version=9p2000.L,msize=262144  0 0" >> /etc/fstab
     fi
     mount "$localreposdir_target"


### PR DESCRIPTION
Seeing:

```
9pnet: Could not find request transport: virtio
```

Errors in the logs when admin machine is starting. This means 9p shares
are not mounted, and thus boot process is halted, presenting a recovery
mode. Adding a module to be loaded earlier seems to fix this issue.

The sloution was taken from here:

https://superuser.com/a/879012