### PR TITLE
qa_crowbarsetup: dont run repocheck for develcloud

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5024,6 +5024,7 @@ function onadmin_upgrade_admin_backup
 
 function onadmin_upgrade_admin_repocheck
 {
+    [[ $clousource =~ GM ]] || return
     if safely crowbarctl upgrade repocheck crowbar --format plain | grep "missing" ; then
         complain 11 "Some repository is missing on admin server. Cannot upgrade."
     fi


### PR DESCRIPTION
because it is looking for a Pool repo
which we dont want to have in that case

As an alternative to PR #2078