### PR TITLE
qa_crowbarsetup: allow to not reapply proposals

### DIFF
--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -38,6 +38,9 @@ function qacrowbarsetup_help
         increase all wait_for sleeps by this factor
     want_sbd=1 (default 0)
         Setup SBD over iSCSI for cluster nodes, with iSCSI target on admin node. Only usable for HA configuration.
+    want_reapply_proposal=0 (default 1)
+        If set to 0, only newly created proposals will be applied
+        to speed up running a 2nd proposal step
     want_devel_repos=list of Devel Projects to use for other products
         Adds Devel Projects for other products on deployed nodes
         Example:

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3075,6 +3075,9 @@ function do_one_proposal
     local proposaltypemapped=$proposaltype
     proposaltype=${proposaltype%%+*}
     crowbar "$proposal" proposal create $proposaltype
+    if [[ $? != 0 ]] && [[ $want_reapply_proposal = 0 ]] ; then
+        return
+    fi
     update_one_proposal "$proposal" "$proposaltypemapped"
 }
 


### PR DESCRIPTION
that were already created in an earlier run
to speed up things
and to not mess up proposals like pacemaker
that get updated when nodes were added since the last run