### PR TITLE
mkcloud: support IPMI with libvirt nodes

### DIFF
--- a/scripts/lib/ipmi/ipmi_sim.emu
+++ b/scripts/lib/ipmi/ipmi_sim.emu
@@ -1,0 +1,5 @@
+# Create a single management controller as a BMC, with no sensors
+mc_setbmc 0x20
+mc_add 0x20 0 no-device-sdrs 0x23 9 8 0x9f 0x1291 0xf02 persist_sdr
+sel_enable 0x20 1000 0x0a
+mc_enable 0x20

--- a/scripts/lib/ipmi/ipmi_sim_lancontrol
+++ b/scripts/lib/ipmi/ipmi_sim_lancontrol
@@ -11,16 +11,20 @@ set -eu
 # arguments: dev op var
 # network interface
 dev=$1
-# get or set.  This script just supports get
+# get or set.
 op=$2
 # var name
 var=$3
+# value to set if any
+val=${4:-''}
 
 veth_peer=$(ip link show dev $dev | awk 'NR==1 { split($2, subfield, "@"); print substr(subfield[2], 1, length(subfield[2])-1)}')
 gw_dev=$(bridge link show dev $veth_peer |  awk '{for(j=0;j<=NF;j++) if ($j == "master" ) print $(j+1) }')
 
 link_ip() {
-    ip -o -4 addr list $1 | sed -ne 's/.* inet \([.0-9]*\)\/.*/\1/p'
+    # We might want to change the IP address of the BMC device, but to avoid having
+    # to change the lan conf and re-bind, we just take the latest address
+    ip -o -4 addr list $1 | tail -1 | sed -ne 's/.* inet \([.0-9]*\)\/.*/\1/p'
 }
 
 link_mac() {
@@ -71,9 +75,45 @@ get_val() {
     esac
 }
 
-if [ $op = "get" ]; then
-    val=$(get_val $var)
-    echo "$var: $val"
-fi
+set_val() {
+    case $var in
+    ip_addr_src)
+        ;;
 
-#TODO(colleen): implement set_val()
+    ip_addr)
+        # If it already has two addresses, replace the last one.
+        # Otherwise, just add a second one (keep the first one)
+        if [ $(ip -o link list $dev | wc -l) -gt 1 ] ; then
+            local current=$(link_ip $dev)
+            ip addr del $current dev $dev
+        fi
+        ip addr add $val dev $dev
+        ;;
+
+    mac_addr)
+        ;;
+
+    subnet_mask)
+        ifconfig $dev netmask $val
+        ;;
+
+    default_gw_ip_addr)
+        ;;
+
+    default_gw_mac_addr)
+        ;;
+
+    backup_gw_ip_addr)
+        ;;
+
+    backup_gw_mac_addr)
+        ;;
+    esac
+}
+
+if [ $op = "get" ]; then
+    val=$(get_val)
+    echo "$var: $val"
+elif [ $op = "set" ]; then
+    set_val
+fi

--- a/scripts/lib/ipmi/ipmi_sim_lancontrol
+++ b/scripts/lib/ipmi/ipmi_sim_lancontrol
@@ -1,0 +1,79 @@
+#! /bin/sh
+# ipmi_sim_lancontrol - provide link addresses to ipmi_sim for device $1
+# See lan_config_program in ipmi_lan(5)
+#
+# 2015-05-06  Noel Burton-Krahn <noel@pistoncloud.com>
+
+#NOTE(colleen) vendored with modifications from https://github.com/wrouesnel/openipmi/blob/master/ipmi_sim_lancontrol
+
+set -eu
+
+# arguments: dev op var
+# network interface
+dev=$1
+# get or set.  This script just supports get
+op=$2
+# var name
+var=$3
+
+veth_peer=$(ip link show dev $dev | awk 'NR==1 { split($2, subfield, "@"); print substr(subfield[2], 1, length(subfield[2])-1)}')
+gw_dev=$(bridge link show dev $veth_peer |  awk '{for(j=0;j<=NF;j++) if ($j == "master" ) print $(j+1) }')
+
+link_ip() {
+    ip -o -4 addr list $1 | sed -ne 's/.* inet \([.0-9]*\)\/.*/\1/p'
+}
+
+link_mac() {
+    ip -o link list $1 | sed -ne 's/.* link\/ether \([:0-9a-f]*\) .*/\1/p'
+}
+
+link_subnet() {
+    ifconfig $1 | sed -n -e 's/.*Mask:\([.0-9]*\).*/\1/p'
+}
+
+get_val() {
+    case $var in
+    ip_addr_src)
+        if grep $(link_mac $dev) /var/lib/libvirt/dnsmasq/*.hostsfile >/dev/null ; then
+            echo "dhcp"
+        else
+            echo "static"
+        fi
+        ;;
+
+    ip_addr)
+        link_ip $dev
+        ;;
+
+    mac_addr)
+        link_mac $dev
+        ;;
+
+    subnet_mask)
+        link_subnet $dev
+        ;;
+
+    default_gw_ip_addr)
+        link_ip $gw_dev
+        ;;
+
+    default_gw_mac_addr)
+        link_mac $gw_dev
+        ;;
+
+    backup_gw_ip_addr)
+        link_ip $gw_dev
+        ;;
+
+    backup_gw_mac_addr)
+        link_mac $gw_dev
+        ;;
+    esac
+}
+
+if [ $op = "get" ]; then
+    val=$(get_val $var)
+    echo "$var: $val"
+fi
+
+#TODO(colleen): implement set_val()

--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -45,6 +45,8 @@ def main():
                         help="Local Repository Directory Source")
     parser.add_argument("--localrepotgt", required=False,
                         help="Local Repository Directory Target")
+    parser.add_argument("--ipmi", action='store_true',
+                        help="Whether to simulate IPMI BMC devices")
     args = parser.parse_args()
 
     print(libvirt_setup.compute_config(args, libvirt_setup.cpuflags()))

--- a/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>cloud-node1</name>
   <memory>5242880</memory>
   <currentMemory>5242880</currentMemory>
@@ -76,4 +76,5 @@
 </filesystem>
 
   </devices>
+
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>cloud-node1</name>
   <memory>5242880</memory>
   <currentMemory>5242880</currentMemory>
@@ -86,4 +86,5 @@
     </memballoon>
 
   </devices>
+
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>cloud-node1</name>
   <memory>5242880</memory>
   <currentMemory>5242880</currentMemory>
@@ -70,4 +70,5 @@
     </memballoon>
 
   </devices>
+
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>cloud-node1</name>
   <memory>5242880</memory>
   <currentMemory>5242880</currentMemory>
@@ -68,4 +68,5 @@
     <memballoon model='none' />
 
   </devices>
+
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>cloud-node1</name>
   <memory>5242880</memory>
   <currentMemory>5242880</currentMemory>
@@ -70,4 +70,5 @@
     </memballoon>
 
   </devices>
+
 </domain>

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -312,6 +312,15 @@ def compute_config(args, cpu_flags=cpuflags()):
             'target_address': target_address.format('0x1f')},
             configopts))
 
+    if args.ipmi:
+        values = dict(
+          nodecounter=args.nodecounter
+        )
+        ipmi_config = get_config(values,
+                                 os.path.join(TEMPLATE_DIR, "ipmi-device.xml"))
+    else:
+        ipmi_config = ''
+
     values = dict(
         cloud=args.cloud,
         nodecounter=args.nodecounter,
@@ -330,6 +339,7 @@ def compute_config(args, cpu_flags=cpuflags()):
         videodevices=get_video_devices(),
         target_dev=targetdevprefix + 'a',
         serialdevice=get_serial_device(),
+        ipmidevice=ipmi_config,
         target_address=target_address.format('0x0a'),
         bootorder=args.bootorder,
         local_repository_mount=localrepomount)

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>$cloud-node$nodecounter</name>
   <memory>$nodememory</memory>
   <currentMemory>$nodememory</currentMemory>
@@ -35,4 +35,5 @@ $videodevices
 $memballoon
 $local_repository_mount
   </devices>
+$ipmidevice
 </domain>

--- a/scripts/lib/libvirt/templates/ipmi-device.xml
+++ b/scripts/lib/libvirt/templates/ipmi-device.xml
@@ -1,0 +1,8 @@
+  <qemu:commandline>
+    <qemu:arg value='-chardev'/>
+    <qemu:arg value='socket,id=ipmi0,host=0.0.0.0,port=623$nodecounter,reconnect=10'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='ipmi-bmc-extern,id=bmc0,chardev=ipmi0'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='isa-ipmi-bt,bmc=bmc0'/>
+  </qemu:commandline>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -106,6 +106,7 @@ def default_test_args(args):
     args.firmwaretype = "bios"
     args.localreposrc = None
     args.localrepotgt = None
+    args.ipmi = False
 
 
 class TestLibvirtAdminConfig(unittest.TestCase):

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -583,6 +583,10 @@ function common_set_slesversions
 : ${admin_image_password:='linux'}
 : ${susedownload:=download.nue.suse.com}
 
+# bmc credentials
+: ${bmc_user:=root}
+: ${bmc_password:=cr0wBar!}
+
 # NOTE: $clouddata and similar variables are deprecated
 if [[ $clouddata || $clouddatadns || $clouddata_base_path || $clouddata_nfs || $clouddata_nfs_dir ]] ; then
     echo 'Warning: $clouddata and all related variables are deprecated.'

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -634,6 +634,7 @@ fi
 : ${libvirt_type:=kvm}
 : ${networkingplugin:=openvswitch}
 : ${architectures:='aarch64 x86_64 s390x'}
+: ${nodenumbertotal:=$nodenumber}
 : ${nodenumberlonelynode:=0}
 : ${nodenumberironicnode:=0}
 : ${want_mtu_size:=1500}

--- a/scripts/lib/mkcloud-ipmi.sh
+++ b/scripts/lib/mkcloud-ipmi.sh
@@ -1,0 +1,45 @@
+function ipmi_cleanup
+{
+    for node in $(seq $nodenumber) ; do
+        if ip link show v${cloud}${node}-x >/dev/null ; then
+            ip link del dev v${cloud}${node}-x
+        fi
+        screen -X -S $cloud-node$node-bmc-lan quit
+    done
+}
+
+function mkveth
+{
+    local nodenumber=$1
+    local bmc_addr=$2
+    local iface=v$cloud$nodenumber
+    ip link add dev $iface-x type veth peer name $iface-y
+    ip link set dev $iface-x up
+    ip link set dev $iface-y up
+    ip addr add ${bmc_addr}/${adminnetmask} dev $iface-x
+    brctl addif $cloudbr $iface-y
+}
+
+function generate_lan_config()
+{
+    local nodenumber=$1
+    local user=$2
+    local password=$3
+    local listenaddr=$4
+    local nodename=$cloud-node$nodenumber
+    local lanconfig=/tmp/ipmi-lan-$nodename.conf
+    cat > $lanconfig <<EOF
+name "$nodename"
+set_working_mc 0x20
+  startlan 1
+    addr $listenaddr 623
+    allowed_auths_admin md5
+    guid deadbeefdeadbeefdeadbeefdeadbeef
+    lan_config_program "$SCRIPTS_DIR/lib/ipmi/ipmi_sim_lancontrol v${cloud}${nodenumber}-x"
+  endlan
+  serial 15 0.0.0.0 623${nodenumber} codec VM
+  startcmd "virsh start $nodename"
+  startnow false
+  user 2 true  "${user}" "${password}" admin 10 md5
+EOF
+}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -48,7 +48,7 @@ mkdir -p "$cache_dir"
 scripts_lib_dir=${SCRIPTS_DIR}/lib
 # include separate bash libs
 # NOTE that this is a temporary solution during refactoring of mkcloud
-common_scripts="mkcloud-onhost.sh mkcloud-common.sh mkcloud-driver-$mkclouddriver.sh qa_crowbarsetup-help.sh"
+common_scripts="mkcloud-onhost.sh mkcloud-common.sh mkcloud-driver-$mkclouddriver.sh qa_crowbarsetup-help.sh mkcloud-ipmi.sh"
 for script in $common_scripts; do
     source ${scripts_lib_dir}/$script
 done
@@ -323,7 +323,8 @@ function sshrun
         export test_internet_url=$test_internet_url;
         export extraipmipw=$extraipmipw;
         export ipmi_ip_addrs=$ipmi_ip_addrs;
-
+        export bmc_user=$bmc_user;
+        export bmc_password=$bmc_password;
 EOF
     # setting these variables within mkcloud does not make them part of the env, so we need to export them
     export nodenumber nodenumberlonelynode nodenumberironicnode clusterconfig ironicnetmask
@@ -355,6 +356,7 @@ function onhost
 
 function cleanup
 {
+    ipmi_cleanup
     ${mkclouddriver}_do_cleanup
 }
 
@@ -679,7 +681,18 @@ function setupnodes
         fi
 
         local ipmi_params=""
-        [[ $want_ipmi = 1 ]] && ipmi_params="--ipmi"
+        if [[ $want_ipmi = 1 ]] ; then
+            ipmi_params="--ipmi"
+            local bmc_addr=$(( 162 + $i ))
+            if [[ $bmc_addr > 240 ]] ; then
+                echo "You have more nodes than allocated addresses."
+                exit 1
+            fi
+            bmc_addr=$net.$bmc_addr
+            mkveth $i $bmc_addr
+            generate_lan_config $i $bmc_user $bmc_password $bmc_addr
+            screen -S $cloud-node$i-bmc-lan -d -m ipmi_sim -c /tmp/ipmi-lan-$cloud-node$i.conf -f ${SCRIPTS_DIR}/lib/ipmi/ipmi_sim.emu
+        fi
 
         ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
                         $mac_params \

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -678,9 +678,13 @@ function setupnodes
             localrepos_params="--localreposrc ${localreposdir_src} --localrepotgt ${localreposdir_target}"
         fi
 
+        local ipmi_params=""
+        [[ $want_ipmi = 1 ]] && ipmi_params="--ipmi"
+
         ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
                         $mac_params \
                         $ironic_params \
+                        $ipmi_params \
                         --cephvolumenumber $cephvolumenumber \
                         --drbdserial "$drbd_serial"\
                         --computenodememory $compute_node_memory \

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2027,7 +2027,7 @@ function hacloud_configure_cluster_defaults
             "['attributes']['pacemaker']['stonith']['mode']" "'sbd'"
         proposal_set_value pacemaker "$clustername" \
             "['attributes']['pacemaker']['stonith']['sbd']['watchdog_module']" "'softdog'"
-    elif [[ $mkclouddriver = "libvirt" ]]; then
+    elif [[ $mkclouddriver = "libvirt" && $want_ipmi != 1 ]]; then
         proposal_set_value pacemaker "$clustername" \
             "['attributes']['pacemaker']['stonith']['mode']" "'libvirt'"
         proposal_set_value pacemaker "$clustername" \
@@ -2209,7 +2209,12 @@ function custom_configuration
             proposal_set_value dns default "['deployment']['dns']['elements']['dns-server']" "[$dnsnodes]"
         ;;
         ipmi)
-            [[ $want_ipmi = 1 ]] && proposal_set_value ipmi default "['attributes']['ipmi']['bmc_enable']" true
+            if [[ $want_ipmi = 1 ]] ; then
+                proposal_set_value ipmi default "['attributes']['ipmi']['bmc_enable']" true
+                proposal_set_value ipmi default "['attributes']['ipmi']['debug']" true
+                proposal_set_value ipmi default "['attributes']['ipmi']['bmc_user']" "'$bmc_user'"
+                proposal_set_value ipmi default "['attributes']['ipmi']['bmc_password']" "'$bmc_password'"
+            fi
         ;;
         keystone)
             # set a custom region name


### PR DESCRIPTION
This adds a BMC interface to the libvirt node definition through QEMU, which allows IPMI kernel drivers to be loaded, thereby letting crowbar discover information about the BMC interface while the node is being joined. The BMC properties (such as its IP address and credentials) are then managed by binding an ipmi_sim instance to a veth pair that connects the BMC interface to the admin network bridge. This will allow us to properly test the IPMI barclamp in CI, and will also be useful for testing the ironic barclamp with production-grade drivers such as pxe_ipmitool.