### PR TITLE
Use a clouddata mirror locally

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -132,6 +132,7 @@ fi
 
 #if localreposdir_src string is available, the local repositories are used for setup
 : ${localreposdir_src:=""}
+: ${localreposdir_is_clouddata:=""}
 #localreposdir_target is the 9p target dir and also the mount target dir in the VM
 : ${localreposdir_target:="/repositories"}
 [ -z "$localreposdir_src" ] && localreposdir_target=""
@@ -280,6 +281,7 @@ function sshrun
         export nova_shared_instance_storage=$nova_shared_instance_storage ;
 
         export localreposdir_target=$localreposdir_target ;
+        export localreposdir_is_clouddata=$localreposdir_is_clouddata ;
 
         export cinder_backend=$cinder_backend;
         export cinder_netapp_storage_protocol=$cinder_netapp_storage_protocol;
@@ -1196,6 +1198,17 @@ Optional
         Full path to directory containing scenario file.
     log_dir=PATH (default = ${log_dir})
         The standard output and error will be logged in that directory.
+    localreposdir_src (default='')
+        If you want to use repositories from your host's local filesystem, set
+        this variable to point to the root of the hierarchy. Please note that
+        the expected directory structure is somewhat different from the layout
+        that is used by clouddata. If your local directory points to a
+        directory structure that is a mirror of clouddata, then please define
+        localreposdir_is_clouddata as well.
+    localreposdir_is_clouddata (default='')
+        Set this variable to a non-empty value to communicate that the
+        directory hierarchy referenced by localreposdir_src matches clouddata's
+        hierarchy.
 EOUSAGE
     qacrowbarsetup_help
     exit 1
@@ -1221,7 +1234,6 @@ EOUSAGE
 # cloudbr
 # libvirt_type
 # firmware_type
-# localreposdir_src
 # localreposdir_target
 # wipe
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1267,6 +1267,7 @@ function onadmin_repocleanup
 # because the reposerver might not be reachable from where this runs
 function onadmin_setup_local_zypper_repositories
 {
+    local localrepos_base
     # Delete all repos except PTF repo, because this could
     # be called after the addupdaterepo step.
     $zypper lr -e - | sed -n '/^name=/ {s///; /ptf/! p}' | \
@@ -1276,7 +1277,26 @@ function onadmin_setup_local_zypper_repositories
     # restore needed repos depending on localreposdir_target
     if [ -n "${localreposdir_target}" ]; then
         mount_localreposdir_target
-        uri_base="file:///repositories"
+        if [ -z "$localreposdir_is_clouddata" ]; then
+            uri_base="file:///repositories"
+        else
+            localrepos_base="file://$localreposdir_target/repos/$arch"
+            case $(getcloudver) in
+                6)
+                    $zypper ar "$localrepos_base/SLES12-SP1-Pool" sles12sp1
+                    $zypper ar "$localrepos_base/SLES12-SP1-Updates" sles12sp1up
+                ;;
+                7)
+                    $zypper ar "$localrepos_base/SLES12-SP2-Pool" sles12sp2
+                    $zypper ar "$localrepos_base/SLES12-SP2-Updates" sles12sp2up
+                ;;
+                8)
+                    $zypper ar "$localrepos_base/SLES12-SP3-Pool" sles12sp3
+                    $zypper ar "$localrepos_base/SLES12-SP3-Updates" sles12sp3up
+                ;;
+            esac
+            return
+        fi
     fi
     case $(getcloudver) in
         6)


### PR DESCRIPTION
With this change people can mirror clouddata to a local directory, and point to that with `localreposdir_src`, and set a non-empty value for `localreposdir_is_clouddata` and do an mkcloud run without being connected to the VPN