### PR TITLE
Allow to use crowbar batch for single proposals

### DIFF
--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -12,6 +12,9 @@ function qacrowbarsetup_help
         Option to set variable MTU size or select Jumbo Frames for Admin and Storage nodes. 1500 is used if not set.
     want_raidtype (default='raid1')
         The type of RAID to create.
+    want_batch_dir (default='${SCRIPTS_DIR}/scenarios')
+        Allow to use crowbar batch for single proposals by placing
+        \$PROPOSAL-batch.yaml files in this directory
     want_database_sql_engine (default='' which picks cloud default)
         The type of database backend to create (only cloud8+)
     want_node_aliases=list of aliases to assign to nodes

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -38,6 +38,7 @@ fi
 : ${want_tempest:=1}
 : ${want_s390:=''}
 : ${want_horizon_integration_test:=''}
+: ${want_batch_dir:="${SCRIPTS_DIR}/scenarios"}
 if iscloudver 8plus; then
     : ${want_cinder_rbd_flatten_snaps:=1}
 else
@@ -3071,6 +3072,11 @@ function do_one_proposal
     # extract them for the proposal creation, but pass them to update_one_proposal
     local proposaltypemapped=$proposaltype
     proposaltype=${proposaltype%%+*}
+    local batchfile=$want_batch_dir/$proposal-batch.yaml
+    if [[ -e $batchfile ]] ; then
+        crowbar batch build "$batchfile"
+        return 0
+    fi
     crowbar "$proposal" proposal create $proposaltype
     update_one_proposal "$proposal" "$proposaltypemapped"
 }


### PR DESCRIPTION
by placing \$PROPOSAL-batch.yaml files in a certain directory.
This allows to keep the flexibility of the default 'proposal' mechanism
while allowing for the power and complexity of the batch file
for certain parts of the configuration