### PR TITLE
qa_crowbarsetup: allow to override IPMI username

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -34,6 +34,7 @@ fi
 : ${crowbar_networkingmode:=single}
 : ${want_rootpw:=linux}
 : ${want_raidtype:="raid1"}
+: ${want_ipmi_username:=root}
 : ${want_multidnstest:=1}
 : ${want_tempest:=1}
 : ${want_s390:=''}
@@ -1756,7 +1757,7 @@ function reboot_nodes_via_ipmi
     local i=0
     for ip in $ipmi_ip_addrs ; do
         let i++
-        local ipmicmd="ipmitool -H $ip -U root"
+        local ipmicmd="ipmitool -H $ip -U $want_ipmi_username"
         local pw
         for pw in 'cr0wBar!' $extraipmipw ; do
             if timeout 5 $ipmicmd -P $pw mc info ; then


### PR DESCRIPTION
because it is not always root (e.g. in ENG-Cloud Provo)