### PR TITLE
mkcloud: make it usable in local caching mode

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -547,14 +547,17 @@ function common_set_slesversions
         12.1)
             slesversion=12-SP1
             slesdist=SLE_12_SP1
+            sesversion=2.1
         ;;
         12.2)
             slesversion=12-SP2
             slesdist=SLE_12_SP2
+            sesversion=4
         ;;
         12.3)
             slesversion=12-SP3
             slesdist=SLE_12_SP3
+            sesversion=5
         ;;
     esac
 }

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -579,7 +579,6 @@ if [[ $clouddata || $clouddatadns || $clouddata_base_path || $clouddata_nfs || $
     echo '    - $reposerver_base_path'
     echo '  - $nfsserver'
     echo '    - $nfsserver_base_path'
-    echo '  - $smtserver'
     : ${clouddatadns:=clouddata.nue.suse.com}
     : ${clouddata:=$(dig -t A +short $clouddatadns)}
     : ${clouddata_base_path:="/repos"}
@@ -593,7 +592,7 @@ if [[ $clouddata || $clouddatadns || $clouddata_base_path || $clouddata_nfs || $
     sleep 5
 fi
 
-# $reposerver,$nfsserver,$rsyncserver,$smtserver are only set from outside
+# $reposerver,$nfsserver,$rsyncserver are only set from outside
 # NOTE: they are not to be used in mkcloud/qa_crowbarsetup
 # Please ONLY use the suffixed variables: '*_ip' or '*_fqdn'
 
@@ -613,11 +612,6 @@ fi
 : ${rsyncserver_ip:=$(to_ip $rsyncserver)}
 : ${rsyncserver_fqdn:=$(to_fqdn $rsyncserver)}
 : ${rsyncserver_images_dir:="cloud/images/$arch"}
-
-: ${smtserver:=$susedownload}
-: ${smtserver_ip:=$(to_ip $smtserver)}
-: ${smtserver_fqdn:=$(to_fqdn $smtserver)}
-: ${smturl:=http://$smtserver_fqdn/update/build.suse.de}
 
 : ${test_internet_url:=http://$reposerver_fqdn/test}
 

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -344,6 +344,7 @@ function libvirt_do_prepare()
     libvirt_do_create_cloud_lvm
     onhost_add_etchosts_entries
     libvirt_prepare
+    onhost_cacheclouddata
     onhost_prepareadmin
 }
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -137,7 +137,6 @@ fi
 
 #if localreposdir_src string is available, the local repositories are used for setup
 : ${localreposdir_src:=""}
-: ${localreposdir_is_clouddata:=""}
 : ${cct_tests:="features:base"}
 
 [ -n "$cache_clouddata" ] && {
@@ -147,7 +146,6 @@ fi
     # Remove cct: requires SDK to mirror which is huge
     export cct_tests=""
     export localreposdir_src=$cache_dir
-    export localreposdir_is_clouddata=1
 }
 
 #localreposdir_target is the 9p target dir and also the mount target dir in the VM
@@ -295,7 +293,6 @@ function sshrun
         export nova_shared_instance_storage=$nova_shared_instance_storage ;
 
         export localreposdir_target=$localreposdir_target ;
-        export localreposdir_is_clouddata=$localreposdir_is_clouddata ;
 
         export cinder_backend=$cinder_backend;
         export cinder_netapp_storage_protocol=$cinder_netapp_storage_protocol;
@@ -1215,15 +1212,7 @@ Optional
         this is a convenience for all the individual options like localreposdir_*.
     localreposdir_src (default='')
         If you want to use repositories from your host's local filesystem, set
-        this variable to point to the root of the hierarchy. Please note that
-        the expected directory structure is somewhat different from the layout
-        that is used by clouddata. If your local directory points to a
-        directory structure that is a mirror of clouddata, then please define
-        localreposdir_is_clouddata as well.
-    localreposdir_is_clouddata (default='')
-        Set this variable to a non-empty value to communicate that the
-        directory hierarchy referenced by localreposdir_src matches clouddata's
-        hierarchy.
+        this variable to point to the root of the hierarchy.
 EOUSAGE
     qacrowbarsetup_help
     exit 1

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -258,10 +258,6 @@ function sshrun
         export rsyncserver_ip=$rsyncserver_ip ;
         export rsyncserver_fqdn=$rsyncserver_fqdn ;
         export rsyncserver_images_dir=$rsyncserver_images_dir ;
-        export smtserver=$smtserver ;
-        export smtserver_ip=$smtserver_ip ;
-        export smtserver_fqdn=$smtserver_fqdn ;
-        export smturl=$smturl ;
         export susedownload=$susedownload ;
         export cloudfqdn=$cloudfqdn ;
         export cloudsource=$cloudsource ;

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -138,11 +138,22 @@ fi
 #if localreposdir_src string is available, the local repositories are used for setup
 : ${localreposdir_src:=""}
 : ${localreposdir_is_clouddata:=""}
+: ${cct_tests:="features:base"}
+
+[ -n "$cache_clouddata" ] && {
+    # Reduce scope a bit for road-warriers
+    # Only host architecture, nothing else
+    export architectures="$arch"
+    # Remove cct: requires SDK to mirror which is huge
+    export cct_tests=""
+    export localreposdir_src=$cache_dir
+    export localreposdir_is_clouddata=1
+}
+
 #localreposdir_target is the 9p target dir and also the mount target dir in the VM
 : ${localreposdir_target:="/repositories"}
 [ -z "$localreposdir_src" ] && localreposdir_target=""
 : ${install_chef_suse_override:=./install-chef-suse.sh}
-: ${cct_tests:="features:base"}
 host_mtu=$(determine_mtu)
 iscloudver 7plus && [[ $arch == x86_64 ]] && \
     [[ -n $want_efi ]] && firmware_type="uefi"
@@ -1197,6 +1208,11 @@ Optional
         Full path to directory containing scenario file.
     log_dir=PATH (default = ${log_dir})
         The standard output and error will be logged in that directory.
+    cache_clouddata (default='')
+        If set, mkcloud will maintain on the host a local cache of clouddata related
+        artifacts (repositories images) and avoid downloading or require a
+        permanent network connection after the initial seed is complete. Setting
+        this is a convenience for all the individual options like localreposdir_*.
     localreposdir_src (default='')
         If you want to use repositories from your host's local filesystem, set
         this variable to point to the root of the hierarchy. Please note that


### PR DESCRIPTION
This is a quick way to enable consistent caching of the clouddata
data on the host system and enforce local-only usage of those
when installing a virtual cloud. This is very useful for unstable
and slow VPN connections (e.g. road warriors) as it doesn't require
downloading gigabytes of data every time or causing machines to
hang due to remote NFS mounts that are timing out.

just do export cache_clouddata=1 and be happy.