### PR TITLE
cleanvm: Update images used for cleanvm runs

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -16,6 +16,7 @@
           values:
             - SLE_12_SP1
             - SLE_12_SP2
+            - SLE_12_SP3
             - openSUSE-Leap-42.2
             - openSUSE-Leap-42.3
       - axis:
@@ -39,8 +40,8 @@
            ( openstack_project=="Liberty" && (image=="SLE_12_SP1" ))
         || ( openstack_project=="Mitaka" && (image=="SLE_12_SP1" || image=="SLE_12_SP2" ))
         || ( openstack_project=="Newton" && (image=="SLE_12_SP2" || image=="openSUSE-Leap-42.2" ))
-        || ( openstack_project=="Ocata" && (image=="SLE_12_SP2" || image=="openSUSE-Leap-42.2" || image=="openSUSE-Leap-42.3"))
-        || ( openstack_project=="Master" && (image=="openSUSE-Leap-42.2" || image=="SLE_12_SP2"))
+        || ( openstack_project=="Ocata" && (image=="SLE_12_SP2" || image=="SLE_12_SP3" || image=="openSUSE-Leap-42.2" || image=="openSUSE-Leap-42.3"))
+        || ( openstack_project=="Master" && (image=="openSUSE-Leap-42.3" || image=="SLE_12_SP3"))
         ))
       sequential: true
     builders:


### PR DESCRIPTION
We want to test with the latest openSUSE and SLES releases, so:

- for Cloud:OpenStack:Master, use Leap-42.3 and SLE_12_SP3
- for Cloud:OpenStack:Ocata, use in addition to the current images SLE_12_SP3