### PR TITLE
sync Updates-test repos for offline build

### DIFF
--- a/scripts/lib/mkcloud-onhost.sh
+++ b/scripts/lib/mkcloud-onhost.sh
@@ -127,6 +127,7 @@ function onhost_cacheclouddata
                 echo "repos/$a/SUSE-OpenStack-Cloud-$cloudver-$suffix/***"
             done
             [[ $want_test_updates = 1 ]] && echo "repos/$a/SLES$slesversion-Updates-test/***"
+	    [[ $hacloud == 1 ]] && echo "repos/$a/SLE$slesversion-HA-Updates-test/***"
             echo "install/suse-$suseversion/$a/install/***"
 
             # Determine which cloudsource based media to mirror

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -34,6 +34,10 @@ cache_dir_default=/var/cache/mkcloud/$cloud
 : ${cache_dir:=$cache_dir_default}
 mkdir -p "$cache_dir"
 
+# want_test_updates is used to determine whether to cache the test repos. If
+# TESTHEAD is set, it implies the test repos are needed.
+[ -z "$want_test_updates" -a -n "$TESTHEAD" ] && export want_test_updates=1
+
 # FIXME: separate user-tweakable parameters from script local variables.
 # Currently there is no clearly defined interface point.  One of the
 # causes of this is violation of the common shell coding standard which


### PR DESCRIPTION
Otherwise, mkcloud (with cache_clouddata enabled) may fail with
something like this.

+(mkcloud-common.sh:102) complain(): printf 'Error (31): %s\n' 'source
/repositories/repos/x86_64/SLE12-SP2-HA-Updates-test/ for bind-mount does
not exist'
Error (31): source /repositories/repos/x86_64/SLE12-SP2-HA-Updates-test/
for bind-mount does not exist