### PR TITLE
Fix typo in add_ha_repo function

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -630,4 +630,6 @@ fi
 : ${want_monasca_proposal:=0}
 : ${want_murano_proposal:=0}
 
+[ -z "$want_test_updates" -a -n "$TESTHEAD" ] && export want_test_updates=1
+
 # ---- END: common variables and defaults

--- a/scripts/lib/mkcloud-onhost.sh
+++ b/scripts/lib/mkcloud-onhost.sh
@@ -126,7 +126,10 @@ function onhost_cacheclouddata
                 [[ $hacloud = 1 ]] && echo "repos/$a/SLE$slesversion-HA-$suffix/***"
                 echo "repos/$a/SUSE-OpenStack-Cloud-$cloudver-$suffix/***"
             done
-            [[ $want_test_updates = 1 ]] && echo "repos/$a/SLES$slesversion-Updates-test/***"
+            [[ $want_test_updates = 1 ]] && {
+                echo "repos/$a/SLES$slesversion-Updates-test/***"
+                [[ $hacloud = 1 ]] && echo "repos/$a/SLE$slesversion-HA-Updates-test/***"
+            }
             echo "install/suse-$suseversion/$a/install/***"
 
             # Determine which cloudsource based media to mirror

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -315,7 +315,7 @@ function add_ha_repo
         add_mount "repos/$arch/$repo" \
             "$tftpboot_repos_dir/$repo"
     done
-    if [[ $hacloud = 1 ]] && isrepoworking SLE$slesversion-HA-Updates-test ; then
+    if [[ $want_test_updates = 1 ]] && isrepoworking SLE$slesversion-HA-Updates-test ; then
         add_mount "repos/$arch/SLE$slesversion-HA-Updates-test/" \
             "$tftpboot_repos_dir/SLE$slesversion-HA-Updates-test/"
     fi

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -88,7 +88,6 @@ export cinder_netapp_login
 export cinder_netapp_password
 export localreposdir_target
 export want_ipmi=${want_ipmi:-}
-[ -z "$want_test_updates" -a -n "$TESTHEAD" ] && export want_test_updates=1
 [ "$libvirt_type" = hyperv ] && export wanthyperv=1
 [ "$libvirt_type" = xen ] && export wantxenpv=1 # xenhvm is broken anyway
 


### PR DESCRIPTION
We were accidentally checking hacloud rather than want_test_updates,
so it was always using the Updates-test channel.