### PR TITLE
Size admin node disk slightly bigger when upgrade is being used

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -98,6 +98,8 @@ iscloudver 7plus && : ${controller_node_memory:=12582912}
     compute_node_memory=$(max $compute_node_memory ${xen_node_memory:-4000000})
 # hdd size defaults (unless defined otherwise)
 : ${adminnode_hdd_size:=15}
+[[ "$upgrade_cloudsource" ]] && \
+    adminnode_hdd_size=$(max $adminnode_hdd_size 20)
 : ${controller_hdd_size:=20}
 : ${computenode_hdd_size:=20}
 : ${cephvolume_hdd_size:=21}


### PR DESCRIPTION
Recently things started to fail with out of disk space issues,
likely because the cloud 7 media grew significantly in size due to
monasca being added.