### PR TITLE
Wait longer for servers to be booted

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1332,6 +1332,8 @@ function set_node_raid
     disks_count="$3"
 
     wait_for 10 5 "getent hosts $node &> /dev/null" "$node name to be resolvable"
+
+    wait_for 300 10 "timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $node true" "$node to become sshable"
     # to find out available disks, we need to look at the nodes directly
     raid_disks=`ssh $node lsblk -n -d | cut -d' ' -f 1 | head -n $disks_count`
     test -n "$raid_disks" || complain 90 "no raid disks found on $node"


### PR DESCRIPTION
In order to query the raid config it does a direct ssh, which
might not be available with real hardware at the time the dns resolves
because the server is still booting.