### PR TITLE
Size admin node disk slightly bigger when upgrade is being used

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -97,6 +97,8 @@ iscloudver 7plus && : ${controller_node_memory:=12582912}
 [[ "$libvirt_type" = "xen" ]] && \
     compute_node_memory=$(max $compute_node_memory ${xen_node_memory:-4000000})
 # hdd size defaults (unless defined otherwise)
+[[ "$upgrade_cloudsource" ]] && \
+    adminnode_hdd_size=$(max $adminnode_hdd_size 20)
 : ${adminnode_hdd_size:=15}
 [[ "$upgrade_cloudsource" ]] && \
     adminnode_hdd_size=$(max $adminnode_hdd_size 20)


### PR DESCRIPTION
Recently things started to fail with out of disk space issues,
likely because the cloud 7 media grew significantly in size due to
monasca being added.