### PR TITLE
mkcloud: Use correct default cache dir

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -29,7 +29,7 @@ if [[ $debug_mkcloud = 1 ]] ; then
     PS4='+(${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
 
-cache_dir_default=/var/cache/mkcloud/$cloud
+cache_dir_default=/var/cache/mkcloud/$cloudsource
 [[ $UID != 0 ]] && cache_dir_default="${XDG_CACHE_HOME:-./cache}/mkcloud"
 : ${cache_dir:=$cache_dir_default}
 mkdir -p "$cache_dir"


### PR DESCRIPTION
Use $cloudsource as variable part for the cache directory. Otherwise
a new cache is created whenever another $cloud name is used.
This is also what is documented at [1]

[1] https://github.com/SUSE-Cloud/automation/blob/master/docs/mkcloud.md