### PR TITLE
Make ironic nic assignment global in jenkins jobs

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
@@ -48,20 +48,6 @@ proposals:
         intf3:
           if_list:
           - "?1g2"
-      pattern: single/.*/.*ironic.*
-    - conduit_list:
-        intf0:
-          if_list:
-          - "?1g1"
-        intf1:
-          if_list:
-          - "?1g1"
-        intf2:
-          if_list:
-          - "?1g1"
-        intf3:
-          if_list:
-          - "?1g1"
       pattern: single/.*/.*
     - conduit_list:
         intf0:

--- a/scripts/scenarios/cloud7/cloud7-ironic-swift-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-swift-ha.yml
@@ -48,20 +48,6 @@ proposals:
         intf3:
           if_list:
           - "?1g2"
-      pattern: single/.*/.*ironic.*
-    - conduit_list:
-        intf0:
-          if_list:
-          - "?1g1"
-        intf1:
-          if_list:
-          - "?1g1"
-        intf2:
-          if_list:
-          - "?1g1"
-        intf3:
-          if_list:
-          - "?1g1"
       pattern: single/.*/.*
     - conduit_list:
         intf0:

--- a/scripts/scenarios/cloud8/cloud8-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud8/cloud8-ironic-basic-ha.yml
@@ -48,20 +48,6 @@ proposals:
         intf3:
           if_list:
           - "?1g2"
-      pattern: single/.*/.*ironic.*
-    - conduit_list:
-        intf0:
-          if_list:
-          - "?1g1"
-        intf1:
-          if_list:
-          - "?1g1"
-        intf2:
-          if_list:
-          - "?1g1"
-        intf3:
-          if_list:
-          - "?1g1"
       pattern: single/.*/.*
     - conduit_list:
         intf0:

--- a/scripts/scenarios/cloud8/cloud8-ironic-swift-ha.yml
+++ b/scripts/scenarios/cloud8/cloud8-ironic-swift-ha.yml
@@ -48,20 +48,6 @@ proposals:
         intf3:
           if_list:
           - "?1g2"
-      pattern: single/.*/.*ironic.*
-    - conduit_list:
-        intf0:
-          if_list:
-          - "?1g1"
-        intf1:
-          if_list:
-          - "?1g1"
-        intf2:
-          if_list:
-          - "?1g1"
-        intf3:
-          if_list:
-          - "?1g1"
       pattern: single/.*/.*
     - conduit_list:
         intf0:


### PR DESCRIPTION
Having ironic=nic2 assignment is better default than any conditional
one as the conduit is not used for anything else and can safely default
to nic2. This is also safer since ironic is untagged and can conflict
with admin if put on the same nic.