### PR TITLE
cache images

### DIFF
--- a/scripts/lib/libvirt/compute-config
+++ b/scripts/lib/libvirt/compute-config
@@ -41,6 +41,10 @@ def main():
     parser.add_argument("--firmwaretype", default="bios",
                         help="Boot firmware type for the node. "
                         "Default: %(default)s")
+    parser.add_argument("--localreposrc", required=False,
+                        help="Local Repository Directory Source")
+    parser.add_argument("--localrepotgt", required=False,
+                        help="Local Repository Directory Target")
     args = parser.parse_args()
 
     print(libvirt_setup.compute_config(args, libvirt_setup.cpuflags()))

--- a/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
@@ -68,6 +68,12 @@
     <memballoon model='virtio' autodeflate='on'>
       <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
+<filesystem type='mount' accessmode='squash'>
+  <source dir='/var/cache/mkcloud/cloud'/>
+  <target dir='/repositories'/>
+  <readonly/>
+  <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+</filesystem>
 
   </devices>
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -84,5 +84,6 @@
     <memballoon model='virtio' autodeflate='on'>
       <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
+
   </devices>
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -68,5 +68,6 @@
     <memballoon model='virtio' autodeflate='on'>
       <address type='pci' bus='0x02' slot='0x01'/>
     </memballoon>
+
   </devices>
 </domain>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -66,5 +66,6 @@
     </video>
 
     <memballoon model='none' />
+
   </devices>
 </domain>

--- a/scripts/lib/libvirt/templates/compute-node.xml
+++ b/scripts/lib/libvirt/templates/compute-node.xml
@@ -33,5 +33,6 @@ $serialdevice
     <input type='mouse' bus='ps2'/>
 $videodevices
 $memballoon
+$local_repository_mount
   </devices>
 </domain>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -104,6 +104,8 @@ def default_test_args(args):
     args.bootorder = 3
     args.numcontrollers = 1
     args.firmwaretype = "bios"
+    args.localreposrc = None
+    args.localrepotgt = None
 
 
 class TestLibvirtAdminConfig(unittest.TestCase):
@@ -172,6 +174,12 @@ class TestLibvirtComputeConfig(unittest.TestCase):
         args.controller_raid_volumes = 2
         args.cephvolumenumber = 2
         self._compare_configs(args, "raid")
+
+    def test_compute_config_with_9pnet_virtio_mount(self):
+        args = self.args
+        args.localreposrc = '/var/cache/mkcloud/cloud'
+        args.localrepotgt = '/repositories'
+        self._compare_configs(args, '9pnet-mount')
 
 
 if __name__ == '__main__':

--- a/scripts/lib/mkcloud-libvirt.sh
+++ b/scripts/lib/mkcloud-libvirt.sh
@@ -352,6 +352,7 @@ function libvirt_do_onhost_deploy_image()
     local role=$1
     local image=${override_disk_image:-$(dist_to_image_name $2)}
     local disk=$3
+    local image_path=$cache_dir/$image
 
     if [[ ! $want_cached_images = 1 ]] ; then
         safely rsync --compress --progress --inplace --archive --verbose \
@@ -359,12 +360,22 @@ function libvirt_do_onhost_deploy_image()
     else
         # In this case the image has to be supplied by other means than
         # mkcloud (e.g. manual upload). If it doesn't exist we bail.
-        [[ -f $cache_dir/$image ]] || complain 19 \
-            "No image found on host and want_cached_images was set."
+        if [ ! -f "${image_path}" ] ; then
+            # look for the image file in the cache if it is not there in the
+            # usual location. Sometimes the image got cache into a different
+            # directory.
+            found_image_path=$(find $cache_dir -name $image | sed -n 1p | tr -d '\n')
+            if [ -n "${found_image_path}" -a -f "${found_image_path}" ] ; then
+                image_path=$found_image_path
+            else
+                complain 19 \
+                "No image found on host and want_cached_images was set."
+            fi
+        fi
     fi
 
     echo "Cloning $role node vdisk from $image ..."
-    safely $sudo qemu-img convert -t none -O raw -S 0 -p $cache_dir/$image $disk
+    safely $sudo qemu-img convert -t none -O raw -S 0 -p $image_path $disk
 
     if [[ ${resize_admin_node_partition:-1} = 1 ]]; then
         # resize the last partition only if it has id 83

--- a/scripts/lib/mkcloud-onhost.sh
+++ b/scripts/lib/mkcloud-onhost.sh
@@ -143,9 +143,23 @@ function onhost_cacheclouddata
             echo "repos/$a/SUSE-OpenStack-Cloud-$cloudver-$suffix/***"
 
             # Now the various test images
-            echo "images/$a/other/magnum-service-image.qcow2"
-            echo "images/$a/other/manila-service-image.qcow2"
+            # NOTE: looks like these images are only availabe on x86_64
+            if [ "${a}" == "x86_64" ] ; then
+                echo "images/$a/other/magnum-service-image.qcow2"
+                echo "images/$a/other/manila-service-image.qcow2"
+                # these are the real ones, the above are just symlinks
+                echo "images/$a/other/fedora-23-atomic-7.qcow2"
+                echo "images/$a/other/manila-service-image.x86_64-0.13.0-Build14.1.qcow2"
+                # need for the testsetup step
+                echo "images/$a/SLES12-SP1-JeOS-SE-for-OpenStack-Cloud.x86_64-GM.qcow2"
+            fi
+
+            # now cache the admin image
+            admin_image_name=$(dist_to_image_name $(get_admin_node_dist))
+            echo "images/${a}/${admin_image_name}"
         done
+
+        echo "images/SLES11-SP3-x86_64-cfntools.qcow2"
     ) > $include
 
     echo "----------------"

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -677,6 +677,10 @@ function setupnodes
         done
         local ironic_params=""
         [[ $want_ironic ]] && ironic_params="--ironicnic $ironicnic"
+        local localrepos_params=""
+        if [ -n "${localreposdir_src}" -a -n "${localreposdir_target}" ] ; then
+            localrepos_params="--localreposrc ${localreposdir_src} --localrepotgt ${localreposdir_target}"
+        fi
 
         ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
                         $mac_params \
@@ -691,6 +695,7 @@ function setupnodes
                         --vdiskdir $vdisk_dir \
                         --bootorder 3 \
                         --numcontrollers $(get_nodenumbercontroller) \
+                        $localrepos_params \
                         --firmwaretype "$firmware_type" \
                         --controller-raid-volumes $controller_raid_volumes > /tmp/$cloud-node$i.xml
 


### PR DESCRIPTION
This patch utilizes the existing pattern to mount the local repositories from
the host using 9pnet_virtio whenever possible so we can make use of the cached
images on the controller nodes when performaing openstack operations such
as image upload/download for testing purposes.