### PR TITLE
Update local openstack-cleanvm

### DIFF
--- a/jenkins/ci.opensuse.org/heat-templates/deploy-cleanvm.sh
+++ b/jenkins/ci.opensuse.org/heat-templates/deploy-cleanvm.sh
@@ -12,6 +12,7 @@ if [ "$IS_HEAT" = HEAT ]; then
   quickstart_repo=_quickstart_repo
   quickstart_branch=_quickstart_branch
   package_repo=_package_repo
+  allow_vendor_change=_allow_vendor_change
 else
   # In standalone mode these defaults are used:
   : ${TESTHEAD:=1}
@@ -21,9 +22,10 @@ else
   : ${quickstart_repo:='https://github.com/suse-cloud/openstack-quickstart.git'}
   : ${quickstart_branch:='stable/ocata'}
   : ${package_repo:=''}
+  : ${allow_vendor_change:=''}
 fi
 
-export TESTHEAD cloudsource automation_repo automation_branch quickstart_repo quickstart_branch package_repo
+export TESTHEAD cloudsource allow_vendor_change automation_repo automation_branch quickstart_repo quickstart_branch package_repo
 
 if [ -n "$package_repo" ]; then
   zypper ar --priority 22 -G -f "$package_repo" extra
@@ -54,12 +56,7 @@ case "$VERSION_ID" in
    ;;
 esac
 
-$zypper install git-core ca-certificates-mozilla
-
-# Make sure these packages are not present. If they present on the system, an
-# upgrade from Devel:Cloud:* would require a vendor change, which causes zypper
-# to abort.
-$zypper remove python-psutil python-backports.ssl_match_hostname
+zypper --non-interactive install git-core ca-certificates-mozilla
 
 # override openstack-quickstart if an alternate repo was specified
 if [ -n "$quickstart_repo" ]; then

--- a/jenkins/ci.opensuse.org/heat-templates/deploy-cleanvm.sh
+++ b/jenkins/ci.opensuse.org/heat-templates/deploy-cleanvm.sh
@@ -15,11 +15,11 @@ if [ "$IS_HEAT" = HEAT ]; then
 else
   # In standalone mode these defaults are used:
   : ${TESTHEAD:=1}
-  : ${cloudsource:=openstacknewton}
-  : ${automation_repo:=''}
+  : ${cloudsource:=openstackocata}
+  : ${automation_repo:='https://github.com/suse-cloud/automation.git'}
   : ${automation_branch:='master'}
-  : ${quickstart_repo:=''}
-  : ${quickstart_branch:='master'}
+  : ${quickstart_repo:='https://github.com/suse-cloud/openstack-quickstart.git'}
+  : ${quickstart_branch:='stable/ocata'}
   : ${package_repo:=''}
 fi
 
@@ -34,6 +34,10 @@ fi
 zypper='zypper --non-interactive'
 
 case "$VERSION_ID" in
+  12.3)
+    $zypper ar 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/' SLE12-SP3-Pool
+    $zypper ar -f 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/' SLES12-SP3-Updates
+    ;;
   "12.2")
     $zypper ar 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product/' SLE12-SP1-Pool
     $zypper ar -f 'http://smt-internal.opensuse.org/repo/$RCE/SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update/' SLES12-SP1-Updates
@@ -50,7 +54,12 @@ case "$VERSION_ID" in
    ;;
 esac
 
-zypper --non-interactive install git-core ca-certificates-mozilla
+$zypper install git-core ca-certificates-mozilla
+
+# Make sure these packages are not present. If they present on the system, an
+# upgrade from Devel:Cloud:* would require a vendor change, which causes zypper
+# to abort.
+$zypper remove python-psutil python-backports.ssl_match_hostname
 
 # override openstack-quickstart if an alternate repo was specified
 if [ -n "$quickstart_repo" ]; then

--- a/jenkins/ci.opensuse.org/heat-templates/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/heat-templates/openstack-cleanvm.yaml
@@ -6,26 +6,26 @@ description: |
 
   Usage examples:
 
-    # Build from Cloud:OpenStack:Newton:Staging on SLE12 SP2
+    # Build from Cloud:OpenStack:Ocata:Staging on SLE12 SP3
     heat stack-create -f openstack-cleanvm.yaml -P key_name=myuser -P TESTHEAD=1 myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Newton on SLE12 SP2
+    # Build from Cloud:OpenStack:Ocata on SLE12 SP3
     heat stack-create -f openstack-cleanvm.yaml -P key_name=myuser myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Liberty on SLE12 SP1
+    # Build from Cloud:OpenStack:Newton on SLE12 SP2
     heat stack-create -f openstack-cleanvm.yaml \
       -P key_name=myuser \
-      -P cloudsource=openstackliberty \
+      -P cloudsource=openstacknewton \
       -P image=SLES12-SP1
       myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Newton on openSUSE Leap 42.1
+    # Build from Cloud:OpenStack:Ocata on openSUSE Leap 42.1
     heat stack-create -f openstack-cleanvm.yaml \
       -P key_name=myuser \
       -P image=openSUSE-Leap-42.1 \
       myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Newton on openSUSE Leap 42.1 and use a
+    # Build from Cloud:OpenStack:Ocata on openSUSE Leap 42.2 and use a
     # openstack-quickstart fork
     heat stack-create -f openstack-cleanvm.yaml \
       -P key_name=myuser \
@@ -34,7 +34,7 @@ description: |
       -P quickstart_branch=my-quickstart-feature
       myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Newton on openSUSE Leap 42.1 and use a
+    # Build from Cloud:OpenStack:Ocata on openSUSE Leap 42.3 and use a
     # fork of SUSE-cloud/automation
     heat stack-create -f openstack-cleanvm.yaml \
       -P key_name=myuser \
@@ -67,7 +67,7 @@ parameters:
     description: The repository URL to clone the automation repository from
   cloudsource:
     type: string
-    default: openstacknewton
+    default: openstackocata
     description: The Cloud source to use.
   floating_network:
     type: string
@@ -75,10 +75,10 @@ parameters:
     description: The network to draw floating IPs from.
   image:
     type: string
-    default: SLES12-SP2
+    default: SLES12-SP3
     description: >
       The Glance image to use for the cleanvm machine. Use `SLES12-SP1`,
-      `SLES12-SP2` or `openSUSE-Leap-42.1` for now.
+      `SLES12-SP2`, `SLES12-SP3`  or `openSUSE-Leap-42.1` for now.
   flavor:
     type: string
     default: m1.large

--- a/jenkins/ci.opensuse.org/heat-templates/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/heat-templates/openstack-cleanvm.yaml
@@ -6,10 +6,10 @@ description: |
 
   Usage examples:
 
-    # Build from Cloud:OpenStack:Ocata:Staging on SLE12 SP3
+    # Build from Cloud:OpenStack:Pike:Staging on SLE12 SP3
     heat stack-create -f openstack-cleanvm.yaml -P key_name=myuser -P TESTHEAD=1 myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Ocata on SLE12 SP3
+    # Build from Cloud:OpenStack:Pike on SLE12 SP3
     heat stack-create -f openstack-cleanvm.yaml -P key_name=myuser myuser-cleanvm
 
     # Build from Cloud:OpenStack:Newton on SLE12 SP2
@@ -19,13 +19,13 @@ description: |
       -P image=SLES12-SP1
       myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Ocata on openSUSE Leap 42.1
+    # Build from Cloud:OpenStack:Pike on openSUSE Leap 42.1
     heat stack-create -f openstack-cleanvm.yaml \
       -P key_name=myuser \
       -P image=openSUSE-Leap-42.1 \
       myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Ocata on openSUSE Leap 42.2 and use a
+    # Build from Cloud:OpenStack:Pike on openSUSE Leap 42.2 and use a
     # openstack-quickstart fork
     heat stack-create -f openstack-cleanvm.yaml \
       -P key_name=myuser \
@@ -34,7 +34,7 @@ description: |
       -P quickstart_branch=my-quickstart-feature
       myuser-cleanvm
 
-    # Build from Cloud:OpenStack:Ocata on openSUSE Leap 42.3 and use a
+    # Build from Cloud:OpenStack:Pike on openSUSE Leap 42.3 and use a
     # fork of SUSE-cloud/automation
     heat stack-create -f openstack-cleanvm.yaml \
       -P key_name=myuser \
@@ -45,6 +45,16 @@ description: |
 
 
 parameters:
+  allow_vendor_change:
+    type: string
+    default: '1'
+    description: >
+      Allow package vendor changes in zypper. This may be needed because the
+      images available in Glance usually have more packages installed than our
+      standard CI image and some of these may have never versions in
+      Cloud:OpenStack:*. Any package for which this is the case will cause
+      zypper to stall deployment by displaying a prompt asking the user whether
+      they'd like to allow a vendor change for the package in question.
   TESTHEAD:
     type: string
     default: '1'
@@ -67,7 +77,7 @@ parameters:
     description: The repository URL to clone the automation repository from
   cloudsource:
     type: string
-    default: openstackocata
+    default: openstackpike
     description: The Cloud source to use.
   floating_network:
     type: string
@@ -142,6 +152,7 @@ resources:
           params:
             _cloudsource: { get_param: cloudsource }
             _TESTHEAD: { get_param: TESTHEAD }
+            _allow_vendor_change: { get_param: allow_vendor_change }
             _automation_repo: { get_param: automation_repo }
             _automation_branch: { get_param: automation_branch }
             _package_repo: { get_param: package_repo }


### PR DESCRIPTION
This pull request polishes up the scripts/heat template for deploying `openstack-cleanvm` locally.

* Added default repository URLs/branches (default is to build Ocata cloud
  on SLES 12 SP3)
* Adjusted defaults in the Heat template to build an Ocata based cloud

Caveat: I haven't tested this yet, so it may still be subtly broken. I'll be off for two weeks starting next week so won't be able to fix it for a while if it does turn out to be broken. Feel free to play with this/fix it/merge it meanwhile. Failing that I'll test/fix it in two weeks :-)