### PR TITLE
FIX idna encoding issues

### DIFF
--- a/scripts/jenkins/jenkins-job-trigger
+++ b/scripts/jenkins/jenkins-job-trigger
@@ -57,7 +57,7 @@ def jenkins_build_job(job_name, job_args=[]):
         p_key, _, p_val = param.partition('=')
         job_parameters[p_key.strip(' ')] = p_val.strip(' ')
 
-    server = jenkins.Jenkins(config['jenkins_url'],
+    server = jenkins.Jenkins(str(config['jenkins_url']),
                              username=config['jenkins_user'],
                              password=config['jenkins_api_token'])
     server.build_job(job_name, job_parameters)


### PR DESCRIPTION
On some machines passing an unicode string as host name triggers an
exception:

    python -c 'import socket; socket.create_connection((u"<some-host>", 8080));'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib64/python2.7/socket.py", line 554, in create_connection
        for res in getaddrinfo(host, port, 0, SOCK_STREAM):
    LookupError: unknown encoding: idna

Whereas using an str does not trigger the problem:

    python -c 'import socket; socket.create_connection(("<some-host>", 8080));'

This fix will convert the host name to a str making the error go away.