### PR TITLE
Disable magnum in develcloud8

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -117,6 +117,13 @@ else
 fi
 : ${drbd_database_size:=5}
 : ${drbd_rabbitmq_size:=5}
+
+# temporarily disabling magnum in develcloud8 due to
+# missing packages python-kubernetes and python-marathon
+# This needs to be re-enabled when Devel:Cloud:8 is switched to pike
+# and missing packages are added
+[[ $cloudsource == develcloud8 ]] && want_magnum_proposal=0
+
 # magnum sets up two nodes using docker/kubernetes on compute node
 # each node requiring 2GB of RAM and 20GB of harddisk for the images
 if [[ $want_magnum_proposal = 1 ]]; then

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4995,7 +4995,13 @@ function onadmin_batch
     sed -i "s/##ironic_net_prefix##/$net_ironic/g" ${scenario}
     sed -i "s/##ironic_netmask##/$ironicnetmask/g" ${scenario}
 
-    safely crowbar batch --exclude manila --timeout 2400 build ${scenario}
+    # temporarily disabling magnum in develcloud8 due to
+    # missing packages python-kubernetes and python-marathon
+    # This needs to be re-enabled when Devel:Cloud:8 is switched to pike
+    # and missing packages are added
+    [[ $cloudsource = develcloud8 ]] && exclude_magnum="--exclude magnum"
+
+    safely crowbar batch --exclude manila ${exclude_magnum} --timeout 2400 build ${scenario}
     if grep -q "barclamp: manila" ${scenario}; then
         get_novacontroller
         safely oncontroller manila_generic_driver_setup


### PR DESCRIPTION
The magnum barclamp currently fails to deploy
in develcloud8 because some packages are missing
from Devel:Cloud:8 (python-kubernetes and
python-marathon).

This commit temporarily disables magnum in develcloud8
in order to get Jenkins jobs to pass over the point
where they try to deploy magnum and fail.

This is required to unblock [the mkcloud8 gating job](https://ci.suse.de/view/Cloud/view/Cloud8/job/cloud-mkcloud8-gating/).