### PR TITLE
qa_crowbarsetup: Use "tempest run"

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -265,7 +265,6 @@ sed -i -e "s/with_magnum=no/with_magnum=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_barbican=no/with_barbican=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_sahara=no/with_sahara=yes/" /etc/openstackquickstartrc
 sed -i -e "s/with_designate=no/with_designate=yes/" /etc/openstackquickstartrc
-sed -i -e "s/with_gnocchi=no/with_gnocchi=yes/" /etc/openstackquickstartrc
 sed -i -e "s/node_is_compute=.*/node_is_compute=yes/" /etc/openstackquickstartrc
 sed -i -e s/br0/brclean/ /etc/openstackquickstartrc
 unset http_proxy

--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -477,7 +477,13 @@ if [ -e /etc/tempest/tempest.conf ]; then
     else
         test -x "$(type -p tempest-cleanup)" && tempest-cleanup --init-saved-state
     fi
-    ./run_tempest.sh -N -t -s $verbose 2>&1 | tee console.log
+
+    if tempest help run; then
+        tempest run 2>&1 | tee console.log
+    else
+        # run_tempest.sh is no longer available since tempest 16 (~ since Pike)
+        ./run_tempest.sh -N -t -s $verbose 2>&1 | tee console.log
+    fi
     ret=${PIPESTATUS[0]}
     if tempest help cleanup; then
         tempest cleanup


### PR DESCRIPTION
run_tempest.sh is no longer available in newer tempest versions (>= 16).