### PR TITLE
Re-enable magnum in develcloud8

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -116,13 +116,6 @@ else
 fi
 : ${drbd_database_size:=5}
 : ${drbd_rabbitmq_size:=5}
-
-# temporarily disabling magnum in develcloud8 due to
-# missing packages python-kubernetes and python-marathon
-# This needs to be re-enabled when Devel:Cloud:8 is switched to pike
-# and missing packages are added
-[[ $cloudsource == develcloud8 ]] && want_magnum_proposal=0
-
 # magnum sets up two nodes using docker/kubernetes on compute node
 # each node requiring 2GB of RAM and 20GB of harddisk for the images
 if [[ $want_magnum_proposal = 1 ]]; then

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5338,13 +5338,7 @@ function onadmin_batch
     sed -i "s/##ironic_net_prefix##/$net_ironic/g" ${scenario}
     sed -i "s/##ironic_netmask##/$ironicnetmask/g" ${scenario}
 
-    # temporarily disabling magnum in develcloud8 due to
-    # missing packages python-kubernetes and python-marathon
-    # This needs to be re-enabled when Devel:Cloud:8 is switched to pike
-    # and missing packages are added
-    [[ $cloudsource = develcloud8 ]] && exclude_magnum="--exclude magnum"
-
-    safely crowbar batch --exclude manila ${exclude_magnum} --timeout 2400 build ${scenario}
+    safely crowbar batch --exclude manila --timeout 2400 build ${scenario}
     if grep -q "barclamp: manila" ${scenario}; then
         get_novacontroller
         safely oncontroller manila_generic_driver_setup


### PR DESCRIPTION
Re-enables the magnum barclamp previously
disabled in #2140 due to missing packages in the
Ocata-aligned Devel:Cloud:8.

NOTE: do not merge this PR until after the develcloud8
cloudsource has been migrated to Pike and the missing
magnum packages have been corrected.