### PR TITLE
Revert "Size admin node disk slightly bigger when upgrade is being used"

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -99,8 +99,6 @@ iscloudver 7plus && : ${controller_node_memory:=12582912}
 [[ "$libvirt_type" = "xen" ]] && \
     compute_node_memory=$(max $compute_node_memory ${xen_node_memory:-4000000})
 # hdd size defaults (unless defined otherwise)
-[[ "$upgrade_cloudsource" ]] && \
-    adminnode_hdd_size=$(max $adminnode_hdd_size 20)
 : ${adminnode_hdd_size:=15}
 [[ "$upgrade_cloudsource" ]] && \
     adminnode_hdd_size=$(max $adminnode_hdd_size 20)


### PR DESCRIPTION
This reverts commit 55263846e19032986464ffd4948c9d1088ba424b.

For some reason this change was merged twice, the first one being
9901dca6. We don't need to set the hdd size twice, and we especially
don't need to check the max value of it before it is initially set.
Doing so causes mkcloud to emit an error:

/root/automation/scripts/lib/mkcloud-common.sh: line 50: 20 >  ? 20 :  : syntax error: operand expected (error token is "? 20 :  ")

which is currently causing the setup_aliases step to fail and therefor
making the batch proposal step impossible[1].

[1] https://ci.suse.de/job/cloud-mkcloud-qam-scenario-1a/26/consoleFull