### PR TITLE
mkcloud-libvirt: ensure non-empty vlan_public

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2200,7 +2200,7 @@ function custom_configuration
             fi
             if iscloudver 7plus; then
                 # The default of 8 is a bit too much for our default virtual setup
-                proposal_set_value keystone default "['attributes']['keystone']['api']['processes']" "2"
+                [[ $cloudsource =~ devel ]] && proposal_set_value keystone default "['attributes']['keystone']['api']['processes']" "2"
                 if [[ $want_keystone_token_type ]]; then
                     proposal_set_value keystone default "['attributes']['keystone']['signing']['token_format']" "'$want_keystone_token_type'"
                 fi


### PR DESCRIPTION
for some reasons, cleanup can run with this value empty,
which will cause an error in cleanup:

+(mkcloud-libvirt.sh:307) libvirt_do_cleanup(): /root/workspace/openstack-mkcloud@2/SUSE-Cloud.automation.8ZLRoZ/automation/scripts/lib/libvirt/cleanup vf1 2 vf1br vf1irobr
usage: cleanup [-h] cloud nodenumber cloudbr vlan_public ironicbr
cleanup: error: too few arguments