### PR TITLE
trackupstream: Do not track openstack-monasca-log-agent

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -49,7 +49,7 @@
             - openstack-magnum
             - openstack-monasca-agent
             - openstack-monasca-api
-            - openstack-monasca-log-agent
+            #- openstack-monasca-log-agent
             - openstack-monasca-log-api
             - openstack-monasca-notification
             - openstack-monasca-persister


### PR DESCRIPTION
We use a hardcoded version. There is nothing to track.