### PR TITLE
Add deployexternalceph step

### DIFF
--- a/scripts/build_ses.sh
+++ b/scripts/build_ses.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+#
+# This script is expected to run on the admin (crowbar) server and will build an external
+# SES cluster on a bunch of nodes. The nodes in question are passed in as arguments as are
+# optionally the ceph public and cluster networks.
+#
+# This script is expecting the arguments in the form:
+#    build_ses.sh [<public net> <cluster net>] <node 1> <node 2> [<node 3> ..]
+#
+# The networks are in the form:
+#    1.2.3.0/24
+# Or as it's used in qa_crowbarsetup.sh:
+#    ${net_public}.0/24
+#
+# The nodes are the crowbar machine names. Because SES uses deepsea, the first node provided
+# will become the salt master. So any other way of viewing the argument list of nodes are as:
+#    <salt master> <salt minion> [<salt minion> ..]
+#
+# This script is used in the function onadmin_external_ceph by qa_crowbarsetup.sh as apart of
+# the deployexternalceph step.
+#
+# For further ses5 install instructions on which this was based
+# see: http://beta.suse.com/private/SUSE-Storage-Beta/doc/ses-manual_en/ceph.install.saltstack.html
+NUM_MASTER=1
+NUM_ADMIN=1
+NUM_MON=3
+NUM_MDS=1
+NUM_IGW=0
+NUM_RGW=2
+
+ip_cidr_regex='^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
+
+if (( $# < 2 ))
+then
+    echo "Usage: $0 [<public_network/cidr> <cluster_network/cidr>] <salt master> <salt minion> [, <salt minion>, ..]"
+    exit 1
+fi
+
+if [[ "$1" =~ $ip_cidr_regex ]]
+then
+    public_network=$1
+    shift
+    if [[ "$1" =~ $ip_cidr_regex ]]
+    then
+        cluster_network=$1
+        shift
+    fi
+fi
+master=$1
+shift
+minions=($@)
+
+function run_ssh_cmd() {
+    host=$1
+    shift
+    ssh $host -C "$@"
+    if (( $? > 0 ))
+    then
+        echo "Ssh command '$@' failed on host '$host'"
+        exit 2
+    fi
+}
+
+function salt_setup() {
+    # install salt master
+    run_ssh_cmd $master "zypper -n in deepsea"
+    run_ssh_cmd $master "systemctl enable salt-master.service"
+    run_ssh_cmd $master "systemctl start salt-master.service"
+    run_ssh_cmd $master "echo 'master: $master' > /etc/salt/minion.d/master.conf"
+    run_ssh_cmd $master "sudo systemctl enable salt-minion.service"
+    run_ssh_cmd $master "sudo systemctl start salt-minion.service"
+    if ssh $master "[ ! -f /srv/pillar/ceph/deepsea_minions.sls.bak ]  && [ -f /srv/pillar/ceph/deepsea_minions.sls ]"
+    then
+        run_ssh_cmd $master "sudo cp /srv/pillar/ceph/deepsea_minions.sls /srv/pillar/ceph/deepsea_minions.sls.bak"
+        cat <<EOF | ssh $master "cat > /srv/pillar/ceph/deepsea_minions.sls"
+# Using the deepsea grain 'G@deepsea:*' wasn't working, so setting to all nodes.
+# original file saved to /srv/pillar/ceph/deepsea_minions.sls.bak
+deepsea_minions: '*'
+EOF
+    fi
+
+    # install salt minion on the minions
+    for minion in "${minions[@]}"
+    do
+        run_ssh_cmd $minion "sudo zypper -n in salt-minion"
+        run_ssh_cmd $minion "sudo systemctl enable salt-minion.service"
+        run_ssh_cmd $minion "echo 'master: $master' > /etc/salt/minion.d/master.conf"
+        run_ssh_cmd $minion "sudo systemctl start salt-minion.service"
+    done
+
+    # Back on master, accept all the minions salt keys
+    run_ssh_cmd $master "salt-key --accept-all -y"
+    echo -n "waiting on keys (wait 20 times in 2 sec increments)."
+    for x in $(seq 20)
+    do
+        if (( $(run_ssh_cmd $master "salt-key -l acc |grep -cv 'Accepted Keys:'") != $(( ${#minions[@]} + 1 )) ))
+        then
+            echo '.'
+            run_ssh_cmd $master "salt-key --accept-all -y 2> /dev/null"
+            sleep 2
+        else
+            echo 'done'
+            break
+        fi
+    done
+    if (( $(run_ssh_cmd $master "salt-key -l acc |grep -cv 'Accepted Keys:'") != $(( ${#minions[@]} + 1 )) ))
+    then
+        echo 'failed'
+        exit 1
+    fi
+}
+
+function rnd_sel_nodes() {
+    num=$1
+    shift
+    local nodes
+    nodes=($@)
+
+    if (( $num >= ${#nodes[@]} ))
+    then
+        echo ${nodes[@]}
+        return
+    fi
+
+    result=()
+    while (( $num > 0 ))
+    do
+        rnd=$(( RANDOM % ${#nodes[@]} ))
+        result=(${result[@]} ${nodes[$rnd]})
+        unset nodes[$rnd]
+        nodes=( ${nodes[@]} )
+        let "num-=1"
+    done
+
+    echo ${result[@]}
+}
+
+function generate_policy_config() {
+    pconf="/srv/pillar/ceph/proposals/policy.cfg"
+
+    cat <<EOF | ssh $master "cat > $pconf"
+# cluster assignment
+cluster-ceph/cluster/*.sls
+
+# Role assignment
+EOF
+
+    # Need to assign roles
+    # masters
+    run_ssh_cmd $master "echo 'role-master/cluster/${master}.sls' >> $pconf"
+    if (( $NUM_MASTER > 1 ))
+    then
+        masters=( $(rnd_sel_nodes $(($NUM_MASTER -1)) ${minions[@]}) )
+        for mas in ${masters[@]}
+        do
+            run_ssh_cmd $master "echo 'role-master/cluster/${mas}.sls' >> $pconf"
+        done
+    fi
+    # admins
+    run_ssh_cmd $master "echo 'role-admin/cluster/${master}.sls' >> $pconf"
+    if (( $NUM_ADMIN > 1 ))
+    then
+        admins=( $(rnd_sel_nodes $(($NUM_ADMIN -1)) ${minions[@]}) )
+        for ad in ${admins[@]}
+        do
+            run_ssh_cmd $master "echo 'role-admin/cluster/${ad}.sls' >> $pconf"
+        done
+    fi
+    # Monitors
+    mons=( $(rnd_sel_nodes $NUM_MON $master ${minions[@]}) )
+    for mon in ${mons[@]}
+    do
+        cat <<EOF | ssh $master "cat >> $pconf"
+role-mon/stack/default/ceph/minions/${mon}.yml
+role-mon/cluster/${mon}.sls
+EOF
+    done
+    # mgrs (ses5 only) - runs on the mon nodes
+    if ssh $master "[ -d $(dirname $pconf)/role-mgr ]"
+    then
+        for mon in ${mons[@]}
+        do
+            run_ssh_cmd $master "echo 'role-mgr/cluster/${mon}.sls' >> $pconf"
+        done
+    fi
+    # mds
+    mds=( $(rnd_sel_nodes $NUM_MDS $master ${minions[@]}) )
+    for md in ${mds[@]}
+    do
+        run_ssh_cmd $master "echo 'role-mds/cluster/${md}.sls' >> $pconf"
+    done
+    # Iscsi gateways
+    igws=( $(rnd_sel_nodes $NUM_IGW $master ${minions[@]}) )
+    for igw in ${igws[@]}
+    do
+        cat <<EOF | ssh $master "cat >> $pconf"
+role-igw/stack/default/ceph/minions/${igw}.yml
+role-igw/cluster/${igw}.sls
+EOF
+    done
+    # Rados gateways
+    rgws=( $(rnd_sel_nodes $NUM_RGW $master ${minions[@]}) )
+    for rgw in ${rgws[@]}
+    do
+        run_ssh_cmd $master "echo 'role-rgw/cluster/${rgw}.sls' >> $pconf"
+    done
+
+    cat <<EOF | ssh $master "cat >> $pconf"
+# common configuration
+config/stack/default/global.yml
+config/stack/default/ceph/cluster.yml
+
+# profile assignment
+EOF
+
+    # Need to assign profiles, we'll just add whatever was found
+    for profile in $(ssh $master "find $(dirname $pconf) -name 'profile*'")
+    do
+        profile=$(echo $profile |sed "s#^$(dirname $pconf)/##g")
+        cat <<EOF | ssh $master "cat >> $pconf"
+$profile/cluster/*.sls
+$profile/stack/default/ceph/minions/*.yml
+EOF
+    done
+}
+
+function install_ses() {
+    echo "== run stage 0 (prep) =="
+    # Note: we don't use run_ssh_cmd because a reboot during prep returns a > 0 errorcode.
+    ssh $master "salt-run state.orch ceph.stage.prep"
+    prep_return=$?
+
+    # there is a chance the nodes will reboot so ping check them
+    if (( $prep_return > 0 ))
+    then
+        # wait a big for the nodes to shutdown.
+        sleep 10
+    fi
+    for hn in $master ${minions[@]}
+    do
+        echo "Attempting to ssh to $hn"
+        ip_good=0
+        for i in $(seq 30)
+        do
+            ssh $hn "zypper --gpg-auto-import-keys ref -f"
+            if (( $? == 0 ))
+            then
+                ip_good=1
+                # refresh repoistories after the reboot, as cloud repo can update key.
+                ssh $hn "zypper --gpg-auto-import-keys ref -f"
+                break
+            fi
+            sleep 2
+        done
+        if (( ip_good == 0 ))
+        then
+            echo "failed to contact $hn"
+            exit 3
+        fi
+    done
+    if (( $prep_return > 0 ))
+    then
+        # prep stage might have needed to reboot, so need to run it a second time
+        echo "== run stage 0 (prep) - take 2 =="
+        run_ssh_cmd $master "salt-run state.orch ceph.stage.prep"
+    fi
+
+    echo "== run stage 1 (discovery) ==" # - collect data from the nodes
+    run_ssh_cmd $master "salt-run state.orch ceph.stage.discovery"
+
+    echo "== generate policy.cfg ==" # from data found during discovery
+    generate_policy_config
+
+    echo "== run stage 2 (configure) =="
+    run_ssh_cmd $master "salt-run state.orch ceph.stage.configure"
+
+    echo "== Setting networks =="
+    if [[ -n "$public_network" ]]
+    then
+        echo "public_network: $public_network"
+        cat <<EOF | ssh $master "cat >> /srv/pillar/ceph/stack/ceph/cluster.yml"
+public_network: $public_network
+EOF
+        if [[ -n "$cluster_network" ]]
+        then
+            echo "cluster_network: $cluster_network"
+            cat <<EOF | ssh $master "cat >> /srv/pillar/ceph/stack/ceph/cluster.yml"
+cluster_network: $cluster_network
+EOF
+        fi
+    fi
+
+    # there seems to be a bug, sometimes during deploy osd.deploy fails. Restarting the salt minions
+    # fixes it, so the minions must not get synced or confused. So now we give them a restart.
+    run_ssh_cmd $master "salt '*' cmd.run 'rcsalt-minion restart'"
+
+    echo "== run stage 3 (deploy) =="
+    run_ssh_cmd $master "salt-run state.orch ceph.stage.deploy"
+
+    # Check the chef status, for those watching at home
+    run_ssh_cmd $master "ceph -s"
+
+    echo "== run stage 4 (services) ==" # - generate keyrings, start services etc.
+    run_ssh_cmd $master "salt-run state.orch ceph.stage.services"
+}
+
+salt_setup
+install_ses
+

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -655,5 +655,6 @@ fi
 
 # mysql (MariaDB actually) is the default option for Cloud8
 iscloudver 8plus && : ${want_database_sql_engine:="mysql"}
+: ${want_external_ceph:=0}
 : ${want_ses_version:=0}
 # ---- END: common variables and defaults

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -572,6 +572,10 @@ function common_set_slesversions
             sesversion=5
         ;;
     esac
+
+    if [ $want_ses_version -gt 0 ]; then
+        sesversion=$want_ses_version
+    fi
 }
 
 # ---- END: functions related to repos and distribution settings
@@ -651,4 +655,5 @@ fi
 
 # mysql (MariaDB actually) is the default option for Cloud8
 iscloudver 8plus && : ${want_database_sql_engine:="mysql"}
+: ${want_ses_version:=0}
 # ---- END: common variables and defaults

--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -424,6 +424,16 @@ function libvirt_do_setuplonelynodes()
         $sudo lvdisplay "$lonely_disk" || \
             _lvcreate "${cloud}.node$i" "${lonelynode_hdd_size}" "$cloudvg"
 
+        local j
+        local lonely_data_disk
+        for j in $(seq $cephvolumenumber); do
+            lonely_data_disk="${lonely_disk}-ceph$j"
+            $sudo lvdisplay "$lonely_data_disk" || \
+                _lvcreate "${cloud}.node$i-ceph$j" "${cephvolume_hdd_size}" "$cloudvg"
+            # make sure the drive is Zapped and ready for use
+            sudo sgdisk -Z $lonely_data_disk
+        done
+
         onhost_deploy_image "lonely" $(get_lonely_node_dist) $lonely_disk
         libvirt_vm_start /tmp/${lonely_node}.xml
     done

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -752,6 +752,24 @@ function instnodes
     safely onadmin post_allocate
 }
 
+function deployexternalceph
+{
+    if [[ $want_external_ceph = 0 ]] ; then
+        echo "\$want_external_ceph not set, skipping"
+        return
+    fi
+    if [[ $(nodes number lonely) = 0 ]] ; then
+        echo "\$nodenumberlonelynode = 0, can't build a ceph cluster of 0 nodes"
+        return
+    fi
+
+    local new_nodes=()
+    for i in $(nodes ids lonely) ; do
+        local mac=$(macfunc $i)
+        new_nodes=(${new_nodes[@]} $(mac_to_nodename $mac))
+    done
+    onadmin external_ceph ${new_nodes[@]}
+}
 
 function proposal
 {
@@ -1048,6 +1066,8 @@ Steps:
     setuplonelynodes: boot a number (defined by nodenumberlonelynode) of non-crowbar registered nodes in the admin network
     setupironicnodes: boot a number of empty nodes to be used by the ironic service
     crowbar_register: register a number (defined by nodenumberlonelynode) of non-crowbar nodes with crowbar (setuplonelynodes needs to have run before)
+    deployexternalceph: Deploy an external SES cluster on a number of crowbar nodes (defined by nodenumberlonelynode),
+                    this step assumes that both setuplonelynodes and crowbar_register have been run first.
     testsetup:      start a VM in the cloud
     addupdaterepo:  addupdate repos defined in UPDATEREPOS= (URLs separated by '+')
     runupdate:      run zypper up on the crowbar node
@@ -1223,6 +1243,10 @@ Optional
         Default value will be applied from Keystone barclamp proposal.
     want_cd='' | 1  (default='')
         Set up a cloud based on the continuous delivery channel.
+    want_ceph=1
+        Setup an internal ceph cluster using the ceph barclamp.
+    want_external_ceph=1 (default=0)
+        Setup an external ceph cluster on a set of recently registered lonely nodes
     want_ses_version=5 (default=0)
         Specify what version of SES you want to use. The value is the SES version (4 = SES4, 5 = SES5)
     want_ironic=1 (default='')
@@ -1383,6 +1407,10 @@ function sanity_checks
         complain 113 "Please increase number of nodes for this setup, minimal nodenumber=3"
     fi
 
+    if [[ $want_ceph = 1 ]] && [[ $want_external_ceph = 1 ]] ; then
+        complain 118 "\$want_ceph and \$want_external_ceph are mutully exclusive. Please choose one or the other"
+    fi
+
     if [[ " ${steplist[*]} " == *" batch "* ]] ; then
         : ${scenario_dir:="${SCRIPTS_DIR}/scenarios/cloud$(getcloudver)"}
         need_scenario=1
@@ -1412,7 +1440,7 @@ allcmds="$step_aliases _test_setuphost \
     lonelynode_nfs_server setupironicnodes\
     restoreadminfromsnapshot createcloudsnapshot restorecloudfromsnapshot \
     cct steps batch setup_aliases onadmin onhost devsetup plain_with_upgrade_test \
-    testpreupgrade testpostupgrade"
+    testpreupgrade testpostupgrade deployexternalceph"
 wantedcmds=$@
 
 function expand_steps

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1223,6 +1223,8 @@ Optional
         Default value will be applied from Keystone barclamp proposal.
     want_cd='' | 1  (default='')
         Set up a cloud based on the continuous delivery channel.
+    want_ses_version=5 (default=0)
+        Specify what version of SES you want to use. The value is the SES version (4 = SES4, 5 = SES5)
     want_ironic=1 (default='')
         Prepare (virtualized) environment for ironic.
     ironicnic=1 (default=1)


### PR DESCRIPTION
Adding initial version of the deployexternalceph step

This step calls:
- lonelynodes to generate nodes for an external ceph cluster
- calls crowbar_register to add them the crowbar
- Adds the storage network to the nodes
- Optionally, adds the ceph network to the nodes
- Sets their aliases to be ceph0 - cephN
- Deploys SES on the cluster nodes using deepsea

You run this step, you need to have first run lonelynodes and crowbar_register. You also need enable want_external_ceph:

  export want_external_ceph=1

If you want to specify a specific version SES version use want_ses_version. E.g to use SES5:

  export want_ses_version=5


