### PR TITLE
jenkins: Add 4nodes-linuxbridge job for Ocata

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -29,6 +29,9 @@
         - 'cloud-mkcloud{version}-job-xen-{arch}'
         - 'cloud-mkcloud{version}-job-2nodes-pike'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-pike'
+        # NOTE: we keep the Ocata job because we need to maintain
+        # Devel:Cloud:8:Ocata for CloudFoundry CI
+        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-ocata'
 - project:
     name: cloud-mkcloud8-ha-x86_64
     disabled: false

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-ocata-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-ocata-template.yaml
@@ -1,0 +1,26 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-4nodes-linuxbridge-ocata'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: 'H 2 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            cloudsource=ocatacloud{version}
+            nodenumber=4
+            networkingplugin=linuxbridge
+            tempestoptions={tempestoptions}
+            mkcloudtarget=all
+            label={label}
+            job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-ocata


### PR DESCRIPTION
We want to keep Devel:Cloud:8:Ocata running for CloudFoundry CI usage.
So add a job for periodic testing.