### PR TITLE
qa_crowbarsetup: Fix magnum service image name

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3419,7 +3419,7 @@ function oncontroller_magnum_service_setup
     # (mjura): https://bugs.launchpad.net/magnum/+bug/1622468
     # Magnum functional tests have hardcoded swarm as coe backend, until then this will
     # not be fixed, we are going to have our own integration tests with SLES Magnum image
-    local service_image_name="magnum-service-image.qcow2"
+    local service_image_name="magnum-service-image"
     local service_image_filename=${service_image_name}.qcow2
     local service_image_url=$imageserver_url/$arch/other/$service_image_filename
     local local_image_path=""


### PR DESCRIPTION
Commit 7835272aa7 added the ability to use locally cached images but
changed the magnum-service-image name wrongly. Fixed with this commit.