### PR TITLE
log-parser: Whitelist mariadb-errormessages RPM

### DIFF
--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -26,6 +26,7 @@ ok /grep -v failed\b/
 # rpms containing "Error"
 ok /perl-Error[ -]/
 ok /libsamba-errors/
+ok /mariadb-errormessages/
 
 # Crowbar upgrade messages
 ok /^\| Check ID +\| Passed \| Required \| Errors/


### PR DESCRIPTION
The mariadb-errormessages package being installed is not an indication
of an error, make sure the log parser doesn't report it in the Parsed
Console output.