### PR TITLE
CI: Document the log parser rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ jenkins-jobs --ignore-cache update \
 
 For this you need a local ini file and add it via the `--conf` parameter to
 the above command.
+
+To tune the Parsed Console Output of mkcloud jobs, edit
+[the rules file](scripts/jenkins/log-parser/openstack-mkcloud-rules.txt) according to
+[the documented rules file syntax](https://wiki.jenkins-ci.org/display/JENKINS/Log+Parser+Plugin#LogParserPlugin-Parsingrulesfiles).


### PR DESCRIPTION
This patch adds a short note in the jenkins section of the README about
the log parser rules file. Having this here would have helped me when I
was grepping for 'Parsed Console Output' which is what the jenkins view
is titled. This does not link back to the
"openstack-mkcloud-log-parser-test" page of our "keep jenkins green"
document since that is in a private repository and this repository is
open source.