### PR TITLE
Correctly remove SP1 repos before upgrading to SP2

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4542,9 +4542,8 @@ function onadmin_prepare_cloudupgrade_admin_repos_6_to_7
     safely createrepo $tftpboot_repos_dir/PTF
 
     # change system repositories to SP2
-    $zypper rr sles12sp1
-    $zypper rr sles12sp1up
-    $zypper rr sles12sp1tup
+    $zypper rr SLES12-SP1-Pool
+    $zypper rr SLES12-SP1-Updates
     onadmin_setup_local_zypper_repositories
 }
 


### PR DESCRIPTION
The repo aliases have been changed recently, so the removal did not work.

Original names were changed by
https://github.com/SUSE-Cloud/automation/commit/7310b5cc2e7e87144a124b639603701af0e81386