### PR TITLE
Use correct method to add HA repository

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4511,7 +4511,7 @@ function onadmin_prepare_cloudupgrade_nodes_repos_6_to_7
     onadmin_prepare_sles12plus_cloud_repos
 
     if [[ $hacloud = 1 ]]; then
-        add_ha12sp2_repo
+        add_ha_repo
     fi
 
     if [ -n "$deployceph" ]; then


### PR DESCRIPTION
add_ha12sp2_repo was removed with https://github.com/SUSE-Cloud/automation/commit/3a9b76fb21dcafd16448c6aebddea9e7b49394dd