### PR TITLE
qa_crowbarsetup: Hide stderr from nova commands

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3342,7 +3342,7 @@ function oncontroller_manila_generic_driver_setup()
             manila-service-image
     fi
 
-    if ! nova flavor-show manila-service-image-flavor; then
+    if ! nova flavor-show manila-service-image-flavor 2> /dev/null ; then
         nova flavor-create manila-service-image-flavor 100 512 0 1
     fi
 
@@ -3362,7 +3362,7 @@ function oncontroller_manila_generic_driver_setup()
             openstack security group rule create --protocol udp --dst-port 111 $sec_group
         fi
     else
-        if ! nova secgroup-list-rules manila-service; then
+        if ! nova secgroup-list-rules manila-service 2> /dev/null ; then
             nova secgroup-create $sec_group "$sec_group description"
             nova secgroup-add-rule $sec_group icmp -1 -1 0.0.0.0/0
             nova secgroup-add-rule $sec_group tcp 22 22 0.0.0.0/0
@@ -3661,7 +3661,9 @@ function oncontroller_testsetup
     # wait for nova-manage to be successful
     wait_for 200 1 nova_services_up "Nova services to be up and running"
 
-    nova flavor-delete m1.smaller || :
+    if nova flavor-show m1.smaller 2> /dev/null ; then
+        nova flavor-delete m1.smaller
+    fi
     nova flavor-create m1.smaller 101 512 8 1
     instanceid=`openstack server show testvm -f value -c id`
     if [[ $instanceid ]] ; then
@@ -3677,7 +3679,9 @@ function oncontroller_testsetup
         openstack security group rule create --protocol tcp --dst-port 1:65535 testvm
         openstack security group rule create --protocol udp --dst-port 1:65535 testvm
     else
-        nova secgroup-delete testvm || :
+        if nova secgroup-list-rules testvm &>/dev/null ; then
+            nova secgroup-delete testvm
+        fi
         nova secgroup-create testvm testvm
         nova secgroup-add-rule testvm icmp -1 -1 0.0.0.0/0
         nova secgroup-add-rule testvm tcp 1 65535 0.0.0.0/0


### PR DESCRIPTION
When the nova client fails something, it produces an ugly ERROR message
that the jenkins log parser treats as a potential error. We don't need
to treat 'show' commands that are checking the existence of something
for idempotency purposes as failures. This also restructures some delete
commands to first check for existence before attempting the delete,
because if the delete fails for some reason other than nonexistence we
want to know about it.

When the openstack client command fails something, the stderr doesn't
contain ERROR and isn't treated as such by the log parser, so we might
as well let it keep being verbose.