### PR TITLE
Do not deploy ceph with mariadb-ha job

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-mariadb-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-mariadb-template.yaml
@@ -20,6 +20,7 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             clusterconfig="data+services+network=3"
+            storage_method=swift
             nodenumber=4
             tempestoptions={tempestoptions}
             hacloud=1


### PR DESCRIPTION
It does not have enough nodes. If we want to test it together with ceph,
we should create separate job for that.