### PR TITLE
qa_crowbarsetup: Really delete testvm

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3582,7 +3582,7 @@ function oncontroller_testsetup
     instanceid=`openstack server show testvm -f value -c id`
     if [[ $instanceid ]] ; then
         nova delete $instanceid
-        wait_for 10 3 "[[ ! \$(nova show $instanceid) ]]" "testvm to be deleted"
+        wait_for 10 3 "[[ \$(nova show $instanceid) ]]" "testvm to be deleted"
     fi
     nova keypair-add --pub-key /root/.ssh/id_rsa.pub testkey
     nova secgroup-delete testvm || :


### PR DESCRIPTION
Currently the testvm does not actually get deleted.
Introduced in https://github.com/SUSE-Cloud/automation/commit/80b70019d03cadbd26218670803065df93ae2d9b
The old code waits for the instance to not be there rather than for it to be present.
Remove negation to fix problem.