### PR TITLE
Add cloud7 to pr gating

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -76,7 +76,7 @@
                       networkingplugin=openvswitch
                       #echo eval `$ghs -a get-pr-config -p $github_pr_sha` # not yet implemented
                       ${automationrepo}/scripts/jenkins/jenkins-job-trigger \
-                          openstack-mkcloud -p mode=standard \
+                          openstack-mkcloud \
                           label=openstack-mkcloud \
                           github_pr=${repo}:${github_pr} \
                           mkcloudtarget=${mkcloudtarget} \

--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -72,19 +72,31 @@
                       # default config / may be overridden by tags from PR message
                       mkcloudtarget=all_noreboot
                       cloudsource=develcloud8
+                      cloudsource_stable=GM7+up
                       nodenumber=2
                       networkingplugin=openvswitch
                       #echo eval `$ghs -a get-pr-config -p $github_pr_sha` # not yet implemented
+
+                      common_parameters="
+                          openstack-mkcloud
+                          label=openstack-mkcloud
+                          mkcloudtarget=${mkcloudtarget}
+                          nodenumber=${nodenumber}
+                          networkingplugin=${networkingplugin}
+                          "
                       ${automationrepo}/scripts/jenkins/jenkins-job-trigger \
-                          openstack-mkcloud \
-                          label=openstack-mkcloud \
+                          $common_parameters \
                           github_pr=${repo}:${github_pr} \
-                          mkcloudtarget=${mkcloudtarget} \
                           cloudsource="${cloudsource}" \
-                          nodenumber=${nodenumber} \
-                          networkingplugin=${networkingplugin} \
                           job_name="automation PR ${github_pr_id} ${github_pr_sha_short}"
                       $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud" -m "Queued automation PR gating"
+
+                      ${automationrepo}/scripts/jenkins/jenkins-job-trigger \
+                          $common_parameters \
+                          github_pr=${repo}:${github_pr}:stable \
+                          cloudsource="${cloudsource_stable}"
+                          job_name="automation PR ${github_pr_id} ${github_pr_sha_short} stable"
+                      $ghs -r $repo -a set-status -s "pending" -t $BUILD_URL -c $github_pr_sha --context "suse/mkcloud/stable" -m "Queued automation PR gating"
                   fi
               done
           done


### PR DESCRIPTION
 cloud-automation-pr-trigger: pr gating for devel and stable release

Due to changes meant for the development release sometimes builds for the stable releases break.
To prevent such changes from being merged we will also build mkcloud for the stable release.