### PR TITLE
testbuild: MariaDB needs at least 3 nodes to deploy Galera

### DIFF
--- a/scripts/crowbar-testbuild.yaml
+++ b/scripts/crowbar-testbuild.yaml
@@ -21,10 +21,10 @@ parameters_template:
     networkingplugin: openvswitch
   ha: &mkcloud_ha
     label: openstack-mkcloud-ha-x86_64
-    nodenumber: 5
+    nodenumber: 6
     hacloud: 1
     networkingmode: vxlan
-    clusterconfig: "data+services+network=2"
+    clusterconfig: "data+services+network=3"
   hyperv: &mkcloud_hyperv
     networkingplugin: linuxbridge
     libvirt_type: hyperv


### PR DESCRIPTION
Since we switched to MariaDB as default we need more nodes to fullfill
the requirements of Galera.