### PR TITLE
Use mysql (MariaDB actually) backend for all Cloud8 deployments

### DIFF
--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -13,7 +13,7 @@ function qacrowbarsetup_help
     want_raidtype (default='raid1')
         The type of RAID to create.
     want_database_sql_engine (default='' which picks cloud default)
-        The type of database backend to create (only cloud8+)
+        The type of database backend to create (only cloud7; cloud8 can only have mysql)
     want_node_aliases=list of aliases to assign to nodes
         Takes all provided aliases and assign them to available nodes successively.
         Note that this doesn't take care about node assignment itself.

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -108,6 +108,10 @@ iscloudver 7plus && : ${controller_node_memory:=12582912}
 : ${controller_ceph_hdd_size:=25}
 : ${lonelynode_hdd_size:=20}
 : ${ironicnode_hdd_size:=20}
+
+# mysql (MariaDB actually) is the default option for Cloud8
+iscloudver 8plus && want_database_sql_engine="mysql"
+
 if [[ $hacloud ]] && [[ "$want_database_sql_engine" != "mysql" ]]; then
     : ${drbd_hdd_size:=15}
 else


### PR DESCRIPTION
We need to set the db backend explicitely so that qa_crowbarsetup code does not try to create DRBD-based cluster...