### PR TITLE
mediacheck: cleanup in error case as well

### DIFF
--- a/jenkins/ci.suse.de/cloud-mediacheck.yaml
+++ b/jenkins/ci.suse.de/cloud-mediacheck.yaml
@@ -50,8 +50,14 @@
           # fetch the latest automation updates
           ${automationrepo}/scripts/jenkins/update_automation
 
+          function cleanup() {
+              # Cleanup isos from old builds
+              rm -f scripts/release-mgmt/*Media1.iso
+          }
+
           function jtsync_trap() {
             $jtsync --ci suse --matrix ${JOB_BASE_NAME},${project},${BUILD_NUMBER} 1 || :
+            cleanup
           }
 
           # only enable jtsync when build is not manually triggered
@@ -80,8 +86,7 @@
           mkdir -p cloud
           rsync -av $d/scripts ./cloud/
 
-          # Cleanup isos from old builds
-          rm -f scripts/release-mgmt/*Media1.iso
+          cleanup
 
           # options
           export RPM_DEPCHECK=1


### PR DESCRIPTION
Otherwise the disk of the worker is filling up with ISO images.