### PR TITLE
fix database engine selection

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -110,7 +110,7 @@ iscloudver 7plus && : ${controller_node_memory:=12582912}
 : ${ironicnode_hdd_size:=20}
 
 # mysql (MariaDB actually) is the default option for Cloud8
-iscloudver 8plus && want_database_sql_engine="mysql"
+iscloudver 8plus && export want_database_sql_engine="mysql"
 
 if [[ $hacloud ]] && [[ "$want_database_sql_engine" != "mysql" ]]; then
     : ${drbd_hdd_size:=15}


### PR DESCRIPTION
If people are deploying cloud8+ we want mysql to be the engine. We
already added a rule for that but we did not export the variable. This
meant that the `want_database_sql_engine` variable was not displayed by
env and not forwarded to onadmin calls, so for qa_crowbarsetup.sh the
variable was still undefined - leaving us with an mkcloud that wants to
deploy drdb on a three-node cluster in some cases.

```
> env | grep variable
> variable=3
> env | grep variable
> export variable=3
> env | grep variable
variable=3
```