### PR TITLE
openstack-submit: Fix Pike submissions

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-submit.yaml
+++ b/jenkins/ci.opensuse.org/openstack-submit.yaml
@@ -34,9 +34,13 @@
               submitcmd="$OSC copypac -K -e"
               OSCBUILDDIST=SLE_12_SP1
             ;;
-            Cloud:OpenStack:[NO]*)
+            Cloud:OpenStack:[N]*)
               submitcmd="$OSC copypac -K -e"
               OSCBUILDDIST=SLE_12_SP2
+            ;;
+            Cloud:OpenStack:[OP]*)
+              submitcmd="$OSC copypac -K -e"
+              OSCBUILDDIST=SLE_12_SP3
             ;;
             *) echo "Please add support for the project: $openstack_project"
               exit 1


### PR DESCRIPTION
The Pike gating was not working. No packages were copied to the non-staging
area. The error[1] was:

Please add support for the project: Pike

[1] https://ci.opensuse.org/view/OpenStack/job/openstack-submit/3692/