### PR TITLE
added missing function called in mkcloud/prepare

### DIFF
--- a/scripts/lib/mkcloud-onhost.sh
+++ b/scripts/lib/mkcloud-onhost.sh
@@ -156,3 +156,8 @@ function onhost_cacheclouddata
     rsync $rsync_options --include-from=$include --include="*/" --exclude="*" $reposerver::cloud $cache_dir
     rm -f $include
 }
+
+function onhost_do_prepare
+{
+    :
+}


### PR DESCRIPTION
empty for now just to avoid mkcloud failures

EDIT: The failure was here: https://github.com/SUSE-Cloud/automation/blob/master/scripts/mkcloud#L397 with `mkclouddriver=onhost` as we do it in some setups.