### PR TITLE
syncSLErepos: sync dlre

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -225,6 +225,11 @@ for arch in $archs ; do
     fi
 done
 
+# repos we need for our test automation (jenkins-swarm-client, github-status, jt_sync, cct)
+for obsrepo in devel:/languages:/ruby:/extensions/SLE_12 devel:/tools:/building/SLE_12_SP1 ; do
+    rsync_with_create rsync://rsync.opensuse.org/buildservice-repos/$obsrepo/ /srv/nfs/repos/repositories/$obsrepo/
+done
+
 # reduce disk usage
 fdupes -q -n -r /srv/nfs/repos/ /srv/nfs/install/ |
     while read _file; do


### PR DESCRIPTION
and devel:tools:building (for jenkins-swarm-client)
to be independent from download.o.o
e.g. for github-status, jt_sync and cct