### PR TITLE
soc-ci: Also allow host vj1.cloud.suse.de

### DIFF
--- a/hostscripts/soc-ci/soc-ci
+++ b/hostscripts/soc-ci/soc-ci
@@ -37,8 +37,8 @@ from six.moves import input
 
 # path to the user configuration file
 USER_CONFIG_PATH = os.path.expanduser('~/.soc-ci.ini')
-# possible mkcX hosts (there is no 'j' host)
-CI_WORKERS = list('abcdefghiklmnp')
+# possible mkcX hosts
+CI_WORKERS = list('abcdefghijklmnop')
 
 
 def _config_credentials_get():


### PR DESCRIPTION
"j" was missing in the list of available hosts.