### PR TITLE
scale-cloud: removed ipmi credentials

### DIFF
--- a/hostscripts/scale-cloud/batches/00_ipmi.batch
+++ b/hostscripts/scale-cloud/batches/00_ipmi.batch
@@ -3,8 +3,8 @@ proposals:
 - barclamp: ipmi
   attributes:
     bmc_enable: true
-    bmc_user: ENGCLOUD
-    bmc_password: ylzTDoH6ZQ4s
+    bmc_user: %IPMIUSER%
+    bmc_password: %IPMIPASS%
     use_dhcp: true
   deployment:
     elements:


### PR DESCRIPTION
Placeholders will be filled by script deploying the batch.