### PR TITLE
ironic: Stop using pxe_ssh driver (SCRD-768)

### DIFF
--- a/scripts/scenarios/cloud8/cloud8-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud8/cloud8-ironic-basic-ha.yml
@@ -198,7 +198,6 @@ proposals:
     keystone_instance: default
     neutron_instance: default
     enabled_drivers:
-    - pxe_ssh
     - pxe_ipmitool
   deployment:
     elements:


### PR DESCRIPTION
The pxe_ssh driver was deprecated in Ocata and removed in Pike[1]. This
patch removes it from the cloud8 job.

We aren't currently testing baremetal deployments with the pxe_ssh
driver so removing it is not a loss. In order to fully test ironic it
would be better to get virtualized deployments to work with the
pxe_ipmitool driver.

[1] https://docs.openstack.org/releasenotes/ironic/pike.html#id10