### PR TITLE
Allow vendor change for cleanvm

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -99,6 +99,14 @@ fi
 
 zypper="zypper --non-interactive"
 
+if test -n "$allow_vendor_change" ; then
+    # Allow vendor change for packages that may already be installed on the image
+    # but have a newer version in Cloud:OpenStack:*
+    # (without a vendor change this scenario would cause zypper to stall deployment
+    # with a prompt)
+    echo 'solver.allowVendorChange = true' >> /etc/zypp/zypp.conf
+fi
+
 zypper rr cloudhead || :
 
 case "$cloudsource" in


### PR DESCRIPTION
Depending on the provenance of the VM image used by cleanvm, it may have
packages beyond the JeOS set of packages installed already. If one of these
packages exists in Devel:Cloud:* in a newer change, a vendor change may be
needed. In this case zypper will prompt for that vendor change, even in
non-interactive mode, thus stalling deployment. This commit generally allows
vendor changes for cleanvm to prevent this from happening.

Related: https://github.com/SUSE-Cloud/automation/pull/2135 (during testing this broke due to this sort of situation. I put a workaround specific to the packages I encountered this with on there, but I'd vastly prefer the general solution I implemented here).