### PR TITLE
Disable mediacheck installability checking for resource-agents package

### DIFF
--- a/jenkins/ci.suse.de/cloud-mediacheck.yaml
+++ b/jenkins/ci.suse.de/cloud-mediacheck.yaml
@@ -90,6 +90,17 @@
               export INSTALLCHECK_EXTRA_OPTS="--exclude pattern:"
           fi
 
+          # temporary, remove once there is a current resource-agents package
+          # in SLE-12-SP3 and we no longer need to keep our own in
+          # Devel:Cloud:8 (otherwise we'd have to pull all the HA dependencies
+          # used by resource-agents into the product just for the sake of
+          # the cloud-mediacheck job since everything except mediacheck has SLE
+          # 12 SP3 HA media available and can thus fulfill the resource-agents
+          # package's dependencies).
+          if [[ "$project" =~ Devel:Cloud:8.* ]]; then
+              export INSTALLCHECK_EXTRA_OPTS="--exclude resource-agents"
+          fi
+
           OBS_PROJECT=$project
           stage=$subproject
           [[ $stage == ":" ]] && stage=


### PR DESCRIPTION
This is a temporary fix for the cloud-mediacheck job.

Currently we have a `resource-agents` package in the `_product` in `Devel:Cloud:8:*` that is more recent than the one in SLE12 SP3 because we are waiting for that package to be updated in a maintenance update of SLE12 SP3 (the old version causes problems with Galera). Since we've got the package in the product, mediacheck attempts to install it from _only_ our product media, which do not contain all of its dependencies.

As a temporary remedy, this commit disables the media check for the problematic package. This commit needs to be reverted once `resource-agents` is updated in SLE 12 SP3.