### PR TITLE
qa_crowbarsetup: fix keystone

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2200,7 +2200,7 @@ function custom_configuration
             fi
             if iscloudver 7plus; then
                 # The default of 8 is a bit too much for our default virtual setup
-                proposal_set_value keystone default "['attributes']['keystone']['api']['processes']" "2"
+                [[ $cloudsource =~ devel ]] && proposal_set_value keystone default "['attributes']['keystone']['api']['processes']" "2"
                 if [[ $want_keystone_token_type ]]; then
                     proposal_set_value keystone default "['attributes']['keystone']['signing']['token_format']" "'$want_keystone_token_type'"
                 fi


### PR DESCRIPTION
because GM7+up does not have an api processes value

This is a fixup on commit f5fcccabdc