### PR TITLE
Fix compute ha job templates

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -29,6 +29,8 @@
     version: 6
     previous_version: 5
     arch: x86_64
+    nodenumber_compute_ha: 4
+    nodenumber_controller: 2
     tempestoptions: -s -t
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: ceph

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -34,6 +34,8 @@
     version: 7
     previous_version: 6
     arch: x86_64
+    nodenumber_compute_ha: 4
+    nodenumber_controller: 2
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: ceph

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -37,6 +37,8 @@
     version: 8
     previous_version: 7
     arch: x86_64
+    nodenumber_compute_ha: 5
+    nodenumber_controller: 3
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: swift

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
@@ -19,11 +19,11 @@
           predefined-parameters: |
             TESTHEAD=1
             cloudsource=develcloud{version}
-            nodenumber=5
+            nodenumber={nodenumber_compute_ha}
             hacloud=1
             mkcloudtarget=all_batch
-            scenario=cloud{version}-5nodes-compute-ha.yml
-            want_node_aliases=controller=3,compute=2
+            scenario=cloud{version}-{nodenumber_compute_ha}nodes-compute-ha.yml
+            want_node_aliases=controller={nodenumber_controller},compute=2
             label={label}
             storage_method=swift
             job_name=cloud-mkcloud{version}-job-ha-compute-{arch}


### PR DESCRIPTION
SOC6 and SOC7 jobs were broken because of template update to use 5 nodes setup instead 4 nodes because of which was not able fetch correct secnario file.
Template for SOC6 and SOC7 updated to have 4 node setup for compute ha setup. cloud-mkcloud6.yaml cloud-mkcloud7.yaml
Template for Cloud8 updated to use 5 nodes cloud-mkcloud8.yaml
cloud-mkcloud-job-ha-compute-template.yaml updated to use parameters for compute and controller nodenumber