### PR TITLE
qa_crowbarsetup: enable wickedd-nanny

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -955,6 +955,8 @@ EOF
     export HOST=$HOSTNAME
     grep -q "$net.*crowbar" /etc/hosts || \
         echo $adminip crowbar.$cloudfqdn crowbar >> /etc/hosts
+    systemctl enable wickedd-nanny
+    rcwickedd-nanny restart
     rcnetwork restart
     hostname -f # make sure it is a FQDN
     ping -c 1 `hostname -f`


### PR DESCRIPTION
because nanny was enabled in /etc/wicked/common.xml of the SP2 image
and without the daemon, network cannot be started or reconfigured