### PR TITLE
qa_crowbarsetup: Output slowest tempest tests if possible

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3167,6 +3167,8 @@ function oncontroller_run_tempest
     # to verify that some tests were executed
     if [ "$tempestret" -eq 0 ]; then
         testr last || complain 96 "Tempest run succeeded but something is wrong"
+        # output the slowest tests from the latest run
+        testr slowest
     fi
     testr last --subunit | subunit-1to2 > tempest.subunit.log
 


### PR DESCRIPTION
It is useful to see a list of slowest tests during a jenkins run. That
way we can easily grep and compare results.