### PR TITLE
stop setting password_hash_round on older cloud8

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2163,7 +2163,7 @@ function custom_configuration
             # set a custom region name
             proposal_set_value keystone default "['attributes']['keystone']['api']['region']" "'CustomRegion'"
             # speedup the deployment
-            if iscloudver 8plus; then
+            if iscloudver 8M3plus && ! [[ $cloudsource =~ ocatacloud ]] ; then
                 proposal_set_value keystone default "['attributes']['keystone']['identity']['password_hash_rounds']" "4"
             fi
             if [[ $hacloud = 1 ]] ; then


### PR DESCRIPTION
This does not work on cloudsource=ocatacloud8