### PR TITLE
Template number of nodes for ironic jobs

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-agent-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-agent-template.yaml
@@ -24,7 +24,7 @@
             mkcloudtarget=instonly batch setupironicnodes
             networkingplugin=openvswitch
             networkingmode=gre
-            want_node_aliases=controller=3,compute=1
+            want_node_aliases=controller={nodenumber_controller},compute=1
             label={label}
             scenario=cloud{version}-ironic-swift-ha.yml
             job_name=cloud-mkcloud{version}-job-ha-ironic-agent-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
@@ -24,7 +24,7 @@
             mkcloudtarget=instonly batch setupironicnodes
             networkingplugin=openvswitch
             networkingmode=gre
-            want_node_aliases=controller=3,compute=1
+            want_node_aliases=controller={nodenumber_controller},compute=1
             label={label}
             scenario=cloud{version}-ironic-basic-ha.yml
             job_name=cloud-mkcloud{version}-job-ha-ironic-{arch}


### PR DESCRIPTION
After increasing number of controllers to fixed 3, in cloud7 runs 
default total number of nodes was 3 and there was no room for compute. 
Using template variables for setting number of nodes should make these
jobs work properly in both cloud7 and 8.

See: https://github.com/SUSE-Cloud/automation/pull/2184