### PR TITLE
mkcloud: find fastest repo server

### DIFF
--- a/scripts/lib/find_fastest_server.pl
+++ b/scripts/lib/find_fastest_server.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/perl -w
+# input: list of servers
+# output: one server name
+#   the one that responded fastest, or the first one if all are unreachable
+
+use strict;
+my %best;
+foreach my $server (@ARGV) {
+    $_ = `ping -W 1 -c 3 -i .2 -q $server |tail -1`;
+    next unless (m/ = ([0-9.]+)\//);
+    my $time = $1;
+    if(!defined $best{"time"} || $time < $best{"time"}) {
+        %best = ("time"=>$time, "server"=>$server);
+    }
+    #print STDERR "$server $time\n"; # debug
+}
+$best{server} ||= $ARGV[0];
+print $best{server},"\n";

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -496,6 +496,16 @@ get_nodenumbercontroller()
     echo "$nodenumbercontroller"
 }
 
+find_fastest_clouddata_server()
+{
+    local cache=~/.mkcloud/fastest_clouddata_server
+    if [[ -r $cache ]] && [[ $cache -nt $BASH_SOURCE ]] ; then
+        exec cat $cache || exit 100
+    fi
+    mkdir -p ~/.mkcloud
+    $scripts_lib_dir/find_fastest_server.pl clouddata.nue.suse.com. {,provo-,provo2-}clouddata.cloud.suse.de. | tee $cache
+}
+
 function get_admin_node_dist
 {
     # echo the name of the current dist for the admin node
@@ -598,7 +608,7 @@ fi
 # NOTE: they are not to be used in mkcloud/qa_crowbarsetup
 # Please ONLY use the suffixed variables: '*_ip' or '*_fqdn'
 
-: ${reposerver:=clouddata.nue.suse.com}
+: ${reposerver:=$(find_fastest_clouddata_server)}
 : ${reposerver_ip:=$(to_ip $reposerver)}
 : ${reposerver_fqdn:=$(to_fqdn $reposerver)}
 : ${reposerver_base_path:=/repos}


### PR DESCRIPTION
so that we don't have to manually adapt scripts to different locations

In case no server is reachable, we fall back to the old default,
so that we do not break in travis and other outside places.