### PR TITLE
Skip setting of CLOUDTESTISO for GM7/GM7+up

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -882,7 +882,6 @@ function onadmin_set_source_variables
             [[ $cs =~ GM7 ]] && cs=GM
             CLOUDISOPATH=${want_cloud7_iso_path:="/install/SLE-12-SP2-Cloud7-$cs/"}
             CLOUDISONAME=${want_cloud7_iso:="SUSE-OPENSTACK-CLOUD-7-${arch}*1.iso"}
-            CLOUDTESTISONAME="CLOUD-7-TESTING-$arch*DVD1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-7-official"
         ;;
         GMC*|M?)


### PR DESCRIPTION
These packages are not installable for GM7+up anymore as the
testiso remains on GM level. furthermore the actual usage of
those packages is commented out so there is little value in
trying to make them installable in the first place. To be
revisited when the magic Cloud 8 testing plan is in place.