### PR TITLE
qa_crowbarsetup: Fix the swift replica count for 3 node jobs

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2428,7 +2428,7 @@ function custom_configuration
             fi
         ;;
         swift)
-            [[ $nodenumber -lt 3 ]] && {
+            [[ $nodenumber -le 3 ]] && {
                 proposal_set_value swift default "['attributes']['swift']['zones']" "1"
                 # This should be set for C6 and C5 as well, but currently the swift barclamp
                 # is broken there..


### PR DESCRIPTION
The current default swift replica count value is 3, which results
in a "Replica count of 3.0 requires more than 2 devices" failure
when the swift barclamp is deployed by mkcloud on setups with 3
nodes.

This change is meant mainly to fix [the DVR SOC8 Jenkins job](https://ci.suse.de/view/Cloud/view/Cloud8/job/cloud-mkcloud8-job-dvr-x86_64/), which
is currently broken.