### PR TITLE
Fix syntax error in JJB for trackupstream

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -103,8 +103,7 @@
               "python-heat-cfntools",
               "openstack-rally",
               "openstack-tempest",
-            ].contains(component)  ||
-            # Pike only
+            ].contains(component) ||
             [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Ocata:Staging", "Cloud:OpenStack:Newton:Staging" ].contains(project) &&
             [
               "openstack-horizon-plugin-neutron-fwaas-ui",


### PR DESCRIPTION
The openstack-trackupstream job was undeployable for a couple of
days due to a syntax error. when you embed a comment in the filter,
it applies to all the rest of the string, not only to the current
line of yaml in the JJB.