### PR TITLE
Properly logrotate artefacts on ci.opensuse.org

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -5,9 +5,9 @@
     triggers:
       - timed: 'H 4 * * *'
 
-    build-discarder:
-      num-to-keep: 30
-      days-to-keep: -1
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 10
 
     axes:
       - axis:

--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -14,7 +14,6 @@
           type: user-defined
           name: image
           values:
-            - SLE_12_SP1
             - SLE_12_SP2
             - SLE_12_SP3
             - openSUSE-Leap-42.2
@@ -23,7 +22,6 @@
           type: user-defined
           name: openstack_project
           values:
-            - Liberty
             - Newton
             - Ocata
             - Pike
@@ -37,8 +35,7 @@
       combination-filter: |
         (
         slave=="cloud-cleanvm" && (
-           ( openstack_project=="Liberty" && (image=="SLE_12_SP1" ))
-        || ( openstack_project=="Newton" && (image=="SLE_12_SP2" || image=="openSUSE-Leap-42.2" ))
+           ( openstack_project=="Newton" && (image=="SLE_12_SP2" || image=="openSUSE-Leap-42.2" ))
         || ( openstack_project=="Ocata" && (image=="SLE_12_SP2" || image=="SLE_12_SP3" || image=="openSUSE-Leap-42.2" || image=="openSUSE-Leap-42.3"))
         || ( openstack_project=="Pike" && (image=="SLE_12_SP3" || image=="openSUSE-Leap-42.3"))
         || ( openstack_project=="Master" && (image=="openSUSE-Leap-42.3" || image=="SLE_12_SP3"))

--- a/jenkins/ci.opensuse.org/openstack-devstack.yaml
+++ b/jenkins/ci.opensuse.org/openstack-devstack.yaml
@@ -3,6 +3,11 @@
     project-type: matrix
     triggers:
       - timed: 'H 5 * * *'
+
+    logrotate:
+       numToKeep: 10
+       daysToKeep: -1
+
     axes:
       - axis:
           type: user-defined

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -5,9 +5,9 @@
     triggers:
       - timed: '@hourly'
 
-    build-discarder:
-      num-to-keep: 10
-      days-to-keep: -1
+    logrotate:
+      numToKeep: 10
+      daysToKeep: -1
 
     axes:
       - axis:

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -14,8 +14,6 @@
           type: user-defined
           name: project
           values:
-            - Cloud:OpenStack:Liberty
-            - Cloud:OpenStack:Liberty:Staging
             - Cloud:OpenStack:Newton
             - Cloud:OpenStack:Newton:Staging
             - Cloud:OpenStack:Ocata
@@ -28,7 +26,6 @@
           type: user-defined
           name: repository
           values:
-            - SLE_12_SP1
             - SLE_12_SP2
             - SLE_12_SP3
             - openSUSE_Leap_42.2
@@ -40,12 +37,9 @@
             - cloud-trackupstream
     execution-strategy:
       combination-filter: |
-       !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP1", "SLE_12_SP2", "openSUSE_Leap_42.2"].contains(repository) ||
-         ["Cloud:OpenStack:Liberty", "Cloud:OpenStack:Liberty:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3", "openSUSE_Leap_42.2", "openSUSE_Leap_42.3"].contains(repository) ||
-         ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["SLE_12_SP1", "openSUSE_Leap_42.3"].contains(repository) ||
-         ["Cloud:OpenStack:Ocata", "Cloud:OpenStack:Ocata:Staging"].contains(project) && ["SLE_12_SP1"].contains(repository) ||
-         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["SLE_12_SP1", "SLE_12_SP2", "openSUSE_Leap_42.2"].contains(repository) ||
-         ["Cloud:Tools"].contains(project) && ["SLE_12", "SLE_12_SP1"].contains(repository)
+       !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP2", "openSUSE_Leap_42.2"].contains(repository) ||
+         ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3"].contains(repository) ||
+         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["SLE_12_SP2", "openSUSE_Leap_42.2"].contains(repository)
        )
       sequential: true
     builders:

--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
@@ -3,9 +3,10 @@
     description: "<b>This job is managed by JJB! Changes must be done in <a href='https://github.com/SUSE-Cloud/automation/tree/master/jenkins/ci.opensuse.org/templates/'>git</a></b>"
     node: openstack-rpm-packaging
     concurrent: true
-    build-discarder:
-      num-to-keep: -1
-      days-to-keep: 31
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 60
+
     builders:
       - gerrit-git-prep
       - shell: |


### PR DESCRIPTION
The build-discarder doesn't seem to be cleaning up "enough" for
ci.opensuse.org to not crawl down. as we use logrotate on ci.s.de
successfully lets switch to that.