### PR TITLE
Set strip_branch_ref compat option

### DIFF
--- a/hostscripts/zuul/zuul.conf
+++ b/hostscripts/zuul/zuul.conf
@@ -9,6 +9,7 @@ log_config=/etc/zuul/gearman-logging.conf
 server=review.openstack.org
 ;baseurl=https://review.example.com/r
 user=suse-ci
+strip_branch_ref=1
 sshkey=/var/lib/zuul/.ssh/id_rsa_suse-cloud-ci
 
 [zuul]


### PR DESCRIPTION
This adds a compatability option to deal with a Gerrit behavior
change between 2.11 and 2.13.