### PR TITLE
Replace testr with ostestr

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3163,7 +3163,7 @@ function oncontroller_run_tempest
         # output the slowest tests from the latest run
         testr slowest
     fi
-    testr last --subunit | subunit-1to2 > tempest.subunit.log
+    ostestr last --subunit --no-pretty > tempest.subunit.log
 
     oncontroller_tempest_cleanup
     popd
@@ -3180,7 +3180,7 @@ function oncontroller_upload_defcore
     # run only the specified tests
     tempest run --whitelist-file defcore.txt
     source /root/.openrc
-    testr last --subunit | subunit-2to1 > tempest.subunit.log
+    ostestr last --subunit --no-pretty | subunit-2to1 > tempest.subunit.log
     test -d refstack-client || safely git clone https://github.com/openstack/refstack-client
     yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL tempest.subunit.log
     popd


### PR DESCRIPTION
~This is was only used to convert from subunit versions, but not needed anymore since all the things support version 2 now.~

~Besides the package python-subunit in Pike does not install/provide subunit-1to2 subunit-2to1 filters/binaries becasue of the single spec switch~


Ostestr is generating subunit ver 2 So we can drop on of the filters
