### PR TITLE
freshadminvm: make SCRIPTS_DIR changeable

### DIFF
--- a/hostscripts/gatehost/freshadminvm
+++ b/hostscripts/gatehost/freshadminvm
@@ -20,7 +20,7 @@ rm -f mkcloud.config
 : ${cachedir:=/root/tmp}
 mkdir -p $cachedir
 export mkclouddriver=libvirt
-SCRIPTS_DIR=/usr/src/automation/scripts
+: ${SCRIPTS_DIR:=/usr/src/automation/scripts}
 scripts_lib_dir=${SCRIPTS_DIR}/lib
 common_scripts="mkcloud-onhost.sh mkcloud-common.sh mkcloud-$mkclouddriver.sh"
 for script in $common_scripts; do


### PR DESCRIPTION
When using local copy of automation scripts, freshadminvm still uses
global /usr/src/automation in some parts. Having this changeable from
outside makes it a bit more flexible.