### PR TITLE
freshadminvm: removed domain from vm addr

### DIFF
--- a/hostscripts/gatehost/freshadminvm
+++ b/hostscripts/gatehost/freshadminvm
@@ -34,5 +34,5 @@ virsh define $SCRIPTS_DIR/../hostscripts/gatehost/$n.xml # is OK to fail if alre
 virsh start $n
 sleep 100 # time for the admin VM to boot
 sshkey=`cat /root/.ssh/id_rsa.pub`
-ssh_password $n.cloud.suse.de. "mkdir -p ~/.ssh ; echo '$sshkey' >> ~/.ssh/authorized_keys"
+ssh_password $n "mkdir -p ~/.ssh ; echo '$sshkey' >> ~/.ssh/authorized_keys"
 


### PR DESCRIPTION
The domain contained dot at the end which failed to resolve.
In addition, the master version doesn't have the domain and it's easy
to define the address in /etc/hosts on adminhost.