### PR TITLE
freshadminvm: Update driver lib path

### DIFF
--- a/hostscripts/gatehost/freshadminvm
+++ b/hostscripts/gatehost/freshadminvm
@@ -22,7 +22,7 @@ mkdir -p $cachedir
 export mkclouddriver=libvirt
 : ${SCRIPTS_DIR:=/usr/src/automation/scripts}
 scripts_lib_dir=${SCRIPTS_DIR}/lib
-common_scripts="mkcloud-onhost.sh mkcloud-common.sh mkcloud-$mkclouddriver.sh"
+common_scripts="mkcloud-onhost.sh mkcloud-common.sh mkcloud-driver-$mkclouddriver.sh"
 for script in $common_scripts; do
     source ${scripts_lib_dir}/$script
 done


### PR DESCRIPTION
Files in lib were renamed recently to handle 'physical' driver.