### PR TITLE
scale-cloud: make sure we use provo ibs mirror

### DIFF
--- a/hostscripts/scale-cloud/setup-baremetal.sh
+++ b/hostscripts/scale-cloud/setup-baremetal.sh
@@ -13,6 +13,7 @@ export want_ldap=1
 export want_all_ssl=1
 export controller_raid_volumes=2
 export reposerver=provo-clouddata.cloud.suse.de
+export susedownload=ibs-mirror.prv.suse.net
 export architectures="x86_64"
 export cloudsource=develcloud7
 export TESTHEAD=1 # for unreleased openstack-keystone and crowbar-openstack LDAP fixes

--- a/hostscripts/scale-cloud/setup.sh
+++ b/hostscripts/scale-cloud/setup.sh
@@ -13,6 +13,7 @@ export want_ldap=1
 export want_all_ssl=1
 export controller_raid_volumes=2
 export reposerver=provo-clouddata.cloud.suse.de
+export susedownload=ibs-mirror.prv.suse.net
 export architectures="x86_64"
 export cloudsource=GM7+up
 #export cloudsource=develcloud7


### PR DESCRIPTION
Sometimes the redirect from download.nue.suse.com to provo ibs mirror
doesn't work and causes download of lots of data from NUE.