### PR TITLE
Fixes the mapping of jtsync and adds tests for it.

### DIFF
--- a/scripts/jtsync/jtsync.rb
+++ b/scripts/jtsync/jtsync.rb
@@ -86,12 +86,12 @@ module Job
   end
 
   MAPPING = {
-    suse: {
-      normal: SuseNormal,
-      matrix: SuseMatrix
+    :suse => {
+      :normal => SuseNormal,
+      :matrix => SuseMatrix
     },
-    opensuse: {
-      matrix: OpenSuseMatrix
+    :opensuse => {
+      :matrix => OpenSuseMatrix
     }
   }.freeze
 

--- a/scripts/jtsync/jtsync.rb
+++ b/scripts/jtsync/jtsync.rb
@@ -52,12 +52,18 @@ module Job
   end
 
   class SuseMatrix < Mapping
+
+    CARDNAMES = {
+      "cloud-mediacheck" => "mediacheck"
+    }
+
     def version
       project.match(/.*Cloud(:)?(\d+).*/)[2]
     end
 
     def card_name
-      "C#{version} #{name}"
+      cname = CARDNAMES[name] || name
+      "C#{version} #{cname}"
     end
 
     def list_name
@@ -67,11 +73,11 @@ module Job
 
   class OpenSuseMatrix < Mapping
     def card_name
-      card = name.gsub("openstack-", "")
+      prefix = name.gsub("openstack-", "")
       if project.include? ":"
-        project = project.split(":")[2]
+         @project = project.split(":")[2]
       end
-      "#{card}: #{project}"
+      "#{prefix}: #{project}"
     end
 
     def list_name

--- a/scripts/jtsync/test_jtsync.sh
+++ b/scripts/jtsync/test_jtsync.sh
@@ -39,6 +39,12 @@ echo "returncode: $?"
 read -p "Press any key to continue... " -n1 -s
 echo ""
 
+echo "set (OpenStack) openstack-cleanvm to success"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci opensuse --matrix openstack-cleanvm,Cloud:OpenStack:Juno,14 0
+echo "returncode: $?"
+read -p "Press any key to continue... " -n1 -s
+echo ""
+
 BUILDNR=$(( ( RANDOM % 10000 )  + 1 ))
 echo "Buildnr is ${BUILDNR}"
 echo "Start new matrix run"
@@ -64,6 +70,38 @@ echo "Buildnr is now ${BUILDNR_NEXT}"
 echo "Start new matrix run to with already set buildnr"
 echo "cloud-trackupstream (${BUILDNR_NEXT}) run successful"
 ${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-trackupstream,Devel:Cloud:7:Staging,${BUILDNR_NEXT} 0
+echo "returncode: $?"
+
+echo ""
+echo "State should be successful and Buildnr should change from ${BUILDNR} to ${BUILDNR_NEXT}"
+read -p "Press any key to continue... " -n1 -s
+echo ""
+
+BUILDNR=$(( ( RANDOM % 10000 )  + 1 ))
+echo "Buildnr is ${BUILDNR}"
+echo "Start new matrix run"
+echo "cloud-mediacheck (${BUILDNR}) run successful"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-mediacheck,Devel:Cloud:7/SLE_12_SP1,${BUILDNR} 0
+echo "returncode: $?"
+
+echo "cloud-mediacheck (${BUILDNR}) run failed"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-mediacheck,Devel:Cloud:7/SLE_12_SP1,${BUILDNR} 1
+echo "returncode: $?"
+
+echo "cloud-mediacheck (${BUILDNR}) run successful"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-mediacheck,Devel:Cloud:7/SLE_12_SP1,${BUILDNR} 0
+echo "returncode: $?"
+
+echo ""
+echo "State should be failed"
+read -p "Press any key to continue... " -n1 -s
+echo ""
+
+BUILDNR_NEXT=$(( BUILDNR + 1 ))
+echo "Buildnr is now ${BUILDNR_NEXT}"
+echo "Start new matrix run to with already set buildnr"
+echo "cloud-mediacheck (${BUILDNR_NEXT}) run successful"
+${RUBY} jtsync.rb --board ${TEST_BOARD} --ci suse --matrix cloud-mediacheck,Devel:Cloud:7/SLE_12_SP1,${BUILDNR_NEXT} 0
 echo "returncode: $?"
 
 echo ""


### PR DESCRIPTION
The mapping for the jenkins job cloud-mediacheck differs from the rest.
The mapping for all ci.opensuse jobs was broken because the variable project of
the class Mapping is only readable.

Signed-off-by: Jürgen Löhel <jloehel@suse.com>