### PR TITLE
qa_crowbarsetup: Do not use the default username for the crowbar DB

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1157,10 +1157,10 @@ function onadmin_bootstrapcrowbar
         else
             if iscloudver 7M6minus || [[ $cloudsource = mitakacloud7 ]] ; then
                 safely crowbar_api_request POST $crowbar_init_api /database/new \
-                    '--data username=crowbar&password=crowbar' "$crowbar_api_v2_header"
+                    '--data username=crowbar-nondefault&password=crowbar' "$crowbar_api_v2_header"
                 safely crowbar_api_request POST $crowbar_init_api /init "" "$crowbar_api_v2_header"
             else
-                safely crowbarctl database create
+                safely crowbarctl database create --db-username=crowbar-nondefault --db-password=cr0wbar\$
             fi
         fi
     fi


### PR DESCRIPTION
bsc#1056750 happened when not using the default username when creating
the crowbar DB. So start using non-defaults.