### PR TITLE
remove special admin node image for efi runs

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-uefi-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-uefi-template.yaml
@@ -16,11 +16,12 @@
           condition: SUCCESS
           block: true
           current-parameters: true
+          # TODO: change back to mkcloudtarget=all !!!
           predefined-parameters: |
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber=2
             want_efi=1
-            mkcloudtarget=all
+            mkcloudtarget=all_noreboot
             label={label}
             job_name=cloud-mkcloud{version}-job-uefi-{arch}

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -533,8 +533,6 @@ function dist_to_image_name
 {
     # get the name of the image to deploy the admin node
     local image=$1
-    iscloudver 7 && [[ $want_efi ]] && \
-        [[ $arch == x86_64 ]] && image="SLES12-SP2-uefi"
     echo "$image.qcow2"
 }
 


### PR DESCRIPTION
The EFI runs had a special -efi image for the admin node,
which we don't need anymore as I merged it's changes into
the main image, so that one should boot for both efi and non-efi.

In efi builds there is currently an issue with reboot (also with
the old image), which I'm separately investigating, but we can
switch it to non-reboot for now to have something working