### PR TITLE
keystone: Add timeout to crowbar batch build

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4075,13 +4075,13 @@ y = YAML.load(ARGF)
 y['proposals'].first['attributes']['admin'] ||= {}
 y['proposals'].first['attributes']['admin']['updated_password'] = '$updated_password'
 puts y.to_yaml" > /root/keystone-test-pw-update.yaml
-    safely crowbar batch build < /root/keystone-test-pw-update.yaml
+    safely crowbar batch --timeout 900 build < /root/keystone-test-pw-update.yaml
     safely oncontroller test_keystone_password
     cat /root/keystone-test-pw-update.yaml | ruby -ryaml -e "
 y = YAML.load(ARGF)
 y['proposals'].first['attributes']['admin']['updated_password'] = '$old_password'
 puts y.to_yaml" > /root/keystone-test-pw-reset.yaml
-    safely crowbar batch build < /root/keystone-test-pw-reset.yaml
+    safely crowbar batch --timeout 900 build < /root/keystone-test-pw-reset.yaml
 }
 
 function onadmin_testsetup


### PR DESCRIPTION
On HA scenarios, a typical proposal can take several minutes to run, but
the default crowbar batch build command times out and fails before it is
finished[1]. This patch adds a timeout flag to the
update_keystone_password test, using 2400 which is the value that other
crowbar batch build commands use in this repository.

[1] https://ci.suse.de/job/openstack-mkcloud/87363/console