### PR TITLE
Add more information to wait_tftpd

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1612,7 +1612,8 @@ function check_node_resolvconf
 function onadmin_wait_tftpd
 {
     wait_for 300 2 \
-        "timeout -k 2 2 tftp $adminip 69 -c get /discovery/x86_64/bios/pxelinux.cfg/default /tmp/default"
+        "timeout -k 2 2 tftp $adminip 69 -c get /discovery/x86_64/bios/pxelinux.cfg/default /tmp/default" \
+        "tftpd server ready"
     echo "Crowbar tftp server ready"
 }
 


### PR DESCRIPTION
The onadmin_wait_tftpd function waits for the tftpd server to be ready
on the admin node. The wait_for call does not include a process name
which leads to the following output on failure:

      Ran into error: Waiting for 'unknown process' timed out.

Since the above message is not very informative by itself, this change
adds some more information to the wait call.