### PR TITLE
for SOC6 use testr not ostester

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3250,10 +3250,10 @@ function oncontroller_run_tempest
         testr slowest
     fi
     if iscloudver 7plus; then
-		ostestr last --subunit --no-pretty > tempest.subunit.log
-	else
-		testr last --subunit | subunit-2to1 > tempest.subunit.log
-	fi
+        ostestr last --subunit --no-pretty > tempest.subunit.log
+    else
+        testr last --subunit | subunit-2to1 > tempest.subunit.log
+    fi
 
     oncontroller_tempest_cleanup
     popd

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3249,7 +3249,11 @@ function oncontroller_run_tempest
         # output the slowest tests from the latest run
         testr slowest
     fi
-    ostestr last --subunit --no-pretty > tempest.subunit.log
+    if iscloudver 7plus; then
+		ostestr last --subunit --no-pretty > tempest.subunit.log
+	else
+		testr last --subunit | subunit-2to1 > tempest.subunit.log
+	fi
 
     oncontroller_tempest_cleanup
     popd


### PR DESCRIPTION
During testsetup with SOC6: `ostestr: error: unrecognized arguments: last`
I checked it on the system and it seems that SOC6 has no ostester --last.

Previous change from Sep 27 in commit 622577f25a2d362d94cf5aa2b2a00d8accb8b70b changed it  from tester to ostestr(but not counts with SOC6).

