### PR TITLE
Install Pool and Updates repos on develcloud*

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -617,21 +617,21 @@ function onadmin_prepare_cloud_repos
         GM6)
             addcloudpool
             ;;
-        GM6+up)
+        develcloud6|GM6+up)
             addcloudpool
             addcloudmaintupdates
             ;;
         GM7)
             addcloudpool
             ;;
-        GM7+up)
+        develcloud7|GM7+up)
             addcloudpool
             addcloudmaintupdates
             ;;
         GM8)
             addcloudpool
             ;;
-        GM8+up)
+        develcloud8|GM8+up)
             addcloudpool
             addcloudmaintupdates
             ;;


### PR DESCRIPTION
The motivation for this patch is that currently develcloud6 builds fail
when SSL is turned on because the SLES12-SP1-Updates repo does not
contain a new enough apache2 package, where the Cloud-6-Updates package
does[1]. It is reasonable to install the Pool and Updates repos on
development builds since we want to mimic how users' systems will be
set up. We can rely on package versioning to ensure that if packages
exist in both Updates and Devel repositories, the ones from Devel will
be installed.

[1] https://trello.com/c/AOI554Pf