### PR TITLE
Enable LTSS Updates for SLE12 SP1

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -140,6 +140,21 @@ for servicepack in 1 2 3; do
 done
 
 
+# LTSS enablement
+for servicepack in 1; do
+
+    version="12-SP$servicepack-LTSS"
+    repo_version="$version"
+    chef_version="12.$servicepack"
+
+    for arch in x86_64; do
+        destdir_sles_updates=/srv/nfs/repos/$arch/SLES$repo_version-Updates/
+        mkdir -p $destdir_sles_updates
+        $rsync ${ibs_source}/SUSE/Updates/SLE-SERVER/$version/$arch/update/ $destdir_sles_updates
+    done
+done
+
+
 ##############
 # Storage
 ##############

--- a/scripts/lib/mkcloud-onhost.sh
+++ b/scripts/lib/mkcloud-onhost.sh
@@ -127,6 +127,7 @@ function onhost_cacheclouddata
                 echo "repos/$a/SUSE-OpenStack-Cloud-$cloudver-$suffix/***"
                 echo "repos/$a/SUSE-Enterprise-Storage-$sesversion-$suffix/***"
             done
+            echo "repos/$a/SLES$slesversion-LTSS-Updates/***"
             [[ $want_test_updates = 1 ]] && {
                 echo "repos/$a/SLES$slesversion-Updates-test/***"
                 [[ $hacloud = 1 ]] && echo "repos/$a/SLE$slesversion-HA-Updates-test/***"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -578,7 +578,7 @@ function onadmin_prepare_sles_installmedia
 
 function onadmin_prepare_sles12sp1_other_repos
 {
-    for repo in SLES12-SP1-{Pool,Updates}; do
+    for repo in SLES12-SP1-{Pool,Updates,LTSS-Updates}; do
         add_mount "repos/$arch/$repo" "$tftpboot_repos_dir/$repo"
         if [[ $want_s390 ]] ; then
             add_mount "repos/s390x/$repo" \
@@ -778,6 +778,8 @@ function create_repos_yml
 
     grep -q SLES$slesversion-Updates-test /etc/fstab && \
         additional_repos+=" SLES$slesversion-Updates-test=$baseurl/suse-$suseversion/$arch/repos/SLES$slesversion-Updates-test"
+    grep -q SLES$slesversion-LTSS-Updates /etc/fstab && \
+        additional_repos+=" SLES$slesversion-LTSS-Updates=$baseurl/suse-$suseversion/$arch/repos/SLES$slesversion-LTSS-Updates"
     grep -q SLE$slesversion-HA-Updates-test /etc/fstab && \
         additional_repos+=" SLE$slesversion-HA-Updates-test=$baseurl/suse-$suseversion/$arch/repos/SLE$slesversion-HA-Updates-test"
     grep -q SUSE-OpenStack-Cloud-$cloudver-Updates-test /etc/fstab && \


### PR DESCRIPTION
Some cloud relevant fixes are only available in the LTSS update
channel as they got released after the general maintenance period
ending, e.g. apache2 in the Cloud 6 case.