### PR TITLE
github_pr: adding new tool to handle github prs

### DIFF
--- a/scripts/github_pr/Gemfile
+++ b/scripts/github_pr/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem "octokit", "~> 3.0"
+gem "netrc"

--- a/scripts/github_pr/github_pr.rb
+++ b/scripts/github_pr/github_pr.rb
@@ -1,0 +1,406 @@
+#!/usr/bin/ruby
+
+require 'octokit'
+require 'optparse'
+require 'yaml'
+require 'json'
+
+class GithubAPI
+  def create_client
+    client = Octokit::Client.new(netrc: true)
+    client.auto_paginate = true
+    client.login
+    client
+  end
+
+  def client
+    @@client ||= create_client
+  end
+
+  def current_rate_limit
+    client.rate_limit.remaining
+  end
+end
+
+
+class GithubClient
+  RESULT_MESSAGES = {
+    success: 'succeeded',
+    failure: 'failed',
+    error:   'has an error',
+    pending: 'is pending',
+  }
+
+  def initialize(conf = {})
+    @config = conf
+  end
+
+  def organization
+    @config[:organization]
+  end
+
+  def repository
+    @config[:repository]
+  end
+
+  def org_repo
+    "#{organization}/#{repository}"
+  end
+
+  def context
+    @config[:context]
+  end
+
+  def create_status(commit, details)
+    result = details[:status].to_sym
+    GithubAPI.new.client.create_status(
+      org_repo,
+      commit,
+      result,
+      { context: context,
+        description: status_description(details[:message], result),
+        target_url: details[:target_url].to_s
+      }
+    )
+  end
+
+  def status_description(description, status)
+    description ||= RESULT_MESSAGES[status]
+    description.to_s
+  end
+
+  def full_sha_status(sha)
+    status = GithubAPI.new.client.status(org_repo, sha)
+    status.statuses.select{ |s| s.context == context }.first rescue {}
+  end
+
+  def sha_status(sha)
+    full_sha_status(sha).state rescue ''
+  end
+
+  def pull_request(pull)
+    GithubAPI.new.client.pull_request(org_repo, pull)
+  end
+
+  def pull_info(pull)
+    pull_request(pull).to_attrs
+  end
+
+  def pull_latest_sha(pull)
+    pull_request(pull).head.sha rescue ''
+  end
+
+  def latest_sha?(pull, sha)
+    pull_latest_sha(pull) == sha
+  end
+
+  # state = ["open"|"closed"]
+  def all_pull_requests(state)
+     GithubAPI.new.client.pull_requests(org_repo, state: state)
+  end
+end
+
+class GithubPRWorker
+  def initialize(base_parameters = {}, config = {})
+    @base_parameters = base_parameters
+    @config = config
+  end
+
+  # metadata for octokit
+  def metadata(org, repo, context)
+    {
+      org_repo: org + "/" + repo,
+      organization: org,
+      repository: repo,
+      context: context,
+      config_base_path: File.dirname(@base_parameters[:config]),
+    }
+  end
+
+  def process_list
+    @config["pr_processing"] || []
+  end
+
+  def status_filter_config(config)
+    # the config for the Status filter might be overridden via command line parameters
+    if (@base_parameters.has_key?(:mode) && @base_parameters[:mode].to_s.size > 0) then
+      config["status"] = @base_parameters[:mode]
+    end
+    config
+  end
+
+  def debug?
+    @base_parameters.has_key?(:debugfilterchain) && \
+      @base_parameters[:debugfilterchain] == true
+  end
+
+  def debug_filterchain(pulls, filter)
+    return unless debug?
+    return unless filter
+    puts "=" * 25
+    puts filter.inspect
+    print_pulls(pulls)
+    puts "-" * 25
+  end
+
+  def run_actions(pulls, actions)
+    return unless actions.is_a?(Array)
+    actions.each do |a|
+      a.run(pulls)
+    end
+  end
+
+  def repos(item)
+    if (item["config"].has_key?("repositories") && item["config"]["repositories"].size > 0) then
+      item["config"]["repositories"]
+    elsif (item["config"].has_key?("repository_filter") && item["config"]["repository_filter"].size > 0) then
+      c = GithubAPI.new.client
+      c.repositories(item["config"]["organization"]).collect do |r|
+        r.name if item["config"]["repository_filter"].find do |rf|
+          r.name =~ rf
+        end
+      end.compact
+    end
+  end
+
+  def run_filterchain(filterchain, mode, white)
+    filterchain.each do |h|
+      white, black = h[:filter].filter(white)
+      debug_filterchain(white, h[:filter])
+      if (mode == :process) then
+         run_actions(black, h[:blacklist_handler])
+         run_actions(white, h[:whitelist_handler])
+      end
+      debug_filterchain(black, h[:blacklist_handler])
+      debug_filterchain(white, h[:whitelist_handler])
+    end
+    return white
+  end
+
+  def filter_pulls(mode = :get, state = :open)
+    process_list.collect do |item|
+      repos(item).collect do |repo|
+        meta = metadata(item["config"]["organization"], repo, item["config"]["context"])
+        filterchain=[]
+        item["filter"].each do |pull_filter|
+          handler = {}
+          fname = "GithubPR::" + pull_filter["type"] + "Filter"
+          filter_config = pull_filter["config"]
+          filter_config = status_filter_config(filter_config) if pull_filter["type"] == "Status"
+          handler[:filter] = Object.const_get(fname).new(meta, filter_config)
+
+          ["black", "white"].each do |list|
+            hname = "#{list}list_handler"
+            next unless pull_filter[hname]
+
+            handler[hname.to_sym] = pull_filter[hname].collect do |one_action|
+              action_class = "GithubPR::" + one_action["type"] + "Action"
+              Object.const_get(action_class).new(meta, one_action["parameters"])
+            end
+          end
+          filterchain.push(handler)
+        end
+
+        white = GithubClient.new(meta).all_pull_requests(state)
+        debug_filterchain(white, "unfiltered PR list")
+        run_filterchain(filterchain, mode, white)
+      end
+    end
+  end
+
+  def print_pulls(pull)
+    if pull.is_a?(Array)
+      pull.each do |p|
+        print_pulls(p)
+      end
+    else
+      puts "#{pull.number}:#{pull.head.sha}:#{pull.base.ref}" if pull
+    end
+  end
+
+  def trigger_pulls
+    filter_pulls(:process, :open)
+  end
+
+  def list_pulls
+    pulls = filter_pulls(:get, :open)
+    print_pulls(pulls)
+  end
+end
+
+
+# MAIN ========================================================
+
+## options
+base_para = {}
+options = {}
+
+optparse = OptionParser.new do |opts|
+  opts.banner = "Tool to trigger mkcloud builds for open pull requests and set the pull request status"
+  opts.on("-h", "--help", "Show usage") do
+    puts opts
+    exit
+  end
+  opts.separator ""
+  opts.separator "Parameters to process PR list"
+  opts.on("-c", "--config CONFIG_FILE", "File with configuration and filter specification") do |c|
+    base_para[:config] = c
+  end
+  opts.on("-a", "--action TYPE", "Action to perform, processing: [trigger-prs list-prs] ; " \
+          "single PR: [set-status get-latest-sha is-latest-sha pr-info]"
+         ) do |a|
+    base_para[:action] = a
+  end
+  opts.on("-m", "--mode MODE", "Override the 'Status' filter definition(s) in the config file: [unseen rebuild forcerebuild all]") do |o|
+    base_para[:mode] = o
+  end
+  opts.on("-i", "--interaction_dirs DIR1,DIR2,DIR3", "Directories with interaction files to require. All files 'ia_*.rb' are included from these directories.") do |i|
+    base_para[:interaction_dirs] = i.split(",")
+  end
+  opts.on("-d", "--debugfilterchain", "Debug the filterchain of the config file. Lists PRs after each filter step.") do
+    base_para[:debugfilterchain] = true
+  end
+  opts.on("-l", "--debugratelimit", "Debugging API rate limit. Print the Github API rate limit to STDERR before and after processing the action.") do
+    base_para[:debugratelimit] = true
+  end
+
+  opts.separator ""
+  opts.separator "Parameters to set/query a github status"
+  opts.on("-o", "--org ORG", "Github Organisation/Repository") do |o|
+    options[:organization] = o
+  end
+  opts.on("-r", "--repo REPO", "Github Organisation/Repository") do |r|
+    options[:repository] = r
+  end
+  opts.on("-x", "--context context-string", "Github Status Context String") do |x|
+    options[:context] = x
+  end
+  opts.on("-p", "--pr PRID", "Github Status Context String") do |p|
+    options[:pr] = p
+  end
+  opts.on("-u", "--sha SHA1SUM", "Github Commit SHA1 Sum") do |u|
+    options[:sha] = u
+  end
+  opts.on("-t", "--targeturl URL", "Target URL of a CI Build; optional.") do |t|
+    options[:target_url] = t
+  end
+  opts.on("-s", "--status STATUS", "Github Status of a CI Build [pending,success,failure,error]") do |s|
+    options[:status] = s
+  end
+  opts.on("-e", "--message MSG", "Message to show in github next to the status; optional.") do |e|
+    options[:message] = e
+  end
+
+  opts.separator ""
+  opts.separator "Parameter for JSON query"
+  opts.on('-k', '--key KEY',
+          'Dot-separated attribute path to extract from PR JSON, e.g. base.head.owner. ' \
+          'Only for use with pr-info action.') do |k|
+    options[:key] = k
+  end
+end
+optparse.parse!
+
+## config
+yaml_config = {}
+begin
+  yaml_config = YAML.load_file(base_para[:config]) if base_para.has_key?(:config)
+rescue Psych::SyntaxError
+  puts "Error: Invalid YAML syntax in config file: #{base_para[:config]}"
+  exit 2
+end
+
+
+## include interaction files
+rel_ia_dir = File.join(File.dirname(__FILE__), "interactions")
+require File.join(rel_ia_dir, "default.rb")
+
+interaction_dirs = [ rel_ia_dir ]
+interaction_dirs += base_para[:interaction_dirs] if base_para[:interaction_dirs].is_a?(Array)
+interaction_dirs += yaml_config["interaction_dirs"] if yaml_config["interaction_dirs"].is_a?(Array)
+
+interaction_dirs.collect{ |d| d.gsub(/\/+$/, "") rescue next}.compact.uniq.each do |dir|
+  begin
+    onedir = Dir.new(dir)
+    Dir.glob(File.expand_path(File.join(onedir, 'ia_*.rb'))).each do |f|
+      require f
+    end
+  rescue Errno::ENOENT
+    raise "Could not find directory: #{dir}"
+  end
+end
+
+## helpers for parameter checks
+def require_parameter(param, message)
+  if param.to_s.empty?
+    abort message
+  end
+end
+
+def prevent_parameter(param, message)
+  unless param.to_s.empty?
+    abort message
+  end
+end
+
+def debug_api_rate_limit(base_para)
+  return unless base_para.has_key?(:debugratelimit) && base_para[:debugratelimit] == true
+  STDERR.puts "API rate limit: " + GithubAPI.new.current_rate_limit.to_s
+end
+
+## main
+debug_api_rate_limit(base_para)
+case base_para[:action]
+  when "list-prs"
+    require_parameter(base_para[:config], 'Config file not defined.')
+    GithubPRWorker.new(base_para, yaml_config).list_pulls
+  when "trigger-prs"
+    require_parameter(base_para[:config], 'Config file not defined.')
+    GithubPRWorker.new(base_para, yaml_config).trigger_pulls
+  when "set-status"
+    prevent_parameter(base_para[:config], 'Config file should not be defined for this action.')
+    require_parameter(options[:organization], 'Organization undefined.')
+    require_parameter(options[:repository], 'Repository undefined.')
+    require_parameter(options[:context], 'Context undefined.')
+    require_parameter(options[:sha], 'SHA1 sum undefined.')
+    require_parameter(options[:status], 'Status undefined.')
+    GithubClient.new(options).create_status(options[:sha], {
+      status: options[:status],
+      message: options[:message],
+      target_url: options[:target_url]
+    })
+  when "pr-info"
+    prevent_parameter(base_para[:config], 'Config file should not be defined for this action.')
+    require_parameter(options[:organization], 'Organization undefined.')
+    require_parameter(options[:repository], 'Repository undefined.')
+    require_parameter(options[:pr], 'PullRequest ID undefined.')
+    data = GithubClient.new(options).pull_info(options[:pr])
+    if options[:key]
+      options[:key].split(/(?<!\\)\./).each do |key|
+        key = key.to_sym
+        if data.has_key? key
+          data = data[key]
+        else
+          abort "No key '#{key}' in PR JSON:\n#{JSON.pretty_generate(data)}"
+        end
+      end
+    end
+    puts data.is_a?(Hash) ? JSON.pretty_generate(data) : data
+  when "is-latest-sha"
+    prevent_parameter(base_para[:config], 'Config file should not be defined for this action.')
+    require_parameter(options[:sha], 'Commit SHA1 sum undefined.')
+    require_parameter(options[:pr], 'PullRequest ID undefined.')
+    require_parameter(options[:organization], 'Organization undefined.')
+    require_parameter(options[:repository], 'Repository undefined.')
+    exit GithubClient.new(options).latest_sha?(options[:pr], options[:sha]) ? 0 : 1
+  when "get-latest-sha"
+    prevent_parameter(base_para[:config], 'Config file should not be defined for this action.')
+    require_parameter(options[:pr], 'PullRequest ID undefined.')
+    require_parameter(options[:organization], 'Organization undefined.')
+    require_parameter(options[:repository], 'Repository undefined.')
+    puts GithubClient.new(options).pull_latest_sha(options[:pr])
+end
+debug_api_rate_limit(base_para)
+
+__END__
+

--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -57,6 +57,28 @@ template:
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 *mkcloud_automation_parameters
+    suse_cct: &suse_cct
+      - type: Status
+        config:
+          status: unseen
+      - type: TrustedSource
+        config:
+          users:
+            *suse_cloud_user
+          teams:
+            *suse_cloud_team
+        whitelist_handler:
+          - type: SetStatus
+            parameters:
+              status: pending
+              message: Queued cct PR gating
+          - type: JenkinsJobTriggerMkcloudCCT
+            parameters:
+              job_name: openstack-mkcloud
+              job_cmd: "../jenkins/jenkins-job-trigger"
+              job_parameters:
+                standard:
+                  *mkcloud_automation_standard
 pr_processing:
   - config:
       organization: SUSE-Cloud
@@ -64,3 +86,9 @@ pr_processing:
         - automation
       context: suse/mkcloud
     filter: *suse_automation
+  - config:
+      organization: SUSE-Cloud
+      repositories:
+        - cct
+      context: suse/mkcloud
+    filter: *suse_cct

--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -1,0 +1,66 @@
+template:
+  mkcloud_parameters: &mkcloud_automation_parameters
+    standard: &mkcloud_automation_standard
+      label: openstack-mkcloud
+      mkcloudtarget: all_noreboot
+      cloudsource: develcloud8
+      nodenumber: 2
+      networkingplugin: openvswitch
+    stable: &mkcloud_automation_stable
+      <<: *mkcloud_automation_standard
+      cloudsource: GM7+up
+  user:
+    suse_cloud_user: &suse_cloud_user
+      - SUSE-Cloud
+  team:
+    suse_cloud_team: &suse_cloud_team
+      - name: SUSE-Cloud/Owners
+        id: 159206
+      - name: SUSE-Cloud/developers
+        id: 1541628
+    crowbar_team: &crowbar_team
+      - name: crowbar/Owners
+        id: 291046
+  filter:
+    suse_automation: &suse_automation
+      - type: MergeBranch
+        config:
+          branches:
+            - master
+      - type: Status
+        config:
+          status: unseen
+      - type: TrustedSource
+        config:
+          users:
+            *suse_cloud_user
+          teams:
+            *suse_cloud_team
+      - type: FileMatch
+        config:
+          paths:
+            -  !ruby/regexp '/scripts\/(mkcloud|qa_crowbarsetup\.sh|lib\/.*)$/'
+            -  !ruby/regexp '/scripts\/jenkins\/log-parser\//'
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: success
+              message: mkcloud gating not applicable
+        whitelist_handler:
+          - type: SetStatus
+            parameters:
+              status: pending
+              message: Queued automation PR gating
+          - type: JenkinsJobTriggerMkcloud
+            parameters:
+              job_name: openstack-mkcloud
+              job_cmd: "../jenkins/jenkins-job-trigger"
+              job_parameters:
+                *mkcloud_automation_parameters
+pr_processing:
+  - config:
+      organization: SUSE-Cloud
+      repositories:
+        - automation
+      context: suse/mkcloud
+    filter: *suse_automation

--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -1,0 +1,49 @@
+template:
+  user:
+    suse_crowbar_user: &suse_crowbar_user
+      - crowbar
+  team:
+    crowbar_team: &crowbar_team
+      - name: crowbar/Owners
+        id: 291046
+  filter:
+    suse_crowbar: &suse_crowbar
+      - type: MergeBranch
+        config:
+          branches:
+            - master
+            - stable/3.0
+            - stable/4.0
+      - type: Status
+        config:
+          status: unseen
+      - type: TrustedSource
+        config:
+          users:
+            *suse_crowbar_user
+          teams:
+            *crowbar_team
+        whitelist_handler:
+          - type: SetStatus
+            parameters:
+              status: pending
+              message: Queued testbuild job
+          - type: JenkinsJobTriggerCrowbarTestbuild
+            parameters:
+              job_name: cloud-crowbar-testbuild-pr
+              job_cmd: "../jenkins/jenkins-job-trigger"
+              job_parameters:
+                standard: {}
+pr_processing:
+  - config:
+      organization: crowbar
+      repositories:
+        - crowbar
+        - crowbar-ceph
+        - crowbar-core
+        - crowbar-ha
+        - crowbar-hyperv
+        - crowbar-init
+        - crowbar-openstack
+      context: suse/mkcloud/testbuild
+    filter: *suse_crowbar

--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -34,6 +34,31 @@ template:
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 standard: {}
+    sap-oc_crowbar: &sap-oc_crowbar
+      - type: MergeBranch
+        config:
+          branches:
+            - stable/sap/3.0
+      - type: Status
+        config:
+          status: unseen
+      - type: TrustedSource
+        config:
+          users:
+            *suse_crowbar_user
+          teams:
+            *crowbar_team
+        whitelist_handler:
+          - type: SetStatus
+            parameters:
+              status: pending
+              message: Queued testbuild job
+          - type: JenkinsJobTriggerCrowbarTestbuild
+            parameters:
+              job_name: cloud-crowbar-testbuild-pr
+              job_cmd: "../jenkins/jenkins-job-trigger"
+              job_parameters:
+                standard: {}
 pr_processing:
   - config:
       organization: crowbar
@@ -47,3 +72,14 @@ pr_processing:
         - crowbar-openstack
       context: suse/mkcloud/testbuild
     filter: *suse_crowbar
+  - config:
+      organization: sap-oc
+      repositories:
+        - crowbar
+        - crowbar-ceph
+        - crowbar-core
+        - crowbar-ha
+        - crowbar-openstack
+        - crowbar-monitoring
+      context: suse/mkcloud/testbuild
+    filter: *sap-oc_crowbar

--- a/scripts/github_pr/github_pr_example.yaml
+++ b/scripts/github_pr/github_pr_example.yaml
@@ -1,0 +1,92 @@
+# directories to search for interaction files (ia_*.rb), will be requried
+interaction_dirs:
+  - /some/where/else/interactions
+# templating is not required, but might make it better readable
+template:
+  mkcloud_parameters: &mkcloud_automation_parameters
+    standard: &mkcloud_automation_standard
+      label: openstack-mkcloud
+      mkcloudtarget: all_noreboot
+      cloudsource: develcloud8
+      nodenumber: 2
+      networkingplugin: openvswitch
+    stable: &mkcloud_automation_stable
+      <<: *mkcloud_automation_standard
+      cloudsource: GM7+up
+  user:
+    suse_cloud_user: &suse_cloud_user
+      - SUSE-Cloud
+  team:
+    suse_cloud_team: &suse_cloud_team
+      - name: SUSE-Cloud/Owners
+        id: 159206
+      - name: SUSE-Cloud/developers
+        id: 1541628
+    crowbar_team: &crowbar_team
+      - name: crowbar/Owners
+        id: 291046
+  filter:
+    # filter and action classes are defined in interaction files
+    # there they are suffixed with .*Filter or .*Action
+    suse_automation: &suse_automation
+      # match the name of the target merge branch
+      - type: MergeBranch
+        config:
+          # can be a list of several branch names
+          branches:
+            - master
+      # match the latest status of the latest sha1sum of the PR
+      #  can be one of [unseen, rebuild, forcerebuild, all]
+      - type: Status
+        config:
+          status: unseen
+      # match users and teams to verify that the PR comes from a trusted source
+      - type: TrustedSource
+        config:
+          users:
+            *suse_cloud_user
+          teams:
+            *suse_cloud_team
+      # match the changed files in the PR to check if/how we care about the PR
+      - type: FileMatch
+        config:
+          paths:
+            -  !ruby/regexp '/scripts\/(mkcloud|qa_crowbarsetup\.sh|lib\/.*)$/'
+            -  !ruby/regexp '/scripts\/jenkins\/log-parser\//'
+        blacklist_handler:
+          # action(s) for the PRs that do not match the filter (blacklist)
+          - type: SetStatus
+            parameters:
+              status: success
+              message: mkcloud gating not applicable
+        whitelist_handler:
+          # action(s) for the PRs that do match the filter (whitelist)
+          - type: SetStatus
+            parameters:
+              status: pending
+              message: Queued automation PR gating
+          - type: JenkinsJobTriggerMkcloud
+            parameters:
+              job_name: openstack-mkcloud
+              job_cmd: "../jenkins/jenkins-job-trigger"
+              job_parameters:
+                *mkcloud_automation_parameters
+# definition of the orgs and repos to be processed wiht this config
+pr_processing:
+  - config:
+    organization: SUSE-Cloud
+    #repositories:
+    #  - automation
+    # if both repository and repository_filter are set, repositories has precedence
+    repository_filter:
+      - !ruby/regexp '/auto-?mati.*/'
+      - !ruby/regexp '/^a/'
+    context: suse/mkcloud
+    filter: *suse_automation
+  # it can have many of these entries
+  - config:
+    organization: other-org
+    repositories:
+      - automation2
+    context: suse/other
+    filter: *other_definition

--- a/scripts/github_pr/interactions/default.rb
+++ b/scripts/github_pr/interactions/default.rb
@@ -1,0 +1,156 @@
+#
+# Github_PR default interactions (filter and action classes)
+#
+# github_pr.rb first requires this default.rb file,
+# then all files in the interaction_dirs that match "ia_*.rb" (ia = interaction)
+# The interaction_dirs can be defined in the yaml config as:
+#   interaction_dirs:
+#     - ./dir1
+#     - /other/dir2
+# or as command line parameter
+#   --interaction_dirs ./dir1,/other/dir2
+#
+
+module GithubPR
+  class Interaction
+    def initialize(metadata, config = {})
+      @metadata = metadata
+      @c = config
+    end
+  end
+
+  class Filter < Interaction
+    def filter(pulls)
+      pulls.partition do |pull|
+        filter_applies?(pull)
+      end
+    end
+
+    def filter_applies?(_pull)
+      true
+    end
+  end
+
+  class Action < Interaction
+    def run(pulls)
+      pulls.each do |pull|
+        action(pull)
+      end
+    end
+
+    def action(_pull)
+      true
+    end
+  end
+
+
+  #=== Filter Classes =======>>
+
+  class FileMatchFilter < Filter
+    def filter_applies?(pull)
+      match_files = GithubAPI.new.client.pull_request_files(@metadata[:org_repo], pull[:number]).select do |f|
+        @c["paths"].find do |path|
+          path.match(f[:filename])
+        end
+      end
+      match_files.size > 0
+    end
+  end
+
+  class TrustedSourceFilter < Filter
+    @@members = {}
+
+    def team_members(team_id)
+      # only query when needed - and cache in class variable
+      @@members[team_id] ||= GithubAPI.new.client.team_members(team_id).map{|m| m["login"]} rescue {}
+    end
+
+    def team_member?(team_id, login)
+      team_members(team_id).include?(login)
+    end
+
+    def allowed_user?(user)
+      if @c.key?("users")
+        return true if @c["users"].include?(user)
+      end
+      false
+    end
+
+    def allowed_team?(user)
+      if @c.key?("teams")
+        return true if @c["teams"].find do |team|
+          team_member?(team["id"], user)
+        end
+      end
+      false
+    end
+
+    def trusted_pull_request_source?(user)
+      return false if (!user || user.nil? || user.empty?)
+      return true if (allowed_user?(user) || allowed_team?(user))
+      false
+    end
+
+    def filter_applies?(pull)
+      user = pull.head.repo.owner.login rescue ''
+      trusted_pull_request_source?(user)
+    end
+  end
+
+  class MergeBranchFilter < Filter
+    def filter_applies?(pull)
+      @c["branches"].include?(pull.base.ref)
+    end
+  end
+
+  class StatusFilter < Filter
+    PULL_REQUEST_STATUS = {
+      "unseen"       => [''],
+      "rebuild"      => ['', 'pending'],
+      "forcerebuild" => ['', 'pending', 'error', 'failure'],
+      "all"          => ['', 'pending', 'error', 'failure', 'success'],
+    }
+
+    def filter_applies?(pull)
+      stati = PULL_REQUEST_STATUS[@c["status"]] rescue ['']
+      stati.include?(GithubClient.new(@metadata).sha_status(pull.head.sha))
+    end
+  end
+
+  #=== Action Classes ========>>
+
+  class SetStatusAction < Action
+    def action(pull)
+      GithubClient.new(@metadata).set_status(pull.head.sha, @c)
+    end
+  end
+
+  class JenkinsJobTriggerAction < Action
+    def action(pull)
+      base_cmd = command
+      parameters(pull).each do |build_mode, job_paras|
+        one_cmd = base_cmd + job_paras
+        system(*one_cmd) or raise
+        puts "Triggering jenkins job for PR #{pull.number} in #{build_mode} mode"
+      end
+    end
+
+    def command
+      jcmd = @c["job_cmd"]
+      jcmd = File.join(@metadata[:config_base_path], @c["job_cmd"]) unless File.exist?(jcmd)
+      cmd = [ jcmd, @c["job_name"] ]
+      cmd
+    end
+
+    def parameters(pull)
+      @c["job_parameters"].map do |build_mode, build_paras|
+        job_paras = build_paras
+        if self.respond_to?(:extra_parameters) then
+          job_paras.merge!(extra_parameters(pull, build_mode))
+        end
+        job_para_string = job_paras.map { |k,v| "#{k}=#{v}" }
+        [ build_mode, job_para_string ]
+      end.to_h
+    end
+  end
+end

--- a/scripts/github_pr/interactions/ia_cloud.rb
+++ b/scripts/github_pr/interactions/ia_cloud.rb
@@ -13,4 +13,20 @@ module GithubPR
       }
     end
   end
+
+  class JenkinsJobTriggerMkcloudCCTAction < JenkinsJobTriggerMkcloudAction
+    CLOUDSOURCE = {
+      "master" => "develcloud8",
+      "cloud7" => "develcloud7",
+      "cloud6" => "develcloud6",
+    }
+
+    def extra_parameters(pull, build_mode = "")
+      para = super(pull, build_mode)
+      para.merge!({
+        cloudsource: CLOUDSOURCE[pull.base.ref]
+      }) if CLOUDSOURCE.has_key?(pull.base.ref)
+      para
+    end
+  end
 end

--- a/scripts/github_pr/interactions/ia_cloud.rb
+++ b/scripts/github_pr/interactions/ia_cloud.rb
@@ -1,0 +1,16 @@
+# Github_PR interactions (filter and action classes)
+
+module GithubPR
+  class JenkinsJobTriggerMkcloudAction < JenkinsJobTriggerAction
+    def extra_parameters(pull, build_mode = "")
+      job_base_name = "#{@metadata[:repository]} PR #{pull.number} #{pull.head.sha[0,8]}"
+      github_pr_base = "#{@metadata[:org_repo]}:#{pull.number}:#{pull.head.sha}:#{pull.base.ref}"
+      sub_context = build_mode == "standard" ? "":build_mode
+      sub_context_suffix = sub_context.empty? ? "" : ":#{sub_context}"
+      {
+        job_name: "#{job_base_name} #{sub_context}",
+        github_pr: "#{github_pr_base}#{sub_context_suffix}"
+      }
+    end
+  end
+end

--- a/scripts/github_pr/interactions/ia_cloud.rb
+++ b/scripts/github_pr/interactions/ia_cloud.rb
@@ -29,4 +29,14 @@ module GithubPR
       para
     end
   end
+
+  class JenkinsJobTriggerCrowbarTestbuildAction < JenkinsJobTriggerAction
+    def extra_parameters(pull, _build_mode = "")
+      {
+        crowbar_repo: @metadata[:repository],
+        crowbar_github_pr: "#{pull.number}:#{pull.head.sha}:#{pull.base.ref}",
+        job_name: "#{@metadata[:org_repo]} testbuild PR #{pull.number} #{pull.head.sha[0,8]}",
+      }
+    end
+  end
 end


### PR DESCRIPTION
Adding a new tool to handle github prs. It should replace github-status soon.

There are the issues with github-status:

It is bound to the SUSE-Cloud organization and our few repos.
It could be changed to set status for other repos, but all defaults
were SUSE and cloud specific.

Due to the need to call github-status several times within a jenkins
job, we wasted several API requests and hit the rate limit several
times.

Other teams (and **companies!**) had interest in using github-status, but had to modify
it to meet their needs.

github_pr fixes these issues:
- it is configurable (org, repo, filters, actions)
- it will login once and cache data to save API requests
- it can call external actions during the filtering
- it brings a set of useful filters and actions
- it can be extended with team/site specific filters and actions

The idea of github_pr is:
For a given github organization and repositories it reads a filter
definition from a config file. This definition describes a filter
chain. PRs that do not match the filter are discarded, the others
are handed to the next filter in the chain.
After each filter actions can be run on the PRs that match and
that do not match (before they are discarded).

This will allow to replace the several pr trigger jobs with a single
jenkins job that does the polling which saves even more API requests.