### PR TITLE
build_ses: increase reboot allowance

### DIFF
--- a/scripts/build_ses.sh
+++ b/scripts/build_ses.sh
@@ -240,7 +240,7 @@ function install_ses() {
     do
         echo "Attempting to ssh to $hn"
         ip_good=0
-        for i in $(seq 30)
+        for i in $(seq 60)
         do
             ssh $hn "zypper --gpg-auto-import-keys ref -f"
             if (( $? == 0 ))


### PR DESCRIPTION
For baremetal nodes, 60s is sometimes too little for a full reboot.