### PR TITLE
qa_crowbarsetup/HA: override default nova-compute role assignment

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2369,6 +2369,9 @@ function custom_configuration
                 fi
                 novanodes_json=$(printf "\"%s\"," ${novanodes[@]})
                 novanodes_json="[ ${novanodes_json%,} ]"
+                for lv_type in kvm qemu xen hyperv; do
+                    proposal_set_value nova default "['deployment']['nova']['elements']['nova-compute-${lv_type}']" "[ ]"
+                done
                 proposal_set_value nova default "['deployment']['nova']['elements']['nova-compute-${libvirt_type}']" "$novanodes_json"
             fi
 


### PR DESCRIPTION
The nova-compute-XXX role assignment computed in the HA case must completely replace the default assignment computed by crowbar based on auto-detected node capabilities, otherwise conflicts may occur. For instance, if nested virtualization was disabled on the host, the default crowbar nova proposal, constructed from the auto-detected platform type & CPU flags, could look like this (for a 5 node setup, and `clusterconfig="services+data+network=2"`):

```
      "elements": {
        "nova-controller": [
          "cluster:services"
        ],
        "nova-compute-hyperv": [
        ],
        "nova-compute-kvm": [
        ],
        "nova-compute-qemu": [
          "d52-54-77-77-01-02.virtual.cloud.suse.de",
          "d52-54-77-77-01-05.virtual.cloud.suse.de"
        ],
        "nova-compute-xen": [
        ]
      },
```

and then mkcloud comes along and only overwrites the nova-compute-kvm list, so the final result looks like this:

```
      "elements": {
        "nova-controller": [
          "cluster:services"
        ],
        "nova-compute-hyperv": [
        ],
        "nova-compute-kvm": [
          "d52-54-77-77-01-03.virtual.cloud.suse.de",
          "d52-54-77-77-01-04.virtual.cloud.suse.de",
          "d52-54-77-77-01-05.virtual.cloud.suse.de"
        ],
        "nova-compute-qemu": [
          "d52-54-77-77-01-02.virtual.cloud.suse.de",
          "d52-54-77-77-01-05.virtual.cloud.suse.de"
        ],
        "nova-compute-xen": [
        ]
      },
```
, which results in a conflict.

Fixes [bsc#1064588](https://bugzilla.suse.com/show_bug.cgi?id=1064588)