### PR TITLE
New job for Cloud7-8 disruptive upgrade

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -13,6 +13,7 @@
     arch: x86_64
     tempestoptions: --smoke
     label: openstack-mkcloud-SLE12-x86_64
+    database_engine: postgresql
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -13,6 +13,7 @@
     arch: x86_64
     tempestoptions: --smoke
     label: openstack-mkcloud-SLE12-x86_64
+    database_engine: mysql
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
@@ -29,6 +30,7 @@
         # NOTE: we keep the Ocata job because we need to maintain
         # Devel:Cloud:8:Ocata for CloudFoundry CI
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-ocata'
+        - 'cloud-mkcloud{version}-job-upgrade-disruptive-{arch}'
 - project:
     name: cloud-mkcloud8-ha-x86_64
     disabled: false

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -24,6 +24,7 @@
             storage_method=swift
             mkcloudtarget=plain_with_upgrade testsetup
             want_nodesupgrade=1
+            want_database_sql_engine={database_engine}
             controller_node_memory=7864320
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-disruptive-{arch}


### PR DESCRIPTION
If no database migration is needed (mariadb already in SOC7),
normal upgrade path should work without significant changes...