### PR TITLE
trackupstream: Do not track ardana-configurationprocessor

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -24,7 +24,6 @@
             - ardana-cinderlm
             - ardana-cluster
             - ardana-cobbler
-            - ardana-configuration-processor
             - ardana-db
             - ardana-designate
             - ardana-extensions-dcn


### PR DESCRIPTION
We use the tarball from pypi for now and the package name changed. So
do not track it for now.