### PR TITLE
Track ardana-extensions-nsx updates

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -28,6 +28,7 @@
             - ardana-designate
             - ardana-extensions-dcn
             - ardana-extensions-example
+            - ardana-extensions-nsx
             - ardana-freezer
             - ardana-glance
             - ardana-glance-check


### PR DESCRIPTION
A new Ardana extension is available for Cloud 8 to integrate
with VMware NSX-v. We want to pull regular updates from it.