### PR TITLE
qa_crowbarsetup: Remove ostestr usage

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3310,11 +3310,7 @@ function oncontroller_run_tempest
         # output the slowest tests from the latest run
         testr slowest
     fi
-    if iscloudver 7plus; then
-        ostestr last --subunit --no-pretty > tempest.subunit.log
-    else
-        testr last --subunit | subunit-2to1 > tempest.subunit.log
-    fi
+    testr last --subunit | subunit-2to1 > tempest.subunit.log
 
     oncontroller_tempest_cleanup
     popd
@@ -3331,7 +3327,7 @@ function oncontroller_upload_defcore
     # run only the specified tests
     tempest run --whitelist-file defcore.txt
     source /root/.openrc
-    ostestr last --subunit --no-pretty | subunit-2to1 > tempest.subunit.log
+    testr last --subunit | subunit-2to1 > tempest.subunit.log
     test -d refstack-client || safely git clone https://github.com/openstack/refstack-client
     yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL tempest.subunit.log
     popd

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3310,7 +3310,7 @@ function oncontroller_run_tempest
         # output the slowest tests from the latest run
         testr slowest
     fi
-    testr last --subunit | subunit-2to1 > tempest.subunit.log
+    testr last --subunit > tempest.subunit.log
 
     oncontroller_tempest_cleanup
     popd
@@ -3327,7 +3327,7 @@ function oncontroller_upload_defcore
     # run only the specified tests
     tempest run --whitelist-file defcore.txt
     source /root/.openrc
-    testr last --subunit | subunit-2to1 > tempest.subunit.log
+    testr last --subunit > tempest.subunit.log
     test -d refstack-client || safely git clone https://github.com/openstack/refstack-client
     yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL tempest.subunit.log
     popd


### PR DESCRIPTION
This commit removes ostestr command usage from qa_crowbarsetup.sh.
Because ostestr doesn't have 'last' subcommand[0] but ostestr just
ignore the 'last' subcommand, actually. However, it just runs same tests
again. It just wastes the resource. So I think it's better to switch to use testr.

In the upstream OpenStack development, we're switching to use stestr[1]
instead of testr. So, it's better to switch to use it in the future.

[0] https://docs.openstack.org/os-testr/latest/user/ostestr.html
[1] http://stestr.readthedocs.io/en/latest/