### PR TITLE
Add LTSS-Updates repo as local zypper repo to admin

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -910,7 +910,7 @@ function onadmin_setup_local_zypper_repositories
 
     [ -n "${localreposdir_target}" ] && mount_localreposdir_target
     mkdir -p /hostmirror
-    for repo in SLES$slesversion-{Pool,Updates}; do
+    for repo in SLES$slesversion-{Pool,Updates,LTSS-Updates}; do
         add_mount "repos/$arch/$repo" "/hostmirror/$repo" $repo
     done
 }


### PR DESCRIPTION
We are running mkcloud tests with the exact production state.
This is done with a snapshot repo given with UPDATEREPOS into
mkcloud. This requires to have all deps available in SLES basis
repos, including LTSS-Updates repo.