### PR TITLE
Added LTSS repo to prepare_repo function for cloud7+

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -589,7 +589,7 @@ function onadmin_prepare_sles12sp1_other_repos
 
 function onadmin_prepare_sles_other_repos
 {
-    for repo in SLES$slesversion-{Pool,Updates}; do
+    for repo in SLES$slesversion-{Pool,Updates,LTSS-Updates}; do
         add_mount "repos/$arch/$repo" "$tftpboot_repos_dir/$repo"
     done
 }


### PR DESCRIPTION
ATM there is only a LTSS-Updates repo for SLES12SP1/cloud6.
But the LTSS-Updates repo is added to the function create_repos_yml
for all cloud versions. This repos will be added to the nodes
allocated in the cloud. That means this repos must be available on
the admin node http://admin:8091/.
Therefore it is required to add the LTSS repo in the prepare function.
Cloud6 has its own onadmin_prepare_sles12sp1_other_repos and for the
newer version there is onadmin_prepare_sles_other_repos.
This requires as well that, if there is not yet a real LTSS repo
available, one has to create an empty folder, export this via NFS and
createrepo in it.