### PR TITLE
trackupstream: Stop tracking gnocchi in Pike and Master

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -108,6 +108,10 @@
             [
               "openstack-horizon-plugin-neutron-fwaas-ui",
               "openstack-horizon-plugin-neutron-vpnaas-ui",
+            ].contains(component) ||
+            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Pike:Staging" ].contains(project) &&
+            [
+              "openstack-gnocchi"
             ].contains(component)
             )
       sequential: true


### PR DESCRIPTION
It's been failing for ages as the package as been removed from OBS.
we don't see to need it anymore for Pike.