### PR TITLE
ardana: Pass needed env vars when calling ardana-init.bash

### DIFF
--- a/ardana/ansible/init.yml
+++ b/ardana/ansible/init.yml
@@ -3,8 +3,12 @@
   hosts: hosts
   gather_facts: False
 
+  environment:
+    ARDANA_INIT_AUTO: 1
+    ARDANA_DEPLOYER_MEDIA_LEGACY_LAYOUT: False
+
   tasks:
-  - name: Download ardana-init
+  - name: Download ardana-init.bash
     get_url:
       url: https://raw.githubusercontent.com/SUSE-Cloud/automation/ardana-ci/ardana/ardana-init.bash
       dest: /var/lib/ardana/ardana-init.bash
@@ -13,7 +17,7 @@
     become: true
     become_user: ardana
 
-  - name: Call ardana-init
-    shell: ARDANA_INIT_AUTO=1 /var/lib/ardana/ardana-init.bash
+  - name: Call ardana-init.bash
+    shell: /var/lib/ardana/ardana-init.bash
     become: true
     become_user: ardana


### PR DESCRIPTION
Otherwise the legacy layout is used during installation.