### PR TITLE
ardana: Download files from master branch (part 2)

### DIFF
--- a/ardana/ansible/init.yml
+++ b/ardana/ansible/init.yml
@@ -10,7 +10,7 @@
   tasks:
   - name: Download ardana-init.bash
     get_url:
-      url: https://raw.githubusercontent.com/SUSE-Cloud/automation/ardana-ci/ardana/ardana-init.bash
+      url: https://raw.githubusercontent.com/SUSE-Cloud/automation/master/ardana/ardana-init.bash
       dest: /var/lib/ardana/ardana-init.bash
       mode: 0775
       owner: ardana


### PR DESCRIPTION
Commit fc4f04fb835e89d missed one part where still the old ardana-ci
branch was used.