### PR TITLE
ardana: Add IPs from different networks to heat stack output

### DIFF
--- a/ardana/heat-template.yaml
+++ b/ardana/heat-template.yaml
@@ -109,6 +109,37 @@ resources:
       port_id: {get_attr: [deployer-controller, addresses, fixed, 0, port]}
 
 outputs:
-  deployer-controller-floatingip:
-    description: IP address of the deployer-controller node
+  # deployer-controller
+  deployer-controller-ip-floating:
+    description: Floating IP address of the deployer-controller node
     value: { get_attr: [deployer-controller-floatingip, floating_ip_address] }
+
+  deployer-controller-net-fixed-ip:
+    description: IP address of the deployer-controller in the fixed network
+    value: { get_attr: [deployer-controller, networks, fixed, 0]}
+
+  deployer-controller-net-ardana-ip:
+    description: IP address of the deployer-controller in the ardana network
+    value: { get_attr: [deployer-controller, networks, { get_resource: network_ardana }, 0]}
+
+  deployer-controller-net-mgmt-ip:
+    description: IP address of the deployer-controller in the mgmt network
+    value: { get_attr: [deployer-controller, networks, { get_resource: network_mgmt }, 0]}
+
+  # compute1
+  compute1-net-ardana-ip:
+    description: IP address of the compute1 node in the ardana network
+    value: { get_attr: [compute1, networks, { get_resource: network_ardana }, 0]}
+
+  compute1-net-mgmt-ip:
+    description: IP address of the compute1 node in the mgmt network
+    value: { get_attr: [compute1, networks, { get_resource: network_mgmt }, 0]}
+
+  # compute2
+  compute2-net-ardana-ip:
+    description: IP address of the compute2 node in the ardana network
+    value: { get_attr: [compute2, networks, { get_resource: network_ardana }, 0]}
+
+  compute2-net-mgmt-ip:
+    description: IP address of the compute2 node in the mgmt network
+    value: { get_attr: [compute2, networks, { get_resource: network_mgmt }, 0]}

--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -16,7 +16,7 @@
           # FIXME: use the template which is in the automation repo once this is merged!
           wget -O $HEAT_TEMPLATE_NAME https://raw.githubusercontent.com/SUSE-Cloud/automation/master/ardana/heat-template.yaml
           openstack --os-cloud $CLOUD_CONFIG_NAME stack create --timeout 5 --wait -t $HEAT_TEMPLATE_NAME  $STACK_NAME
-          DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-floatingip -c output_value -f value)
+          DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-ip-floating -c output_value -f value)
 
           # FIXME: Use cloud-init in the used image
           sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${DEPLOYER_IP}


### PR DESCRIPTION
We need the IP addresses for the different nodes from different
networks to setup the model later on. So create more outputs to be
able to query the IPs.
Also adjust the name for the floatingip output name to be consistent.