### PR TITLE
ardana: Refresh repos on compute nodes

### DIFF
--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -37,6 +37,7 @@
   - name: Copy zypper repo setup from deployer-controller to compute nodes
     shell: |
       sshpass -p linux scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  /etc/zypp/repos.d/* root@{{ item }}:/etc/zypp/repos.d/
+      sshpass -p linux ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  root@{{ item }} zypper -n --gpg-auto-import-keys ref
     with_items:
       - "{{ compute1_ardana_ip }}"
       - "{{ compute2_ardana_ip }}"


### PR DESCRIPTION
Commit 5bf00fbaeb9 did the repository setup on the compute nodes but a
refresh of the newly added repos is also needed. Add this.

Co-Authored-By: Ralf Haferkamp <rhafer@suse.com>