### PR TITLE
ardana: Use ntp.suse.de in model

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -22,9 +22,9 @@
           wget -O $HEAT_TEMPLATE_NAME https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/jenkins/ardana/heat-template.yaml
           openstack --os-cloud $CLOUD_CONFIG_NAME stack create --timeout 5 --wait -t $HEAT_TEMPLATE_NAME  $STACK_NAME
           DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-ip-floating -c output_value -f value)
-          DEPLOYER_ARDANA_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-net-ardana-ip -c output_value -f value)
-          COMPUTE1_ARDANA_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute1-net-ardana-ip -c output_value -f value)
-          COMPUTE2_ARDANA_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute2-net-ardana-ip -c output_value -f value)
+          DEPLOYER_MGMT_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-net-mgmt-ip -c output_value -f value)
+          COMPUTE1_MGMT_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute1-net-mgmt-ip -c output_value -f value)
+          COMPUTE2_MGMT_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute2-net-mgmt-ip -c output_value -f value)
           NETWORK_MGMT_ID=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME network-mgmt-id -c output_value -f value)
 
           # FIXME: Use cloud-init in the used image
@@ -38,9 +38,9 @@
 
           cat << EOF > ardana_net_vars.yml
           ---
-          deployer_ardana_ip: $DEPLOYER_ARDANA_IP
-          compute1_ardana_ip: $COMPUTE1_ARDANA_IP
-          compute2_ardana_ip: $COMPUTE2_ARDANA_IP
+          deployer_mgmt_ip: $DEPLOYER_MGMT_IP
+          compute1_mgmt_ip: $COMPUTE1_MGMT_IP
+          compute2_mgmt_ip: $COMPUTE2_MGMT_IP
           EOF
           # Get the IP addresses of the dns servers from the mgmt network
           echo "mgmt_dnsservers:" >> ardana_net_vars.yml

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -30,8 +30,8 @@
     shell: |
       sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no {{ item }}
     with_items:
-      - "{{ compute1_ardana_ip }}"
-      - "{{ compute2_ardana_ip }}"
+      - "{{ compute1_mgmt_ip }}"
+      - "{{ compute2_mgmt_ip }}"
     ignore_errors: True
 
   - name: Create ardana user on compute nodes
@@ -42,8 +42,8 @@
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  root@{{ item }} chown -R ardana: /var/lib/ardana/.ssh/
       scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  /etc/sudoers.d/ardana root@{{ item }}:/etc/sudoers.d/ardana
     with_items:
-      - "{{ compute1_ardana_ip }}"
-      - "{{ compute2_ardana_ip }}"
+      - "{{ compute1_mgmt_ip }}"
+      - "{{ compute2_mgmt_ip }}"
 
   # FIXME: This is ugly and we do not need all the repos from the deployer on the compute nodes
   - name: Copy zypper repo setup from deployer-controller to compute nodes
@@ -51,8 +51,8 @@
       scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  /etc/zypp/repos.d/* root@{{ item }}:/etc/zypp/repos.d/
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  root@{{ item }} zypper -n --gpg-auto-import-keys ref
     with_items:
-      - "{{ compute1_ardana_ip }}"
-      - "{{ compute2_ardana_ip }}"
+      - "{{ compute1_mgmt_ip }}"
+      - "{{ compute2_mgmt_ip }}"
 
   - name: Initialize target Model from deployerincloud-lite
     synchronize:
@@ -65,9 +65,9 @@
   # FIXME this is ugly we need to find a better way to edit the model
   - name: Update IP Addresses in Model
     shell: |
-      sed -i "s/ 192\.168\.110\.3/ x{{ deployer_ardana_ip }}/; \
-              s/ 192\.168\.110\.4/ x{{ compute1_ardana_ip }}/; \
-              s/ 192\.168\.110\.5/ x{{ compute2_ardana_ip }}/; \
+      sed -i "s/ 192\.168\.110\.3/ x{{ deployer_mgmt_ip }}/; \
+              s/ 192\.168\.110\.4/ x{{ compute1_mgmt_ip }}/; \
+              s/ 192\.168\.110\.5/ x{{ compute2_mgmt_ip }}/; \
               s/x192/ 192/;" \
               /var/lib/ardana/openstack/my_cloud/definition/data/servers.yml
 
@@ -133,8 +133,8 @@
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  {{ item }} sudo mkdir /etc/openstack/
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  {{ item }} sudo touch /etc/openstack/skip_disk_config
     with_items:
-      - "{{ compute1_ardana_ip }}"
-      - "{{ compute2_ardana_ip }}"
+      - "{{ compute1_mgmt_ip }}"
+      - "{{ compute2_mgmt_ip }}"
     become: true
     become_user: ardana
 

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -84,6 +84,7 @@
          data = yaml.load(f.read());
          f.close();
          data['cloud']['dns-settings']['nameservers'] = {{ mgmt_dnsservers }} ;
+         data['cloud']['ntp-servers'] = ['ntp.suse.de'];
          f = open('cloudConfig.yml', 'w');
          f.write(yaml.safe_dump(data, default_flow_style=False));
          f.close();"


### PR DESCRIPTION
pool.ntp.org does not work so we need to adjust the ntp server we
use.

Co-Authored-By: Ralf Haferkamp <rhafer@suse.com>