### PR TITLE
ardana: Simplify network config of heat stack a bit

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/input-model-nic-mappings.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-nic-mappings.yml
@@ -3,41 +3,7 @@
     version: 2
 
   nic-mappings:
-    - name: DEPLOYER
-      physical-ports:
-        - logical-name: hed1
-          type: simple-port
-          bus-address: "0000:00:04.0"
-
-        - logical-name: hed2
-          type: simple-port
-          bus-address: "0000:00:05.0"
-
-        - logical-name: hed3
-          type: simple-port
-          bus-address: "0000:00:08.0"
-
-        - logical-name: hed4
-          type: simple-port
-          bus-address: "0000:00:09.0"
-
-        - logical-name: hed5
-          type: simple-port
-          bus-address: "0000:00:0a.0"
-
-        - logical-name: hed6
-          type: simple-port
-          bus-address: "0000:00:0b.0"
-
-        - logical-name: hed7
-          type: simple-port
-          bus-address: "0000:00:0c.0"
-
-        - logical-name: hed8
-          type: simple-port
-          bus-address: "0000:00:0d.0"
-
-    - name: COMPUTE
+    - name: HEAT
       physical-ports:
         - logical-name: hed1
           type: simple-port

--- a/scripts/jenkins/ardana/ansible/templates/input-model-servers.yml
+++ b/scripts/jenkins/ardana/ansible/templates/input-model-servers.yml
@@ -15,7 +15,7 @@
       ilo-ip: 192.168.109.3
       ilo-password: password
       ilo-user: admin
-      nic-mapping: DEPLOYER
+      nic-mapping: HEAT
 
     - id: cpn-0001
       ip-addr:  {{ compute1_mgmt_ip }}
@@ -24,7 +24,7 @@
       ilo-ip: 192.168.109.4
       ilo-password: password
       ilo-user: admin
-      nic-mapping: COMPUTE
+      nic-mapping: HEAT
 
     - id: cpn-0002
       ip-addr:  {{ compute2_mgmt_ip }}
@@ -33,4 +33,4 @@
       ilo-ip: 192.168.109.5
       ilo-password: password
       ilo-user: admin
-      nic-mapping: COMPUTE
+      nic-mapping: HEAT

--- a/scripts/jenkins/ardana/heat-template.yaml
+++ b/scripts/jenkins/ardana/heat-template.yaml
@@ -91,7 +91,6 @@ resources:
       security_groups:
         - { get_resource: security-group-base }
       networks:
-        - network: fixed
         - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }
 
@@ -124,17 +123,13 @@ resources:
     type: OS::Neutron::FloatingIPAssociation
     properties:
       floatingip_id: { get_resource: deployer-controller-floatingip }
-      port_id: {get_attr: [deployer-controller, addresses, fixed, 0, port]}
+      port_id: {get_attr: [deployer-controller, addresses, { get_resource: network_mgmt }, 0, port]}
 
 outputs:
   # deployer-controller
   deployer-controller-ip-floating:
     description: Floating IP address of the deployer-controller node
     value: { get_attr: [deployer-controller-floatingip, floating_ip_address] }
-
-  deployer-controller-net-fixed-ip:
-    description: IP address of the deployer-controller in the fixed network
-    value: { get_attr: [deployer-controller, networks, fixed, 0]}
 
   deployer-controller-net-ardana-ip:
     description: IP address of the deployer-controller in the ardana network


### PR DESCRIPTION
As the ardana management network is already connecting to the external
router we don't need to connect the deployer instance to the "fixed"
network just for assigning a floating IP. This allows us to use the same
nic mappings on all nodes.