### PR TITLE
ardana: Restructure network config

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -39,10 +39,10 @@
 
           openstack --os-cloud $CLOUD_CONFIG_NAME stack create --timeout 5 --wait -t heat-template.yaml  $STACK_NAME
           DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-ip-floating -c output_value -f value)
-          DEPLOYER_MGMT_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-net-mgmt-ip -c output_value -f value)
-          COMPUTE1_MGMT_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute1-net-mgmt-ip -c output_value -f value)
-          COMPUTE2_MGMT_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute2-net-mgmt-ip -c output_value -f value)
-          NETWORK_MGMT_ID=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME network-mgmt-id -c output_value -f value)
+          DEPLOYER_ARDANA_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-controller-net-ardana-ip -c output_value -f value)
+          COMPUTE1_ARDANA_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute1-net-ardana-ip -c output_value -f value)
+          COMPUTE2_ARDANA_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute2-net-ardana-ip -c output_value -f value)
+          NETWORK_ARDANA_ID=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME network-ardana-id -c output_value -f value)
           # FIXME: Use cloud-init in the used image
           sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${DEPLOYER_IP}
           pushd ansible
@@ -54,13 +54,13 @@
 
           cat << EOF > ardana_net_vars.yml
           ---
-          deployer_mgmt_ip: $DEPLOYER_MGMT_IP
-          compute1_mgmt_ip: $COMPUTE1_MGMT_IP
-          compute2_mgmt_ip: $COMPUTE2_MGMT_IP
+          deployer_ardana_ip: $DEPLOYER_ARDANA_IP
+          compute1_ardana_ip: $COMPUTE1_ARDANA_IP
+          compute2_ardana_ip: $COMPUTE2_ARDANA_IP
           EOF
-          # Get the IP addresses of the dns servers from the mgmt network
-          echo "mgmt_dnsservers:" >> ardana_net_vars.yml
-          openstack --os-cloud $CLOUD_CONFIG_NAME port list --network $NETWORK_MGMT_ID \
+          # Get the IP addresses of the dns servers from the ardana network
+          echo "ardana_dnsservers:" >> ardana_net_vars.yml
+          openstack --os-cloud $CLOUD_CONFIG_NAME port list --network $NETWORK_ARDANA_ID \
                     --device-owner network:dhcp -f value -c 'Fixed IP Addresses' | \
               sed -e "s/^ip_address='\(.*\)', .*$/\1/" | \
               while read line; do echo "  - $line" >> ardana_net_vars.yml; done;

--- a/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
@@ -7,8 +7,6 @@
       vlanid: 101
       tagged-vlan: false
       cidr: 192.168.110.0/24
-      addresses:
-        - 192.168.110.10-192.168.110.200
       gateway-ip: 192.168.110.1
       network-group: ARDANA
 
@@ -16,6 +14,8 @@
       vlanid: 102
       tagged-vlan: false
       cidr: 192.168.245.0/24
+      addresses:
+        - 192.168.245.10-192.168.245.200
       gateway-ip: 192.168.245.1
       network-group: MANAGEMENT
 

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -29,8 +29,8 @@
     shell: |
       sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no {{ item }}
     with_items:
-      - "{{ compute1_mgmt_ip }}"
-      - "{{ compute2_mgmt_ip }}"
+      - "{{ compute1_ardana_ip }}"
+      - "{{ compute2_ardana_ip }}"
     ignore_errors: True
 
   - name: Create ardana user on compute nodes
@@ -41,8 +41,8 @@
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  root@{{ item }} chown -R ardana: /var/lib/ardana/.ssh/
       scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  /etc/sudoers.d/ardana root@{{ item }}:/etc/sudoers.d/ardana
     with_items:
-      - "{{ compute1_mgmt_ip }}"
-      - "{{ compute2_mgmt_ip }}"
+      - "{{ compute1_ardana_ip }}"
+      - "{{ compute2_ardana_ip }}"
 
   # FIXME: This is ugly and we do not need all the repos from the deployer on the compute nodes
   - name: Copy zypper repo setup from deployer-controller to compute nodes
@@ -50,8 +50,8 @@
       scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  /etc/zypp/repos.d/* root@{{ item }}:/etc/zypp/repos.d/
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  root@{{ item }} zypper -n --gpg-auto-import-keys ref
     with_items:
-      - "{{ compute1_mgmt_ip }}"
-      - "{{ compute2_mgmt_ip }}"
+      - "{{ compute1_ardana_ip }}"
+      - "{{ compute2_ardana_ip }}"
 
   - name: Initialize target Model from deployerincloud-lite
     synchronize:
@@ -79,7 +79,7 @@
          f = open('cloudConfig.yml');
          data = yaml.load(f.read());
          f.close();
-         data['cloud']['dns-settings']['nameservers'] = {{ mgmt_dnsservers }} ;
+         data['cloud']['dns-settings']['nameservers'] = {{ ardana_dnsservers }} ;
          data['cloud']['ntp-servers'] = ['ntp.suse.de'];
          f = open('cloudConfig.yml', 'w');
          f.write(yaml.safe_dump(data, default_flow_style=False));
@@ -145,8 +145,8 @@
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  {{ item }} sudo mkdir /etc/openstack/
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  {{ item }} sudo touch /etc/openstack/skip_disk_config
     with_items:
-      - "{{ compute1_mgmt_ip }}"
-      - "{{ compute2_mgmt_ip }}"
+      - "{{ compute1_ardana_ip }}"
+      - "{{ compute2_ardana_ip }}"
     become: true
     become_user: ardana
 

--- a/scripts/jenkins/ardana/ansible/templates/input-model-servers.yml
+++ b/scripts/jenkins/ardana/ansible/templates/input-model-servers.yml
@@ -9,7 +9,7 @@
   servers:
 
     - id: ccn-0001
-      ip-addr:  {{ deployer_mgmt_ip }}
+      ip-addr:  {{ deployer_ardana_ip }}
       role: LITE-CONTROLLER-ROLE
       mac-addr: b2:72:8d:ac:7c:6f
       ilo-ip: 192.168.109.3
@@ -18,7 +18,7 @@
       nic-mapping: HEAT
 
     - id: cpn-0001
-      ip-addr:  {{ compute1_mgmt_ip }}
+      ip-addr:  {{ compute1_ardana_ip }}
       role: LITE-COMPUTE-ROLE
       mac-addr: d6:70:c1:36:43:f7
       ilo-ip: 192.168.109.4
@@ -27,7 +27,7 @@
       nic-mapping: HEAT
 
     - id: cpn-0002
-      ip-addr:  {{ compute2_mgmt_ip }}
+      ip-addr:  {{ compute2_ardana_ip }}
       role: LITE-COMPUTE-ROLE
       mac-addr: 8e:8e:62:a6:ce:76
       ilo-ip: 192.168.109.5

--- a/scripts/jenkins/ardana/heat-template.yaml
+++ b/scripts/jenkins/ardana/heat-template.yaml
@@ -43,27 +43,27 @@ resources:
       network_id: { get_resource: network_mgmt }
       cidr: "192.168.245.0/24"
       ip_version: 4
-      gateway_ip: 192.168.245.1
+      gateway_ip: null
   subnet_ardana:
     type: OS::Neutron::Subnet
     properties:
       network_id: { get_resource: network_ardana }
       cidr: "192.168.110.0/24"
       ip_version: 4
-      gateway_ip: null
+      gateway_ip: 192.168.110.1
 
   # router
-  router_mgmt:
+  router_ardana:
     type: OS::Neutron::Router
     properties:
       external_gateway_info:
         network: floating
 
-  router_mgmt_interface:
+  router_ardana_interface:
     type: OS::Neutron::RouterInterface
     properties:
-      router_id: { get_resource: router_mgmt }
-      subnet_id: { get_resource: subnet_mgmt }
+      router_id: { get_resource: router_ardana }
+      subnet_id: { get_resource: subnet_ardana }
 
   # floating IPs
   deployer-controller-floatingip:
@@ -79,8 +79,8 @@ resources:
       image: { get_param: image_id }
       flavor: { get_param: instance_type_controller }
       networks:
-        - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }
+        - network: { get_resource: network_mgmt }
 
   compute1:
     type: OS::Nova::Server
@@ -89,8 +89,8 @@ resources:
       image: { get_param: image_id }
       flavor: { get_param: instance_type_compute }
       networks:
-        - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }
+        - network: { get_resource: network_mgmt }
 
   compute2:
     type: OS::Nova::Server
@@ -99,15 +99,15 @@ resources:
       image: { get_param: image_id }
       flavor: { get_param: instance_type_compute }
       networks:
-        - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }
+        - network: { get_resource: network_mgmt }
 
 
   deployer-controller-floating-assignment:
     type: OS::Neutron::FloatingIPAssociation
     properties:
       floatingip_id: { get_resource: deployer-controller-floatingip }
-      port_id: {get_attr: [deployer-controller, addresses, { get_resource: network_mgmt }, 0, port]}
+      port_id: {get_attr: [deployer-controller, addresses, { get_resource: network_ardana }, 0, port]}
 
 outputs:
   # deployer-controller
@@ -142,6 +142,6 @@ outputs:
     value: { get_attr: [compute2, networks, { get_resource: network_mgmt }, 0]}
 
   # network info
-  network-mgmt-id:
-    description: Neutron Network ID of management network
-    value: { get_resource: network_mgmt }
+  network-ardana-id:
+    description: Neutron Network ID of ardana network
+    value: { get_resource: network_ardana }


### PR DESCRIPTION
To be more aligned with vagrant based setups, restructure the
networking config of the heat template and the used input model.

Co-Authored-By: Ralf Haferkamp <rhafer@suse.com>