### PR TITLE
ardana: Use "mgmt" for baremetal network

### DIFF
--- a/scripts/jenkins/ardana/ansible/templates/input-model-servers.yml
+++ b/scripts/jenkins/ardana/ansible/templates/input-model-servers.yml
@@ -3,7 +3,7 @@
     version: 2
 
   baremetal:
-    subnet: 192.168.110.0
+    subnet: 192.168.245.0
     netmask: 255.255.255.0
 
   servers:


### PR DESCRIPTION
As the IP of the baremetal network needs to stay the same during
deployment we need to switch to the "mgmt" network, which is using the
pre-allocated IP from neutron.