### PR TITLE
ardana: Skip neutron router/dns addresses in ardana nets

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
@@ -8,7 +8,7 @@
       tagged-vlan: false
       cidr: 192.168.110.0/24
       addresses:
-        - 192.168.110.10-192.168.110.200
+        - 192.168.110.5-192.168.110.200
       gateway-ip: 192.168.110.1
       network-group: ARDANA
 
@@ -16,6 +16,8 @@
       vlanid: 102
       tagged-vlan: false
       cidr: 192.168.245.0/24
+      addresses:
+        - 192.168.245.5-192.168.245.200
       gateway-ip: 192.168.245.1
       network-group: MANAGEMENT
 

--- a/scripts/jenkins/ardana/heat-template.yaml
+++ b/scripts/jenkins/ardana/heat-template.yaml
@@ -42,6 +42,9 @@ resources:
     properties:
       network_id: { get_resource: network_mgmt }
       cidr: "192.168.245.0/24"
+      allocation_pools:
+          - start: "192.168.245.2"
+            end: "192.168.245.100"
       ip_version: 4
       gateway_ip: 192.168.245.1
   subnet_ardana:
@@ -49,6 +52,9 @@ resources:
     properties:
       network_id: { get_resource: network_ardana }
       cidr: "192.168.110.0/24"
+      allocation_pools:
+          - start: "192.168.110.2"
+            end: "192.168.110.100"
       ip_version: 4
       gateway_ip: null
 


### PR DESCRIPTION
To avoid ardana allocating IPs that are already used by neutron.