### PR TITLE
syncSLErepos: Fix sync for the Cloud pool repos

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -218,12 +218,16 @@ for version in 6 7 8; do
         if [ -z "$sync_from_ibs" ]; then
             $rsync /mnt/dist/install/SLP/SLE-12-SP$servicepack-Cloud$version-GM/$arch/DVD1/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-official
         else
-            mount_and_rsync "/mnt/dist/ibs/SUSE:/SLE-12-SP$servicepack:/Update:/Products:/Cloud$version/images/iso/SUSE-OPENSTACK-CLOUD-$version-$arch-Build[0-9][0-9][0-9][0-9]-Media1.iso" $arch/SUSE-OpenStack-Cloud-$version-official
+            rsync_with_create ${ibs_source}/SUSE\:/SLE-12-SP$servicepack\:/Update\:/Products\:/Cloud$version/images/repo/SUSE-OPENSTACK-CLOUD-$version-POOL-$arch-Media1/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-official
         fi
 
-        mount_and_rsync "/mnt/dist/ibs/Devel\:/Cloud\:/$version/images/iso/SUSE-OPENSTACK-CLOUD-$version-$arch-Build[0-9][0-9][0-9][0-9]-Media1.iso" $arch/SUSE-OpenStack-Cloud-$version-devel
-        mount_and_rsync "/mnt/dist/ibs/Devel\:/Cloud\:/$version\:/Staging/images/iso/SUSE-OPENSTACK-CLOUD-$version-$arch-Build[0-9][0-9][0-9][0-9]-Media1.iso" $arch/SUSE-OpenStack-Cloud-$version-devel-staging
-
+        if [ -z "$sync_from_ibs" ]; then
+            rsync_with_create ${ibs_source}/Devel\:/Cloud\:/$version/images/repo/SUSE-OPENSTACK-CLOUD-$version-POOL-$arch-Media1/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-devel
+            rsync_with_create ${ibs_source}/Devel\:/Cloud\:/$version\:/Staging/images/repo/SUSE-OPENSTACK-CLOUD-$version-POOL-$arch-Media1/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-devel-staging
+        else
+            rsync_with_create ${ibs_source_nue}/Devel\:/Cloud\:/$version/images/repo/SUSE-OPENSTACK-CLOUD-$version-POOL-$arch-Media1/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-devel
+            rsync_with_create ${ibs_source_nue}/Devel\:/Cloud\:/$version\:/Staging/images/repo/SUSE-OPENSTACK-CLOUD-$version-POOL-$arch-Media1/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-devel-staging
+        fi
         rsync_with_create ${ibs_source}/SUSE/Products/OpenStack-Cloud/$version/$arch/product/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-Pool/
         rsync_with_create ${ibs_source}/SUSE/Updates/OpenStack-Cloud/$version/$arch/update/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-Updates/
         rsync_with_create $ibsmaint/OpenStack-Cloud\:/$version\:/$arch/update/ /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-$version-Updates-test/

--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -190,17 +190,6 @@ done
 # Cloud
 ##############
 
-function mount_and_rsync {
-    local from=$1
-    local to=$2
-    local oneiso=`ls $from | tail -1`
-    if [ -e "$oneiso" ] ; then
-        $M mount -o loop,ro "$oneiso" /mnt/cloud
-        [ $? == 0 ] && $rsync /mnt/cloud/ /srv/nfs/repos/$to/
-        $M umount /mnt/cloud
-    fi
-}
-
 for version in 6 7 8; do
     # fetch latest code from version in development (not just latest beta)
     sync_from_ibs=


### PR DESCRIPTION
rsyncing from /mnt/dist doesn't work for the provo mirror because
it doesn't have access to NFS. we need to use rsync. as the ibs-mirror
provo is constantly broken, we sync Cloud 8 from NUE directly