### PR TITLE
aradana: Move lifecycle-manager endpoint the Management network

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/input-model-network-groups.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-network-groups.yml
@@ -1,0 +1,70 @@
+#
+# (c) Copyright 2015,2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+  product:
+    version: 2
+
+  network-groups:
+    - name: ARDANA
+      hostname-suffix: ardana
+
+    - name: MANAGEMENT
+      hostname-suffix: mgmt
+      hostname: true
+
+      tags:
+        - neutron.networks.vxlan
+        - neutron.networks.vlan:
+            provider-physical-network: physnet1
+
+      tls-component-endpoints:
+        - barbican-api
+        - mysql
+        - rabbitmq
+      component-endpoints:
+        - default
+
+      routes:
+        - OCTAVIA-MGMT-NET
+        - default
+
+      load-balancers:
+        - provider: ip-cluster
+          name: lb
+          tls-components:
+            - default
+          components:
+            - vertica
+            - nova-metadata
+          roles:
+            - internal
+            - admin
+          cert-file: ardana-internal-cert
+
+        - provider: ip-cluster
+          name: extlb
+          external-name: myardana.test
+          tls-components:
+            - default
+          roles:
+            - public
+          cert-file: my-public-deployerincloud-cert
+
+
+    - name: EXTERNAL-VM
+      tags:
+        - neutron.l3_agent.external_network_bridge

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -89,6 +89,13 @@
     tags:
       - create-ardana-input-model
 
+  - name: Update network-groups in Model
+    copy:
+      src: input-model-network-groups.yml
+      dest: /var/lib/ardana//openstack/my_cloud/definition/data/network_groups.yml
+    tags:
+      - create-ardana-input-model
+
   - name: Update nic-mappings in Model
     copy:
       src: input-model-nic-mappings.yml


### PR DESCRIPTION
With commit c5858c0390c we switched the packager to serve repos in the
Management network. This change is reflected that also in the
network-groups attribute to have ardana create the IP Tables rules for
the packager/lifecycle-manager port (79 by default) for the correct IP
Address.

That also me that until we find a way to declare static IP allocations
in the input mode for all networks we're hosting everything in the
Management network.

Co-Authored-By: Thomas Bechtold <tbechtold@suse.com>