### PR TITLE
ardana: Remove glance-cache from volume groups

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/input-model-disks-controller.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-disks-controller.yml
@@ -1,0 +1,71 @@
+---
+  product:
+    version: 2
+
+  disk-models:
+  - name: DISK_SET_CONTROLLER
+    # two disk node; remainder of disk 1 and all of disk 2 combined in single VG
+    # VG is used to create three logical vols for /var, /var/log, and /var/crash
+    device-groups:
+      - name: swiftobj
+        devices:
+          - name: /dev/vdb
+          - name: /dev/vdc
+          - name: /dev/vdd
+        consumer:
+          name: swift
+          attrs:
+            rings:
+              - account
+              - container
+              - object-0
+      - name: cinder-volume
+        devices:
+          - name: /dev/vde
+        consumer:
+           name: cinder
+    volume-groups:
+    # The policy is not to consume 100% of the space of each volume group.
+    # 5% should be left free for snapshots and to allow for some flexibility.
+    # sda_root is a templated value to align with whatever partition is really used
+      - name: ardana-vg
+        physical-volumes:
+          - /dev/vda_root
+        logical-volumes:
+          - name: root
+            size: 35%
+            fstype: ext4
+            mount: /
+          - name: log
+            size: 30%
+            mount: /var/log
+            fstype: ext4
+            mkfs-opts: -O large_file
+          - name: crash
+            size: 10%
+            mount: /var/crash
+            fstype: ext4
+            mkfs-opts: -O large_file
+          - name: elasticsearch
+            size: 10%
+            mount: /var/lib/elasticsearch
+            fstype: ext4
+            mkfs-opts: -O large_file
+          - name: zookeeper
+            size: 5%
+            mount: /var/lib/zookeeper
+            fstype: ext4
+            mkfs-opts: -O large_file
+          # Glance cache: if a logical volume with consumer usage 'glance-cache'
+          # is defined Glance caching will be enabled. The logical volume can be
+          # part of an existing volume group or a dedicated volume group.
+          # - name: glance-cache
+          #   size: 5%
+          #   mount: /var/lib/glance/cache
+          #   fstype: ext4
+          #   mkfs-opts: -O large_file
+          #   consumer:
+          #      name: glance-api
+          #      usage: glance-cache
+        consumer:
+           name: os

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -110,11 +110,10 @@
     tags:
       - create-ardana-input-model
 
-  - name: Update disk mapping in Model
-    replace:
+  - name: Update controller disk mapping in Model
+    copy:
+      src: input-model-disks-controller.yml
       dest: /var/lib/ardana/openstack/my_cloud/definition/data/disks_controller.yml
-      regexp: '/dev/sd'
-      replace: '/dev/vd'
     tags:
       - create-ardana-input-model
 


### PR DESCRIPTION
We currently don't have VGs setup in the image (see also commit
38907cc96c94) so we need to remove the glance-cache VG. Otherwise the
deployment fails later when checking for a mountpoint for
/var/lib/glance/cache .
Also use a ansible file/ instead of replacing lines in the
disks_controller.yml file. This simplifies changes to the model.