### PR TITLE
Add new param for setting use_dhcp on ipmi proposal

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2234,6 +2234,9 @@ function custom_configuration
         ;;
         ipmi)
             if [[ $want_ipmi = 1 ]] ; then
+                if [[ $want_ipmi_dhcp = 1 ]] ; then
+                    proposal_set_value ipmi default "['attributes']['ipmi']['use_dhcp']" true
+                fi
                 proposal_set_value ipmi default "['attributes']['ipmi']['bmc_enable']" true
                 proposal_set_value ipmi default "['attributes']['ipmi']['debug']" true
                 proposal_set_value ipmi default "['attributes']['ipmi']['bmc_user']" "'$bmc_user'"


### PR DESCRIPTION
New parameter for enabling setting the attribute use_dhcp at the ipmi proposal.

to avoid crowbar changing to static BMC IP addresses.