### PR TITLE
Update QA scenarios to enable snapshot on cinder with NFS backend

### DIFF
--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1a.yaml
@@ -98,6 +98,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
@@ -104,6 +104,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
@@ -160,6 +160,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
@@ -114,6 +114,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
     - backend_driver: vmware
       backend_name: vmware
       vmware:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8a.yaml
@@ -111,6 +111,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
   deployment:
     elements:
       cinder-controller:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -120,6 +120,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -127,6 +127,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -175,6 +175,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -130,6 +130,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
     - backend_driver: vmware
       backend_name: vmware-backend
       vmware:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-8a.yaml
@@ -123,6 +123,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
     api:
       protocol: https
     ssl:

--- a/scripts/scenarios/cloud8/qa/ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl/qa-scenario-1a.yaml
@@ -120,6 +120,7 @@ proposals:
       backend_name: nfs
       nfs:
         nfs_shares: ##cinder-storage-shares##
+        nfs_snapshot: true
     api:
       protocol: https
     ssl:


### PR DESCRIPTION
Change [1] introduced a new parameter for the cinder barclamp which
enable snapshots on cinder when using NFS as backend.
This change adds this parameter to all QA scenarios which uses NFS
as backend for cinder.

[1] https://github.com/crowbar/crowbar-openstack/pull/1217