### PR TITLE
Remove renamed packages from ardana-trackupstream

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -31,7 +31,6 @@
             - ardana-extensions-nsx
             - ardana-freezer
             - ardana-glance
-            - ardana-glance-check
             - ardana-heat
             - ardana-horizon
             - ardana-input-model
@@ -56,7 +55,6 @@
             - ardana-service-ansible
             - ardana-spark
             - ardana-swift
-            - ardana-swiftlm
             - ardana-tempest
             - ardana-tls
             - ardana-ui-common


### PR DESCRIPTION
Packages renamed away from ardana-* prefix should not be handled
by trackupstream. e.g. python-glance-check now comes from pypi.