### PR TITLE
Stop downloading ansible from Leap 42.1

### DIFF
--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -52,6 +52,12 @@
       name: 'sshpass'
       state: present
 
+  - name: Remove Repo for sshpass
+    zypper_repository:
+      repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
+      name: sshpass
+      state: absent
+
   # NOTE: ansible's zypper extra_args are only supported in >= 2.4 and even if that version,
   # adding --replacefiles does not work
   # FIXME: Resolve the file conflicts in the ardana packages and use the zypper module

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -35,12 +35,6 @@
       repo: "http://{{ clouddata_server }}/repos/x86_64/SUSE-OpenStack-Cloud-8-devel-staging"
       name: DC8S-Media
 
-  # FIXME: needs to be removed. we want to use a newer ansible which we use already for monasca
-  - name: Repo for old ansible version
-    zypper_repository:
-      repo: "http://ftp5.gwdg.de/pub/opensuse/discontinued/distribution/leap/42.1/repo/oss/suse/"
-      name: ansible-FIXME
-
   - name: Repo for sshpass
     zypper_repository:
       repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
@@ -52,12 +46,6 @@
       repo: '*'
       auto_import_keys: yes
       runrefresh: yes
-
-  # FIXME: ardana has to work with ansible 2.x
-  - name: Install ansible 1.9.3
-    zypper:
-      name: 'ansible-1.9.3'
-      state: present
 
   - name: Install sshpass
     zypper:

--- a/scripts/jenkins/ardana/ardana-init.bash
+++ b/scripts/jenkins/ardana/ardana-init.bash
@@ -109,9 +109,9 @@ sudo mkdir -p "${ansible_package_dir}"
 sudo mkdir -p "${ansible_service_dir}"
 # Extract the Ansible venv from the venv tarball.
 if [ "${OS,,}" == "sles" ]; then
-   rpmqpack | grep -x ansible > /dev/null || {
-       sudo rpm -Uvh http://ftp5.gwdg.de/pub/opensuse/discontinued/distribution/leap/42.1/repo/oss/suse/noarch/ansible-1.9.3-1.1.noarch.rpm
-   }
+   rpmqpack | grep -x ansible1 > /dev/null || sudo zypper -n install ansible1
+   ansiblever=$(ansible --version | head  -n 1 | cut -d' ' -f2 )
+   echo "Using Ansible $ansiblever"
 else
    echo "Unsupported OS: $OS"
 fi


### PR DESCRIPTION
We're embedding the right ansible version in the media
directly now for full offline install.