### PR TITLE
ardana: Write deployer floating ip to /etc/motd

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -68,4 +68,4 @@
           cat ardana_net_vars.yml
 
           ansible-playbook -vvv -i hosts repositories.yml
-          ansible-playbook -vvv -i hosts init.yml
+          ansible-playbook -vvv -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" init.yml

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -10,6 +10,11 @@
     ARDANA_INIT_AUTO: 1
 
   tasks:
+  - name: Write deployer info to /etc/motd
+    become: yes
+    shell: |
+      echo "DEPLOYER_IP={{ deployer_floating_ip | default(None) }}" > /etc/motd
+
   - name: Grow 1st partition filesystem
     become: yes
     shell: |


### PR DESCRIPTION
When working in an environment it is not obvious which reachable IP
address the deployer has. Write that info to /etc/motd . Then it is
easily accessable when working in an env.