### PR TITLE
ardana: No need to use tee for logging

### DIFF
--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -187,7 +187,7 @@
 
   - name: Run the actual deployment site.yml playbook
     shell: |
-      ansible-playbook -vvv -i hosts/verb_hosts site.yml 2>&1 | tee site-playbook-run.log
+      ansible-playbook -vvv -i hosts/verb_hosts site.yml
     args:
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true


### PR DESCRIPTION
ansible is already logging to ~/.ansible/ansible.log. And the "| tee"
screws up the exit code of the "shell" command leading to false
positives.