### PR TITLE
mkcloud: use e2fsck instead fsck

### DIFF
--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -387,7 +387,7 @@ function libvirt_do_onhost_deploy_image()
             local part=$($sudo kpartx -asv $disk|perl -ne 'm/add map (\S+'"$last_part"') / && print $1')
             test -n "$part" || complain 31 "failed to find partition #$last_part"
             local bdev=/dev/mapper/$part
-            safely $sudo fsck -y -f $bdev
+            safely $sudo e2fsck -y -f $bdev
             safely $sudo resize2fs $bdev
             time $sudo udevadm settle
             sleep 1 # time for dev to become unused


### PR DESCRIPTION
This is to prevent fsck from incorrectly getting a different file system
type from fstab. This would happen when a file system in fstab is
mounted by label, with the same label in use by the fs to fsck but a
different type.

A different way around this would be to set the env FSTAB_FILE to the
empty string for fsck invocation. This more generic solution is not
necessary as resize2fs is used on the same fs, which like e2fsck only
works on the ext fs types.

Example log of the problem this fixes:
mkcloud# ./mkcloud.sh plain
...
resize2fs /dev/mapper/cloud-cloud.admin1 failed! (safelyret=1) Aborting.
...
mkcloud# grep xfs /etc/fstab
/dev/disk/by-label/ROOT / xfs defaults 1 1
mkcloud# fsck -V -y -f /dev/mapper/cloud-cloud.admin1
fsck from util-linux 2.29.2
[/sbin/fsck.xfs (1) -- /] fsck.xfs -y -f /dev/mapper/cloud-cloud.admin1
/sbin/fsck.xfs: XFS file system.