### PR TITLE
jenkins: force --serial tempest in SOC7

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -11,7 +11,7 @@
     version: 7
     previous_version: 6
     arch: x86_64
-    tempestoptions: --smoke
+    tempestoptions: --smoke --serial
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: postgresql
     jobs:
@@ -37,7 +37,7 @@
     arch: x86_64
     nodenumber: 4
     nodenumber_controller: 2
-    tempestoptions: --smoke
+    tempestoptions: --smoke --serial
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: ceph
     jobs:


### PR DESCRIPTION
Temporarily change the way tempest runs test cases
in SOC7 from parallel (default) to serial, to clear
the CI job failures while bsc#1074009 is being worked
on.

Several temporary solutions have been explored so far,
this is the one with the least impact.

More info here: http://bugzilla.suse.com/show_bug.cgi?id=1074009