### PR TITLE
trackupstream: Remove opsconsole-server from trackupstream

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -48,7 +48,6 @@
             - ardana-octavia
             - ardana-opsconsole
             - ardana-opsconsole-ui
-            - ardana-opsconsole-server
             - ardana-osconfig
             - ardana-qa-ansible
             - ardana-service


### PR DESCRIPTION
ardana-opsconsole-server has been renamed to
python-ardana-opsconsole-server and is now living on pypi.