### PR TITLE
qa_crowbarsetup: allow kernels in PTF repo

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1016,8 +1016,10 @@ EOF
 
     if [ -z "$NOINSTALLCLOUDPATTERN" ] ; then
         safely $zypper in -l -t pattern cloud_admin
+        $zypper al kernel-default # dup below breaks for kernel-default so skip it
         # make sure to use packages from PTF repo (needs zypper dup)
         $zypper mr -G -e cloud-ptf && safely $zypper dup --no-recommends --from cloud-ptf
+        $zypper rl kernel-default
     fi
 
     cd /tmp


### PR DESCRIPTION
for some reason zypper dup would complain:
Problem: problem with installed package kernel-default-3.12.74-60.64.40.1.x86_64
Solution 1: deinstallation of kernel-default-3.12.74-60.64.40.1.x86_64
Solution 2: keep obsolete kernel-default-3.12.74-60.64.40.1.x86_64

and not consider installing both old and new kernels in parallel.

Newer zypper versions have a --force-resolution switch that might help
but on SOC6/SLE-12-SP1 it is unavailable