### PR TITLE
Remove Leap 42.2

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -16,7 +16,6 @@
           values:
             - SLE_12_SP2
             - SLE_12_SP3
-            - openSUSE-Leap-42.2
             - openSUSE-Leap-42.3
       - axis:
           type: user-defined
@@ -35,7 +34,7 @@
       combination-filter: |
         (
         slave=="cloud-cleanvm" && (
-           ( openstack_project=="Newton" && (image=="SLE_12_SP2" || image=="openSUSE-Leap-42.2" ))
+           ( openstack_project=="Newton" && (image=="SLE_12_SP2" ))
         || ( openstack_project=="Ocata" && (image=="SLE_12_SP3" || image=="openSUSE-Leap-42.3"))
         || ( openstack_project=="Pike" && (image=="SLE_12_SP3" || image=="openSUSE-Leap-42.3"))
         || ( openstack_project=="Master" && (image=="openSUSE-Leap-42.3" || image=="SLE_12_SP3"))

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -28,7 +28,6 @@
           values:
             - SLE_12_SP2
             - SLE_12_SP3
-            - openSUSE_Leap_42.2
             - openSUSE_Leap_42.3
       - axis:
           type: slave
@@ -37,9 +36,9 @@
             - cloud-trackupstream
     execution-strategy:
       combination-filter: |
-       !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP2", "openSUSE_Leap_42.2"].contains(repository) ||
+       !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP2"].contains(repository) ||
          ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3"].contains(repository) ||
-         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["SLE_12_SP2", "openSUSE_Leap_42.2"].contains(repository)
+         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["SLE_12_SP2"].contains(repository)
        )
       sequential: true
     builders:


### PR DESCRIPTION
It is  EOL:
https://news.opensuse.org/2018/01/22/opensuse-42-2-to-reach-end-of-life-this-week/