### PR TITLE
ardana: Create additional network in heat template

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
@@ -23,4 +23,5 @@
 
     - name: EXTERNAL-VM-NET
       vlanid: 103
+      tagged-vlan: false
       network-group: EXTERNAL-VM

--- a/scripts/jenkins/ardana/ansible/files/input-model-nic-mappings.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-nic-mappings.yml
@@ -15,7 +15,7 @@
 
         - logical-name: hed3
           type: simple-port
-          bus-address: "0000:00:08.0"
+          bus-address: "0000:00:05.0"
 
         - logical-name: hed4
           type: simple-port

--- a/scripts/jenkins/ardana/heat-ardana-deployerincloud-lite.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-deployerincloud-lite.yaml
@@ -35,6 +35,10 @@ resources:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: False
+  network_external:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
 
   # subnet
   subnet_mgmt:
@@ -57,6 +61,16 @@ resources:
             end: "192.168.110.100"
       ip_version: 4
       gateway_ip: null
+  subnet_external:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_external }
+      allocation_pools:
+          - start: "172.31.0.2"
+            end: "172.31.255.154"
+      cidr: "172.31.0.0/16"
+      enable_dhcp: False
+      gateway_ip: 172.31.0.1
 
   # router
   router_mgmt:
@@ -70,6 +84,12 @@ resources:
     properties:
       router_id: { get_resource: router_mgmt }
       subnet_id: { get_resource: subnet_mgmt }
+
+  router_external_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router_mgmt }
+      subnet_id: { get_resource: subnet_external }
 
   # floating IPs
   deployer-controller-floatingip:
@@ -87,6 +107,7 @@ resources:
       networks:
         - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }
+        - network: { get_resource: network_external }
 
   compute1:
     type: OS::Nova::Server
@@ -97,6 +118,7 @@ resources:
       networks:
         - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }
+        - network: { get_resource: network_external }
 
   compute2:
     type: OS::Nova::Server
@@ -107,6 +129,7 @@ resources:
       networks:
         - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }
+        - network: { get_resource: network_external }
 
   # disks
   controller_vdb:


### PR DESCRIPTION
This network is needed for the "ext_net" (external network for neutron)
in the deployerincloud input models. This commit also adjusts the
nic_mapping accordingly.

This is should get us past the remaining tempest failure.