### PR TITLE
ardana: Add tempest_run_filter parameter

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -50,6 +50,15 @@
           description: >-
             This is used as input repository (from provo-clouddata) for testing
 
+      - string:
+          name: tempest_run_filter
+          default: smoke
+          description: >-
+            Name of the filter file to use for tempest. Possible values:
+            ci, compute, designate, lbaas, network, neutron-api, periodic,
+            periodic-virtual, refstack, smoke, swift, tests2skip, tests-ci,
+            upgrade-ci or upgrade
+
     builders:
       - shell: |
           set -ex
@@ -94,4 +103,7 @@
           cat ardana_net_vars.yml
 
           ansible-playbook -vvv -i hosts -e "cloudsource=${cloudsource}" repositories.yml
-          ansible-playbook -vvv -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" -e "deployer_model=${model}" init.yml
+          ansible-playbook -vvv -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" \
+                                         -e "deployer_model=${model}" \
+                                         -e "tempest_run_filter=${tempest_run_filter}" \
+                                         init.yml

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -8,6 +8,7 @@
 
   vars:
     deployer_model: deployerincloud-lite
+    tempest_run_filter: smoke
 
   environment:
     ARDANA_INIT_AUTO: 1
@@ -215,7 +216,8 @@
 
   - name: Run tempest
     shell: |
-      ansible-playbook -vvv -i hosts/verb_hosts tempest-run.yml
+      ansible-playbook -vvv -i hosts/verb_hosts tempest-run.yml \
+                       -e run_filter="{{ tempest_run_filter }}"
     args:
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true


### PR DESCRIPTION
The new parameter allows to specify the name of a filter file to be
passed to the tempest-run playbook. Then name must match on of the
existing filter file in tempest-ansible/roles/tempest/files/run_filters/
minus the .txt.j2 extension.