### PR TITLE
Allow ICMP in input model

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/input-model-firewall-rules.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-firewall-rules.yml
@@ -1,0 +1,25 @@
+---
+  product:
+    version: 2
+
+  firewall-rules:
+
+    - name: PING
+      network-groups:
+      - MANAGEMENT
+      rules:
+      - type: allow
+        remote-ip-prefix:  0.0.0.0/0
+        port-range-min: 8
+        port-range-max: 0
+        protocol: icmp
+
+    - name: NETCAT
+      network-groups:
+      - MANAGEMENT
+      rules:
+      - type: allow
+        remote-ip-prefix:  0.0.0.0/0
+        port-range-min: 11382
+        port-range-max: 11382
+        protocol: tcp

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -151,6 +151,11 @@
     tags:
       - create-ardana-input-model
 
+  - name: Allow ICMP in Model
+    copy:
+      src: input-model-firewall-rules.yml
+      dest: /var/lib/ardana/openstack/my_cloud/definition/data/firewall_rules.yml
+
   - name: Add my_cloud config to git
     shell: |
       git add -A


### PR DESCRIPTION
By default, ICMP is blocked, which is silly for a development
environment. Configure the firewall rules to allow ICMP.

This input model definition is copied from the deployerincloud-lite
example model with the ICMP rules uncommented.