### PR TITLE
ardana: Add job_name to heat stack name

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -62,7 +62,10 @@
     builders:
       - shell: |
           set -ex
-          STACK_NAME=cloud-ci-ardana-job-$BUILD_NUMBER
+          STACK_NAME=cloud-ci-ardana-job-${BUILD_NUMBER}
+          if [ -n "${JOB_NAME}" ]; then
+              STACK_NAME=${STACK_NAME}-${JOB_NAME}
+          fi
           export ANSIBLE_HOST_KEY_CHECKING=False
           export ANSIBLE_KEEP_REMOTE_FILES=1
           # the name for the cloud defined in ~./config/openstack/clouds.yaml


### PR DESCRIPTION
That way, it is easier to find out the owner of a stack (assuming
people set the job_name variable to their own username).