### PR TITLE
qa_crowbarsetup.sh: fix proxy exclusion for internal network

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2734,8 +2734,8 @@ function set_noproxyvar
 {
     [[ $http_proxy ]] || [[ $https_proxy ]] || return 0
     [[ $no_proxy =~ "localhost" ]] || no_proxy="127.0.0.1,localhost,$no_proxy"
-    [[ $admin_ip ]] || return 0
-    [[ $no_proxy =~ "$adminip" ]] || no_proxy="$adminip,$no_proxy"
+    [[ ! $adminip ]] || [[ $no_proxy =~ "$adminip" ]] || no_proxy="$adminip,$no_proxy"
+    [[ ! $cloudfqdn ]] || [[ $no_proxy =~ "$cloudfqdn" ]] || no_proxy="$cloudfqdn,$no_proxy"
     export no_proxy="${no_proxy%,}";
     if [[ ! $net_public ]] || [[ $no_proxy =~ $net_public ]] ; then
         return 0 # only apply this once


### PR DESCRIPTION
The no_proxy environment variable did not work for a curl connection to
the dashboard.

Fix a variable name typo.

Add the domain for nodes as only the URL is inspected before resolving
the host part.