### PR TITLE
Drop Cloud 8 testing ISO

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -860,7 +860,6 @@ function onadmin_set_source_variables
             CLOUDISOPATH=/ibs/Devel:/Cloud:/8/images/iso
             [ -n "$TESTHEAD" ] && CLOUDISOPATH=/ibs/Devel:/Cloud:/8:/Staging/images/iso
             CLOUDISONAME="SUSE-OPENSTACK-CLOUD-8-${arch}-Media1.iso"
-            CLOUDTESTISONAME="CLOUD-8-TESTING-${arch}-Media1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-8-devel"
         ;;
         ocatacloud8)
@@ -873,7 +872,6 @@ function onadmin_set_source_variables
         susecloud8)
             CLOUDISOPATH=/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Cloud8/images/iso/
             CLOUDISONAME="SUSE-OPENSTACK-CLOUD-8-${arch}*Media1.iso"
-            CLOUDTESTISONAME="CLOUD-8-TESTING-${arch}*Media1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-8-official"
         ;;
         GM6|GM6+up)
@@ -894,7 +892,6 @@ function onadmin_set_source_variables
             cs=${cloudsource/#M/Milestone}
             CLOUDISOPATH=${want_cloud8_iso_path:="/install/SLE-12-SP3-Cloud8-$cs/"}
             CLOUDISONAME=${want_cloud8_iso:="SUSE-OPENSTACK-CLOUD-8-${arch}*1.iso"}
-            CLOUDTESTISONAME="CLOUD-8-TESTING-$arch*1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-8-official"
         ;;
         *)


### PR DESCRIPTION
The Cloud 8 testing ISO is not fully resolvable anymore and the only
part this is used is for the CCT nova and manila functional test. Based
on the feedback from QE we don't really care about this tests.