### PR TITLE
jjb: Mediacheck fix pattern matching in case if 3rd optional param

### DIFF
--- a/jenkins/ci.suse.de/cloud-mediacheck.yaml
+++ b/jenkins/ci.suse.de/cloud-mediacheck.yaml
@@ -128,7 +128,7 @@
 
           if [ -n "$stage" ]; then
               if [ "${OBS_PROJECT##*\/}" != "${OBS_PROJECT}" ]; then
-                  OBS_PROJECT=${OBS_PROJECT%%\/*}$stage/${OBS_PROJECT##*\/}
+                  OBS_PROJECT=${OBS_PROJECT%%\/*}$stage/${OBS_PROJECT#*\/}
               else
                   OBS_PROJECT=${OBS_PROJECT%%\/*}$stage
               fi


### PR DESCRIPTION
In case we provide a media flavor then the pattern matching would cut
the OBS_TARGET.