### PR TITLE
github_pr: add console logging for automation, cct, crowbar PRs

### DIFF
--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -59,6 +59,7 @@ template:
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 *mkcloud_automation_parameters
+          - type: LogPullRequestDetails
     suse_cct: &suse_cct
       - type: Status
         config:
@@ -81,6 +82,7 @@ template:
               job_parameters:
                 standard:
                   *mkcloud_automation_standard
+          - type: LogPullRequestDetails
 pr_processing:
   - config:
       organization: SUSE-Cloud

--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -34,6 +34,7 @@ template:
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 standard: {}
+          - type: LogPullRequestDetails
     sap-oc_crowbar: &sap-oc_crowbar
       - type: MergeBranch
         config:
@@ -59,6 +60,7 @@ template:
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 standard: {}
+          - type: LogPullRequestDetails
 pr_processing:
   - config:
       organization: crowbar


### PR DESCRIPTION
With this logging output to stdout we can now see which jobs were triggered within a run of github_pr.
This is useful when running it regularly within a CI.