### PR TITLE
soc-ci: make SSL verification configurable

### DIFF
--- a/hostscripts/soc-ci/README.soc-ci.md
+++ b/hostscripts/soc-ci/README.soc-ci.md
@@ -102,3 +102,6 @@ config:
 
 * ```artifacts_dir```
 The directory path where to store the Jenkins artifacts.
+
+* ```ssl_verify```
+Turn verification of SSL certificates on or off.

--- a/hostscripts/soc-ci/soc-ci
+++ b/hostscripts/soc-ci/soc-ci
@@ -73,6 +73,8 @@ def _config_get():
     if not conf.has_option(CONFIG_SECTION, "artifacts_dir"):
         conf.set(CONFIG_SECTION, "artifacts_dir",
                  os.path.expanduser('~/.soc-ci/artifacts/'))
+    if not conf.has_option(CONFIG_SECTION, "ssl_verify"):
+        conf.set(CONFIG_SECTION, "ssl_verify", "True")
 
     # create things where needed
     if not os.path.exists(conf.get(CONFIG_SECTION, "artifacts_dir")):
@@ -86,7 +88,8 @@ def _get_jenkins_job(conf=None):
         conf = _config_get()
     server = Jenkins(conf.get(CONFIG_SECTION, 'url'),
                      username=conf.get(CONFIG_SECTION, 'user'),
-                     password=conf.get(CONFIG_SECTION, 'password'))
+                     password=conf.get(CONFIG_SECTION, 'password'),
+                     ssl_verify=conf.getboolean(CONFIG_SECTION, 'ssl_verify'))
     return server['openstack-mkcloud']
 
 


### PR DESCRIPTION
SSL verification should be configurable to deal with the cases where the
certificate is invalid (because out of date), or to deal with the
possibility that the host system does not trust the signing CA.