### PR TITLE
NFS mount Cloud and SLES repos

### DIFF
--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -62,11 +62,29 @@
       - "{{ compute_mgmt_ips }}"
     when: item != "" and item != deployer_mgmt_ip
 
-  # FIXME: This is ugly and we do not need all the repos from the deployer on the compute nodes
+  # Ardana creates directory /opt/ardana_packager and serves content from it
+  # (with symlinks followed). Ensure it can serve required SLES and Cloud media.
+  - name: Link maintenance repos to PACKAGE_CONSTANTS.REPO_DIR
+    file:
+      state: link
+      path: /opt/ardana_packager/ardana/sles12/zypper/suse
+      src: /srv/www/suse-12.3/x86_64/repos
+
+  # FIXME(colleen): This can go away when https://gerrit.suse.provo.cloud/3061 merges
   - name: Copy zypper repo setup from deployer to other nodes
     shell: |
-      scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  /etc/zypp/repos.d/* root@{{ item }}:/etc/zypp/repos.d/
+      scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  /etc/zypp/repos.d/*-http.repo root@{{ item }}:/etc/zypp/repos.d/
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  root@{{ item }} zypper -n --gpg-auto-import-keys ref
+    with_items:
+      - "{{ controller_mgmt_ips|default([]) }}"
+      - "{{ compute_mgmt_ips }}"
+    when: item != "" and item != deployer_mgmt_ip
+
+  # osconfig-ansible should take care of installing the repositories itself,
+  # it's just that it won't auto accept the Devel key, so do that now
+  - name: Import Devel:Cloud:8 key
+    shell: |
+      cat /srv/www/suse-12.3/x86_64/repos/Cloud/repodata/repomd.xml.key | ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@{{ item }} "cat >/tmp/cloud.key && rpm --import /tmp/cloud.key && rm /tmp/cloud.key"
     with_items:
       - "{{ controller_mgmt_ips|default([]) }}"
       - "{{ compute_mgmt_ips }}"

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -14,21 +14,69 @@
 
   tasks:
   # SLES repos
+  # FIXME(colleen): This can go away once https://gerrit.suse.provo.cloud/3061 merges
   - name: Add SLES12SP3-Pool zypper repo
     zypper_repository:
       repo: "{{ repos_url }}/SLES12-SP3-Pool"
-      name: SLES12SP3-Pool
+      name: SLES12SP3-Pool-http
 
+  # FIXME(colleen): This can go away once https://gerrit.suse.provo.cloud/3061 merges
   - name: Add SLES12SP3-Updates zypper repo
     zypper_repository:
       repo: "{{ repos_url }}/SLES12-SP3-Updates"
-      name: SLES12SP3-Updates
+      name: SLES12SP3-Updates-http
 
+  # FIXME(colleen): This can go away once https://gerrit.suse.provo.cloud/3061 merges
   # Devel:Cloud:8
   - name: "Add {{ cloudsource }} media"
     zypper_repository:
       repo: "{{ cloudsource_url }}"
-      name: DC8S-Media
+      name: DC8S-Media-http
+
+  - name: Create srv directories
+    file:
+      state: directory
+      path: /srv/www/suse-12.3/x86_64/repos/{{ item }}
+      mode: 0755
+    with_items:
+      - Cloud
+      - SLES12-SP3-Pool
+      - SLES12-SP3-Updates
+      - SUSE-OpenStack-Cloud-8-Pool
+      - SUSE-OpenStack-Cloud-8-Updates
+
+  - name: Mount zypper repos
+    mount:
+      state: mounted
+      fstype: nfs
+      opts: ro,nosuid,rsize=8192,wsize=8192,hard,intr,nolock
+      name: /srv/www/suse-12.3/x86_64/repos/{{ item.name }}
+      src: "{{ clouddata_server }}:/srv/nfs/repos/x86_64/{{ item.src }}"
+    with_items:
+      # Use a consistent name for the Cloud media install repo so that we
+      # don't have to account for development versus production repos in the
+      # playbooks
+      - name: Cloud
+        src: "{{ cloudsource }}"
+      - name: SLES12-SP3-Pool
+        src: SLES12-SP3-Pool
+      - name: SLES12-SP3-Updates
+        src:  SLES12-SP3-Updates
+      - name: SUSE-OpenStack-Cloud-8-Pool
+        src: SUSE-OpenStack-Cloud-8-Pool
+      - name: SUSE-OpenStack-Cloud-8-Updates
+        src: SUSE-OpenStack-Cloud-8-Updates
+
+  - name: Add zypper repos
+    zypper_repository:
+      repo: "/srv/www/suse-12.3/x86_64/repos/{{ item }}"
+      name: "{{ item }}"
+    with_items:
+      - Cloud
+      - SLES12-SP3-Pool
+      - SLES12-SP3-Updates
+      - SUSE-OpenStack-Cloud-8-Pool
+      - SUSE-OpenStack-Cloud-8-Updates
 
   - name: Repo for sshpass
     zypper_repository:


### PR DESCRIPTION
In preparation for being able to serve them to managed nodes, NFS mount
the SLES and Cloud repositories from the mirror instead of configuring
them with HTTP. Since Ardana already serves repositories from
/opt/ardana_packager, symlink the mounts there after ardana-init sets it
up. We also need to ensure the nodes trust the Devel:Cloud:8 so that we
don't have to use disable_gpg_check in the ansible playbooks.

With mkcloud/crowbar, we mounted these repositories in /srv/tftpboot.
With Ardana, we must choose a different directory since the
deployerincloud* models install the dnsmasq package (for neutron) on the
deployer node, which forces /srv/tftpboot to be globally unreadable and
unsearchable.

For now, we still need to keep the HTTP-based repositories installed.
Once changes in osconfig-ansible[1] are merged, Ardana will be capable
of consuming these required repositories from the deployer node.

[1] https://gerrit.suse.provo.cloud/3061