### PR TITLE
Switch to std-min model by default

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -34,7 +34,7 @@
 
       - string:
           name: model
-          default: deployerincloud-lite
+          default: std-min
           description: >-
             The Input Model to use
 


### PR DESCRIPTION
The std-min model exposes more issues in testing and is also
what Gozer CI currently is testing, so we should default
to that one.