### PR TITLE
Fix QA scenario 2c

### DIFF
--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2c.yaml
@@ -1,5 +1,5 @@
 ---
-# 2c - 7 nodes: HA 1 x 2 SBD, KVM x 2, ESXi x 2
+# 2c - 7 nodes: HA x 3 SBD, KVM x 3, SES x 1
 proposals:
 - barclamp: pacemaker
   name: services
@@ -10,34 +10,33 @@ proposals:
         nodes:
           @@controller1@@:
             devices:
-            - "/dev/sda"
+            - "@@sbd_device_services@@"
           @@controller2@@:
             devices:
-            - "/dev/sda"
+            - "@@sbd_device_services@@"
+          @@controller3@@:
+            devices:
+            - "@@sbd_device_services@@"
       per_node:
         nodes:
           @@controller1@@:
             params: ''
           @@controller2@@:
             params: ''
-    drbd:
-      enabled: true
+          @@controller3@@:
+            params: ''
   deployment:
     elements:
       pacemaker-cluster-member:
       - @@controller1@@
       - @@controller2@@
+      - @@controller3@@
       hawk-server:
       - @@controller1@@
       - @@controller2@@
+      - @@controller3@@
 
 - barclamp: database
-  attributes:
-    ha:
-      storage:
-        mode: drbd
-        drbd:
-          size: 5
   deployment:
     elements:
       database-server:
@@ -47,11 +46,6 @@ proposals:
   attributes:
     trove:
       enabled: true
-    ha:
-      storage:
-        mode: drbd
-        drbd:
-          size: 5
   deployment:
     elements:
       rabbitmq-server:
@@ -63,25 +57,6 @@ proposals:
     elements:
       keystone-server:
       - cluster:services
-
-- barclamp: ceph
-  attributes:
-    disk_mode: first
-  deployment:
-    elements:
-      ceph-calamari: []
-      ceph-mon:
-      - @@ceph1@@
-      - @@ceph2@@
-      - @@ceph3@@
-      ceph-osd:
-      - @@ceph1@@
-      - @@ceph2@@
-      - @@ceph3@@
-      ceph-radosgw:
-      - @@ceph1@@
-      ceph-mds:
-      - @@compute2@@
 
 - barclamp: glance
   attributes:
@@ -97,19 +72,19 @@ proposals:
     - backend_driver: rbd
       backend_name: rbd
       rbd:
-        use_crowbar: true
+        use_crowbar: false
         config_file: "/etc/ceph/ceph.conf"
         admin_keyring: "/etc/ceph/ceph.client.admin.keyring"
         pool: volumes
         user: cinder
         secret_uuid: ''
+        flatten_volume_from_snapshot: false
   deployment:
     elements:
       cinder-controller:
       - cluster:services
       cinder-volume:
-      - @@controller1@@
-      - @@controller2@@
+      - cluster:services
 
 - barclamp: neutron
   attributes:
@@ -147,6 +122,7 @@ proposals:
       nova-compute-kvm:
       - @@compute1@@
       - @@compute2@@
+      - @@compute3@@
       nova-compute-qemu: []
       nova-compute-xen: []
 
@@ -168,6 +144,7 @@ proposals:
       ceilometer-agent:
       - @@compute1@@
       - @@compute2@@
+      - @@compute3@@
       ceilometer-agent-hyperv: []
       ceilometer-central:
       - cluster:services
@@ -182,7 +159,7 @@ proposals:
     - backend_driver: cephfs
       backend_name: cephfs-backend
       cephfs:
-        use_crowbar: true
+        use_crowbar: false
         cephfs_conf_path: "/etc/ceph/ceph.conf"
         cephfs_auth_id: manila
         cephfs_cluster_name: ceph
@@ -191,8 +168,7 @@ proposals:
       manila-server:
       - cluster:services
       manila-share:
-      - @@controller1@@
-      - @@controller2@@
+      - cluster:services
 
 - barclamp: trove
   deployment:
@@ -203,12 +179,10 @@ proposals:
 - barclamp: tempest
   attributes:
     manila:
-      run_consistency_group_tests: false
       run_snapshot_tests: false
       enable_protocols: cephfs
       enable_ip_rules_for_protocols: ""
       enable_cert_rules_for_protocols: ""
-      storage_protocol: CEPHFS
   deployment:
     elements:
       tempest:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -1,5 +1,5 @@
 ---
-# 2c - 7 nodes: HA 1 x 2 SBD, KVM x 2, ESXi x 2
+# 2c - 7 nodes: HA x 3 SBD, KVM x 3, SES x 1
 proposals:
 - barclamp: pacemaker
   name: services
@@ -10,34 +10,34 @@ proposals:
         nodes:
           @@controller1@@:
             devices:
-            - "/dev/sda"
+            - "@@sbd_device_services@@"
           @@controller2@@:
             devices:
-            - "/dev/sda"
+            - "@@sbd_device_services@@"
+          @@controller3@@:
+            devices:
+            - @@sbd_device_services@@
       per_node:
         nodes:
           @@controller1@@:
             params: ''
           @@controller2@@:
             params: ''
-    drbd:
-      enabled: true
+          @@controller3@@:
+            params: ''
   deployment:
     elements:
       pacemaker-cluster-member:
       - @@controller1@@
       - @@controller2@@
+      - @@controller3@@
       hawk-server:
       - @@controller1@@
       - @@controller2@@
+      - @@controller3@@
 
 - barclamp: database
   attributes:
-    ha:
-      storage:
-        mode: drbd
-        drbd:
-          size: 5
   deployment:
     elements:
       database-server:
@@ -47,11 +47,6 @@ proposals:
   attributes:
     trove:
       enabled: true
-    ha:
-      storage:
-        mode: drbd
-        drbd:
-          size: 5
   deployment:
     elements:
       rabbitmq-server:
@@ -63,39 +58,11 @@ proposals:
       generate_certs: true
       insecure: true
     api:
-      # FIXME: disabled due to issues in trove (https://bugs.launchpad.net/trove/+bug/1535895) and radosgw (https://bugzilla.suse.com/show_bug.cgi?id=962672)
-      #protocol: https
+      protocol: https
   deployment:
     elements:
       keystone-server:
       - cluster:services
-
-- barclamp: ceph
-  attributes:
-    disk_mode: first
-    radosgw:
-      ssl:
-        enabled: true
-        generate_certs: true
-        insecure: true
-    calamari:
-      ssl:
-        enabled: true
-  deployment:
-    elements:
-      ceph-calamari: []
-      ceph-mon:
-      - @@ceph1@@
-      - @@ceph2@@
-      - @@ceph3@@
-      ceph-osd:
-      - @@ceph1@@
-      - @@ceph2@@
-      - @@ceph3@@
-      ceph-radosgw:
-      - @@ceph1@@
-      ceph-mds:
-      - @@compute2@@
 
 - barclamp: glance
   attributes:
@@ -116,12 +83,13 @@ proposals:
     - backend_driver: rbd
       backend_name: rbd
       rbd:
-        use_crowbar: true
+        use_crowbar: false
         config_file: "/etc/ceph/ceph.conf"
         admin_keyring: "/etc/ceph/ceph.client.admin.keyring"
         pool: volumes
         user: cinder
         secret_uuid: ''
+        flatten_volume_from_snapshot: false
     api:
       protocol: https
     ssl:
@@ -132,8 +100,7 @@ proposals:
       cinder-controller:
       - cluster:services
       cinder-volume:
-      - @@controller1@@
-      - @@controller2@@
+      - cluster:services
 
 - barclamp: neutron
   attributes:
@@ -159,14 +126,12 @@ proposals:
     kvm:
       ksm_enabled: true
     ssl:
-      # FIXME: disabled due to issues in trove (https://bugs.launchpad.net/trove/+bug/1535895) and radosgw (https://bugzilla.suse.com/show_bug.cgi?id=962672)
-      #enabled: true
+      enabled: true
       generate_certs: true
       insecure: true
     novnc:
       ssl:
-        # FIXME: see comment above
-        #enabled: true
+        enabled: true
     metadata:
       vendordata:
         json: '{"custom-key": "custom-value"}'
@@ -180,6 +145,7 @@ proposals:
       nova-compute-kvm:
       - @@compute1@@
       - @@compute2@@
+      - @@compute3@@
       nova-compute-qemu: []
       nova-compute-xen: []
 
@@ -207,6 +173,7 @@ proposals:
       ceilometer-agent:
       - @@compute1@@
       - @@compute2@@
+      - @@compute3@@
       ceilometer-agent-hyperv: []
       ceilometer-central:
       - cluster:services
@@ -221,7 +188,7 @@ proposals:
     - backend_driver: cephfs
       backend_name: cephfs-backend
       cephfs:
-        use_crowbar: true
+        use_crowbar: false
         cephfs_conf_path: "/etc/ceph/ceph.conf"
         cephfs_auth_id: manila
         cephfs_cluster_name: ceph
@@ -230,8 +197,7 @@ proposals:
       manila-server:
       - cluster:services
       manila-share:
-      - @@controller1@@
-      - @@controller2@@
+      - cluster:services
 
 - barclamp: trove
   deployment:
@@ -242,12 +208,10 @@ proposals:
 - barclamp: tempest
   attributes:
     manila:
-      run_consistency_group_tests: false
       run_snapshot_tests: false
       enable_protocols: cephfs
       enable_ip_rules_for_protocols: ""
       enable_cert_rules_for_protocols: ""
-      storage_protocol: CEPHFS
   deployment:
     elements:
       tempest:


### PR DESCRIPTION
Ceph deployment through crowbar is not supported in SOC8. This
change removes the Ceph barclamp and update the scenario to support
consuming an external SES deployment.