### PR TITLE
Track upstream opscon server

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -48,6 +48,7 @@
             - ardana-nova
             - ardana-octavia
             - ardana-opsconsole
+            - ardana-opsconsole-server
             - ardana-opsconsole-ui
             - ardana-osconfig
             - ardana-qa-ansible


### PR DESCRIPTION
Add tracking for ardana-opsconsole-server (recently changed to obscpio generated rather than static tarball: https://build.suse.de/request/show/154848) 