### PR TITLE
SCRD-2756 post-deployment sanity checks

### DIFF
--- a/docs/ardana/rpm-file-checks.md
+++ b/docs/ardana/rpm-file-checks.md
@@ -1,0 +1,59 @@
+# rpm file checks
+
+[`ardana-job`](testing.md) performs some automated checks to ensure
+that Ardana doesn't mess with the filesystem inappropriately by
+removing or modifying rpm-owned files, or adding files into /usr.
+This is done by running `rpm -Va` and `rpm -qf` before and after
+Ardana deployment (including a tempest run, if deployment succeeded),
+and comparing the results.  If any tampering is discovered, `init.yml`
+will fail with a helpful error.
+
+[Whitelists](../../scripts/jenkins/ardana/ansible/files/) are used to
+ignore known exceptions, some of which need to be fixed in the future.
+
+## Testing changes to the checks
+
+[The `test-post-deployment-checks.yml`
+playbook](../../scripts/jenkins/ardana/ansible/test-post-deployment-checks.yml)
+is also provided for rapid repeated testing of the post-deployment
+checks, without having to deploy an entire fresh cloud each time:
+
+-   Choose [a previous run of
+    `ardana-job`](https://ci.suse.de/job/ardana-job/) to reuse for
+    testing the changes.
+
+-   Locate the `DEPLOYER_IP` from the job log.
+
+-   `ssh` to the deployer via that IP, and find the name of the
+    temporary directory used by these checks to store state.  It will
+    be named something like
+    `/tmp/ardana-job-rpm-verification.Si3yBCUe/`, but obviously with a
+    different suffix.
+
+-   `ssh` to the Jenkins worker used to run the job.  It will probably
+    be [`cloud-swarm-ardana-ci`](https://ci.suse.de/computer/cloud-swarm-ardana-ci/).
+
+-   `su` to the `jenkins` user.
+
+-   `cd` to the subdirectory for the `ardana-job` run you want to
+    reuse.
+
+-   `cd automation-git`
+
+-   Ensure this checkout of the repo has the changes you want to test.
+    For example you could push your changes from your development
+    machine to github, and then do:
+
+        git fetch myremote
+        git reset --hard myremote/mybranch
+
+-   `cd scripts/jenkins/ardana/ansible/`
+
+-   Run the following command, replacing the temporary directory with
+    the one you identified above:
+
+        ansible-playbook \
+            -i hosts \
+            test-post-deployment-checks.yml \
+            -e verification_temp_dir=/tmp/ardana-job-rpm-verification.Si3yBCUe
+

--- a/docs/ardana/testing.md
+++ b/docs/ardana/testing.md
@@ -27,12 +27,23 @@ To be able to use the Jenkins job and login to a deployed env, you need:
 
 ## Create a new environment
 
-Start the deployment via [Build with parameters](https://ci.nue.suse.com/job/ardana-job/build). The available parameters should be self-descriptive. Here are some best practices:
+Start the deployment via [Build with
+parameters](https://ci.nue.suse.com/job/ardana-job/build). The
+available parameters should be self-descriptive. Here are some best
+practices:
 
-* use your Rocket/irc nickname as ```job_name```
-* To test a different than the default model, adjust the ```model``` parameter in the deployment.
-* To test a custom automation repo, push to your fork and adjust ```git_automation_repo``` and ```git_automation_branch```
+*   Use your Rocket/irc nickname as ```job_name```.
+*   To test a different than the default model, adjust the
+    ```model``` parameter in the deployment.
+*   To test a custom automation repo, push to your fork and adjust
+    ```git_automation_repo``` and ```git_automation_branch```
 
-In the Jenkins log (also available as output in the Heat stack), the variable
-```DEPLOYER_IP``` is set to the floating IP. You can login as root into the
-environment then.
+In the Jenkins log (also available as output in the Heat stack), the
+variable ```DEPLOYER_IP``` is set to the floating IP. You can login as
+root into the environment then.
+
+## Automated checks
+
+Some extra checks are automatically run by the Jenkins job:
+
+- [rpm file checks](rpm-file-checks.md)

--- a/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
@@ -1,0 +1,42 @@
+## Whitelist of files and symlinks for which it is either acceptable
+## to be added to /usr, or which need to be fixed so that they are
+## no longer added.
+##
+## Symlinks can be optionally whitelisted only if they point to
+## a given destination, via the format:
+##
+##    /path/to/symlink -> /other/path/to/symlink/target
+##
+## It's just a substring match, so either side can be omitted.
+##
+## Comments and blank lines are stripped from this file before
+## usage.
+
+# alternatives system is expected to change stuff under /usr
+-> /etc/alternatives/.
+
+# Installed by osconfig/ansible/role/udev/tasks/configure.yml
+/usr/lib/systemd/system/ardana-udev\.service
+
+# Created by java-1_8_0-openjdk-headless %posttrans scriptlet
+/usr/lib64/jvm/java-1.8.0-openjdk-1.8.0/jre/lib/security/cacerts -> /var/lib/ca-certificates/java-cacerts
+
+# Created when python-selinux rpm is installed
+/usr/lib64/python2.7/site-packages/selinux/__init__.pyc
+
+# Ardana installs stuff in here, e.g. links to /opt/stack/service/.../venv/bin/...
+/usr/local/bin/.
+
+/usr/sbin/httpd -> /usr/sbin/httpd-prefork
+
+# Seems to be an issue with SLE12 packaging of libsnappy1
+/usr/share/doc/packages/snappy
+
+# Nothing to do with Ardana
+/usr/share/icons/hicolor
+
+# From neutron-ansible/roles/neutron-common/tasks/_create_user_and_group.yml
+/usr/share/neutron
+
+# From tls-ansible/roles/tls-trust/tasks/install.yml
+/usr/share/pki/trust/anchors/ardana

--- a/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
@@ -40,3 +40,8 @@
 
 # From tls-ansible/roles/tls-trust/tasks/install.yml
 /usr/share/pki/trust/anchors/ardana
+
+# Standard (upstream) path for custom detection plugins for
+# monasca-agent i.e. if you've got agent plugins local to your site
+# you drop them in this directory.
+/usr/lib/monasca/agent/custom_detect.d/.*.pyc?

--- a/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
@@ -8,28 +8,28 @@
 ## Ideally comments should be used to indicate which exceptions are
 ## FIXMEs and which are considered acceptable.
 
-S.5....T.  c /etc/logrotate.conf
-S.5....T.    /usr/lib/systemd/system/rabbitmq-server.service
-.M.......    /var/lib/elasticsearch
-.M.......    /var/log/logstash
-S.5....T.    /usr/lib/systemd/system/apache2.service
-SM5....T.    /usr/share/ardana-opsconsole-ui/opscon_config.json
-......G..    /var/log/shibboleth
-.....UG..    /var/log/shibboleth-www
-S.5....T.    /usr/share/ardana/ardana-installer-ui/web/config.json
 .M.......    /etc/ardana
 SM5..U.T.  c /etc/kafka/log4j.properties
 S.5..U.T.  c /etc/kafka/server.properties
-.M.......    /var/cache/swift
-......G..    /var/lib/swift
-.M...UG..    /var/log/swift
 S.5....T.  c /etc/kibana/kibana.yml
-.....UG..    /opt/kibana/optimize
-......G..    /var/log/kibana
-.M.......    /var/log/ops-console
-.M.......    /var/log/beaver
+S.5....T.  c /etc/logrotate.conf
 ......G..    /etc/monasca
 .M...UG..    /etc/monasca/agent
 .M...UG..    /etc/monasca/agent/conf.d
+.....UG..    /opt/kibana/optimize
 .M.......    /usr/lib/monasca/agent/custom_checks.d
 .M.......    /usr/lib/monasca/agent/custom_detect.d
+S.5....T.    /usr/lib/systemd/system/apache2.service
+S.5....T.    /usr/lib/systemd/system/rabbitmq-server.service
+S.5....T.    /usr/share/ardana/ardana-installer-ui/web/config.json
+SM5....T.    /usr/share/ardana-opsconsole-ui/opscon_config.json
+.M.......    /var/cache/swift
+.M.......    /var/lib/elasticsearch
+......G..    /var/lib/swift
+.M.......    /var/log/beaver
+......G..    /var/log/kibana
+.M.......    /var/log/logstash
+.M.......    /var/log/ops-console
+......G..    /var/log/shibboleth
+.....UG..    /var/log/shibboleth-www
+.M...UG..    /var/log/swift

--- a/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
@@ -1,0 +1,35 @@
+## Whitelist of files for which it is either acceptable to be modified
+## by the Ardana deployment process, or which need to be fixed so that
+## they are no longer modified.
+##
+## Comments and blank lines are stripped from this file before
+## usage as a filter via "grep -vf".
+##
+## Ideally comments should be used to indicate which exceptions are
+## FIXMEs and which are considered acceptable.
+
+S.5....T.  c /etc/logrotate.conf
+S.5....T.    /usr/lib/systemd/system/rabbitmq-server.service
+.M.......    /var/lib/elasticsearch
+.M.......    /var/log/logstash
+S.5....T.    /usr/lib/systemd/system/apache2.service
+SM5....T.    /usr/share/ardana-opsconsole-ui/opscon_config.json
+......G..    /var/log/shibboleth
+.....UG..    /var/log/shibboleth-www
+S.5....T.    /usr/share/ardana/ardana-installer-ui/web/config.json
+.M.......    /etc/ardana
+SM5..U.T.  c /etc/kafka/log4j.properties
+S.5..U.T.  c /etc/kafka/server.properties
+.M.......    /var/cache/swift
+......G..    /var/lib/swift
+.M...UG..    /var/log/swift
+S.5....T.  c /etc/kibana/kibana.yml
+.....UG..    /opt/kibana/optimize
+......G..    /var/log/kibana
+.M.......    /var/log/ops-console
+.M.......    /var/log/beaver
+......G..    /etc/monasca
+.M...UG..    /etc/monasca/agent
+.M...UG..    /etc/monasca/agent/conf.d
+.M.......    /usr/lib/monasca/agent/custom_checks.d
+.M.......    /usr/lib/monasca/agent/custom_detect.d

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -22,6 +22,8 @@
       /usr/sbin/growpart /dev/vda 1 && /sbin/resize2fs /dev/vda1
     ignore_errors: True
 
+  - include: pre-deploy-checks.yml
+
   - name: Call ardana-init
     shell: /usr/bin/ardana-init
     environment:
@@ -228,6 +230,10 @@
     when: item != "" and item != deployer_mgmt_ip
     become_user: ardana
 
+  - name: Initialise array tracking failures
+    set_fact:
+      failures: []
+
   - name: Run the actual deployment site.yml playbook
     shell: |
       ansible-playbook -vvv -i hosts/verb_hosts site.yml
@@ -235,6 +241,13 @@
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true
     become_user: ardana
+    register: site_result
+    ignore_errors: true
+
+  - name: Record any failure of site.yml
+    set_fact:
+      failures: "{{ failures + ['site.yml'] }}"
+    when: site_result|failed
 
   - name: Configure Cloud for Tempest run
     shell: |
@@ -243,6 +256,7 @@
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true
     become_user: ardana
+    when: site_result|succeeded
 
   - name: Run tempest
     shell: |
@@ -252,3 +266,28 @@
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true
     become_user: ardana
+    register: tempest_run_result
+    ignore_errors: true
+    when: site_result|succeeded
+
+  - name: Record any failure of tempest
+    set_fact:
+      failures: "{{ failures + ['tempest'] }}"
+    when: tempest_run_result|failed
+
+  - include: post-deploy-checks.yml
+
+  # If you change the below, also change test-post-deployment-checks.yml to match!
+
+  - name: Record any failures of post-deployment checks
+    set_fact:
+      failures: "{{ failures + post_deploy_checks_failures }}"
+
+  - name: Report any failures
+    fail:
+      msg: |
+        {{failures|length}} failures:
+        {% for failure in failures %}
+        {{ failure }}
+        {% endfor %}
+    when: failures|length > 0

--- a/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
@@ -1,0 +1,134 @@
+- name: Set files to contain output of various verification steps
+  set_fact:
+    post_deploy_rpm_verification:
+      "{{ verification_temp_dir }}/rpm-verify-post.out"
+    rpm_verification_fixmes:
+      "{{ verification_temp_dir }}/rpm-verify-modification-whitelist.txt"
+    rpm_modifiable_config_files:
+      "{{ verification_temp_dir }}/rpm-modifiable-config-files.txt"
+    rpm_modifiable_config_file_regexps:
+      "{{ verification_temp_dir }}/rpm-modifiable-config-file-regexps.txt"
+    rpm_added_files_whitelist:
+      "{{ verification_temp_dir }}/rpm-added-files-whitelist.txt"
+
+- name: Initialise array tracking post-deployment checks failures
+  set_fact:
+    post_deploy_checks_failures: []
+
+- name: Take snapshot of modified/deleted rpm-owned files post deployment
+  become: yes
+  shell: |
+    rpm -Va | grep -vxFf "{{ pre_deploy_rpm_verification }}" \
+      > "{{ post_deploy_rpm_verification }}"
+  failed_when: false
+  register: rpm_verify_delta
+
+- name: Obtain list of rpm-owned files removed by deployment
+  shell: |
+    grep '^missing ' "{{ post_deploy_rpm_verification }}"
+  failed_when: false
+  register: rpm_verify_removed_files
+
+- name: Write list of known FIXMEs for incorrect modifications of rpm-owned files
+  copy:
+    src: rpm-verify-modification-whitelist.txt
+    dest: "{{ rpm_verification_fixmes }}"
+
+- name: Trim comments and blank lines from FIXME file
+  lineinfile:
+    dest: "{{ rpm_verification_fixmes }}"
+    regexp: '^(#|$)'
+    state: absent
+
+- name: Write list of rpm %config files not endangered by update
+  shell: |
+    # Find all %config(noreplace) files, since if written to by
+    # Ardana, these will be safely left in place by an update (the new
+    # version would be written to a .rpmnew file).  Similarly include
+    # ghost configs since presumably these would not pose problems
+    # during an update.
+    rpm -qa --qf '[%{filenames} ## %{fileflags:fflags}\n]' | \
+      grep ' ## .*c.*[gn]' | \
+      sed 's/ ## .*//' \
+      > "{{ rpm_modifiable_config_files }}"
+
+- name: Write list of regexps matching rpm %config files not endangered by update
+  shell: |
+    # The files are written as a list of regexps into a file which can
+    # be used with grep -vf as an exclusion list for the output of rpm -Va.
+    sed 's/^/ /; s/$/$/' "{{ rpm_modifiable_config_files }}" \
+      > "{{ rpm_modifiable_config_file_regexps }}"
+
+- name: Obtain list of rpm-owned files incorrectly modified by deployment
+  # Exclude both the whitelist of fixmes (known issues), and config files
+  # which we calculated above as being safe to modify.
+  shell: |
+    egrep -v '^missing' "{{ post_deploy_rpm_verification }}" | \
+      grep -vf "{{ rpm_verification_fixmes }}" | \
+      grep -vf "{{ rpm_modifiable_config_file_regexps }}"
+  failed_when: false
+  register: rpm_verify_modified_files
+
+- name: Check no rpm-owned files removed by deployment
+  fail: msg="Found files removed by deployment:\n{{ rpm_verify_removed_files.stdout }}"
+  when:
+    - "rpm_verify_removed_files.stdout | match('^missing ')"
+  ignore_errors: true
+
+- name: Record failure if rpm-owned files removed by deployment
+  set_fact:
+    post_deploy_checks_failures:
+      "{{ post_deploy_checks_failures + [ 'rpm-owned files removed by deployment' ] }}"
+  when:
+    - "rpm_verify_removed_files.stdout | match('^missing ')"
+
+- name: Check no rpm-owned files modified by deployment
+  fail: msg="Found files modified by deployment:\n{{ rpm_verify_modified_files.stdout }}"
+  when:
+    - "rpm_verify_modified_files.stdout != ''"
+  ignore_errors: true
+
+- name: Record failure if rpm-owned files modified by deployment
+  set_fact:
+    post_deploy_checks_failures:
+      "{{ post_deploy_checks_failures + [ 'rpm-owned files modified by deployment' ] }}"
+  when:
+    - "rpm_verify_modified_files.stdout != ''"
+
+- name: Write list of known FIXMEs for incorrect modifications of rpm-owned files
+  copy:
+    src: rpm-added-files-whitelist.txt
+    dest: "{{ rpm_added_files_whitelist }}"
+
+- name: Trim comments and blank lines from rpm added files white-list
+  lineinfile:
+    dest: "{{ rpm_added_files_whitelist }}"
+    regexp: '^(#|$)'
+    state: absent
+
+- name: Check for rogue files introduced by deployment which are not owned by a package
+  shell: |
+    ! find /usr -printf "%p -> %l\n" | \
+      egrep -vf "{{ rpm_added_files_whitelist }}" | \
+      sed 's/ -> .*//' | \
+      xargs -r -d '\n' rpm -qf | \
+      grep -vxFf "{{ pre_deploy_unowned_files }}" | \
+      grep "is not owned"
+  register: rogue_files
+  ignore_errors: true
+
+- name: Record failure if rogue files introduced by deployment
+  set_fact:
+    post_deploy_checks_failures:
+      "{{ post_deploy_checks_failures + [ 'Rogue files introduced by deployment' ] }}"
+  when:
+    - rogue_files | failed
+
+- name: Remove temporary directory if not running in test mode and all checks succeeded
+  become: yes
+  file:
+    path: "{{ verification_temp_dir }}"
+    state: absent
+  when:
+    - rpm_verification_test_mode is not defined
+    - post_deploy_checks_failures|length == 0

--- a/scripts/jenkins/ardana/ansible/pre-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/pre-deploy-checks.yml
@@ -1,0 +1,30 @@
+- name: Create a temporary directory to store pre-deployment verification state
+  become: yes
+  shell: mktemp -d /tmp/ardana-job-rpm-verification.XXXXXXXX
+  register: verification_mktemp_dir
+
+# This allows us to easily pass a value for the temporary directory
+# in to the test-post-deployment-checks.yml playbook when testing.
+- name: Store path to temporary directory
+  set_fact:
+    verification_temp_dir:
+      "{{ verification_mktemp_dir.stdout }}"
+
+- name: Set files to contain output of rpm -qf and -Va pre-deployment
+  set_fact:
+    pre_deploy_unowned_files:
+      "{{ verification_temp_dir }}/rpm-qf-pre.out"
+    pre_deploy_rpm_verification:
+      "{{ verification_temp_dir }}/rpm-verify-pre.out"
+
+- name: Take snapshot of files not owned by a package prior to deployment
+  become: yes
+  failed_when: false
+  shell: |
+    find /usr -print0 | xargs -0 rpm -qf | grep "is not owned" \
+      > "{{ pre_deploy_unowned_files }}"
+
+- name: Take snapshot of modified/deleted rpm-owned files prior to deployment
+  become: yes
+  shell: rpm -Va > "{{ pre_deploy_rpm_verification }}"
+  failed_when: false

--- a/scripts/jenkins/ardana/ansible/test-post-deployment-checks.yml
+++ b/scripts/jenkins/ardana/ansible/test-post-deployment-checks.yml
@@ -1,0 +1,51 @@
+# Use this playbook for quick tests of the post-deployment checks
+# without having to repeatedly go through a full deployment.  This
+# assumes you already have a deployment which got as far as finishing
+# the pre-deploy-checks.yml playbook and (at least partially)
+# deploying Ardana.
+#
+# Run it from the same environment in which the original deployment
+# was run, via:
+#
+#   ansible-playbook \
+#     -e verification_temp_dir=/tmp/ardana-job-rpm-verification.XXXXXXXX \
+#     test-post-deployment-checks.yml
+#
+# replacing XXXXXXXX with whichever temporary directory was already
+# written to.
+
+---
+- name: Test post-deployment checks
+  hosts: hosts
+  gather_facts: False
+  vars:
+    rpm_verification_test_mode:
+      true
+    pre_deploy_unowned_files:
+      "{{ verification_temp_dir }}/rpm-qf-pre.out"
+    pre_deploy_rpm_verification:
+      "{{ verification_temp_dir }}/rpm-verify-pre.out"
+    failures:
+      []
+
+  tasks:
+  - name: Check verification_temp_dir is defined
+    fail: msg="Pass -e verification_temp_dir=/tmp/... when running this playbook"
+    when: verification_temp_dir is not defined
+
+  - include: post-deploy-checks.yml
+
+  # If you change the below, also change init.yml to match!
+
+  - name: Record any failures of post-deployment checks
+    set_fact:
+      failures: "{{ failures + post_deploy_checks_failures }}"
+
+  - name: Report any failures
+    fail:
+      msg: |
+        {{failures|length}} failures:
+        {% for failure in failures %}
+        {{ failure }}
+        {% endfor %}
+    when: failures|length > 0


### PR DESCRIPTION
See [SCRD-2756 (Add CI checks to ensure SLES updates can be installed any time)](https://suse-jira.dyndns.org/browse/SCRD-2756)

**NOTE:** hasn't been successfully tested the whole way through in a single run yet, due to unrelated issues preventing everything else working.

Check that Ardana doesn't mess with the filesystem inappropriately by removing or modifying rpm-owned files, or adding files into `/usr`.  This is done by running `rpm -Va` and `rpm -qf` before and after Ardana deployment, and comparing the results.

If any tampering is discovered, `init.yml` will fail with a helpful error.

The checks will run even if `site.yml` or tempest failed.  A list of all failures (including `site.yml` and tempest) is displayed at the end, to avoid hiding multiple failures behind one failure.