### PR TITLE
soc-ci: Return ConfigParser object for config usage

### DIFF
--- a/hostscripts/soc-ci/soc-ci
+++ b/hostscripts/soc-ci/soc-ci
@@ -37,6 +37,10 @@ from six.moves import input
 
 # path to the user configuration file
 USER_CONFIG_PATH = os.path.expanduser('~/.soc-ci.ini')
+
+# the default config section
+CONFIG_SECTION = "defaults"
+
 # possible mkcX hosts
 CI_WORKERS = list('abcdefghijklmnop')
 
@@ -54,28 +58,27 @@ def _config_get():
     """get the configuration"""
     conf = configparser.RawConfigParser()
     conf.read([USER_CONFIG_PATH])
-    section_name = "defaults"
-    if not conf.has_section(section_name):
+    if not conf.has_section(CONFIG_SECTION):
         user, password, url, nick = _config_credentials_get()
-        conf.add_section(section_name)
-        conf.set(section_name, "user", user)
-        conf.set(section_name, "password", password)
-        conf.set(section_name, "url", url)
-        conf.set(section_name, "nick", nick)
+        conf.add_section(CONFIG_SECTION)
+        conf.set(CONFIG_SECTION, "user", user)
+        conf.set(CONFIG_SECTION, "password", password)
+        conf.set(CONFIG_SECTION, "url", url)
+        conf.set(CONFIG_SECTION, "nick", nick)
         with os.fdopen(os.open(
                 USER_CONFIG_PATH, os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
             conf.write(f)
 
     # some optional configuration options
-    if not conf.has_option(section_name, "artifacts_dir"):
-        conf.set(section_name, "artifacts_dir",
+    if not conf.has_option(CONFIG_SECTION, "artifacts_dir"):
+        conf.set(CONFIG_SECTION, "artifacts_dir",
                  os.path.expanduser('~/.soc-ci/artifacts/'))
 
     # create things where needed
-    if not os.path.exists(conf.get(section_name, "artifacts_dir")):
-        os.makedirs(conf.get(section_name, "artifacts_dir"))
+    if not os.path.exists(conf.get(CONFIG_SECTION, "artifacts_dir")):
+        os.makedirs(conf.get(CONFIG_SECTION, "artifacts_dir"))
 
-    return dict(conf.items(section_name))
+    return conf
 
 
 ###############################################################################
@@ -97,9 +100,9 @@ def _ssh_get_client():
 
 def _os_mkcloud_where(job_id):
     conf = _config_get()
-    server = Jenkins(conf['url'],
-                     username=conf['user'],
-                     password=conf['password'])
+    server = Jenkins(conf.get(CONFIG_SECTION, 'url'),
+                     username=conf.get(CONFIG_SECTION, 'user'),
+                     password=conf.get(CONFIG_SECTION, 'password'))
     job = server['openstack-mkcloud']
 
     build = job.get_build(job_id)
@@ -120,9 +123,9 @@ def os_mkcloud_where(args):
 
 def os_mkcloud_console_log(args):
     conf = _config_get()
-    server = Jenkins(conf['url'],
-                     username=conf['user'],
-                     password=conf['password'])
+    server = Jenkins(conf.get(CONFIG_SECTION, 'url'),
+                     username=conf.get(CONFIG_SECTION, 'user'),
+                     password=conf.get(CONFIG_SECTION, 'password'))
     job = server['openstack-mkcloud']
 
     build = job.get_build(args.job_id)
@@ -170,9 +173,9 @@ def _unpack_supportconfigs(cwd):
 def os_mkcloud_artifacts(args):
     """download artifacts for the given job"""
     conf = _config_get()
-    server = Jenkins(conf['url'],
-                     username=conf['user'],
-                     password=conf['password'])
+    server = Jenkins(conf.get(CONFIG_SECTION, 'url'),
+                     username=conf.get(CONFIG_SECTION, 'user'),
+                     password=conf.get(CONFIG_SECTION, 'password'))
     job = server['openstack-mkcloud']
 
     build = job.get_build(args.job_id)
@@ -225,7 +228,7 @@ def ci_worker_pool_reserve(args):
     stdin, stdout, stderr = client.exec_command(
         'mv /root/pool/%s /root/pool/%s.%s.`date "+%%Y-%%m-%%d"`' % (
             args.slot,
-            args.slot, conf['nick']))
+            args.slot, conf.get(CONFIG_SECTION, 'nick')))
     print(stdout.read())
     sys.exit(stdout.channel.recv_exit_status())
 
@@ -236,8 +239,8 @@ def ci_worker_pool_release(args):
     client.connect('mkch%s.cloud.suse.de' % args.worker,
                    username='root', password='linux')
     stdin, stdout, stderr = client.exec_command(
-        'mv /root/pool/%s.%s.* /root/pool/%s' % (args.slot, conf['nick'],
-                                                 args.slot))
+        'mv /root/pool/%s.%s.* /root/pool/%s' % (
+            args.slot, conf.get(CONFIG_SECTION, 'nick'), args.slot))
     print(stdout.read())
     sys.exit(stdout.channel.recv_exit_status())
 
@@ -258,7 +261,8 @@ def ci_workers_pool_list(args):
     for worker in sorted(data.keys()):
         print('### mkch%s.cloud.suse.de ###' % worker)
         for pool in data[worker]:
-            if args.all or pool.find('.%s' % conf['nick']) != -1:
+            if args.all or pool.find('.%s' % conf.get(
+                    CONFIG_SECTION, 'nick')) != -1:
                 print(pool)
     sys.exit(0)
 


### PR DESCRIPTION
Instead of returning a dict with strings, return the config object
itself. That way, functions can get also a boolean value (via
conf.getboolean()) if needed.