### PR TITLE
ardana-job: capture cloud media build version

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -61,6 +61,14 @@
 
     builders:
       - shell: |
+          set +x
+          cloudsource_url=http://provo-clouddata.cloud.suse.de/repos/x86_64/$cloudsource
+          cloudsource_media_build=$( curl -s $cloudsource_url/media.1/build )
+          echo cloudsource=$cloudsource
+          echo cloudsource URL is $cloudsource_url
+          echo media build version is $cloudsource_media_build
+          echo
+
           set -ex
           STACK_NAME=cloud-ci-ardana-job-${BUILD_NUMBER}
           if [ -n "${JOB_NAME}" ]; then

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -17,7 +17,7 @@
   - name: Write deployer info to /etc/motd
     become: yes
     shell: |
-      echo "DEPLOYER_IP={{ deployer_floating_ip | default(None) }}" > /etc/motd
+      echo "DEPLOYER_IP={{ deployer_floating_ip | default(None) }}" >> /etc/motd
 
   - name: Grow 1st partition filesystem
     become: yes

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -7,28 +7,31 @@
     clouddata_server: provo-clouddata.cloud.suse.de
     download_suse_server: download.suse.de
     cloudsource: SUSE-OpenStack-Cloud-8-devel-staging
+    arch: x86_64
+    repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
+    sshpass_repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
 
   tasks:
   # SLES repos
   - name: Add SLES12SP3-Pool zypper repo
     zypper_repository:
-      repo: "http://{{ clouddata_server }}/repos/x86_64/SLES12-SP3-Pool"
+      repo: "{{ repos_url }}/SLES12-SP3-Pool"
       name: SLES12SP3-Pool
 
   - name: Add SLES12SP3-Updates zypper repo
     zypper_repository:
-      repo: "http://{{ clouddata_server }}/repos/x86_64/SLES12-SP3-Updates"
+      repo: "{{ repos_url }}/SLES12-SP3-Updates"
       name: SLES12SP3-Updates
 
   # Devel:Cloud:8
   - name: "Add {{ cloudsource }} media"
     zypper_repository:
-      repo: "http://{{ clouddata_server }}/repos/x86_64/{{ cloudsource }}"
+      repo: "{{ repos_url }}/{{ cloudsource }}"
       name: DC8S-Media
 
   - name: Repo for sshpass
     zypper_repository:
-      repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
+      repo: "{{ sshpass_repo }}"
       name: sshpass
 
   # Refresh all repos
@@ -45,7 +48,7 @@
 
   - name: Remove Repo for sshpass
     zypper_repository:
-      repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
+      repo: "{{ sshpass_repo }}"
       name: sshpass
       state: absent
 

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -9,6 +9,7 @@
     cloudsource: SUSE-OpenStack-Cloud-8-devel-staging
     arch: x86_64
     repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
+    cloudsource_url: "{{ repos_url }}/{{ cloudsource }}"
     sshpass_repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
 
   tasks:
@@ -26,7 +27,7 @@
   # Devel:Cloud:8
   - name: "Add {{ cloudsource }} media"
     zypper_repository:
-      repo: "{{ repos_url }}/{{ cloudsource }}"
+      repo: "{{ cloudsource_url }}"
       name: DC8S-Media
 
   - name: Repo for sshpass
@@ -57,3 +58,23 @@
   # FIXME: Resolve the file conflicts in the ardana packages and use the zypper module
   - name: Install ardana pattern
     command: zypper -n in patterns-cloud-ardana
+
+  # This can't happen earlier because we rely on the ardana pattern for creating
+  # the ardana user/group
+  - name: Ensure /etc/ardana exists
+    file:
+      path: /etc/ardana
+      state: directory
+      owner: ardana
+      group: ardana
+
+  - name: Capture build number of cloudsource media
+    get_url:
+      url: "{{ cloudsource_url }}/media.1/build"
+      dest: /etc/ardana/media-build-version
+
+  - name: Add build information to /etc/motd
+    shell: |
+      media_build_version=$(cat /etc/ardana/media-build-version)
+      echo "Built from: {{ cloudsource_url }}" >>/etc/motd
+      echo "Media build version: $media_build_version" >>/etc/motd


### PR DESCRIPTION
Capture the build version of the IBS Cloud media ISO used for each `ardana-job`, and make it clearly visible at the top of the job's console output and also in `/etc/motd` and `/etc/ardana/media-build-version`.  This should help development and testing, especially since it helps QE find a recent media build ISO which had a successful ardana-job run.

https://ci.suse.de/job/ardana-job-aspiers/12/consoleText is an example of what the job log looks like with this change.