### PR TITLE
Add field to check out playbook changes

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -51,6 +51,14 @@
             This is used as input repository (from provo-clouddata) for testing
 
       - string:
+          name: playbook_changes
+          default: ''
+          description: >-
+            Space-separated list of repositories and change numbers
+            identifying playbook changes to test, example:
+            ardana/osconfig-ansible,9999 ardana/keystone-ansible,8675
+
+      - string:
           name: tempest_run_filter
           default: smoke
           description: >-
@@ -158,4 +166,5 @@
           ansible-playbook -vvv -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" \
                                          -e "deployer_model=${model}" \
                                          -e "tempest_run_filter=${tempest_run_filter}" \
+                                         -e "playbook_changes=${playbook_changes}" \
                                          init.yml

--- a/scripts/jenkins/ardana/ansible/checkout-playbook-changes.yml
+++ b/scripts/jenkins/ardana/ansible/checkout-playbook-changes.yml
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# (c) Copyright 2018 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+- name: Prepare working space
+  file:
+    path: /tmp/changes_to_test
+    state: directory
+
+- name: Check out remote playbook
+  shell: |
+    set -eux
+    set -o pipefail
+    change={{ item }}
+    repo=${change%%,*}
+    changenum=${change##*,}
+    git -c http.sslVerify=false clone https://git.suse.provo.cloud/${repo} ${repo}
+    cd $repo
+    remote=https://gerrit.suse.provo.cloud/${repo}
+    ref=$(git -c http.sslVerify=false ls-remote $remote | awk '/'$changenum'/{print $2|"sort -t'/' -k5 -n|tail -1"}')
+    git -c http.sslVerify=false fetch $remote $ref
+    git format-patch -1 --stdout FETCH_HEAD > /tmp/changes_to_test/test-${changenum}.patch
+    cd /var/lib/ardana/openstack/ardana/ansible
+    patch -p1 </tmp/changes_to_test/test-${changenum}.patch
+    rm /tmp/changes_to_test/test-${changenum}.patch
+  vars:
+    chdir: /tmp/changes_to_test
+  with_items: "{{ changes }}"
+
+- name: Clean up working space
+  file:
+    path: /tmp/changes_to_test
+    state: absent

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -9,6 +9,7 @@
   vars:
     deployer_model: deployerincloud-lite
     tempest_run_filter: smoke
+    playbook_changes: ''
 
   environment:
     ARDANA_INIT_AUTO: 1
@@ -25,10 +26,20 @@
       /usr/sbin/growpart /dev/vda 1 && /sbin/resize2fs /dev/vda1
     ignore_errors: True
 
+  - name: Install patch package
+    zypper:
+      name: patch
+
   - name: Call ardana-init
     shell: /usr/bin/ardana-init
     become: true
     become_user: ardana
+
+  - name: Prepare playbook changes to test
+    include: checkout-playbook-changes.yml
+    vars:
+      changes: "{{ playbook_changes.split() }}"
+    when: playbook_changes != ''
 
   - name: Create ssh key for ardana user on deployer
     shell: |


### PR DESCRIPTION
Add a field to the Ardana jenkins job launcher to specify remote
playbook changes in gerrit to check out for the proposed build. The
field takes a space-separated list of changes of the form `<repo
name>,<change number>`, for example:

  ardana/osconfig-ansible,8657 ardana/monasca-ansible,309

This uses the patch command to make changes in
~ardana/openstack/ardana/ansible after ardana-init has run. The
implications of this are:

1) ardana-init itself runs some playbooks, so some playbooks will run
   before the jenkins job has had a chance to make modifications
2) files are patched, not merged, so an inexact patch will not apply
   cleanly and must be rebased in the gerrit review