### PR TITLE
github_pr: update crowbar teams

### DIFF
--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -6,8 +6,12 @@ template:
       - crowbar
   team:
     crowbar_team: &crowbar_team
-      - name: crowbar/Owners
+      - name: crowbar/Maintainers
         id: 291046
+      - name: crowbar/SUSE
+        id: 294160
+      - name: crowbar/Admins
+        id: 1990312
   filter:
     suse_crowbar: &suse_crowbar
       - type: MergeBranch


### PR DESCRIPTION
Meanwhile there are more teams than just one.
The original one was renamed as well.

The pull requests of members with write access should be built by our CI. So we need to allow all these teams in the github_pr config for crowbar.

Without this fix there are several people whose pull requests will never be built.