### PR TITLE
skip workspace cleanup when the build failed

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -196,4 +196,8 @@
                 openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait \
                       $STACK_NAME || :
             fi
-      - workspace-cleanup
+      - workspace-cleanup:
+          clean-if:
+            - failure: false
+            - aborted: false
+            - unstable: false


### PR DESCRIPTION
We still need some of the files from the workspace then to
manually debug stuff