### PR TITLE
testbuild: log rebuild links to easier rerun a job

### DIFF
--- a/scripts/crowbar-testbuild.rb
+++ b/scripts/crowbar-testbuild.rb
@@ -20,6 +20,7 @@ require "yaml"
 require "optparse"
 require "fileutils"
 require "tmpdir"
+require "open-uri"
 
 class CrowbarTestbuild
   def initialize(options, config)
@@ -118,10 +119,12 @@ class CrowbarTestbuild
       job_name: job_name
     }
     para_extra = extra_build_parameters(mode)
-    p = para_default.merge(para_extra).map { |k,v| "#{k}=#{v}" }
-    jcmd += p
-    puts "Triggering jenkins job with url #{ptf_url} and directory #{ptf_dir}"
+    all_paras = para_default.merge(para_extra)
+    jcmd += all_paras.map{ |k,v| "#{k}=#{v}" }
     system(*jcmd) or raise
+    puts "Triggered jenkins job with url #{ptf_url} and directory #{ptf_dir}"
+    puts "   Rebuild Link: https://ci.suse.de/job/#{mkcloud_job_name}/parambuild/?#{URI.encode_www_form(all_paras)}"
+    puts "   => NOTE: Job already triggered. Make sure there are no identical parallel jobs!"
   end
 
   def jenkins_jobs_scenarios


### PR DESCRIPTION
From time to time triggered jenkins jobs are not processed.
This might be due to various reasons.

In order to easier rebuild a missing job the testbuild
script will now log a rebuild link. The link will open
a confirmation page in jenkins and prefill all parameters.
The job is not starting automatically, one additional
button klick is needed (and wanted as protection).

The one who starts the rebuild should make sure that not
two identical jobs are running in parallel. If there are two
identical jobs the status of the job reporting last will be
the status of that commit on github.