### PR TITLE
PR job trigger: log rebuild links to easier rerun a job

### DIFF
--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -55,11 +55,11 @@ template:
               message: Queued automation PR gating
           - type: JenkinsJobTriggerMkcloud
             parameters:
+              detail_logging: true
               job_name: openstack-mkcloud
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 *mkcloud_automation_parameters
-          - type: LogPullRequestDetails
     suse_cct: &suse_cct
       - type: Status
         config:
@@ -77,12 +77,12 @@ template:
               message: Queued cct PR gating
           - type: JenkinsJobTriggerMkcloudCCT
             parameters:
+              detail_logging: true
               job_name: openstack-mkcloud
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 standard:
                   *mkcloud_automation_standard
-          - type: LogPullRequestDetails
 pr_processing:
   - config:
       organization: SUSE-Cloud

--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -36,11 +36,11 @@ template:
               message: Queued testbuild job
           - type: JenkinsJobTriggerCrowbarTestbuild
             parameters:
+              detail_logging: true
               job_name: cloud-crowbar-testbuild-pr
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 standard: {}
-          - type: LogPullRequestDetails
     sap-oc_crowbar: &sap-oc_crowbar
       - type: MergeBranch
         config:
@@ -62,11 +62,11 @@ template:
               message: Queued testbuild job
           - type: JenkinsJobTriggerCrowbarTestbuild
             parameters:
+              detail_logging: true
               job_name: cloud-crowbar-testbuild-pr
               job_cmd: "../jenkins/jenkins-job-trigger"
               job_parameters:
                 standard: {}
-          - type: LogPullRequestDetails
 pr_processing:
   - config:
       organization: crowbar


### PR DESCRIPTION
This is similar to https://github.com/SUSE-Cloud/automation/pull/2412
but just adds the logging also to the pull request trigger jobs.

----

From time to time triggered jenkins jobs are not processed.
This might be due to various reasons.

In order to easier rebuild a missing job the PR trigger
jobs will now log a rebuild link. The link will open
a confirmation page in jenkins and prefill all parameters.
The job is not starting automatically, one additional
button klick is needed (and wanted as protection).

The one who starts the rebuild should make sure that not
two identical jobs are running in parallel. If there are two
identical jobs the status of the job reporting last will be
the status of that commit on github.