### PR TITLE
ardana-job: put the Jenkins build job URL in /etc/motd

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -178,7 +178,8 @@
           cat ardana_net_vars.yml
 
           ansible-playbook -vvv -i hosts ssh-keys.yml
-          ansible-playbook -vvv -i hosts -e "cloudsource=${cloudsource}" repositories.yml
+          ansible-playbook -vvv -i hosts -e "build_url=$BUILD_URL" \
+                                         -e "cloudsource=${cloudsource}" repositories.yml
           ansible-playbook -vvv -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" \
                                          -e "deployer_model=${model}" \
                                          -e "tempest_run_filter=${tempest_run_filter}" \

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -124,5 +124,6 @@
   - name: Add build information to /etc/motd
     shell: |
       media_build_version=$(cat /etc/ardana/media-build-version)
+      echo "Build job:  {{ build_url }}" >>/etc/motd
       echo "Built from: {{ cloudsource_url }}" >>/etc/motd
       echo "Media build version: $media_build_version" >>/etc/motd


### PR DESCRIPTION
This makes it easy to look at the build job log for a host which you're already connected to.