### PR TITLE
update_automation: allow to override automation repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ pythoncheck:
 
 rounduptest:
 	cd scripts && roundup
+	cd scripts/jenkins && roundup
 
 flake8:
 	flake8 scripts/ hostscripts/soc-ci/soc-ci

--- a/scripts/jenkins/update_automation
+++ b/scripts/jenkins/update_automation
@@ -12,9 +12,23 @@
 # Bernhard M. Wiedemann <bwiedemann suse.de>
 #
 
+declare -a must_have_repos=(
+    github.com/openSUSE/github-pr#master
+)
+
+# allow to override the automation repo
+: ${automation_repo:="github.com/SUSE-Cloud/automation#master"}
+
+if [[ $automation_repo =~ ^(https?|git): || $automation_repo =~ \.git ]] ; then
+    echo "Syntax error with automation repo definition."
+    echo "Please use this pattern: <domain>/<owner>/<repo>#<branch>"
+    echo "  eg.: github.com/SUSE-Cloud/automation#master"
+    exit 1
+fi
+
 declare -a needed_repos=(
-    github.com/SUSE-Cloud/automation
-    github.com/openSUSE/github-pr
+    $automation_repo
+    ${must_have_repos[@]}
 )
 
 function get_archive_url
@@ -25,6 +39,11 @@ function get_archive_url
 function get_repo_url
 {
     echo -n https://${1}.git
+}
+
+function echo_info
+{
+    echo "Handling repo: $1 with branch: $2"
 }
 
 function do_wget
@@ -82,14 +101,16 @@ function do_git
     fi
 }
 
-: ${branch:=master}
-
 pushd ~ > /dev/null
-for repo_url_dir in "${needed_repos[@]}" ; do
+for repo_str in "${needed_repos[@]}" ; do
+    IFS='#' read -r -a repo_arr <<< "$repo_str"
+    repo_url_dir=${repo_arr[0]}
+    branch=${repo_arr[1]:-master}
     checkout_base_dir=${repo_url_dir%/*}
     mkdir -p $checkout_base_dir
-    do_git "$repo_url_dir" "$branch" || do_wget "$repo_url_dir" "$branch"
-    # branch variable only overrides branch for 1st repo, so switch back to master now
-    branch="master"
+    echo_info "$repo_url_dir" "$branch"
+    if [[ ! $dryrun_update_automation ]] ; then
+        do_git "$repo_url_dir" "$branch" || do_wget "$repo_url_dir" "$branch"
+    fi
 done
 popd > /dev/null

--- a/scripts/jenkins/update_automation-test.sh
+++ b/scripts/jenkins/update_automation-test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env roundup
+
+describe "roundup(1) testing of update_automation"
+
+export dryrun_update_automation=1
+
+it_fetches_upstream_repos_with_master() {
+    results=`./update_automation`
+    [[ $results =~ github.com/SUSE-Cloud/automation\ .*\ master ]]
+    [[ $results =~ github.com/openSUSE/github-pr\ .*\ master ]]
+}
+
+it_fetches_other_automation_repo_with_master() {
+    results=`automation_repo=github.com/other-org/other-repo ./update_automation`
+    [[ $results =~ github.com/other-org/other-repo\ .*\ master ]]
+    [[ $results =~ github.com/openSUSE/github-pr\ .*\ master ]]
+}
+
+it_fetches_other_automation_repo_with_other_branch() {
+    results=`automation_repo="github.com/other-org/other-repo#other-branch" ./update_automation`
+    [[ $results =~ github.com/other-org/other-repo\ .*\ other-branch ]]
+    [[ $results =~ github.com/openSUSE/github-pr\ .*\ master ]]
+}
+
+it_prints_usage_on_wrong_repo_definition() {
+    results=`! automation_repo="https://github.com/other-org/other-repo.git" ./update_automation`
+    [[ $results =~ "Syntax error with automation repo definition" ]]
+}


### PR DESCRIPTION
For several QA jenkins jobs the feature was used to override
the location of the automation repo. This was used to stage
code changes before they became a pull request.

This feature was accidentally dropped with the latest
refactoring of update_automation.

This commit adds back this feature but with a slightly different
usage.
The definition must follow this pattern:
`<domain>/<owner>/<repo>#<branch>`
e.g. github.com/SUSE-Cloud/automation#master

The definition of the branch can be omitted (incl. the "#").
Then the branch name will use "master" as default.

@gosipyan @kbaikov You will need to adapt the QA jobs to use the new definition.