### PR TITLE
ardana: Increase inactivity timeout even further

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -10,7 +10,7 @@
           name: '#${BUILD_NUMBER}: ${ENV,var="job_name"}/${ENV,var="model"}'
 
       - timeout:
-          timeout: 180
+          timeout: 300
           type: no-activity
           abort: true
           write-description: "Job aborted due to 180 minutes of inactivity"


### PR DESCRIPTION
When init.yml is running site.yml there is not log activity for a very
long time, which cause the jenkins job to timeout for the larger models.

In the mid term we need to find a better solution here. This should be
considererd a temporary fix to address the immediate issue of all jobs
timeing out.