### PR TITLE
jjb: Remove packagefilter from gating

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
@@ -44,4 +44,3 @@
           predefined-parameters: |
             project=Devel:Cloud:{version}
             subproject=Staging
-            packagefilter=crowbar python openstack patterns release-notes-suse-openstack-cloud suse-cloud-upgrade


### PR DESCRIPTION
Instead of only copying a subset from Staging to non-Staging we should copy everything which has a valid link and exists in both repos otherwise we can forget packages.