### PR TITLE
mkcloud: enable mkcloud options specific for CI

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -441,6 +441,9 @@
           # to not fail when two concurrent zypper runs happen:
           export ZYPP_LOCK_TIMEOUT=120
 
+          # enable mkcloud options specific for CI runs
+          export CI_RUN=1
+
           case $cloudsource in
               develcloud6)
                   if [[ $mkcloudtarget =~ upgrade ]]; then

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -206,8 +206,10 @@ function show_environment
     echo "-------------------------------"
     env | grep -i "^want_"
     echo "-------------------------------"
-    column -s"," -t $timing_file_host  | tee ${timing_file_host}.byTime.txt
-    sort -t, -k3,3 -k1,1 $timing_file_host | column -s"," -t  | tee ${timing_file_host}.byType.txt
+    if [[ $CI_RUN = 1 ]]; then
+        column -s"," -t $timing_file_host  | tee ${timing_file_host}.byTime.txt
+        sort -t, -k3,3 -k1,1 $timing_file_host | column -s"," -t  | tee ${timing_file_host}.byType.txt
+    fi
 }
 
 function pre_exit_cleanup


### PR DESCRIPTION
We may want mkcloud to act differently on CI runs than on manual
executions. A good example for this would be the timing reports at the
end of the mkcloud run which make more sense only in a CI environment.

We introduce the variable CI_RUN: when enabled, mkcloud should consider
this a CI run. The first use of this variable will be for only enabling
timing reports on manual runs. Note that timing is still profiled, but
not reported.
