### PR TITLE
also sync SP2-LTSS

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -175,7 +175,7 @@ done
 
 
 # LTSS enablement
-for servicepack in 1; do
+for servicepack in 1 2 3; do
 
     version="12-SP$servicepack-LTSS"
     repo_version="$version"


### PR DESCRIPTION
because the standard maintenance expired
and SP3 even though it is empty+unused atm, it will be used later