### PR TITLE
mkcloud: safely for libvirt_vm_start

### DIFF
--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -85,7 +85,7 @@ function libvirt_prepare()
 function libvirt_do_setupadmin()
 {
     ${scripts_lib_dir}/libvirt/admin-config $cloud $admin_node_memory $adminvcpus $(get_emulator) $admin_node_disk "$localreposdir_src" "$localreposdir_target" "$firmware_type" > /tmp/$cloud-admin.xml
-    libvirt_vm_start /tmp/$cloud-admin.xml
+    safely libvirt_vm_start /tmp/$cloud-admin.xml
 }
 
 libvirt_vm_start()
@@ -438,7 +438,7 @@ function libvirt_do_setuplonelynodes()
         done
 
         onhost_deploy_image "lonely" $(get_lonely_node_dist) $lonely_disk
-        libvirt_vm_start /tmp/${lonely_node}.xml
+        safely libvirt_vm_start /tmp/${lonely_node}.xml
     done
 }
 
@@ -471,7 +471,7 @@ function libvirt_do_setupironicnodes()
         $sudo lvdisplay "$ironic_disk" || \
             _lvcreate "${cloud}.node$i" "${ironicnode_hdd_size}" "$cloudvg"
 
-        libvirt_vm_start /tmp/${ironic_node}.xml
+        safely libvirt_vm_start /tmp/${ironic_node}.xml
     done
 }
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -731,7 +731,7 @@ function setupnodes
                         --firmwaretype "$firmware_type" \
                         --controller-raid-volumes $controller_raid_volumes > /tmp/$cloud-node$i.xml
 
-        libvirt_vm_start /tmp/$cloud-node$i.xml
+        safely libvirt_vm_start /tmp/$cloud-node$i.xml
     done
 
     echo "========================================================"


### PR DESCRIPTION
It can happen that libvirt_vm_start fails (i.e. libvirt: DBus Utils
error : Connection timed out). Right after vm_start there's a wait for
the VM to actually start. This change uses 'safely' to call
libvirt_vm_start and abort it faster in case of an error.