### PR TITLE
createproject.py: increase cut off for errors to 9000

### DIFF
--- a/hostscripts/rpm-packaging/createproject.py
+++ b/hostscripts/rpm-packaging/createproject.py
@@ -280,6 +280,7 @@ def main():
 
     args = parser.parse_args()
 
+    sh.ErrorReturnCode.truncate_cap = 9000
     create_project(args.worktree, args.project, args.linkproject)
 
 


### PR DESCRIPTION
Sometimes backtraces are longer than 750.