### PR TITLE
openstack-trackupstream: Add openstack-neutron-vsphere

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -65,6 +65,7 @@
             - openstack-neutron-lbaas
             - openstack-neutron-vpnaas
             - openstack-neutron-zvm-agent
+            - openstack-neutron-vsphere
             - openstack-nova
             - openstack-nova-virt-zvm
             - openstack-octavia
@@ -119,6 +120,7 @@
             [
               "openstack-horizon-plugin-neutron-fwaas-ui",
               "openstack-horizon-plugin-neutron-vpnaas-ui",
+              "openstack-neutron-vsphere",
             ].contains(component) ||
             [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Pike:Staging", "Cloud:OpenStack:Queens:Staging" ].contains(project) &&
             [


### PR DESCRIPTION
Add tracking for openstack-neutron-vsphere for everything that is not
Master or Ocata.