### PR TITLE
jjb: fix submit task for ardana packages in submit job

### DIFF
--- a/jenkins/ci.suse.de/openstack-submit-project.yaml
+++ b/jenkins/ci.suse.de/openstack-submit-project.yaml
@@ -102,12 +102,20 @@
                   fi
 
                   # submit package
-                  $E $submitcmd $coss $component $cos || :
-                  if [[ $ecos && $component =~ ^crowbar ]] ; then
-                      $E $submitcmd $coss $component -t https://api.opensuse.org/ $ecos || :
-                  fi
-                  if [[ $eard && $component =~ ^ardana ]] ; then
-                      $E $submitcmd $coss $component -t https://api.opensuse.org/ $eard || :
-                  fi
+                  case $component in
+                      crowbar*)
+                          # submit to non-Staging project
+                          $E $submitcmd $coss $component $cos || :
+                          # submit to OBS
+                          [[ $ecos ]] && $E $submitcmd $coss $component -t https://api.opensuse.org/ $ecos || :
+                      ;;
+                      ardana*)
+                          # submit to OBS
+                          [[ $eard ]] && $E $submitcmd $coss $component -t https://api.opensuse.org/ $eard || :
+                      ;;
+                      *)
+                          echo "INFO: package $component is not submitted to another repo."
+                      ;;
+                  esac
               fi
           done


### PR DESCRIPTION
In the last refactoring an error sneaked in with commit
bdf9bf63a9648090ac8a56f775e4808a633d05c3

The unwanted behaviour is that ardana packages should not be submitted to non-Staging project.

The wanted new behaviour (in PR #2429) after the refactoring was that ardana packages are also submitted to OBS.

These changes fix these issue.