### PR TITLE
ardana: cleanup environment usage

### DIFF
--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -10,9 +10,6 @@
     deployer_model: deployerincloud-lite
     tempest_run_filter: smoke
 
-  environment:
-    ARDANA_INIT_AUTO: 1
-
   tasks:
   - name: Write deployer info to /etc/motd
     become: yes
@@ -27,6 +24,8 @@
 
   - name: Call ardana-init
     shell: /usr/bin/ardana-init
+    environment:
+      ARDANA_INIT_AUTO: 1
     become: true
     become_user: ardana
 


### PR DESCRIPTION
Set ARDANA_INIT_AUTO only for the ardana-init task instead of globally
on the playbook. It's the only place where it is needed.