### PR TITLE
SCRD-2502 Cleanup link from NFS mount to /opt

### DIFF
--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -62,14 +62,6 @@
       - "{{ compute_mgmt_ips }}"
     when: item != "" and item != deployer_mgmt_ip
 
-  # Ardana creates directory /opt/ardana_packager and serves content from it
-  # (with symlinks followed). Ensure it can serve required SLES and Cloud media.
-  - name: Link maintenance repos to PACKAGE_CONSTANTS.REPO_DIR
-    file:
-      state: link
-      path: /opt/ardana_packager/ardana/sles12/zypper/suse
-      src: /srv/www/suse-12.3/x86_64/repos
-
   # FIXME(colleen): This can go away when https://gerrit.suse.provo.cloud/3061 merges
   - name: Copy zypper repo setup from deployer to other nodes
     shell: |


### PR DESCRIPTION
We no longer plan to ask users to set up repos themselves under /opt.
Instead, we'll ask them to follow a procedure similar to the old
crowbar procedure[1] to set up repositories under /srv. We can also
automate this as a later optimization. In any case, ardana-ansible will
create the needed links from /srv to wherever.

[1] https://www.suse.com/documentation/suse-openstack-cloud-7/book_cloud_deploy/data/sec_depl_adm_conf_repos_product.html