### PR TITLE
Automation: add shellcheck to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,5 @@ genericinstall:
 	make && \
 	sudo make install
 
+shellcheck:
+	shellcheck `grep -Erl '^#! ?/bin/b?a?sh'`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ jenkins/openstack-unittest-testconfig.pl syntax OK
 jenkins/track-upstream-and-package.pl syntax OK
 ```
 
+# shellcheck
+
+You can run [shellcheck](https://github.com/koalaman/shellcheck) locally to check for warnings and suggestions for shell scripts.
+
+First install it:
+
+```
+$ zypper in ShellCheck
+```
+
+Then run it with:
+```
+$ make shellcheck
+```
+
+> Note that there is currently a high number of warnings and errors discovered by shellcheck so the check is supposed to fail until
+we can fix all those issues
+
+
 # jenkins jobs
 There are manually maintained jobs, and some jobs are now using
 [jenkins-job-builder](http://docs.openstack.org/infra/jenkins-job-builder/)


### PR DESCRIPTION
To allow for running it locally, add shellcheck command to
Makefile. searches for all files that contains /bin/bash
(to find the shell scripts) and excludes the yml/yaml files
as they also contains /bin/bash but they are not scripts.

REF: https://github.com/SUSE-Cloud/automation/pull/936