### PR TITLE
Use a test that works for physical nodes too

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4201,7 +4201,10 @@ function onadmin_testsalt
     test -e /etc/salt/roster || onadmin_setupsalt
     salt-ssh \* test.ping | tee /tmp/salt.test.log
     # compare successful pings to node number (+1 for crowbar)
-    test $((1 + $(nodes number all))) = $(grep "^  *True$" /tmp/salt.test.log | wc -l)
+    # FIX ME #jdsn please add the correct distiction between virtual and
+    # physical nodes in the function nodes
+    # test $((1 + $(nodes number all))) = $(grep "^  *True$" /tmp/salt.test.log | wc -l)
+    test $(crowbar machines list | wc -l) = $(grep "^  *True$" /tmp/salt.test.log | wc -l)
 }
 
 function onadmin_testsetup


### PR DESCRIPTION
The test simply compares the number of nodes required with the number of
nodes that salt can ping
The `nodes number all` did not
produce the correct result for the physical
setups. So the temprorary solution is to use
`crowbar machines list` until the nodes
function can handle all the cases