### PR TITLE
magnum: Remove tests for SLES Image (bsc#1082278)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3945,7 +3945,7 @@ function oncontroller_testsetup
     wait_for 100 1 "test \"x\$(nova show \"$instanceid\" | perl -ne 'm/ status [ |]*([a-zA-Z]+)/ && print \$1')\" == xSHUTOFF" "testvm to stop"
 
     # run tests for Magnum bay deployment
-    if iscloudver 7plus && [[ $want_magnum_proposal = 1 ]]; then
+    if iscloudver 7 && [[ $want_magnum_proposal = 1 ]]; then
 
         # This test will cover simple Kubernetes cluster with TLS disabled and no LoadBalancer
         if ! magnum cluster-template-show k8s_template_tls_lb_off > /dev/null 2>&1; then


### PR DESCRIPTION
This patch removes the integration tests we added for the SLES based magnum
image. As for testing magnum, there are funtional tests specific for API and
each COE which should cover creating a cluster template and cluster if
configured properly.