### PR TITLE
ardana-job: add ssh keys also to ~ardana

### DIFF
--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -32,8 +32,14 @@
   - name: Create ssh key for ardana user on deployer
     shell: |
       [ -f ~/.ssh/id_rsa ] || ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
+      [ -f ~/.ssh/authorized_keys ] || touch ~/.ssh/authorized_keys
     become: true
     become_user: ardana
+
+  - name: Copy authorized keys from root to ardana user on deployer
+    shell: |
+      cat ~root/.ssh/authorized_keys ~ardana/.ssh/authorized_keys | sort -u  > ~ardana/.ssh/authorized_keys
+    become: true
 
   - name: Create ssh key for root user on deployer
     shell: |


### PR DESCRIPTION
This avoids having to login as root, which is commonly not
a good practice to follow :-)