### PR TITLE
ardana-trackupstream: remove tracking of not-required projects

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -18,9 +18,6 @@
             - ardana-barbican
             - ardana-cassandra
             - ardana-ceilometer
-            - ardana-ceph
-            - ardana-cephlm
-            - ardana-ci
             - ardana-cinder
             - ardana-cluster
             - ardana-cobbler


### PR DESCRIPTION
ceph/cephlm is being replaced by extensions-ses, and ardana-ci
seems unused (and is not on the media)