### PR TITLE
mkcloud: no config collection on shutdowncloud

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1527,7 +1527,7 @@ function expand_steps
 steplist=`expand_steps $wantedcmds`
 
 : ${steplist:=help}
-if [[ $steplist =~ ^(cleanup|help|steps|setuphost)$ ]] ; then
+if [[ $steplist =~ ^(cleanup|help|steps|setuphost|shutdowncloud)$ ]] ; then
     # skipping sanity checks
     $steplist
     exit $?


### PR DESCRIPTION
This fixes the case that when even one of the vm's was already shut down,
shutdowncloud would throw an error and mkcloud would hang on the
support config collection, because it waits for the ssh timeout of an
already offline vm.