### PR TITLE
mkcloud: shutdowncloud now prints the cloud name

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -643,6 +643,8 @@ function setuppublicnet
 
 function shutdowncloud
 {
+    echo "Shutting down: $cloud"
+    echo
     ${mkclouddriver}_do_shutdowncloud
 }
 


### PR DESCRIPTION
So that the user knows which cloud gets turned off, when
there are multiple.