### PR TITLE
mkcloud: Wrapped SKIPSUPPORTCONFIG in function

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -115,6 +115,11 @@ function safely
     fi
 }
 
+function safely_skip_support
+{
+    SKIPSUPPORTCONFIG=1 safely "$@"
+}
+
 function rubyjsonparse
 {
     ruby -e "

--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -123,8 +123,8 @@ function libvirt_do_setuphost()
     echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
     libvirt_do_sanity_checks
     if [ -n "$needcvol" ] ; then
-        safely pvcreate "$cloudpv"
-        safely vgcreate "$cloudvg" "$cloudpv"
+        safely_skip_support pvcreate "$cloudpv"
+        safely_skip_support vgcreate "$cloudvg" "$cloudpv"
     fi
 
     if is_debian ; then

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -388,7 +388,7 @@ function onhost_add_etchosts_entries
 
 function setuphost
 {
-    SKIPSUPPORTCONFIG=1 ${mkclouddriver}_do_setuphost
+    ${mkclouddriver}_do_setuphost
 }
 
 function prepare


### PR DESCRIPTION
The function setuphost was called with SKIPSUPPORTCONFIG, but since
setuphost is part of the regex in line 1532 (in ## MAIN ##) error_exit
is not called on setuphost errors, thus the config wasn't collected in
the first place.

The exceptions to this are the two calls to pvcreate and vgcreate
inside the function libvirt_do_setuphost(), which were decorated with
safely, which calls error_exit. But since SKIPSUPPORTCONFIG was set, it
wouldn't collect the configs either.

I removed the SKIPSUPPORTCONFIG on the setuphost call and added a
safely_skip_support decorator function, which provides the same functionality,
but without the config collection, which should make the code more
readable.