### PR TITLE
mkcloud: Added timout to sshopts

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -194,7 +194,7 @@ function log_timing
     echo "$start,$end,$kind,$item,$(($end - $start))" >> $logfile
 }
 
-sshopts="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oServerAliveInterval=20"
+sshopts="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oServerAliveInterval=20 -oConnectTimeout=5"
 scp="scp $sshopts"
 ssh="ssh $sshopts"
 function ssh_password


### PR DESCRIPTION
So that in the case that a vm can't be reached, e.g. because it was shutdown or
an error occured before the vm was started, mkcloud doesn't hang on an
ssh request.