### PR TITLE
add organisation parameter to job_parameters

### DIFF
--- a/scripts/github_pr/interactions/ia_crowbar.rb
+++ b/scripts/github_pr/interactions/ia_crowbar.rb
@@ -5,6 +5,7 @@ module GithubPR
     def extra_parameters(pull, _build_mode = "")
       {
         crowbar_repo: @metadata[:repository],
+        crowbar_org: @metadata[:organization],
         crowbar_github_pr: "#{pull.number}:#{pull.head.sha}:#{pull.base.ref}",
         job_name: "#{@metadata[:org_repo]} testbuild PR #{pull.number} #{pull.head.sha[0,8]}",
       }


### PR DESCRIPTION
Without this parameter the triggered jenkins jobs will default to "crowbar" as organization.
This is an error in case github_pr handles other organizations.