### PR TITLE
SCRD-2080 Revert to expecting logrotate.conf not to be modified

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
@@ -12,7 +12,6 @@
 SM5..U.T.  c /etc/kafka/log4j.properties
 S.5..U.T.  c /etc/kafka/server.properties
 S.5....T.  c /etc/kibana/kibana.yml
-S.5....T.  c /etc/logrotate.conf
 ......G..    /etc/monasca
 .M...UG..    /etc/monasca/agent
 .M...UG..    /etc/monasca/agent/conf.d


### PR DESCRIPTION
**DON'T MERGE until [gerrit#I51c2bf0c](https://gerrit.suse.provo.cloud/#/c/3800/) is merged**

Ardana was incorrectly modifying `/etc/logrotate.conf`, so we had to temporarily add an exception to the rpm verification whitelist for modified files in order to avoid `ardana-job` permanently failing.  However once [gerrit#I51c2bf0c (SCRD-2080 don't replace standard /etc/logrotate.conf)](https://gerrit.suse.provo.cloud/#/c/3800/) is merged, this exception is no longer necessary.
