### PR TITLE
Run site.yml from the Jenkins Job directly

### DIFF
--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -62,7 +62,7 @@
 
       - string:
           name: tempest_run_filter
-          default: smoke
+          default: ''
           description: >-
             Name of the filter file to use for tempest. Possible values:
             ci, compute, designate, lbaas, network, neutron-api, periodic,

--- a/jenkins/ci.suse.de/ardana-job.yaml
+++ b/jenkins/ci.suse.de/ardana-job.yaml
@@ -139,8 +139,9 @@
 
           DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-ip-floating -c output_value -f value)
           NETWORK_MGMT_ID=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME network-mgmt-id -c output_value -f value)
+          sshargs="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
           # FIXME: Use cloud-init in the used image
-          sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${DEPLOYER_IP}
+          sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 $sshargs root@${DEPLOYER_IP}
           pushd ansible
           cat << EOF > hosts
           [hosts]
@@ -177,14 +178,22 @@
 
           cat ardana_net_vars.yml
 
-          ansible-playbook -vvv -i hosts ssh-keys.yml
-          ansible-playbook -vvv -i hosts -e "build_url=$BUILD_URL" \
-                                         -e "cloudsource=${cloudsource}" repositories.yml
-          ansible-playbook -vvv -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" \
-                                         -e "deployer_model=${model}" \
-                                         -e "tempest_run_filter=${tempest_run_filter}" \
-                                         init.yml
+          ansible-playbook -v -i hosts ssh-keys.yml
+          ansible-playbook -v -i hosts -e "build_url=$BUILD_URL" \
+                                       -e "cloudsource=${cloudsource}" repositories.yml
+          verification_temp_dir=$(ssh $sshargs root@$DEPLOYER_IP \
+                                    "mktemp -d /tmp/ardana-job-rpm-verification.XXXXXXXX")
+          ansible-playbook -v -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" \
+                                       -e "deployer_model=${model}" \
+                                       -e "verification_temp_dir=$verification_temp_dir" \
+                                       init.yml
+          # Run site.yml outside ansible for output streaming
+          ssh $sshargs ardana@$DEPLOYER_IP "cd ~/scratch/ansible/next/ardana/ansible ; \
+               ansible-playbook -vvv -i hosts/verb_hosts site.yml"
 
+          ansible-playbook -v -i hosts -e "tempest_run_filter=${tempest_run_filter}" \
+                                       -e "verification_temp_dir=$verification_temp_dir" \
+                                       post-deploy-checks.yml
 
     publishers:
       - post-tasks:

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -5,10 +5,10 @@
 
   vars_files:
     - ardana_net_vars.yml
+    - vars/main.yml
 
   vars:
     deployer_model: deployerincloud-lite
-    tempest_run_filter: smoke
 
   tasks:
   - name: Write deployer info to /etc/motd
@@ -204,65 +204,3 @@
     become: true
     when: item != "" and item != deployer_mgmt_ip
     become_user: ardana
-
-  - name: Initialise array tracking failures
-    set_fact:
-      failures: []
-
-  - name: Run the actual deployment site.yml playbook
-    shell: |
-      ansible-playbook -vvv -i hosts/verb_hosts site.yml
-    args:
-      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
-    become: true
-    become_user: ardana
-    register: site_result
-    ignore_errors: true
-
-  - name: Record any failure of site.yml
-    set_fact:
-      failures: "{{ failures + ['site.yml'] }}"
-    when: site_result|failed
-
-  - name: Configure Cloud for Tempest run
-    shell: |
-      ansible-playbook -vvv -i hosts/verb_hosts ardana-cloud-configure.yml
-    args:
-      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
-    become: true
-    become_user: ardana
-    when: site_result|succeeded
-
-  - name: Run tempest
-    shell: |
-      ansible-playbook -vvv -i hosts/verb_hosts tempest-run.yml \
-                       -e run_filter="{{ tempest_run_filter }}"
-    args:
-      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
-    become: true
-    become_user: ardana
-    register: tempest_run_result
-    ignore_errors: true
-    when: site_result|succeeded
-
-  - name: Record any failure of tempest
-    set_fact:
-      failures: "{{ failures + ['tempest'] }}"
-    when: tempest_run_result|failed
-
-  - include: post-deploy-checks.yml
-
-  # If you change the below, also change test-post-deployment-checks.yml to match!
-
-  - name: Record any failures of post-deployment checks
-    set_fact:
-      failures: "{{ failures + post_deploy_checks_failures }}"
-
-  - name: Report any failures
-    fail:
-      msg: |
-        {{failures|length}} failures:
-        {% for failure in failures %}
-        {{ failure }}
-        {% endfor %}
-    when: failures|length > 0

--- a/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
@@ -30,6 +30,7 @@
     become_user: ardana
     register: tempest_run_result
     ignore_errors: true
+    when: tempest_run_filter != ""
 
   - name: Record any failure of tempest
     set_fact:

--- a/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
@@ -20,6 +20,16 @@
     become: true
     become_user: ardana
 
+  - name: Stop irrelevant services to survive tempest
+    shell: |
+      ansible-playbook -v -i hosts/verb_hosts logging-stop.yml
+      ansible-playbook -v -i hosts/verb_hosts monasca-transform-stop.yml
+    args:
+      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
+    become: true
+    become_user: ardana
+    when: tempest_run_filter != ""
+
   - name: Run tempest
     shell: |
       ansible-playbook -v -i hosts/verb_hosts tempest-run.yml \

--- a/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
@@ -1,134 +1,173 @@
-- name: Set files to contain output of various verification steps
-  set_fact:
-    post_deploy_rpm_verification:
-      "{{ verification_temp_dir }}/rpm-verify-post.out"
-    rpm_verification_fixmes:
-      "{{ verification_temp_dir }}/rpm-verify-modification-whitelist.txt"
-    rpm_modifiable_config_files:
-      "{{ verification_temp_dir }}/rpm-modifiable-config-files.txt"
-    rpm_modifiable_config_file_regexps:
-      "{{ verification_temp_dir }}/rpm-modifiable-config-file-regexps.txt"
-    rpm_added_files_whitelist:
-      "{{ verification_temp_dir }}/rpm-added-files-whitelist.txt"
+---
+- name: Post deployment checks
+  hosts: hosts
+  gather_facts: False
 
-- name: Initialise array tracking post-deployment checks failures
-  set_fact:
-    post_deploy_checks_failures: []
+  vars_files:
+    - ardana_net_vars.yml
+    - vars/main.yml
 
-- name: Take snapshot of modified/deleted rpm-owned files post deployment
-  become: yes
-  shell: |
-    rpm -Va | grep -vxFf "{{ pre_deploy_rpm_verification }}" \
-      > "{{ post_deploy_rpm_verification }}"
-  failed_when: false
-  register: rpm_verify_delta
+  tasks:
+  - name: Initialise array tracking failures
+    set_fact:
+      failures: []
 
-- name: Obtain list of rpm-owned files removed by deployment
-  shell: |
-    grep '^missing ' "{{ post_deploy_rpm_verification }}"
-  failed_when: false
-  register: rpm_verify_removed_files
+  - name: Configure Cloud for Tempest run
+    shell: |
+      ansible-playbook -v -i hosts/verb_hosts ardana-cloud-configure.yml
+    args:
+      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
+    become: true
+    become_user: ardana
 
-- name: Write list of known FIXMEs for incorrect modifications of rpm-owned files
-  copy:
-    src: rpm-verify-modification-whitelist.txt
-    dest: "{{ rpm_verification_fixmes }}"
+  - name: Run tempest
+    shell: |
+      ansible-playbook -v -i hosts/verb_hosts tempest-run.yml \
+                       -e run_filter="{{ tempest_run_filter }}"
+    args:
+      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
+    become: true
+    become_user: ardana
+    register: tempest_run_result
+    ignore_errors: true
 
-- name: Trim comments and blank lines from FIXME file
-  lineinfile:
-    dest: "{{ rpm_verification_fixmes }}"
-    regexp: '^(#|$)'
-    state: absent
+  - name: Record any failure of tempest
+    set_fact:
+      failures: "{{ failures + ['tempest'] }}"
+    when: tempest_run_result|failed
 
-- name: Write list of rpm %config files not endangered by update
-  shell: |
-    # Find all %config(noreplace) files, since if written to by
-    # Ardana, these will be safely left in place by an update (the new
-    # version would be written to a .rpmnew file).  Similarly include
-    # ghost configs since presumably these would not pose problems
-    # during an update.
-    rpm -qa --qf '[%{filenames} ## %{fileflags:fflags}\n]' | \
-      grep ' ## .*c.*[gn]' | \
-      sed 's/ ## .*//' \
-      > "{{ rpm_modifiable_config_files }}"
+  - name: Initialise array tracking post-deployment checks failures
+    set_fact:
+      post_deploy_checks_failures: []
 
-- name: Write list of regexps matching rpm %config files not endangered by update
-  shell: |
-    # The files are written as a list of regexps into a file which can
-    # be used with grep -vf as an exclusion list for the output of rpm -Va.
-    sed 's/^/ /; s/$/$/' "{{ rpm_modifiable_config_files }}" \
-      > "{{ rpm_modifiable_config_file_regexps }}"
+  - name: Take snapshot of modified/deleted rpm-owned files post deployment
+    become: yes
+    shell: |
+      rpm -Va | grep -vxFf "{{ pre_deploy_rpm_verification }}" \
+        > "{{ post_deploy_rpm_verification }}"
+    failed_when: false
+    register: rpm_verify_delta
 
-- name: Obtain list of rpm-owned files incorrectly modified by deployment
-  # Exclude both the whitelist of fixmes (known issues), and config files
-  # which we calculated above as being safe to modify.
-  shell: |
-    egrep -v '^missing' "{{ post_deploy_rpm_verification }}" | \
-      grep -vf "{{ rpm_verification_fixmes }}" | \
-      grep -vf "{{ rpm_modifiable_config_file_regexps }}"
-  failed_when: false
-  register: rpm_verify_modified_files
+  - name: Obtain list of rpm-owned files removed by deployment
+    shell: |
+      grep '^missing ' "{{ post_deploy_rpm_verification }}"
+    failed_when: false
+    register: rpm_verify_removed_files
 
-- name: Check no rpm-owned files removed by deployment
-  fail: msg="Found files removed by deployment:\n{{ rpm_verify_removed_files.stdout }}"
-  when:
-    - "rpm_verify_removed_files.stdout | match('^missing ')"
-  ignore_errors: true
+  - name: Write list of known FIXMEs for incorrect modifications of rpm-owned files
+    copy:
+      src: rpm-verify-modification-whitelist.txt
+      dest: "{{ rpm_verification_fixmes }}"
 
-- name: Record failure if rpm-owned files removed by deployment
-  set_fact:
-    post_deploy_checks_failures:
-      "{{ post_deploy_checks_failures + [ 'rpm-owned files removed by deployment' ] }}"
-  when:
-    - "rpm_verify_removed_files.stdout | match('^missing ')"
+  - name: Trim comments and blank lines from FIXME file
+    lineinfile:
+      dest: "{{ rpm_verification_fixmes }}"
+      regexp: '^(#|$)'
+      state: absent
 
-- name: Check no rpm-owned files modified by deployment
-  fail: msg="Found files modified by deployment:\n{{ rpm_verify_modified_files.stdout }}"
-  when:
-    - "rpm_verify_modified_files.stdout != ''"
-  ignore_errors: true
+  - name: Write list of rpm %config files not endangered by update
+    shell: |
+      # Find all %config(noreplace) files, since if written to by
+      # Ardana, these will be safely left in place by an update (the new
+      # version would be written to a .rpmnew file).  Similarly include
+      # ghost configs since presumably these would not pose problems
+      # during an update.
+      rpm -qa --qf '[%{filenames} ## %{fileflags:fflags}\n]' | \
+        grep ' ## .*c.*[gn]' | \
+        sed 's/ ## .*//' \
+        > "{{ rpm_modifiable_config_files }}"
 
-- name: Record failure if rpm-owned files modified by deployment
-  set_fact:
-    post_deploy_checks_failures:
-      "{{ post_deploy_checks_failures + [ 'rpm-owned files modified by deployment' ] }}"
-  when:
-    - "rpm_verify_modified_files.stdout != ''"
+  - name: Write list of regexps matching rpm %config files not endangered by update
+    shell: |
+      # The files are written as a list of regexps into a file which can
+      # be used with grep -vf as an exclusion list for the output of rpm -Va.
+      sed 's/^/ /; s/$/$/' "{{ rpm_modifiable_config_files }}" \
+        > "{{ rpm_modifiable_config_file_regexps }}"
 
-- name: Write list of known FIXMEs for incorrect modifications of rpm-owned files
-  copy:
-    src: rpm-added-files-whitelist.txt
-    dest: "{{ rpm_added_files_whitelist }}"
+  - name: Obtain list of rpm-owned files incorrectly modified by deployment
+    # Exclude both the whitelist of fixmes (known issues), and config files
+    # which we calculated above as being safe to modify.
+    shell: |
+      egrep -v '^missing' "{{ post_deploy_rpm_verification }}" | \
+        grep -vf "{{ rpm_verification_fixmes }}" | \
+        grep -vf "{{ rpm_modifiable_config_file_regexps }}"
+    failed_when: false
+    register: rpm_verify_modified_files
 
-- name: Trim comments and blank lines from rpm added files white-list
-  lineinfile:
-    dest: "{{ rpm_added_files_whitelist }}"
-    regexp: '^(#|$)'
-    state: absent
+  - name: Check no rpm-owned files removed by deployment
+    fail: msg="Found files removed by deployment:\n{{ rpm_verify_removed_files.stdout }}"
+    when:
+      - "rpm_verify_removed_files.stdout | match('^missing ')"
+    ignore_errors: true
 
-- name: Check for rogue files introduced by deployment which are not owned by a package
-  shell: |
-    ! find /usr -printf "%p -> %l\n" | \
-      egrep -vf "{{ rpm_added_files_whitelist }}" | \
-      sed 's/ -> .*//' | \
-      xargs -r -d '\n' rpm -qf | \
-      grep -vxFf "{{ pre_deploy_unowned_files }}" | \
-      grep "is not owned"
-  register: rogue_files
-  ignore_errors: true
+  - name: Record failure if rpm-owned files removed by deployment
+    set_fact:
+      post_deploy_checks_failures:
+        "{{ post_deploy_checks_failures + [ 'rpm-owned files removed by deployment' ] }}"
+    when:
+      - "rpm_verify_removed_files.stdout | match('^missing ')"
 
-- name: Record failure if rogue files introduced by deployment
-  set_fact:
-    post_deploy_checks_failures:
-      "{{ post_deploy_checks_failures + [ 'Rogue files introduced by deployment' ] }}"
-  when:
-    - rogue_files | failed
+  - name: Check no rpm-owned files modified by deployment
+    fail: msg="Found files modified by deployment:\n{{ rpm_verify_modified_files.stdout }}"
+    when:
+      - "rpm_verify_modified_files.stdout != ''"
+    ignore_errors: true
 
-- name: Remove temporary directory if not running in test mode and all checks succeeded
-  become: yes
-  file:
-    path: "{{ verification_temp_dir }}"
-    state: absent
-  when:
-    - rpm_verification_test_mode is not defined
-    - post_deploy_checks_failures|length == 0
+  - name: Record failure if rpm-owned files modified by deployment
+    set_fact:
+      post_deploy_checks_failures:
+        "{{ post_deploy_checks_failures + [ 'rpm-owned files modified by deployment' ] }}"
+    when:
+      - "rpm_verify_modified_files.stdout != ''"
+
+  - name: Write list of known FIXMEs for incorrect modifications of rpm-owned files
+    copy:
+      src: rpm-added-files-whitelist.txt
+      dest: "{{ rpm_added_files_whitelist }}"
+
+  - name: Trim comments and blank lines from rpm added files white-list
+    lineinfile:
+      dest: "{{ rpm_added_files_whitelist }}"
+      regexp: '^(#|$)'
+      state: absent
+
+  - name: Check for rogue files introduced by deployment which are not owned by a package
+    shell: |
+      ! find /usr -printf "%p -> %l\n" | \
+        egrep -vf "{{ rpm_added_files_whitelist }}" | \
+        sed 's/ -> .*//' | \
+        xargs -r -d '\n' rpm -qf | \
+        grep -vxFf "{{ pre_deploy_unowned_files }}" | \
+        grep "is not owned"
+    register: rogue_files
+    ignore_errors: true
+
+  - name: Record failure if rogue files introduced by deployment
+    set_fact:
+      post_deploy_checks_failures:
+        "{{ post_deploy_checks_failures + [ 'Rogue files introduced by deployment' ] }}"
+    when:
+      - rogue_files | failed
+
+  - name: Remove temporary directory if not running in test mode and all checks succeeded
+    become: yes
+    file:
+      path: "{{ verification_temp_dir }}"
+      state: absent
+    when:
+      - rpm_verification_test_mode is not defined
+      - post_deploy_checks_failures|length == 0
+
+  # If you change the below, also change test-post-deployment-checks.yml to match!
+  - name: Record any failures of post-deployment checks
+    set_fact:
+      failures: "{{ failures + post_deploy_checks_failures }}"
+
+  - name: Report any failures
+    fail:
+      msg: |
+        {{failures|length}} failures:
+        {% for failure in failures %}
+        {{ failure }}
+        {% endfor %}
+    when: failures|length > 0

--- a/scripts/jenkins/ardana/ansible/pre-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/pre-deploy-checks.yml
@@ -1,22 +1,3 @@
-- name: Create a temporary directory to store pre-deployment verification state
-  become: yes
-  shell: mktemp -d /tmp/ardana-job-rpm-verification.XXXXXXXX
-  register: verification_mktemp_dir
-
-# This allows us to easily pass a value for the temporary directory
-# in to the test-post-deployment-checks.yml playbook when testing.
-- name: Store path to temporary directory
-  set_fact:
-    verification_temp_dir:
-      "{{ verification_mktemp_dir.stdout }}"
-
-- name: Set files to contain output of rpm -qf and -Va pre-deployment
-  set_fact:
-    pre_deploy_unowned_files:
-      "{{ verification_temp_dir }}/rpm-qf-pre.out"
-    pre_deploy_rpm_verification:
-      "{{ verification_temp_dir }}/rpm-verify-pre.out"
-
 - name: Take snapshot of files not owned by a package prior to deployment
   become: yes
   failed_when: false

--- a/scripts/jenkins/ardana/ansible/vars/main.yml
+++ b/scripts/jenkins/ardana/ansible/vars/main.yml
@@ -1,0 +1,10 @@
+---
+
+pre_deploy_unowned_files: "{{ verification_temp_dir }}/rpm-qf-pre.out"
+pre_deploy_rpm_verification: "{{ verification_temp_dir }}/rpm-verify-pre.out"
+
+post_deploy_rpm_verification: "{{ verification_temp_dir }}/rpm-verify-post.out"
+rpm_verification_fixmes: "{{ verification_temp_dir }}/rpm-verify-modification-whitelist.txt"
+rpm_modifiable_config_files: "{{ verification_temp_dir }}/rpm-modifiable-config-files.txt"
+rpm_modifiable_config_file_regexps: "{{ verification_temp_dir }}/rpm-modifiable-config-file-regexps.txt"
+rpm_added_files_whitelist: "{{ verification_temp_dir }}/rpm-added-files-whitelist.txt"


### PR DESCRIPTION
This avoids 3 hours of no output and lets us follow the
stream of the deployment instead. convert post-deploy checks into
a playbook that can be invoked on its own.