### PR TITLE
The drivers pxe_ssh, agent_ssh and fake_ssh are no longer available

### DIFF
--- a/scripts/scenarios/cloud8/cloud8-ironic-swift-ha.yml
+++ b/scripts/scenarios/cloud8/cloud8-ironic-swift-ha.yml
@@ -218,7 +218,6 @@ proposals:
     keystone_instance: default
     neutron_instance: default
     enabled_drivers:
-    - agent_ssh
     - agent_ipmitool
   deployment:
     elements:


### PR DESCRIPTION
See bug https://bugzilla.suse.com/show_bug.cgi?id=1087472