### PR TITLE
Increase memory for ardana jobs

### DIFF
--- a/scripts/jenkins/ardana/heat-ardana-deployerincloud-lite.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-deployerincloud-lite.yaml
@@ -18,12 +18,12 @@ parameters:
     type: string
     label: Instance Type
     description: Type of instance (flavor) to be used for the controller
-    default: m1.xxlarge
+    default: cloud-ardana-job-controller
   instance_type_compute:
     type: string
     label: Instance Type
     description: Type of instance (flavor) to be used for compute nodes
-    default: m1.large
+    default: cloud-ardana-job-compute
   number_of_computes:
     type: number
     description: Count of compute nodes to create

--- a/scripts/jenkins/ardana/heat-ardana-standard.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-standard.yaml
@@ -181,7 +181,7 @@ resources:
     properties:
       key_name: { get_param: key_name }
       image: { get_param: image_id }
-      flavor: { get_param: instance_type_controller }
+      flavor: { get_param: instance_type_compute }
       networks:
         - network: { get_resource: network_mgmt }
         - network: { get_resource: network_ardana }

--- a/scripts/jenkins/ardana/heat-ardana-standard.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-standard.yaml
@@ -18,12 +18,12 @@ parameters:
     type: string
     label: Instance Type
     description: Type of instance (flavor) to be used for the controller
-    default: m1.xxlarge
+    default: cloud-ardana-job-controller
   instance_type_compute:
     type: string
     label: Instance Type
     description: Type of instance (flavor) to be used for compute nodes
-    default: m1.large
+    default: cloud-ardana-job-compute
   number_of_computes:
     type: number
     description: Count of compute nodes to create

--- a/scripts/jenkins/ardana/heat-ardana-std-controller.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-std-controller.yaml
@@ -18,7 +18,7 @@ parameters:
     type: string
     label: Instance Type
     description: Type of instance (flavor) to be used for the controller
-    default: m1.xxlarge
+    default: cloud-ardana-job-controller
   index:
     type: number
     description: controller index suffix


### PR DESCRIPTION
The cassandra and spark stuff crashes with OOM all the time, even already during deploy. we need to switch to larger flavors. use custom flavor names to that we're more flexible going forward. 