### PR TITLE
Add support for std-split model testing

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/std-split/input-model/disks_controller.yml
+++ b/scripts/jenkins/ardana/ansible/files/std-split/input-model/disks_controller.yml
@@ -1,0 +1,1 @@
+../../input-model-disks-controller.yml

--- a/scripts/jenkins/ardana/ansible/files/std-split/input-model/firewall_rules.yml
+++ b/scripts/jenkins/ardana/ansible/files/std-split/input-model/firewall_rules.yml
@@ -1,0 +1,1 @@
+../../input-model-firewall-rules.yml

--- a/scripts/jenkins/ardana/ansible/files/std-split/input-model/interfaces_set_1.yml
+++ b/scripts/jenkins/ardana/ansible/files/std-split/input-model/interfaces_set_1.yml
@@ -1,0 +1,145 @@
+#
+# (c) Copyright 2015-2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+  product:
+    version: 2
+
+  interface-models:
+    - name: ARDANA-INTERFACES
+      network-interfaces:
+
+        - name: hed1
+          device:
+            name: hed1
+          network-groups:
+            - MANAGEMENT
+
+        - name: hed2
+          device:
+            name: hed2
+          network-groups:
+            - ARDANA
+
+        - name: hed8
+          device:
+            name: hed8
+          forced-network-groups:
+            - HOSTNAME
+
+
+    - name: CONTROLLER-INTERFACES
+      network-interfaces:
+
+        - name: hed2
+          device:
+            name: hed2
+          network-groups:
+            - ARDANA
+
+        - name: BOND0
+          device:
+              name: bond0
+          bond-data:
+             options:
+                 mode: active-backup
+                 miimon: 200
+                 primary: hed1
+             provider: linux
+             devices:
+               - name: hed1
+               - name: hed3
+          network-groups:
+            - MANAGEMENT
+
+        - name: hed4
+          device:
+            name: hed4
+          network-groups:
+            - EXTERNAL-VM
+
+        - name: hed5
+          device:
+            name: hed5
+          network-groups:
+            - GUEST
+
+        - name: hed6
+          device:
+            name: hed6
+          network-groups:
+            - SWIFT
+          forced-network-groups:
+            - ISCSI
+
+        - name: hed7
+          device:
+            name: hed7
+          network-groups:
+            - TENANT-VLAN
+
+        - name: hed8
+          device:
+            name: hed8
+          forced-network-groups:
+            - HOSTNAME
+          network-groups:
+            - EXTERNAL-API
+
+    - name: COMPUTE-INTERFACES
+      network-interfaces:
+
+        - name: hed1
+          device:
+            name: hed1
+          network-groups:
+            - MANAGEMENT
+
+        - name: hed2
+          device:
+            name: hed2
+          network-groups:
+            - ARDANA
+
+        - name: hed4
+          device:
+            name: hed4
+          network-groups:
+            - EXTERNAL-VM
+
+        - name: hed5
+          device:
+            name: hed5
+          network-groups:
+            - GUEST
+
+        - name: hed6
+          device:
+            name: hed6
+          forced-network-groups:
+            - ISCSI
+
+        - name: hed7
+          device:
+            name: hed7
+          network-groups:
+            - TENANT-VLAN
+
+        - name: hed8
+          device:
+            name: hed8
+          forced-network-groups:
+            - HOSTNAME

--- a/scripts/jenkins/ardana/ansible/files/std-split/input-model/net_global.yml
+++ b/scripts/jenkins/ardana/ansible/files/std-split/input-model/net_global.yml
@@ -1,0 +1,1 @@
+../../input-model-net-global.yml

--- a/scripts/jenkins/ardana/ansible/files/std-split/input-model/network_groups.yml
+++ b/scripts/jenkins/ardana/ansible/files/std-split/input-model/network_groups.yml
@@ -1,0 +1,1 @@
+../../input-model-network-groups.yml

--- a/scripts/jenkins/ardana/ansible/files/std-split/input-model/nic_mappings.yml
+++ b/scripts/jenkins/ardana/ansible/files/std-split/input-model/nic_mappings.yml
@@ -1,0 +1,1 @@
+../../input-model-nic-mappings.yml

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -136,6 +136,19 @@
       recursive: yes
     become: true
     become_user: ardana
+
+  - name: Replace disks to accomodate virtio_blk
+    replace:
+      dest: "/var/lib/ardana//openstack/my_cloud/definition/data/{{ item }}"
+      regexp: '/dev/sd([a-f]) *$'
+      replace: '/dev/vd\1'
+    with_items:
+      - disks_ardana.yml
+      - disks_compute.yml
+      - disks_dbmq.yml
+      - disks_mml.yml
+      - disks_osc.yml
+    ignore_errors: True
     tags:
       - create-ardana-input-model
 

--- a/scripts/jenkins/ardana/ansible/templates/std-split/input-model-servers.yml
+++ b/scripts/jenkins/ardana/ansible/templates/std-split/input-model-servers.yml
@@ -1,0 +1,59 @@
+---
+  product:
+    version: 2
+
+  baremetal:
+    subnet: 192.168.245.0
+    netmask: 255.255.255.0
+
+  servers:
+
+    - id: deployer
+      ip-addr: {{ deployer_mgmt_ip }}
+      role: STD-ARDANA-ROLE
+      server-group: RACK1
+      mac-addr: b2:72:8d:ac:7c:6f
+      ilo-ip: 192.168.109.3
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT
+
+    - id: osc-0001
+      ip-addr: {{ controller_mgmt_ips[0] }}
+      role: STD-OSC-CONTROLLER-ROLE
+      server-group: RACK1
+      mac-addr: d6:70:c1:36:43:f7
+      ilo-ip: 192.168.109.5
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT
+
+    - id: dbmq-0001
+      ip-addr: {{ controller_mgmt_ips[1] }}
+      role: STD-DBMQ-CONTROLLER-ROLE
+      server-group: RACK2
+      mac-addr: d6:70:c1:36:43:f7
+      ilo-ip: 192.168.109.5
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT
+
+    - id: mml-0001
+      ip-addr: {{ controller_mgmt_ips[2] }}
+      role: STD-MML-CONTROLLER-ROLE
+      server-group: RACK3
+      mac-addr: 52:54:00:aa:04:01
+      ilo-ip: 192.168.109.5
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT
+
+    - id: comp-0001
+      ip-addr: {{ compute_mgmt_ips[0] }}
+      role: STD-COMPUTE-ROLE
+      server-group: RACK2
+      mac-addr: 8e:8e:62:a6:ce:76
+      ilo-ip: 192.168.109.6
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT

--- a/scripts/jenkins/ardana/heat-ardana-std-split.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-std-split.yaml
@@ -1,0 +1,1 @@
+heat-ardana-standard.yaml


### PR DESCRIPTION
The std-split model is testing a 3 control plane cluster
separation and is hence useful for testing a more scaled out
mid-sized cloud