### PR TITLE
openstack-ardana: Adjust stack name to jenkins job name

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -70,7 +70,7 @@
           echo
 
           set -ex
-          STACK_NAME=cloud-ci-ardana-job-${BUILD_NUMBER}
+          STACK_NAME=cloud-ci-openstack-ardana-${BUILD_NUMBER}
           if [ -n "${JOB_NAME}" ]; then
               STACK_NAME=${STACK_NAME}-${JOB_NAME}
           fi


### PR DESCRIPTION
The jenkins job is now openstack-ardana so adjust the Heat stack name,
too.