### PR TITLE
upgrade: Create and sign PTF repos the same way as normal install

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4800,7 +4800,7 @@ function onadmin_prepare_cloudupgrade_admin_repos
     # during installation, this would be done by install-suse-cloud
     mkdir -p $tftpboot_repos_dir/PTF
     ensure_packages_installed createrepo
-    safely createrepo $tftpboot_repos_dir/PTF
+    createrepo-cloud-ptf || createrepo $tftpboot_repos_dir/PTF
 
     # remove old repositories
     # (so that zypper does not have an option to choose from the old ones)


### PR DESCRIPTION
We were missing this bit when creating new PTF repos for next version
of the product.

See https://github.com/SUSE-Cloud/automation/commit/0b7e5f2af609951ead16bf6390e0fd6f97c79d97