### PR TITLE
qa_crowbarsetup.sh: Set insecure flag for crowbar when using ssl

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1930,6 +1930,7 @@ function enable_ssl_generic
             if iscloudver 7plus ; then
                 $p "$a['apache']['ssl']" true
                 $p "$a['apache']['generate_certs']" true
+                $p "$a['apache']['insecure']" true
             fi
             return
         ;;


### PR DESCRIPTION
We generate the certificates, so the insecure flag is necessary; without
this, crowbarctl command will fail trying to validate the certificates.