### PR TITLE
Remove cloud6 jobs that were never green

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -18,10 +18,8 @@
         - 'cloud-mkcloud{version}-job-backup-restore-{arch}'
         - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
         - 'cloud-mkcloud{version}-job-dvr-{arch}'
-        - 'cloud-mkcloud{version}-job-hyperv-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-{arch}'
         - 'cloud-mkcloud{version}-job-xen-{arch}'
 - project:
     name: cloud-mkcloud6-ha-x86_64
@@ -38,17 +36,6 @@
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
         - 'cloud-mkcloud{version}-job-ha-{arch}'
-- project:
-    name: cloud-mkcloud6-tempestfull-x86_64
-    disabled: false
-    version: 6
-    previous_version: 5
-    arch: x86_64
-    tempestoptions: -t
-    label: openstack-mkcloud-SLE12-x86_64
-    jobs:
-        - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
-        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
 - project:
     name: cloud-mkcloud6-cd-x86_64
     disabled: false


### PR DESCRIPTION
With Cloud6 going into LTSS mode, we can reduce those tests that
never passed during the lifecycle of cloud6