### PR TITLE
openstack-ardana: enable dac-3cp input model

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -101,7 +101,7 @@
                   num_controller=3
                   num_compute=3
                   ;;
-              std-split|std-3cp)
+              std-split|std-3cp|dac-3cp)
                   num_controller=3
                   num_compute=1
                   ;;

--- a/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/disks_controller.yml
+++ b/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/disks_controller.yml
@@ -1,0 +1,1 @@
+../../input-model-disks-controller.yml

--- a/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/firewall_rules.yml
+++ b/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/firewall_rules.yml
@@ -1,0 +1,1 @@
+../../input-model-firewall-rules.yml

--- a/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/interfaces_set_1.yml
+++ b/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/interfaces_set_1.yml
@@ -1,0 +1,123 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+  product:
+    version: 2
+
+  interface-models:
+
+    - name: CONTROLLER-INTERFACES
+      network-interfaces:
+
+        - name: hed2
+          device:
+            name: hed2
+          network-groups:
+            - ARDANA
+
+        - name: BOND0
+          device:
+              name: bond0
+          bond-data:
+             options:
+                 mode: active-backup
+                 miimon: 200
+                 primary: hed1
+             provider: linux
+             devices:
+               - name: hed1
+               - name: hed3
+          network-groups:
+            - MANAGEMENT
+
+        - name: hed4
+          device:
+            name: hed4
+          network-groups:
+            - EXTERNAL-VM
+
+        - name: hed5
+          device:
+            name: hed5
+          network-groups:
+            - GUEST
+
+        - name: hed6
+          device:
+            name: hed6
+          network-groups:
+            - SWIFT
+          forced-network-groups:
+            - ISCSI
+
+        - name: hed7
+          device:
+            name: hed7
+          network-groups:
+            - TENANT-VLAN
+
+        - name: hed8
+          device:
+            name: hed8
+          forced-network-groups:
+            - HOSTNAME
+          network-groups:
+            - EXTERNAL-API
+
+    - name: COMPUTE-INTERFACES
+      network-interfaces:
+
+        - name: hed1
+          device:
+            name: hed1
+          network-groups:
+            - MANAGEMENT
+
+        - name: hed2
+          device:
+            name: hed2
+          network-groups:
+            - ARDANA
+
+        - name: hed4
+          device:
+            name: hed4
+          network-groups:
+            - EXTERNAL-VM
+
+        - name: hed5
+          device:
+            name: hed5
+          network-groups:
+            - GUEST
+
+        - name: hed6
+          device:
+            name: hed6
+          forced-network-groups:
+            - ISCSI
+
+        - name: hed7
+          device:
+            name: hed7
+          network-groups:
+            - TENANT-VLAN
+
+        - name: hed8
+          device:
+            name: hed8
+          forced-network-groups:
+            - HOSTNAME

--- a/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/net_global.yml
+++ b/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/net_global.yml
@@ -1,0 +1,1 @@
+../../input-model-net-global.yml

--- a/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/network_groups.yml
+++ b/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/network_groups.yml
@@ -1,0 +1,1 @@
+../../input-model-network-groups.yml

--- a/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/nic_mappings.yml
+++ b/scripts/jenkins/ardana/ansible/files/dac-3cp/input-model/nic_mappings.yml
@@ -1,0 +1,1 @@
+../../input-model-nic-mappings.yml

--- a/scripts/jenkins/ardana/ansible/templates/dac-3cp/input-model-servers.yml
+++ b/scripts/jenkins/ardana/ansible/templates/dac-3cp/input-model-servers.yml
@@ -1,0 +1,49 @@
+---
+  product:
+    version: 2
+
+  baremetal:
+    subnet: 192.168.245.0
+    netmask: 255.255.255.0
+
+  servers:
+
+    - id: cp1-0001
+      ip-addr: {{ controller_mgmt_ips[0] }}
+      role: STD-CONTROLLER-ROLE
+      server-group: RACK1
+      mac-addr: b2:72:8d:ac:7c:6f
+      ilo-ip: 192.168.109.3
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT
+
+    - id: cp1-0002
+      ip-addr: {{ controller_mgmt_ips[1] }}
+      role: STD-CONTROLLER-ROLE
+      server-group: RACK2
+      mac-addr: 8a:8e:64:55:43:76
+      ilo-ip: 192.168.109.4
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT
+
+    - id: cp1-0003
+      ip-addr: {{ controller_mgmt_ips[2] }}
+      role: STD-CONTROLLER-ROLE
+      server-group: RACK3
+      mac-addr: 26:67:3e:49:5a:a7
+      ilo-ip: 192.168.109.5
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT
+
+    - id: cm1-0001
+      ip-addr: {{ compute_mgmt_ips[0] }}
+      role: STD-COMPUTE-ROLE
+      server-group: RACK1
+      mac-addr: d6:70:c1:36:43:f7
+      ilo-ip: 192.168.109.6
+      ilo-password: password
+      ilo-user: admin
+      nic-mapping: HEAT

--- a/scripts/jenkins/ardana/heat-ardana-dac-3cp.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-dac-3cp.yaml
@@ -1,0 +1,1 @@
+heat-ardana-dac.yaml

--- a/scripts/jenkins/ardana/heat-ardana-dac.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-dac.yaml
@@ -1,0 +1,259 @@
+heat_template_version: 2016-10-14
+
+description: >
+  Template for deploying Ardana in a multinode setup
+
+parameters:
+  key_name:
+    type: string
+    label: Key Name
+    description: Name of key-pair to be used for compute instance
+    default: engcloud-cloud-ci
+  image_id_controller:
+    type: string
+    label: Image ID
+    description: Image to be used for compute instance (controller)
+    default: cleanvm-jeos-SLE12SP3
+  image_id_compute:
+    type: string
+    label: Image ID
+    description: Image to be used for compute instance (compute node)
+    default: cleanvm-jeos-SLE12SP3
+  instance_type_controller:
+    type: string
+    label: Instance Type
+    description: Type of instance (flavor) to be used for the controller
+    default: cloud-ardana-job-controller
+  instance_type_compute:
+    type: string
+    label: Instance Type
+    description: Type of instance (flavor) to be used for compute nodes
+    default: cloud-ardana-job-compute
+  number_of_computes:
+    type: number
+    description: Count of compute nodes to create
+    default: 2
+  number_of_controllers:
+    type: number
+    description: Count of controller nodes to create
+    default: 1
+
+resources:
+  # networks
+  network_mgmt:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+  network_ardana:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+  network_external_vm:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+  network_mgmt2:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+  network_guest:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+  network_iscsi:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+  network_tenant:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+  network_hostname_and_external_api:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: False
+
+  # subnet
+  subnet_mgmt:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_mgmt }
+      cidr: "192.168.245.0/24"
+      allocation_pools:
+          - start: "192.168.245.2"
+            end: "192.168.245.100"
+      ip_version: 4
+      gateway_ip: 192.168.245.1
+  subnet_ardana:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_ardana }
+      cidr: "192.168.110.0/24"
+      allocation_pools:
+          - start: "192.168.110.2"
+            end: "192.168.110.100"
+      ip_version: 4
+      gateway_ip: null
+  subnet_external_api:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_hostname_and_external_api }
+      allocation_pools:
+          - start: "192.168.114.100"
+            end: "192.168.114.200"
+      cidr: "192.168.114.0/24"
+      enable_dhcp: False
+      gateway_ip: 192.168.114.1
+  subnet_external_vm:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_external_vm }
+      allocation_pools:
+          - start: "172.31.0.2"
+            end: "172.31.255.154"
+      cidr: "172.31.0.0/16"
+      enable_dhcp: False
+      gateway_ip: 172.31.0.1
+  subnet_mgmt2:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_mgmt2 }
+      allocation_pools:
+          - start: "172.32.0.2"
+            end: "172.32.0.127"
+      cidr: "172.32.0.0/24"
+      enable_dhcp: False
+  subnet_guest:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_guest }
+      enable_dhcp: False
+      allocation_pools:
+          - start: "192.168.115.2"
+            end: "192.168.115.250"
+      cidr: "192.168.115.0/24"
+      enable_dhcp: False
+      gateway_ip: 192.168.115.1
+  subnet_iscsi:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_iscsi }
+      enable_dhcp: False
+      allocation_pools:
+          - start: "192.168.113.2"
+            end: "192.168.113.250"
+      cidr: "192.168.113.0/24"
+      enable_dhcp: False
+      gateway_ip: 192.168.113.1
+  subnet_tenant:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network_tenant }
+      allocation_pools:
+          - start: "172.30.0.2"
+            end: "172.30.0.127"
+      cidr: "172.30.0.0/24"
+      enable_dhcp: False
+
+  # router
+  router_mgmt:
+    type: OS::Neutron::Router
+    properties:
+      external_gateway_info:
+        network: floating
+
+  router_mgmt_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router_mgmt }
+      subnet_id: { get_resource: subnet_mgmt }
+
+  router_external_api_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router_mgmt }
+      subnet_id: { get_resource: subnet_external_api }
+
+  router_external_vm_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router_mgmt }
+      subnet_id: { get_resource: subnet_external_vm }
+
+  # floating IPs
+  deployer-controller-floatingip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: floating
+  # instances
+  controllers:
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: { get_param: number_of_controllers }
+      resource_def:
+        type: heat-ardana-std-controller.yaml
+        properties:
+          key_name: { get_param: key_name }
+          index: "%index%"
+          image_id_controller: { get_param: image_id_controller }
+          instance_type_controller: { get_param: instance_type_controller }
+          networks:
+              - network: { get_resource: network_mgmt }
+              - network: { get_resource: network_ardana }
+              - network: { get_resource: network_mgmt2 }
+              - network: { get_resource: network_external_vm }
+              - network: { get_resource: network_guest }
+              - network: { get_resource: network_iscsi }
+              - network: { get_resource: network_tenant }
+              - network: { get_resource: network_hostname_and_external_api }
+  computes:
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: { get_param: number_of_computes }
+      resource_def:
+        type: OS::Nova::Server
+        properties:
+          name: compute%index%
+          key_name: { get_param: key_name }
+          image: { get_param: image_id_compute }
+          flavor: { get_param: instance_type_compute }
+          networks:
+            - network: { get_resource: network_mgmt }
+            - network: { get_resource: network_ardana }
+            - network: { get_resource: network_mgmt2 }
+            - network: { get_resource: network_external_vm }
+            - network: { get_resource: network_guest }
+            - network: { get_resource: network_iscsi }
+            - network: { get_resource: network_tenant }
+            - network: { get_resource: network_hostname_and_external_api }
+
+  deployer-controller-floating-assignment:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: deployer-controller-floatingip }
+      port_id: {get_attr: [controllers, resource.0.addresses, { get_resource: network_mgmt }, 0, port]}
+
+outputs:
+  # deployer-controller
+  deployer-ip-floating:
+    description: Floating IP address of the deployer—controller node
+    value: { get_attr: [deployer-controller-floatingip, floating_ip_address] }
+
+  deployer-net-mgmt-ip:
+    description: IP address of the deployer-controller in the mgmt network
+    value: { get_attr: [controllers, resource.0.networks, { get_resource: network_mgmt }, 0]}
+
+  # controller
+  controllers-net-mgmt-ips:
+    description: List of IPs of the controllers in the mgmt network
+    value: { list_join: ["\n", { get_attr: [controllers, networks, { get_resource: network_mgmt }, 0]} ]}
+
+  # computes
+  computes-net-mgmt-ips:
+    description: List of IPs of the computes on the mgmt network
+    value: { list_join: ["\n", { get_attr: [computes, networks, { get_resource: network_mgmt }, 0]} ]}
+
+  # network info
+  network-mgmt-id:
+    description: Neutron Network ID of management network
+    value: { get_resource: network_mgmt }

--- a/scripts/jenkins/ardana/heat-ardana-std-controller.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-std-controller.yaml
@@ -101,3 +101,7 @@ outputs:
   networks:
     description: networks
     value: { get_attr: [ controller, networks] }
+  # addresses
+  addresses:
+    description: addresses
+    value: { get_attr: [ controller, addresses] }


### PR DESCRIPTION
Add support for the dac-3cp input model, which combines
a 3 controller cluster with a deployer-as-controller
scenario. This can be used to test controller reboot
scenarios (3 controllers are needed to ensure galera
cluster quorum).