### PR TITLE
syncSLErepos: Sync the Helion Openstack iso

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -133,9 +133,9 @@ for version in 8 7 6; do
 
         if [ "$version" == "8" ]; then
             if [ "$arch" = "x86_64" ]; then
-                rsync_and_unpack_iso ${ibs_source_nue}/Devel:/Cloud:/$version/images/iso/HPE-HELION-OPENSTACK-CLOUD-$version-$arch-Media1.iso /srv/nfs/repos/$arch/HPE-Helion-OpenStack-Cloud-$version-devel
-                rsync_with_create ${ibs_source}/SUSE/Products/HPE-Helion-OpenStack-Cloud/$version/$arch/product/ /srv/nfs/repos/$arch/HPE-Helion-OpenStack-Cloud-$version-Pool/
-                rsync_with_create ${ibs_source}/SUSE/Updates/HPE-Helion-OpenStack-Cloud/$version/$arch/update/ /srv/nfs/repos/$arch/HPE-Helion-OpenStack-Cloud-$version-Updates/
+                rsync_and_unpack_iso ${ibs_source_nue}/Devel:/Cloud:/$version/images/iso/HPE-HELION-OPENSTACK-$version-$arch-Media1.iso /srv/nfs/repos/$arch/HPE-Helion-OpenStack-$version-devel
+                rsync_with_create ${ibs_source}/SUSE/Products/HPE-Helion-OpenStack/$version/$arch/product/ /srv/nfs/repos/$arch/HPE-Helion-OpenStack-$version-Pool/
+                rsync_with_create ${ibs_source}/SUSE/Updates/HPE-Helion-OpenStack/$version/$arch/update/ /srv/nfs/repos/$arch/HPE-Helion-OpenStack-$version-Updates/
             fi
 
             rsync_and_unpack_iso ${ibs_source_nue}/Devel\:/Cloud\:/$version/images/iso/SUSE-OPENSTACK-CLOUD-CROWBAR-$version-$arch-Media1.iso /srv/nfs/repos/$arch/SUSE-OpenStack-Cloud-Crowbar-$version-devel


### PR DESCRIPTION
We have to rename the "HPE Helion OpenStack Cloud" product to "HPE
Helion OpenStack" (see bsc#1090093).