### PR TITLE
jjb: stop building for PRs to crowbar branch stable/3.0

### DIFF
--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -18,7 +18,6 @@ template:
         config:
           branches:
             - master
-            - stable/3.0
             - stable/4.0
       - type: Status
         config:


### PR DESCRIPTION
As Cloud 6 is EOL now (soon), we can stop building the PRs to the stable/3.0 braches of the crowbar repos.

Do **not** merge as long as there are PRs that should go out to customers.