### PR TITLE
Cleanup cloud specs tests

### DIFF
--- a/jenkins/ci.suse.de/cloud-suse-cloud-specs.yaml
+++ b/jenkins/ci.suse.de/cloud-suse-cloud-specs.yaml
@@ -19,6 +19,10 @@
     triggers:
       - timed: 'H H/12 * * *'
 
+    wrappers:
+      - workspace-cleanup:
+          dirmatch: true
+
     logrotate:
       numToKeep: 300
       daysToKeep: -1

--- a/scripts/github_pr/suse.cloud-specs.helper.sh
+++ b/scripts/github_pr/suse.cloud-specs.helper.sh
@@ -38,3 +38,9 @@ git --no-pager show | sed 's/^/|@| /'
 
 ### run tox
 tox -e docs
+ret=$?
+
+# cleanup
+popd
+rm -rf "$pr_dir"
+exit "$ret"


### PR DESCRIPTION
Make sure a new job starts with an empty workspace.

Even save space during a specs-test run, by removing the artifacts after each PR, to not let the workspace accumulate to much disk usage.