### PR TITLE
force upgrade existing python packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ suseinstall:
 	sudo zypper install perl-JSON-XS perl-libxml-perl python-pip libvirt-python
 
 genericinstall:
-	sudo pip install 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder
+	sudo pip install -U 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder requests
 	git clone https://github.com/SUSE-Cloud/roundup && \
 	cd roundup && \
 	./configure && \


### PR DESCRIPTION
There seems to be some existing packages in travis which may be outdated
or missing requirements. In this case requests seems to be installed
but not urllib3.

A simple pip install wont update those existing packages leaving the
environment kind of broken for our tests. So instead mark the pip
install with -U so it upgrades the existing  packages, which in turn
installs the dependencies correctly.