### PR TITLE
Update vmware scenario 2b to use vmware_fvs ml2 plugin

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
@@ -8,14 +8,15 @@
 
       This job will redeploy the scenario-2b:
         - total 7 nodes
-        - database: default, postgresql
+        - database: default
         - pacemaker: 1 cluster with 3 controllers
-        - nova: ssl, libvirt migration enabled, shared storage, kvm kernel samepage merging, 2 kvm and 2 ESXi compute nodes
+        - nova: no ssl, libvirt migration enabled, shared storage, kvm kernel samepage merging, 1 kvm and 1 ESXi compute nodes
+        - glance: vmare
         - cinder: vmware
-        - neutron: vmware (but currently ovs as NSX plugin is kind of out of order)
-        - eveyrthing with SSL.
+        - neutron: vmware (vmware_dvs ml2 plugin)
 
-      Warning: It will wipe all machines!
+      Warning: You need to have vmware installed at 10.162.66.201
+      Follow the instructions in: https://gitlab.suse.de/qa/cloud-doc/blob/master/vmware.md
 
     wrappers:
       - mkphyscloud-qa-common-wrappers
@@ -41,6 +42,11 @@
           name: shared_storage_ip
           default: 10.162.66.1
           description: Mandatory, shared storage server IP
+
+      - string:
+          name: vcenter_ip
+          default: 10.162.66.201
+          description: Mandatory, ip of the vcenter
 
       - string:
           name: repo_owner
@@ -119,7 +125,7 @@
 
       - string:
           name: commands
-          default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases
+          default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
           description: All the steps that needs to be completed to have cloud installed
 
       - string:
@@ -141,8 +147,9 @@
           #!/bin/bash
           admin=crowbar$hw_number
           cloud=qa$hw_number
-          vcenter_user="Administrator@vsphere.qa.suse.de"
-          vcenter_password=`cat /home/jenkins/passwords/Administrator\@vsphere.qa.suse.de`
+          vcenter_ip=$vcenter_ip
+          vcenter_user="Administrator@vsphere.local"
+          vcenter_password=`cat /home/jenkins/passwords/administrator@vsphere.local`
 
           if [ ! -z "$UPDATEREPOS" ] ; then
             export UPDATEREPOS=${UPDATEREPOS//$'\n'/+}
@@ -191,11 +198,17 @@
           export want_node_aliases=controller=3,computekvm=2,computevmw=1 ;
           export want_node_roles=controller=3,compute=4 ;
           export scenario=\"/root/scenario.yml\" ;
+          export vcenter_ip=$vcenter_ip ;
+          export vcenter_user="Administrator@vsphere.local" ;
+          export vcenter_password=$vcenter_password ;
           export commands=\"$commands\" "'
 
           sed -i -e "s,##shared_nfs_for_database##,$shared_storage_ip:/var/$cloud/ha-database," scenario.yml
           sed -i -e "s,##shared_nfs_for_rabbitmq##,$shared_storage_ip:/var/$cloud/ha-rabbitmq," scenario.yml
           sed -i -e "s,##cinder-storage-shares##,$shared_storage_ip:/var/$cloud/cinder-storage," scenario.yml
+          sed -i -e "s,@@vcenter_ip@@,${vcenter_ip}," scenario.yml
+          sed -i -e "s,@@vcenter_user@@,${vcenter_user}," scenario.yml
+          sed -i -e "s,@@vcenter_password@@,${vcenter_password}," scenario.yml
 
           [ $UPDATEBEFOREINSTALL == "true" ] && export updatesteps="addupdaterepo runupdate"
 
@@ -203,47 +216,6 @@
           ' || ret=$?
 
           echo "mkphyscloud ret=$ret (before scenario)"
-
-          if [ "$ret" = "0" ]; then
-            # ----- Prepare the SBD setup:
-            cat > /tmp/sbd_prepare_$admin <<EOSCRIPT
-              # preparation of iSCSI
-              zypper --gpg-auto-import-keys -p http://download.opensuse.org/repositories/devel:/languages:/python/SLE_12_SP2/ --non-interactive install python-sh
-              wget --no-check-certificate https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/iscsictl.py
-              chmod +x iscsictl.py
-              ./iscsictl.py --service target --host \$(hostname) --no-key
-              ./iscsictl.py --service initiator --target_host \$(hostname) --host controller1 --no-key
-              ./iscsictl.py --service initiator --target_host \$(hostname) --host controller2 --no-key
-              ./iscsictl.py --service initiator --target_host \$(hostname) --host controller3 --no-key
-              # preparation of SBD
-              SBD_DEV=\$(ssh controller1 echo '/dev/disk/by-id/scsi-\$(lsscsi -i | grep LIO | tr -s " " |cut -d " " -f7)')
-              ssh controller1 "zypper --non-interactive install sbd; sbd -d \$SBD_DEV create"
-              ssh controller2 "zypper --non-interactive install sbd"
-              ssh controller3 "zypper --non-interactive install sbd"
-              # watchdog configuration
-              ssh controller1 modprobe softdog; echo softdog > /etc/modules-load.d/watchdog.conf
-              ssh controller2 modprobe softdog; echo softdog > /etc/modules-load.d/watchdog.conf
-              ssh controller3 modprobe softdog; echo softdog > /etc/modules-load.d/watchdog.conf
-              # take scenario yaml file and replace placeholders with right things:
-              sed -i "s|@@sbd_device@@|\${SBD_DEV}|g" scenario.yml
-              sed -i "s|@@vcenter_user@@|\${vcenter_user}|g" scenario.yml
-              sed -i "s|@@vcenter_password@@|\${vcenter_password}|g" scenario.yml
-              # ----- End of SBD
-          EOSCRIPT
-            chmod +x /tmp/sbd_prepare_$admin
-            scp /tmp/sbd_prepare_$admin root@$admin:sbd_prepare
-
-            # Check if zypper is used by other application
-            ssh root@$admin '
-              source scripts/qa_crowbarsetup.sh;
-              for node in $(crowbar machines aliases | grep "controller" | grep -oE "^.*[[:space:]]"); do
-                wait_for 20 10 "ssh $node \"zypper refresh\"" "zypper to be available on $node"
-              done
-            '
-
-            ssh root@$admin './sbd_prepare
-            ' || ret=$?
-          fi
 
           if [ "$ret" = "0" ]; then
             ssh root@$admin "

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
@@ -1,30 +1,30 @@
 ---
 # Placeholders for node devices must be replaced by some real values
-# 2b - 8 nodes, HA (SBD 1 x 3), KVM x 2, ESXi x 1
+# 2b - 8 nodes, HA (IPMI - stonith x 3), KVM x 1, ESXi x 1
 proposals:
 - barclamp: pacemaker
   name: services
   attributes:
     stonith:
-      mode: sbd
+      mode: ipmi_barclamp
       sbd:
         nodes:
-          "@@controller1@@":
+          @@controller1@@:
             devices:
-            - "@@sbd_device@@"
-          "@@controller2@@":
+            - ''
+          @@controller2@@:
             devices:
-            - "@@sbd_device@@"
-          "@@controller3@@":
+            - ''
+          @@controller3@@:
             devices:
-            - "@@sbd_device@@"
+            - ''
       per_node:
         nodes:
-          "@@controller1@@":
+          @@controller1@@:
             params: ''
-          "@@controller2@@":
+          @@controller2@@:
             params: ''
-          "@@controller3@@":
+          @@controller3@@:
             params: ''
   deployment:
     elements:
@@ -65,42 +65,21 @@ proposals:
 
 - barclamp: keystone
   attributes:
-    signing:
-      token_format: uuid
   deployment:
     elements:
       keystone-server:
       - cluster:services
 
-- barclamp: swift
-  attributes:
-    replicas: 2
-    keystone_delay_auth_decision: true
-    allow_versions: true
-    middlewares:
-      crossdomain:
-        enabled: true
-      formpost:
-        enabled: true
-      staticweb:
-        enabled: true
-      tempurl:
-        enabled: true
-  deployment:
-    elements:
-      swift-dispersion:
-      - "@@controller1@@"
-      swift-proxy:
-      - cluster:services
-      swift-ring-compute:
-      - "@@controller1@@"
-      swift-storage:
-      - "@@computekvm1@@"
-      - "@@computekvm2@@"
-
 - barclamp: glance
   attributes:
-    default_store: swift
+    default_store: vsphere
+    vsphere:
+      host: "@@vcenter_ip@@"
+      user: "@@vcenter_user@@"
+      password: "@@vcenter_password@@"
+      datastores:
+      - "Datacenter:datastore1"
+      insecure: true
   deployment:
     elements:
       glance-server:
@@ -118,11 +97,12 @@ proposals:
     - backend_driver: vmware
       backend_name: vmware
       vmware:
-        volume_folder: cinder-vmw-volume
-        host: vcs.qa.suse.de
+        volume_folder: cinder-volume
+        host: "@@vcenter_ip@@"
         user: "@@vcenter_user@@"
         password: "@@vcenter_password@@"
-        cluster_name: []
+        cluster_name:
+        - Openstack
         insecure: true
         ca_file: ""
   deployment:
@@ -136,6 +116,7 @@ proposals:
   attributes:
     ml2_mechanism_drivers:
     - openvswitch
+    - vmware_dvs
     ml2_type_drivers:
     - vlan
     ml2_type_drivers_default_provider_network: vlan
@@ -148,7 +129,6 @@ proposals:
       neutron-network:
       - cluster:services
 
-# vcenter credentials must be replaced by some real values
 - barclamp: nova
   attributes:
     itxt_instance: ''
@@ -158,10 +138,12 @@ proposals:
       ksm_enabled: true
     vcenter:
       clusters:
-      - QA
-      host: vcs.qa.suse.de
+      - Openstack
+      host: "@@vcenter_ip@@"
       user: "@@vcenter_user@@"
       password: "@@vcenter_password@@"
+      datastore: datastore1
+      insecure: true
     metadata:
       vendordata:
         json: '{"custom-key": "custom-value"}'
@@ -198,7 +180,6 @@ proposals:
     elements:
       ceilometer-agent:
       - "@@computekvm1@@"
-      - "@@computekvm2@@"
       - "@@computevmw@@"
       ceilometer-agent-hyperv: []
       ceilometer-central:
@@ -229,14 +210,6 @@ proposals:
       - "@@controller1@@"
       - "@@controller2@@"
       - "@@controller3@@"
-
-- barclamp: trove
-  attributes:
-    volume_support: true
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: tempest
   deployment:


### PR DESCRIPTION
Scenario 2b update to use the vmware_dvs ml2 plugin.
See the documentation in: https://gitlab.suse.de/qa/cloud-doc/blob/master/vmware-dvs.md

The original scenario was not using the DVS ml2 plugin, so could connect to the existing vmware cluster installation.

vmware_dvs plugin has a limitation: the openstack and vmware should be connected to the same Layer 2 segment (same switch). So before running the scenario the user has to install vmware manually on the spare node (documented in https://gitlab.suse.de/qa/cloud-doc/blob/master/vmware.md).

Several barclamps now use vmware (glance, cinder, neutron and nova)
