### PR TITLE
testpostupgrade: Use openstack stack show

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4387,7 +4387,7 @@ function oncontroller_testpostupgrade
     done
 
     openstack --insecure stack delete --yes upgrade_test
-    wait_for 15 20 "! heat --insecure stack-show upgrade_test" \
+    wait_for 15 20 "! openstack --insecure stack show upgrade_test" \
              "heat stack for upgrade tests to be deleted"
     echo "test post-upgrade successful."
 }


### PR DESCRIPTION
Interestingly, testpostupgrade used openstack stack delete to drop the
stack, and then used the heat command to check the status. Switch to the
openstack CLI.