### PR TITLE
Remove trove from all qa cloud 8 scenarios

### DIFF
--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
@@ -45,8 +45,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
   deployment:
     elements:
       rabbitmq-server:
@@ -200,14 +198,6 @@ proposals:
       - "@@controller1@@"
       - "@@controller2@@"
       - "@@controller3@@"
-
-- barclamp: trove
-  attributes:
-    volume_support: true
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: tempest
   deployment:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
@@ -100,8 +100,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
   deployment:
     elements:
       rabbitmq-server:
@@ -256,14 +254,6 @@ proposals:
       manila-share:
       - "@@data1@@"
       - "@@data2@@"
-
-- barclamp: trove
-  attributes:
-    volume_support: true
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
@@ -51,8 +51,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         shared:
@@ -229,14 +227,6 @@ proposals:
       - "@@controller1@@"
       - "@@controller2@@"
       - "@@controller3@@"
-
-- barclamp: trove
-  attributes:
-    volume_support: true
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: tempest
   deployment:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2c.yaml
@@ -44,8 +44,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
   deployment:
     elements:
       rabbitmq-server:
@@ -169,12 +167,6 @@ proposals:
       - cluster:services
       manila-share:
       - cluster:services
-
-- barclamp: trove
-  deployment:
-    elements:
-      trove-server:
-      - @@controller1@@
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-3.yaml
@@ -64,8 +64,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         shared:
@@ -196,13 +194,6 @@ proposals:
       - @@controller1@@
       - @@controller2@@
       - @@controller3@@
-
-- barclamp: trove
-  attributes:
-  deployment:
-    elements:
-      trove-server:
-      - @@controller1@@
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-6a.yaml
@@ -60,8 +60,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
   deployment:
     elements:
       rabbitmq-server:
@@ -160,12 +158,6 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-
-- barclamp: trove
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: magnum
   attributes:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8b.yaml
@@ -45,8 +45,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-9.yaml
@@ -45,8 +45,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         mode: drbd
@@ -170,12 +168,6 @@ proposals:
       ceilometer-server:
       - cluster:services
       ceilometer-swift-proxy-middleware: []
-
-- barclamp: trove
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: tempest
   deployment:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -52,8 +52,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         shared:
@@ -251,15 +249,6 @@ proposals:
       - "@@controller1@@"
       - "@@controller2@@"
       - "@@controller3@@"
-
-# FIXME: disabled due to issues in trove with insecure SSL (https://bugs.launchpad.net/trove/+bug/1535895)
-#- barclamp: trove
-#  attributes:
-#    volume_support: true
-#  deployment:
-#    elements:
-#      trove-server:
-#      - cluster:services
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -100,8 +100,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         shared:
@@ -296,15 +294,6 @@ proposals:
       manila-share:
       - "@@data1@@"
       - "@@data2@@"
-
-# FIXME: disabled due to issues in trove with insecure SSL (https://bugs.launchpad.net/trove/+bug/1535895)
-#- barclamp: trove
-#  attributes:
-#    volume_support: true
-#  deployment:
-#    elements:
-#      trove-server:
-#        - cluster:services
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -52,8 +52,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         shared:
@@ -263,15 +261,6 @@ proposals:
       - "@@controller1@@"
       - "@@controller2@@"
       - "@@controller3@@"
-
-- barclamp: trove
-  attributes:
-    swift_instance: ''
-    volume_support: true
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -45,8 +45,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
   deployment:
     elements:
       rabbitmq-server:
@@ -198,12 +196,6 @@ proposals:
       - cluster:services
       manila-share:
       - cluster:services
-
-- barclamp: trove
-  deployment:
-    elements:
-      trove-server:
-      - @@controller1@@
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-3.yaml
@@ -72,8 +72,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         shared:
@@ -236,13 +234,6 @@ proposals:
       - @@controller1@@
       - @@controller2@@
       - @@controller3@@
-
-- barclamp: trove
-  attributes:
-  deployment:
-    elements:
-      trove-server:
-      - @@controller1@@
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -69,8 +69,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
     ha:
       storage:
         shared:
@@ -213,12 +211,6 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-
-- barclamp: trove
-  deployment:
-    elements:
-      trove-server:
-      - "@@controller1@@"
 
 - barclamp: magnum
   attributes:


### PR DESCRIPTION
Trove was declared unsupported
See: https://github.com/SUSE/cloud-specs/pull/89