### PR TITLE
Update defcore function to use the latest guidelines

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3369,15 +3369,16 @@ function oncontroller_upload_defcore
 {
     pushd /var/lib/openstack-tempest-test
     # get the test list
-    wget "https://refstack.openstack.org/api/v1/guidelines/2017.09/tests" -O defcore-with-id.txt
+    wget "https://refstack.openstack.org/api/v1/guidelines/2018.02/tests" -O defcore-with-id.txt
     # remove the id in [] or tempest will complain on incorrect regex
     sed -e 's/\[[^][]*\]//g' defcore-with-id.txt > defcore.txt
     # run only the specified tests
     tempest run --whitelist-file defcore.txt
     source /root/.openrc
-    testr last --subunit > tempest.subunit.log
+    wget https://raw.githubusercontent.com/testing-cabal/subunit/master/filters/subunit-2to1
+    testr last --subunit | python subunit-2to1 > tempest.subunit_1.log
     test -d refstack-client || safely git clone https://github.com/openstack/refstack-client
-    yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL tempest.subunit.log
+    yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL --url https://10.86.0.98 --insecure tempest.subunit_1.log
     popd
 }
 


### PR DESCRIPTION
The latest guidelines are 2018.02
Use the subunit-2to1 filter
Use the local refstackserver to upload the resuls since
the official server now requires keys