### PR TITLE
nova_services_up: Use openstack cli

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3668,7 +3668,7 @@ function oncontroller_magnum_service_setup
 function nova_services_up
 {
     if iscloudver 7plus; then
-        test $(nova service-list | fgrep -cv -- \ up\ ) -lt 5
+        test $(openstack compute service list -f value -c State | grep -c down) -eq 0
     else
         test $(nova-manage service list  | fgrep -cv -- \:\-\)) -lt 2
     fi


### PR DESCRIPTION
Rather than having to effectively parse remaining lines from nova
service-list to see if any services are down while ignoring ASCII tables
and column headers, only print out the data we care about using the
openstack cli, and grep directly for down.