### PR TITLE
github_pr: allow pr checks from non-fork branches

### DIFF
--- a/scripts/github_pr/github_cloud-specs.yaml
+++ b/scripts/github_pr/github_cloud-specs.yaml
@@ -1,6 +1,9 @@
 interaction_dirs:
   - ./interactions
 template:
+  user:
+    suse_user: &suse_user
+      - SUSE
   team:
     suse_cloud_specs_team: &suse_cloud_specs_team
       - name: SUSE/SUSE OpenStack Cloud Team
@@ -18,6 +21,8 @@ template:
           status: unseen
       - type: TrustedSource
         config:
+          users:
+            *suse_user
           teams:
             *suse_cloud_specs_team
         whitelist_handler:


### PR DESCRIPTION
Usually developers fork a repository and create PRs from their
forks to the upstream repository.
For SUSE/cloud-specs this is a bit different.

To allow PR checking for all PRs even if they came from the a
branch of the repository itself (instead of a fork) we hereby
allow PRs from the user SUSE (which is the organization user).