### PR TITLE
jjb: add cloud-ardana8-update-x86_64 job (SCRD-3018)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -15,6 +15,15 @@
         - 'cloud-ardana{version}-job-std-min-{arch}'
 
 - project:
+    name: cloud-ardana8-update-x86_64
+    disabled: false
+    version: 8
+    arch: x86_64
+    tempestoptions: ci
+    jobs:
+        - 'cloud-ardana{version}-job-std-3cp-update-{arch}'
+
+- project:
     name: cloud-ardana8-centos-x86_64
     disabled: false
     version: 8

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-update-template.yaml
@@ -1,0 +1,21 @@
+- job-template:
+    name: 'cloud-ardana{version}-job-std-3cp-update-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-ardana
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            model=std-3cp
+            cloudsource=SUSE-OpenStack-Cloud-8-devel-staging
+            update_cloudsource=SUSE-OpenStack-Cloud-8-devel
+            tempest_run_filter=ci
+


### PR DESCRIPTION
Create a job that installs a 3 controller node cloud based
on D:C:8 and then runs the maintenance update workflow [1] to
update packages to the D:C:8:Staging baseline.

The purpose of this job is to test that staging changes do
not break the documented maintenance update workflow.

[1] http://docserv.suse.de/documents/SUSE_OpenStack_Cloud_8/suse-openstack-cloud-operations/html/system_maintenance.html#maintenance_update