### PR TITLE
upgrade: Use MariaDB as initial database option for SOC7-SOC8 upgrades

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -39,6 +39,7 @@
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: ceph
+    database_engine: postgresql
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -42,6 +42,7 @@
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: swift
+    database_engine: mysql
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
@@ -49,6 +50,8 @@
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-agent-{arch}'
+        - 'cloud-mkcloud{version}-job-upgrade-disruptive-ha-{arch}'
+        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-{arch}'
 - project:
     name: cloud-mkcloud8-tempestfull-x86_64
     disabled: false

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-ha-template.yaml
@@ -1,4 +1,5 @@
 - job-template:
+    ### The reason why this upgrade job is "disruptive" is the default cinder backend
     name: 'cloud-mkcloud{version}-job-upgrade-disruptive-ha-{arch}'
     node: cloud-trigger
 
@@ -19,9 +20,10 @@
             TESTHEAD=1
             cloudsource=develcloud{previous_version}
             upgrade_cloudsource=develcloud{version}
-            nodenumber=4
+            nodenumber={nodenumber}
             mkcloudtarget=plain_with_upgrade testsetup
             want_nodesupgrade=1
+            want_database_sql_engine={database_engine}
             hacloud=1
             storage_method=swift
             label={label}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
@@ -1,0 +1,33 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: '32 22 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{previous_version}
+            upgrade_cloudsource=develcloud{version}
+            ### 3 nodes for HA cluster, 2 compute nodes, 1 lonelynode for nfs server
+            nodenumber=6
+            hacloud=1
+            storage_method=swift
+            cinder_backend=nfs
+            want_nodesupgrade=1
+            want_database_sql_engine={database_engine}
+            want_ping_running_instances=1
+            mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server proposal testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
+            label={label}
+            job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}


### PR DESCRIPTION
For now we're testing the setups that do not need DB migration.