### PR TITLE
openstack-ardana: fixes for the cloud-ardana8-update job

### DIFF
--- a/scripts/jenkins/ardana/ansible/reboot-node.yml
+++ b/scripts/jenkins/ardana/ansible/reboot-node.yml
@@ -61,10 +61,11 @@
     timeout: 300
   when: node_is_deployer
 
-  # Sometimes¸ if the deployer is also a controller node, there are problems
-  # mounting the NFS zypper repositories during boot, probably because there
-  # is a race condition with the neutron-openvswitch-agent service or the
-  # Neutron OVS Cleanup Service, which temporarily disrupts connectivity.
+  # Workaround for bsc#1091226: Sometimes¸if the deployer is also a controller
+  # node, there are problems mounting the NFS zypper repositories during boot,
+  # probably because there is a race condition with the neutron-openvswitch-agent
+  # service or the Neutron OVS Cleanup Service, which temporarily disrupts
+  # connectivity. Remounting repositories fixes that.
 - name: Remount zypper repositories on deployer
   shell: |
     mount --all
@@ -80,3 +81,12 @@
   become: true
   become_user: ardana
   when: node_is_deployer
+
+  # Workaround for bsc#1091479 - start spark on all nodes after rebooting one node
+- name: Restart spark on all nodes to correct for bsc#1091479
+  shell: |
+    ansible-playbook -vvv -i hosts/verb_hosts spark-start.yml
+  args:
+    chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
+  become: true
+  become_user: ardana

--- a/scripts/jenkins/ardana/ansible/update-node.yml
+++ b/scripts/jenkins/ardana/ansible/update-node.yml
@@ -123,7 +123,7 @@
 
 - name: Update CLM services
   include: _update-clm.yml
-  when: pending_clm_update
+  when: node_is_deployer and pending_clm_update
 
 - name: Update services
   shell: |


### PR DESCRIPTION
Introduces a couple of fixes for the Jenkins Ardana package update job:
1. fixes a bug which ran ardana-init several times instead of just one time when a CLM package update was installed
2. adds a workaround for [bsc#1091479](https://bugzilla.suse.com/show_bug.cgi?id=1091479) which is to restart spark services on all nodes after a node reboot

With the workaround at 2. in place, we should have a successful update run. 