### PR TITLE
jjb: add cloud-ardana8-test-mu-x86_64 job (SCRD-3207)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -24,6 +24,15 @@
         - 'cloud-ardana{version}-job-std-3cp-update-{arch}'
 
 - project:
+    name: cloud-ardana8-test-mu-x86_64
+    disabled: false
+    version: 8
+    arch: x86_64
+    tempestoptions: ci
+    jobs:
+        - 'cloud-ardana{version}-job-std-3cp-test-mu-{arch}'
+
+- project:
     name: cloud-ardana8-centos-x86_64
     disabled: false
     version: 8

--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -56,11 +56,33 @@
           description: >-
             This is used as input repository (from provo-clouddata) for testing
 
+      - extended-choice:
+          name: repositories
+          type: multi-select
+          value: SLES12-SP3-Pool,SLES12-SP3-Updates,SLES12-SP3-Updates-test,SUSE-OpenStack-Cloud-8-Pool,SUSE-OpenStack-Cloud-8-Updates,SUSE-OpenStack-Cloud-8-Updates-test
+          visible-items: 6
+          multi-select-delimiter: ','
+          default-value: SLES12-SP3-Pool,SLES12-SP3-Updates
+          description: >-
+            Set of zypper repositories (from provo-clouddata) to be used during installation
+
       - string:
           name: update_cloudsource
           default: ''
           description: >-
-            If set, this is used for update testing
+            Repository to be used for update testing. Use a value different than
+            cloudsource to enable update testing.
+
+      - extended-choice:
+          name: update_repositories
+          type: multi-select
+          value: SLES12-SP3-Pool,SLES12-SP3-Updates,SLES12-SP3-Updates-test,SUSE-OpenStack-Cloud-8-Pool,SUSE-OpenStack-Cloud-8-Updates,SUSE-OpenStack-Cloud-8-Updates-test
+          visible-items: 6
+          multi-select-delimiter: ','
+          default-value: ''
+          description: >-
+            Set of repositories to be added after the initial installation and used
+            during update testing. Select one or more repositories to enable update testing.
 
       - choice:
           name: update_method
@@ -69,7 +91,7 @@
             - patch
             - dist-upgrade
           description: >-
-            The update method used for update testing
+            The update method used for update testing.
 
       - string:
           name: tempest_run_filter
@@ -193,6 +215,7 @@
           ansible-playbook -v -i hosts ssh-keys.yml
           ansible-playbook -v -i hosts -e "build_url=$BUILD_URL" \
                                        -e "cloudsource=${cloudsource}" \
+                                       -e "repositories='${repositories}'" \
                                        repositories.yml
           verification_temp_dir=$(ssh $sshargs root@$DEPLOYER_IP \
                                     "mktemp -d /tmp/ardana-job-rpm-verification.XXXXXXXX")
@@ -206,10 +229,17 @@
                ansible-playbook -vvv -i hosts/verb_hosts site.yml"
 
           # Run Update if required
-          if [ -n "$update_cloudsource" -a "$update_cloudsource" != "$cloudsource" ]; then
+          if [ -n "$update_cloudsource" -a "$update_cloudsource" != "$cloudsource" -o -n "$update_repositories" ]; then
+
+              # Run pre-update checks
+              ansible-playbook -v -i hosts -e "tempest_run_filter=${tempest_run_filter}" \
+                                           pre-update-checks.yml
+
               ansible-playbook -v -i hosts \
-                  -e "build_url=$BUILD_URL" -e "cloudsource=${update_cloudsource}" \
-                  repositories.yml
+                  -e "build_url=$BUILD_URL" \
+                  -e "cloudsource=${update_cloudsource}" \
+                  -e "repositories='${update_repositories}'" \
+                                        repositories.yml
 
               ansible-playbook -v -i hosts \
                   -e "cloudsource=${update_cloudsource}" \

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-test-mu-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-test-mu-template.yaml
@@ -1,0 +1,22 @@
+- job-template:
+    name: 'cloud-ardana{version}-job-std-3cp-test-mu-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-ardana
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            model=std-3cp
+            cloudsource=SUSE-OpenStack-Cloud-8-Pool
+            repositories=SLES12-SP3-Pool,SLES12-SP3-Updates,SUSE-OpenStack-Cloud-8-Pool,SUSE-OpenStack-Cloud-8-Updates
+            update_repositories=SLES12-SP3-Updates-test,SUSE-OpenStack-Cloud-8-Updates-test
+            tempest_run_filter=ci
+

--- a/scripts/jenkins/ardana/ansible/pre-update-checks.yml
+++ b/scripts/jenkins/ardana/ansible/pre-update-checks.yml
@@ -1,0 +1,29 @@
+---
+- name: Pre update checks
+  hosts: hosts
+  gather_facts: False
+
+  vars_files:
+    - ardana_net_vars.yml
+    - vars/main.yml
+
+  tasks:
+
+  - name: Configure Cloud for Tempest run
+    shell: |
+      ansible-playbook -v -i hosts/verb_hosts ardana-cloud-configure.yml
+    args:
+      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
+    become: true
+    become_user: ardana
+
+  - name: Run tempest
+    shell: |
+      ansible-playbook -v -i hosts/verb_hosts tempest-run.yml \
+                       -e run_filter="{{ tempest_run_filter }}"
+    args:
+      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
+    become: true
+    become_user: ardana
+    register: tempest_run_result
+    when: tempest_run_filter != ""

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -7,76 +7,73 @@
     clouddata_server: provo-clouddata.cloud.suse.de
     download_suse_server: download.suse.de
     cloudsource: SUSE-OpenStack-Cloud-8-devel-staging
+    repositories: SLES12-SP3-Pool,SLES12-SP3-Updates
     arch: x86_64
     repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
     cloudsource_url: "{{ repos_url }}/{{ cloudsource }}"
     sshpass_repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
 
   tasks:
+
+  - name: Parse repositories
+    set_fact:
+      repos_dict: "{{ repos_dict|default({})|combine({item: item}) }}"
+    with_items: "{{ repositories.split(',')|unique|list }}"
+
+  - name: Add Cloud to repository list
+    set_fact:
+      # Use a consistent name for the Cloud media install repo so that we
+      # don't have to account for development versus production repos in the
+      # playbooks
+      repos_dict: "{{ {'Cloud': cloudsource}|combine(repos_dict) }}"
+    when: cloudsource != ''
+
   - name: Check srv directories
     stat:
-      path: "/srv/www/suse-12.3/x86_64/repos/{{ item }}"
+      path: "/srv/www/suse-12.3/x86_64/repos/{{ item.key }}"
     register: srv_dir_stats
-    with_items:
-      - Cloud
-      - SLES12-SP3-Pool
-      - SLES12-SP3-Updates
-      - SUSE-OpenStack-Cloud-8-Pool
-      - SUSE-OpenStack-Cloud-8-Updates
+    with_dict: "{{ repos_dict }}"
 
   - name: Create srv directories
     file:
       state: directory
-      path: "/srv/www/suse-12.3/x86_64/repos/{{ item.item }}"
+      path: "/srv/www/suse-12.3/x86_64/repos/{{ item.item.key }}"
       mode: 0755
     when: not item.stat.exists
     with_items:
       - "{{ srv_dir_stats.results }}"
 
-  - name: Unmount the Cloud repo, if already present
+  - name: Unmount the Cloud repo, if cloudsource was changed
     mount:
       state: unmounted
       name: /srv/www/suse-12.3/x86_64/repos/Cloud
+    when: cloudsource != ''
 
   - name: Mount zypper repos
     mount:
       state: mounted
       fstype: nfs
       opts: ro,nosuid,rsize=8192,wsize=8192,hard,intr,nolock
-      name: /srv/www/suse-12.3/x86_64/repos/{{ item.name }}
-      src: "{{ clouddata_server }}:/srv/nfs/repos/x86_64/{{ item.src }}"
+      name: /srv/www/suse-12.3/x86_64/repos/{{ item.item.key }}
+      src: "{{ clouddata_server }}:/srv/nfs/repos/x86_64/{{ item.item.value }}"
     with_items:
-      # Use a consistent name for the Cloud media install repo so that we
-      # don't have to account for development versus production repos in the
-      # playbooks
-      - name: Cloud
-        src: "{{ cloudsource }}"
-      - name: SLES12-SP3-Pool
-        src: SLES12-SP3-Pool
-      - name: SLES12-SP3-Updates
-        src:  SLES12-SP3-Updates
-        #TODO Add these only if not develcloud media is used
-        # - name: SUSE-OpenStack-Cloud-8-Pool
-        # src: SUSE-OpenStack-Cloud-8-Pool
-        # - name: SUSE-OpenStack-Cloud-8-Updates
-        # src: SUSE-OpenStack-Cloud-8-Updates
+      - "{{ srv_dir_stats.results }}"
 
-  - name: Add SLES repos
+  - name: Add zypper repos
     zypper_repository:
-      repo: "/srv/www/suse-12.3/x86_64/repos/{{ item }}"
-      name: "{{ item }}"
+      repo: "/srv/www/suse-12.3/x86_64/repos/{{ item.item.value }}"
+      name: "{{ item.item.key }}"
+    register: added_repos
+    when: item.item.key != 'Cloud'
     with_items:
-      - SLES12-SP3-Pool
-      - SLES12-SP3-Updates
-        #TODO Add these only if not develcloud media is used
-        # - SUSE-OpenStack-Cloud-8-Pool
-        # - SUSE-OpenStack-Cloud-8-Updates
+      - "{{ srv_dir_stats.results }}"
 
   # Need to add Cloud repo as repo-md not as the default "yast2" type as that
   # one refuses to install packages if the media build number changes
   - name: Add Cloud repo
     shell: |
       zypper -n lr Cloud || zypper -n ar -c -K -f -t rpm-md /srv/www/suse-12.3/x86_64/repos/Cloud Cloud
+    when: cloudsource != ''
 
   - name: Repo for sshpass
     zypper_repository:
@@ -101,10 +98,10 @@
       name: sshpass
       state: absent
 
-  - name: Install/Update ardana pattern
+  - name: Install ardana pattern
     zypper:
       name: "patterns-cloud-ardana"
-      state: latest
+      state: present
 
   # This can't happen earlier because we rely on the ardana pattern for creating
   # the ardana user/group
@@ -119,10 +116,20 @@
     get_url:
       url: "{{ cloudsource_url }}/media.1/build"
       dest: /etc/ardana/media-build-version
+    when: cloudsource != ''
 
   - name: Add build information to /etc/motd
     shell: |
-      media_build_version=$(cat /etc/ardana/media-build-version)
       echo "Build job:  {{ build_url }}" >>/etc/motd
+
+  - name: Add cloudsource information to /etc/motd
+    shell: |
+      media_build_version=$(cat /etc/ardana/media-build-version)
       echo "Built from: {{ cloudsource_url }}" >>/etc/motd
       echo "Media build version: $media_build_version" >>/etc/motd
+    when: cloudsource != ''
+
+  - name: Add repos information to /etc/motd
+    shell: |
+      echo "Configured repositories: {{ repositories }}" >>/etc/motd
+    when: repositories != ''


### PR DESCRIPTION
Creates a job which tests that it is possible to install
pending SLES and Cloud8 test updates as maintenance updates
using the Ardana update workflow. The test automation job
does the following:
 - uses SOC8 GM cloudsource + already released maintenance updates
 - does a full deployment (min 3 controller nodes are required)
 - validate that the deployment works (runs tempest tests)
 - add the SLES12-SP3-Updates-test and SUSE-OpenStack-Cloud-8-Updates-test 
 repositories
 - run the maintenance update workflow to update all nodes in the cloud
 - validate that the deployment works (tempest tests again)

Also updates the openstack-ardana job to allow for individual repositories to be
configured and to run tempest before applying the update.