### PR TITLE
upgrade: Do not deploy barclamps that are tech previews

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
@@ -30,6 +30,9 @@
             want_database_sql_engine={database_engine}
             want_ping_running_instances=1
             want_clustered_rabbitmq=1
+            want_trove_proposal=0
+            want_barbican_proposal=0
+            want_sahara_proposal=0
             mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server proposal testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-template.yaml
@@ -26,6 +26,9 @@
             cinder_backend=nfs
             want_nodesupgrade=1
             want_ping_running_instances=1
+            want_trove_proposal=0
+            want_barbican_proposal=0
+            want_sahara_proposal=0
             mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server proposal testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
@@ -25,5 +25,8 @@
             storage_method=swift
             mkcloudtarget=plain_with_upgrade
             want_nodesupgrade=
+            want_trove_proposal=0
+            want_barbican_proposal=0
+            want_sahara_proposal=0
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}


### PR DESCRIPTION
This is due to speed up the deployment process, so that regular
testing is more efficient.