### PR TITLE
jjb: openstack-ardana keep logs the same time as for mkcloud

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -16,8 +16,8 @@
           write-description: "Job aborted due to 180 minutes of inactivity"
 
     logrotate:
-      numToKeep: 20
-      daysToKeep: 30
+      numToKeep: 2000
+      daysToKeep: 300
 
     parameters:
       - string:


### PR DESCRIPTION
We delete the logs in less then a day but they are important so we
should keep them longer.