### PR TITLE
openstack-ardana: add post-validation exceptions

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
@@ -51,4 +51,27 @@
 # Standard (upstream) path for custom detection plugins for
 # monasca-agent i.e. if you've got agent plugins local to your site
 # you drop them in this directory.
-/usr/lib/monasca/agent/custom_detect.d/.*.pyc?
+/usr/lib/monasca/agent/custom_detect\.d/.*\.pyc?
+
+# Standard (upstream) path for custom check plugins for
+# monasca-agent i.e. if you've got agent plugins local to your site
+# you drop them in this directory.
+/usr/lib/monasca/agent/custom_checks\.d/.*\.pyc?
+
+# From monasca-ansible/roles/storm/tasks/install.yml, links to /usr/share/java/mysql-connector-java.jar
+/usr/lib64/storm/extlib/mysql-connector-java\.jar
+
+# From spark-ansible/roles/FND-SPA/tasks/install.yml, links to /usr/share/java/mysql-connector-java.jar
+/usr/share/spark/lib/mysql-connector-java\.jar
+
+# From monasca-transform-ansible/roles/MON-TRA/configure.yml
+/usr/lib/tmpfiles\.d/monasca-transform\.conf
+
+# Octavia service files created by playbooks (bsc#1094847)
+/usr/lib/systemd/system/octavia-.*\.service
+
+# created by Octavia playbooks (bsc#1094847)
+/usr/share/octavia
+
+# left over after installing maintenance updates (bsc#1094401)
+/usr/lib64/libreiserfscore\.so\.0

--- a/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
@@ -13,8 +13,11 @@ SM5..U.T.  c /etc/kafka/log4j.properties
 S.5..U.T.  c /etc/kafka/server.properties
 S.5....T.  c /etc/kibana/kibana.yml
 ......G..    /etc/monasca
-.M...UG..    /etc/monasca/agent
-.M...UG..    /etc/monasca/agent/conf.d
+# permissions changed by Monasca playbooks (bsc#1094873)
+.M...U...    /etc/monasca/agent
+.M...U...    /etc/monasca/agent/conf.d
+# permissions and owner changed by Monasca playbooks (bsc#1094971)
+SM5..U.T.  c /etc/storm/storm.yaml
 .....UG..    /opt/kibana/optimize
 .M.......    /usr/lib/monasca/agent/custom_checks.d
 .M.......    /usr/lib/monasca/agent/custom_detect.d
@@ -26,9 +29,15 @@ SM5....T.    /usr/share/ardana-opsconsole-ui/opscon_config.json
 .M.......    /var/lib/elasticsearch
 ......G..    /var/lib/swift
 .M.......    /var/log/beaver
+# owner changed by Cassandra playbooks (bsc#1094850)
+.M....G..    /var/log/cassandra
 ......G..    /var/log/kibana
 .M.......    /var/log/logstash
+# permissions changed by Monasca playbooks (bsc#1094873)
+.M.......    /var/log/monasca
 .M.......    /var/log/ops-console
 ......G..    /var/log/shibboleth
 .....UG..    /var/log/shibboleth-www
+# permissions changed by Spark playbooks (bsc#1094851)
+.M.......    /var/log/spark
 .M...UG..    /var/log/swift


### PR DESCRIPTION
Adds more exceptions to the post-validation whitelist for
rogue files and modified RPM owned files, to work around issues
revealed when running on the dac-3cp input model, which installs
an integrated deployer (e.g. https://ci.suse.de/job/openstack-ardana/1515).

Bugzilla entries have been created to track exceptions that need
to be fixed:

 * octavia installs in /usr/lib/systemd/system/ and /usr/share/octavia system paths (bsc#1094847)
 * permissions changed for RPM owned path /var/log/spark (bsc#1094851)
 * permissions changed for RPM owned paths /var/log/monasca and /etc/monasca/agent (bsc#1094873)
 * permissions changed for RPM owned path /var/log/cassandra (bsc#1094850)
 * permissions/owner changed for RPM owned file /etc/storm/storm.yaml (bsc#1094971)
 * /usr/lib64/libreiserfscore.so.0 is left over after installing maintenance updates (bsc#1094401)