### PR TITLE
openstack-ardana: fix build pool cleanup

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -183,15 +183,14 @@
 
           # Simple build pool management
           if [[ -n $build_pool_name ]]; then
-              tail_no_old_stacks=$(( 1-build_pool_size ))
-              (( $tail_no_old_stacks >= 0 )) && tail_no_old_stacks='+0'
+              keep_no_old_stacks=$(( build_pool_size-1 ))
               # NOTE: cannot use --property status=SUSPEND_COMPLETE as a filter when --tags is also present
               old_stacks_to_delete=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack list \
                                       --tags "$build_pool_name" \
                                       -f value -c 'Stack Name' -c 'Stack Status' \
                                       --sort 'creation_time:desc' |
                                       grep SUSPEND_COMPLETE | cut -d' ' -f1 |
-                                      tail -n $tail_no_old_stacks)
+                                      awk 'NR > '$keep_no_old_stacks' {print $1}')
               if [[ -n $old_stacks_to_delete ]]; then
                   for old_stack in $old_stacks_to_delete
                   do


### PR DESCRIPTION
Fixes the cleanup logic used to determine the list
of old stacks in a stack pool which need to be
deleted when a job begins.

The current logic fails to cover cases where the number
of old jobs is lower than the maximum number set for the
job pool. The effect is that a new job deletes all old
stacks that it finds.

Replacing tail with awk helps better encode the logic of
selecting "all but the first X-1, chronologically sorted
stacks" used to determine which stacks need to be deleted.