### PR TITLE
Wait for crowbar to be running end responding after the reboot

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -973,6 +973,7 @@ function crowbarupgrade_5plus
         onadmin check_admin_server_upgraded
         # use crowbar-init to bootstrap crowbar (only for 6-7 upgrade)
         iscloudver 7 && onadmin bootstrapcrowbar "with_upgrade"
+        onadmin wait_for_crowbar_api
     else
         onadmin prepare_crowbar_upgrade
         crowbarbackup "with_upgrade"


### PR DESCRIPTION
I think this job https://ci.suse.de/job/openstack-mkcloud/119839/console has failed because crowbar was not yet available when the `crowbarctl upgrade repocheck nodes` command was executed.