### PR TITLE
openstack-ardana: fix subnet heat resource deps

### DIFF
--- a/scripts/jenkins/ardana/heat-ardana-dac.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-dac.yaml
@@ -188,6 +188,8 @@ resources:
   # instances
   controllers:
     type: OS::Heat::ResourceGroup
+    depends_on:
+      - subnet_mgmt
     properties:
       count: { get_param: number_of_controllers }
       resource_def:
@@ -198,14 +200,14 @@ resources:
           image_id_controller: { get_param: image_id_controller }
           instance_type_controller: { get_param: instance_type_controller }
           networks:
-              - network: { get_resource: network_mgmt }
-              - network: { get_resource: network_ardana }
-              - network: { get_resource: network_mgmt2 }
-              - network: { get_resource: network_external_vm }
-              - network: { get_resource: network_guest }
-              - network: { get_resource: network_iscsi }
-              - network: { get_resource: network_tenant }
-              - network: { get_resource: network_hostname_and_external_api }
+            - network: { get_resource: network_mgmt }
+            - subnet: { get_resource: subnet_ardana }
+            - subnet: { get_resource: subnet_mgmt2 }
+            - subnet: { get_resource: subnet_external_vm }
+            - subnet: { get_resource: subnet_guest }
+            - subnet: { get_resource: subnet_iscsi }
+            - subnet: { get_resource: subnet_tenant }
+            - subnet: { get_resource: subnet_external_api }
   computes:
     type: OS::Heat::ResourceGroup
     properties:
@@ -218,14 +220,14 @@ resources:
           image: { get_param: image_id_compute }
           flavor: { get_param: instance_type_compute }
           networks:
-            - network: { get_resource: network_mgmt }
-            - network: { get_resource: network_ardana }
-            - network: { get_resource: network_mgmt2 }
-            - network: { get_resource: network_external_vm }
-            - network: { get_resource: network_guest }
-            - network: { get_resource: network_iscsi }
-            - network: { get_resource: network_tenant }
-            - network: { get_resource: network_hostname_and_external_api }
+            - subnet: { get_resource: subnet_mgmt }
+            - subnet: { get_resource: subnet_ardana }
+            - subnet: { get_resource: subnet_mgmt2 }
+            - subnet: { get_resource: subnet_external_vm }
+            - subnet: { get_resource: subnet_guest }
+            - subnet: { get_resource: subnet_iscsi }
+            - subnet: { get_resource: subnet_tenant }
+            - subnet: { get_resource: subnet_external_api }
 
   deployer-controller-floating-assignment:
     type: OS::Neutron::FloatingIPAssociation

--- a/scripts/jenkins/ardana/heat-ardana-deployerincloud-lite.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-deployerincloud-lite.yaml
@@ -110,6 +110,13 @@ resources:
     properties:
       floating_network: floating
 
+  deployer_controller_mgmt_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_resource: network_mgmt }
+      fixed_ips:
+        - subnet_id: { get_resource: subnet_mgmt }
+
   # instances
   deployer-controller:
     type: OS::Nova::Server
@@ -118,9 +125,9 @@ resources:
       image: { get_param: image_id_controller }
       flavor: { get_param: instance_type_controller }
       networks:
-        - network: { get_resource: network_mgmt }
-        - network: { get_resource: network_ardana }
-        - network: { get_resource: network_external }
+        - port: { get_resource: deployer_controller_mgmt_port }
+        - subnet: { get_resource: subnet_ardana }
+        - subnet: { get_resource: subnet_external }
 
   computes:
     type: OS::Heat::ResourceGroup
@@ -134,9 +141,9 @@ resources:
           image: { get_param: image_id_compute }
           flavor: { get_param: instance_type_compute }
           networks:
-            - network: { get_resource: network_mgmt }
-            - network: { get_resource: network_ardana }
-            - network: { get_resource: network_external }
+            - subnet: { get_resource: subnet_mgmt }
+            - subnet: { get_resource: subnet_ardana }
+            - subnet: { get_resource: subnet_external }
 
   # disks
   controller_vdb:
@@ -186,7 +193,7 @@ resources:
     type: OS::Neutron::FloatingIPAssociation
     properties:
       floatingip_id: { get_resource: deployer-controller-floatingip }
-      port_id: {get_attr: [deployer-controller, addresses, { get_resource: network_mgmt }, 0, port]}
+      port_id: { get_resource: deployer_controller_mgmt_port }
 
 outputs:
   # deployer-controller

--- a/scripts/jenkins/ardana/heat-ardana-standard.yaml
+++ b/scripts/jenkins/ardana/heat-ardana-standard.yaml
@@ -185,6 +185,14 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: floating
+
+  deployer_mgmt_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_resource: network_mgmt }
+      fixed_ips:
+        - subnet_id: { get_resource: subnet_mgmt }
+
   # instances
   deployer:
     type: OS::Nova::Server
@@ -193,14 +201,14 @@ resources:
       image: { get_param: image_id_controller }
       flavor: { get_param: instance_type_compute }
       networks:
-        - network: { get_resource: network_mgmt }
-        - network: { get_resource: network_ardana }
-        - network: { get_resource: network_mgmt2 }
-        - network: { get_resource: network_external_vm }
-        - network: { get_resource: network_guest }
-        - network: { get_resource: network_iscsi }
-        - network: { get_resource: network_tenant }
-        - network: { get_resource: network_hostname_and_external_api }
+        - port: { get_resource: deployer_mgmt_port }
+        - subnet: { get_resource: subnet_ardana }
+        - subnet: { get_resource: subnet_mgmt2 }
+        - subnet: { get_resource: subnet_external_vm }
+        - subnet: { get_resource: subnet_guest }
+        - subnet: { get_resource: subnet_iscsi }
+        - subnet: { get_resource: subnet_tenant }
+        - subnet: { get_resource: subnet_external_api }
 
   controllers:
     type: OS::Heat::ResourceGroup
@@ -214,14 +222,14 @@ resources:
           image_id_controller: { get_param: image_id_controller }
           instance_type_controller: { get_param: instance_type_controller }
           networks:
-              - network: { get_resource: network_mgmt }
-              - network: { get_resource: network_ardana }
-              - network: { get_resource: network_mgmt2 }
-              - network: { get_resource: network_external_vm }
-              - network: { get_resource: network_guest }
-              - network: { get_resource: network_iscsi }
-              - network: { get_resource: network_tenant }
-              - network: { get_resource: network_hostname_and_external_api }
+            - subnet: { get_resource: subnet_mgmt }
+            - subnet: { get_resource: subnet_ardana }
+            - subnet: { get_resource: subnet_mgmt2 }
+            - subnet: { get_resource: subnet_external_vm }
+            - subnet: { get_resource: subnet_guest }
+            - subnet: { get_resource: subnet_iscsi }
+            - subnet: { get_resource: subnet_tenant }
+            - subnet: { get_resource: subnet_external_api }
   computes:
     type: OS::Heat::ResourceGroup
     properties:
@@ -234,20 +242,20 @@ resources:
           image: { get_param: image_id_compute }
           flavor: { get_param: instance_type_compute }
           networks:
-            - network: { get_resource: network_mgmt }
-            - network: { get_resource: network_ardana }
-            - network: { get_resource: network_mgmt2 }
-            - network: { get_resource: network_external_vm }
-            - network: { get_resource: network_guest }
-            - network: { get_resource: network_iscsi }
-            - network: { get_resource: network_tenant }
-            - network: { get_resource: network_hostname_and_external_api }
+            - subnet: { get_resource: subnet_mgmt }
+            - subnet: { get_resource: subnet_ardana }
+            - subnet: { get_resource: subnet_mgmt2 }
+            - subnet: { get_resource: subnet_external_vm }
+            - subnet: { get_resource: subnet_guest }
+            - subnet: { get_resource: subnet_iscsi }
+            - subnet: { get_resource: subnet_tenant }
+            - subnet: { get_resource: subnet_external_api }
 
   deployer-floating-assignment:
     type: OS::Neutron::FloatingIPAssociation
     properties:
       floatingip_id: { get_resource: deployer-floatingip }
-      port_id: {get_attr: [deployer, addresses, { get_resource: network_mgmt }, 0, port]}
+      port_id: { get_resource: deployer_mgmt_port }
 
 outputs:
   # deployer

--- a/scripts/jenkins/ardana/heat-ses-cluster.yaml
+++ b/scripts/jenkins/ardana/heat-ses-cluster.yaml
@@ -279,6 +279,13 @@ resources:
     properties:
       floating_network: { get_param: ses_external_network }
 
+  ses_admin_mgmt_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_resource: ses_network }
+      fixed_ips:
+        - subnet_id: { get_resource: ses_subnet }
+
   # instances
   ses-admin:
     type: OS::Nova::Server
@@ -287,7 +294,7 @@ resources:
       image: { get_param: ses_image_id }
       flavor: { get_param: ses_instance_type_admin }
       networks:
-        - network: { get_resource: ses_network }
+        - port: { get_resource: ses_admin_mgmt_port }
         - network: { get_param: ses_extra_network }
       user_data_format: RAW
       user_data:
@@ -306,7 +313,7 @@ resources:
           ses_image_id: { get_param: ses_image_id }
           ses_instance_type: { get_param: ses_instance_type_osd }
           ses_networks:
-              - network: { get_resource: ses_network }
+              - subnet: { get_resource: ses_subnet }
               - network: { get_param: ses_extra_network }
           ses_user_data: { get_resource: ses_init_osd }
 
@@ -323,7 +330,7 @@ resources:
           ses_image_id: { get_param: ses_image_id }
           ses_instance_type: { get_param: ses_instance_type_mon }
           ses_networks:
-              - network: { get_resource: ses_network }
+              - subnet: { get_resource: ses_subnet }
               - network: { get_param: ses_extra_network }
           ses_user_data: { get_resource: ses_init_mon }
 
@@ -331,7 +338,7 @@ resources:
     type: OS::Neutron::FloatingIPAssociation
     properties:
       floatingip_id: { get_resource: ses-admin-floatingip }
-      port_id: {get_attr: [ses-admin, addresses, { get_resource: ses_network }, 0, port]}
+      port_id: { get_resource: ses_admin_mgmt_port }
 
 outputs:
   # SES admin
@@ -344,7 +351,7 @@ outputs:
   # IP addresses of the nodes in the ses_extra_network
   ses-admin-extra-network-ip:
     description: IP address of the SES admin in the ses extra network
-    value: { get_attr: [ses-admin, networks, { get_resource: ses_extra_network }, 0]}
+    value: { get_attr: [ses-admin, networks, { get_param: ses_extra_network }, 0]}
   ses-osds-extra-network-ips:
     description: IP addresses of the OSD nodes in the ses_extra_network
     value: { get_attr: [ses-osds, networks, { get_param: ses_extra_network }, 0]}


### PR DESCRIPTION
When a ResourceGroup is used to group multiple servers
together, the implicit dependency between those servers
and the list of networks they are attached to no longer
works [1].

The result of this is we get intermittent errors when
deleting heat stacks, because subnets are deleted before
the servers that are using them.

The workaround (and recommendation [2]) is to use a subnet
list or a port list instead of a network list when defining
OS::Nova::Server resources.

[1] https://bugs.launchpad.net/heat/+bug/1547435
[2] https://bugs.launchpad.net/heat/+bug/1243992