### PR TITLE
jjb: add timeout of 60 min. for devstack job

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-devstack.yaml
+++ b/jenkins/ci.opensuse.org/openstack-devstack.yaml
@@ -13,6 +13,13 @@
        numToKeep: 10
        daysToKeep: -1
 
+    wrappers:
+      - timeout:
+          timeout: 60
+          type: no-activity
+          abort: true
+          write-description: "Job aborted due to 60 minutes of inactivity."
+
     builders:
       - update-automation
       - shell: |


### PR DESCRIPTION
This should prevent from blocking the build worker for too long.
Sometimes it happens that the devstack job gets stuck and produces no more output. In these cases we want to abort the job and free the worker for the next job.