### PR TITLE
fix usage of next function

### DIFF
--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -275,7 +275,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                 args.cloud,
                 args.nodecounter,
                 i),
-            'target_dev': targetdevprefix + ''.join(alldevices.next()),
+            'target_dev': targetdevprefix + ''.join(next(alldevices)),
             'target_address': target_address.format(hex(0x10 + i)),
         }, configopts))
 
@@ -294,7 +294,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                     args.cloud,
                     args.nodecounter,
                     i),
-                'target_dev': targetdevprefix + ''.join(alldevices.next()),
+                'target_dev': targetdevprefix + ''.join(next(alldevices)),
                 'target_address': target_address.format(hex(0x16 + i)),
             }, configopts))
 
@@ -308,7 +308,7 @@ def compute_config(args, cpu_flags=cpuflags()):
                 args.vdiskdir,
                 args.cloud,
                 args.nodecounter),
-            'target_dev': targetdevprefix + ''.join(alldevices.next()),
+            'target_dev': targetdevprefix + ''.join(next(alldevices)),
             'target_address': target_address.format('0x1f')},
             configopts))
 


### PR DESCRIPTION
making it more python2 and python3 compatible

python2
```
In [2]: next(itertools.chain('abc','def'))
Out[2]: 'a'
```
python3
```
In [25]: itertools.chain('abc','def').next()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-25-c7429c06af55> in <module>()
----> 1 itertools.chain('abc','def').next()

AttributeError: 'itertools.chain' object has no attribute 'next'

In [26]: next(itertools.chain('abc','def'))
Out[26]: 'a'

```
