### PR TITLE
Increase days to keep logs for the *ardana* jobs

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-dac-3cp-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-dac-3cp-template.yaml
@@ -8,7 +8,7 @@
 
     logrotate:
       numToKeep: -1
-      daysToKeep: 7
+      daysToKeep: 14
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-devel-staging-updates-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-devel-staging-updates-template.yaml
@@ -8,7 +8,7 @@
 
     logrotate:
       numToKeep: -1
-      daysToKeep: 7
+      daysToKeep: 14
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-template.yaml
@@ -8,7 +8,7 @@
 
     logrotate:
       numToKeep: -1
-      daysToKeep: 7
+      daysToKeep: 14
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-test-maintenance-updates-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-test-maintenance-updates-template.yaml
@@ -8,7 +8,7 @@
 
     logrotate:
       numToKeep: -1
-      daysToKeep: 7
+      daysToKeep: 14
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-centos-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-centos-template.yaml
@@ -8,7 +8,7 @@
 
     logrotate:
       numToKeep: -1
-      daysToKeep: 7
+      daysToKeep: 14
 
     builders:
       - trigger-builds:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-template.yaml
@@ -8,7 +8,7 @@
 
     logrotate:
       numToKeep: -1
-      daysToKeep: 7
+      daysToKeep: 14
 
     builders:
       - trigger-builds:


### PR DESCRIPTION
These fail so often that we need more history to see what
is relevantly regressed in the recent days.