### PR TITLE
 make mkvlan idempotent

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -628,7 +628,9 @@ function mkvlan
     local intf=$cloudbr.$defvlan
     $sudo ip link add link $cloudbr name $intf type vlan id $defvlan
     safely $sudo ip link set $intf up
-    safely $sudo ip addr add $ip/24 dev $intf
+    if ! ip addr show $intf | grep -q $ip/24; then
+        safely $sudo ip addr add $ip/24 dev $intf
+    fi
 }
 
 function setuppublicnet

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -623,11 +623,11 @@ function instcrowbarfromgit
 
 function mkvlan
 {
-    local DEFVLAN=$1 ; shift
-    local IP=$1 ; shift
-    $sudo ip link add link $cloudbr name $cloudbr.$DEFVLAN type vlan id $DEFVLAN
-    safely $sudo ip link set $cloudbr.$DEFVLAN up
-    safely $sudo ip addr add $IP/24 dev $cloudbr.$DEFVLAN
+    local defvlan=$1 ; shift
+    local ip=$1 ; shift
+    $sudo ip link add link $cloudbr name $cloudbr.$defvlan type vlan id $defvlan
+    safely $sudo ip link set $cloudbr.$defvlan up
+    safely $sudo ip addr add $ip/24 dev $cloudbr.$defvlan
 }
 
 function setuppublicnet

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -625,9 +625,10 @@ function mkvlan
 {
     local defvlan=$1 ; shift
     local ip=$1 ; shift
-    $sudo ip link add link $cloudbr name $cloudbr.$defvlan type vlan id $defvlan
-    safely $sudo ip link set $cloudbr.$defvlan up
-    safely $sudo ip addr add $ip/24 dev $cloudbr.$defvlan
+    local intf=$cloudbr.$defvlan
+    $sudo ip link add link $cloudbr name $intf type vlan id $defvlan
+    safely $sudo ip link set $intf up
+    safely $sudo ip addr add $ip/24 dev $intf
 }
 
 function setuppublicnet


### PR DESCRIPTION
e342651 switched mkvlan from using `ifconfig(8)` to `ip(8)`, because `ifconfig` was deprecated.  Unfortunately this broke idempotence, because if the IP address already exists, `ip addr add` will fail, causing steps which call `setuppublicnet` to break if called more than once after a reboot.

So check whether the IP exists, and if it does, don't try to re-add.