### PR TITLE
upgrade: Do not deploy barclamps that are tech previews

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-ha-template.yaml
@@ -24,6 +24,9 @@
             mkcloudtarget=plain_with_upgrade testsetup
             want_nodesupgrade=1
             want_database_sql_engine={database_engine}
+            want_trove_proposal=0
+            want_barbican_proposal=0
+            want_sahara_proposal=0
             hacloud=1
             clusterconfig=data+services+network={nodenumber_controller}
             storage_method=swift


### PR DESCRIPTION
This is due to speed up the deployment process, so that regular
testing is more efficient.