### PR TITLE
qa_crowbarsetup: Use swift backend for glance when swift is deployed

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2323,6 +2323,9 @@ function custom_configuration
                 proposal_set_value glance default "['attributes']['glance']['default_store']" "'rbd'"
             fi
             if [[ $hacloud = 1 ]] ; then
+                if [[ $deployswift ]]; then
+                    proposal_set_value glance default "['attributes']['glance']['default_store']" "'swift'"
+                fi
                 proposal_set_value glance default "['deployment']['glance']['elements']['glance-server']" "['cluster:$clusternameservices']"
             fi
         ;;
@@ -2881,7 +2884,9 @@ function deploy_single_proposal
             fi
             ;;
         nfs_client)
-            [[ $hacloud = 1 ]] || return
+            # nfs client (used by glance) is needed for ha setups but only when
+            # neither swift nor ceph are deployed
+            [[ $hacloud = 1 && -z "$deployceph"  && -z "$deployswift" ]] || return
             ;;
         pacemaker)
             [[ $hacloud = 1 ]] || return


### PR DESCRIPTION
In HA setups apply nfs_client barclamp only when neither swift nor
ceph are deployed.

In non HA setups stay with the local file backend for glance, even when
swift is deployed.