### PR TITLE
github_pr: allow dryrun for cloud config

### DIFF
--- a/scripts/github_pr/interactions/ia_cloud.rb
+++ b/scripts/github_pr/interactions/ia_cloud.rb
@@ -16,7 +16,7 @@ module GithubPR
       base_cmd = command("job_cmd")
       job_parameters(pull).each do |build_mode, job_paras|
         one_cmd = base_cmd + [@c["job_name"]] + parameters_to_cmd_paras(job_paras)
-        system(*one_cmd) or raise
+        system_cmd(one_cmd)
         if logging? then
           puts "  Triggered jenkins job in mode: #{build_mode}"
           puts "  Rebuild Link: #{JENKINS_URL}/job/#{@c["job_name"]}/parambuild/?#{parameters_to_uri(job_paras)}"


### PR DESCRIPTION
github_pr supports a dryrun option. In order to support this the call to 'system' needs to be change to a wrapper method that will check if dryrun is set.

Without this dryrun is not possible with the cloud config for github_pr.

The change in github_pr is in this commit:
https://github.com/openSUSE/github-pr/commit/fcb1b30ba15869571e766e1d07c2ee9878920094