### PR TITLE
Filter Leap 15 for Ocata

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -41,6 +41,7 @@
       combination-filter: |
        !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP2"].contains(repository) ||
          ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3", "openSUSE_Leap_15.0"].contains(repository) ||
+         ["Cloud:OpenStack:Ocata", "Cloud:OpenStack:Ocata:Staging"].contains(project) && ["openSUSE_Leap_15.0"].contains(repository) ||
          ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["SLE_12_SP2", "openSUSE_Leap_15.0"].contains(repository) ||
          ["Cloud:OpenStack:Queens", "Cloud:OpenStack:Queens:Staging"].contains(project) && ["SLE_12_SP2"].contains(repository)
        )


### PR DESCRIPTION
Ocata wasn't build for Leap15 and we have no interest in adding
it - Pike+ would be a better target