### PR TITLE
Add an extra upgrade job that has OpenStack debug logging on

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -52,6 +52,7 @@
         - 'cloud-mkcloud{version}-job-ha-ironic-agent-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-disruptive-ha-mariadb-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-{arch}'
+        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-debug-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
 - project:
     name: cloud-mkcloud8-tempestfull-x86_64

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-debug-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-debug-template.yaml
@@ -1,0 +1,39 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-debug-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: '32 22 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=develcloud{previous_version}
+            upgrade_cloudsource=develcloud{version}
+            ### 3 nodes for HA cluster, 2 compute nodes, 1 lonelynode for nfs server
+            nodenumber=6
+            clusterconfig=data+services+network={nodenumber_controller}
+            hacloud=1
+            debug_openstack=1
+            storage_method=swift
+            cinder_backend=nfs
+            want_nodesupgrade=1
+            want_database_sql_engine={database_engine}
+            want_ping_running_instances=1
+            want_clustered_rabbitmq=1
+            want_trove_proposal=0
+            want_barbican_proposal=0
+            want_sahara_proposal=0
+            mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server proposal testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
+            label={label}
+            job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-debug-{arch}


### PR DESCRIPTION
Other than the debug option, it's just a copy of cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml