### PR TITLE
Remove ocata mkcloud job

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -76,22 +76,3 @@
     tempestoptions: --smoke
     jobs:
         - 'cloud-mkcloud{version}-job-uefi-{arch}'
-
-- project:
-    name: cloud-mkcloud7-aarch64
-    disabled: false
-    version: 7
-    previous_version: 6
-    arch: aarch64
-    label: openstack-mkcloud-SLE12-{arch}
-    tempestoptions: --smoke
-    jobs:
-        - 'cloud-mkcloud{version}-job-2nodes-{arch}'
-        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
-        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
-        - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
-        - 'cloud-mkcloud{version}-job-magnum-{arch}'
-        - 'cloud-mkcloud{version}-job-raid-{arch}'
-        - 'cloud-mkcloud{version}-job-ssl-{arch}'
-
-

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -27,9 +27,6 @@
         - 'cloud-mkcloud{version}-job-raid-{arch}'
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
         - 'cloud-mkcloud{version}-job-xen-{arch}'
-        # NOTE: we keep the Ocata job because we need to maintain
-        # Devel:Cloud:8:Ocata for CloudFoundry CI
-        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-ocata'
         - 'cloud-mkcloud{version}-job-upgrade-disruptive-{arch}'
 - project:
     name: cloud-mkcloud8-ha-x86_64


### PR DESCRIPTION
The Cloudfoundry Ci has upgraded to Pike+, they're no longer
interested in ocata, so we can retire the testing.