### PR TITLE
Give supportconfig more time to gather data

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -218,11 +218,11 @@ function onhost_supportconfig
             for node in $(crowbar machines list | grep ^d) ; do
             (
                 echo "Collecting supportconfig from $node"
-                timeout 400 ssh $node supportconfig | wc
+                timeout 1200 ssh $node supportconfig | wc
                 timeout 300 scp $node:/var/log/\*tbz /var/log/
             )&
             done
-            timeout 500 supportconfig | wc &
+            timeout 600 supportconfig | wc &
             wait
         '
         $scp root@$adminip:/var/log/*tbz $artifacts_dir/


### PR DESCRIPTION
Several jobs fail to gather supportconfig data from the nodes
because of the timeout. 
See e.g. https://ci.suse.de/job/openstack-mkcloud/124937/console