### PR TITLE
Always show the upgrade prechecks result in the build log

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4947,10 +4947,12 @@ function onadmin_reapply_openstack_proposals
 
 function onadmin_upgrade_prechecks
 {
+    # always show the prechecks output in the build log
+    crowbarctl upgrade prechecks
+
     if ! crowbarctl upgrade prechecks --format json | rubyjsonparse \
         "exit false if j.any? { |test| test['required'] && test['passed'] == false }"
     then
-        crowbarctl upgrade prechecks
         complain 11 "Some necessary check before the upgrade has failed"
     fi
 }


### PR DESCRIPTION
That means also for the successful case, so we know the values
of all those checks.
Especially so we know why the upgrade mode was selected as non-disruptive or normal.