### PR TITLE
Make sure testpostupgrade step is only executed for non-disruptive upgrade

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4390,6 +4390,11 @@ function oncontroller_testpreupgrade
 
 function oncontroller_testpostupgrade
 {
+
+    if ! grep non_disruptive /var/lib/crowbar/upgrade/*-progress.yml ; then
+        complain 11 "The testpostupgrade step is only valid for non-disruptive upgrade mode!"
+    fi
+
     # retrieve the ping results
     local fips=$(openstack --insecure floating ip list -f value -c "Floating IP Address")
 


### PR DESCRIPTION

In some cases it was mistakingly executed for the normal mode causing
confusing errors (see SCRD-4051)