### PR TITLE
allocpool: match cmd name when pid found

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -636,6 +636,8 @@
 
           starttime=`date +%s`
 
+          # CHECKPROC in env tells 'allocpool' the process name to compare
+          export CHECKPROC=mkcloud
           mkcloudwrapper="${automationrepo}/scripts/mkcloudhost/allocpool ${automationrepo}/scripts/mkcloudhost/mkcloude"
           #FIXME - drop next 3 lines once the change in allocpool is merged
           if grep -q "exec.*mkcloude" ${automationrepo}/scripts/mkcloudhost/allocpool ; then

--- a/scripts/mkcloudhost/allocpool
+++ b/scripts/mkcloudhost/allocpool
@@ -28,8 +28,10 @@ foreach my $d (@dirs) {
                 my $signalled=kill(0, $num);
                 diag "PID file had $num";
                 if($signalled) {
-                        diag "someone else owns $a and is alive";
-                        next;
+                        if(!$ENV{CHECKPROC} || `grep $ENV{CHECKPROC} /proc/$num/cmdline` == 0) {
+                                diag "someone else owns $a and is alive";
+                                next;
+                        }
                 }
         }
         # process is dead => cleanup


### PR DESCRIPTION
In case allocpool finds a process with the pid of the pid file,
also the cmdline needs to be matched to verify, if this process
was an mkcloud run.
Otherwise it might happen (and it did) that the pid counter runs
over and restarts and a pidfile now holds a pid of a different
process (in our case a deamon). This would block a slot from
allocpool even though there no longer is an mkcloud process.

This change does the comparision of the cmdline.