### PR TITLE
Check for upgrade progress file must be done on admin node

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4460,6 +4460,10 @@ function onadmin_ping_running_instances
 
 function onadmin_testpostupgrade
 {
+    if ! grep non_disruptive /var/lib/crowbar/upgrade/*-progress.yml ; then
+        complain 11 "The testpostupgrade step is only valid for non-disruptive upgrade mode!"
+    fi
+
     get_novacontroller
     check_novacontroller
 


### PR DESCRIPTION
Next try for "Make sure testpostupgrade step is only executed for non-disruptive upgrade": 
https://github.com/SUSE-Cloud/automation/pull/2591

In some cases it was mistakingly executed for the normal mode causing confusing errors (see SCRD-4051)

The original PR had the check on the wrong place.