### PR TITLE
Revert "Make sure testpostupgrade step is only executed for non-disru…

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4390,11 +4390,6 @@ function oncontroller_testpreupgrade
 
 function oncontroller_testpostupgrade
 {
-
-    if ! grep non_disruptive /var/lib/crowbar/upgrade/*-progress.yml ; then
-        complain 11 "The testpostupgrade step is only valid for non-disruptive upgrade mode!"
-    fi
-
     # retrieve the ping results
     local fips=$(openstack --insecure floating ip list -f value -c "Floating IP Address")
 


### PR DESCRIPTION
…ptive upgrade."

This reverts commit 76e570c4d29a5af2cddd932b1722e113c38588b9.

revert of https://github.com/SUSE-Cloud/automation/pull/2591, it was on wrong place (checking file presence on controller)