### PR TITLE
Replace zypper repo for sshpass

### DIFF
--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -11,7 +11,7 @@
     arch: x86_64
     repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
     cloudsource_url: "{{ repos_url }}/{{ cloudsource }}"
-    sshpass_repo: "http://download.suse.de/ibs/QA:/SLE12SP3/update/"
+    sshpass_repo: "http://download.suse.de/ibs/NON_Public:/infrastructure/SUSE_SLE_12_SP3_Update/"
 
   tasks:
 


### PR DESCRIPTION
Using the repository from the SUSE internal IT team
to install sshpass instead of the old one, which is
not well maintained.

NOTE: this is requires to unblock the Ardana gating job, which is now failing due to an expired or incorrect key being used with the old repository.