### PR TITLE
openstack-ardana: fix network subnet ranges

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
+++ b/scripts/jenkins/ardana/ansible/files/input-model-net-global.yml
@@ -24,7 +24,7 @@
       tagged-vlan: false
       cidr: 192.168.110.0/24
       addresses:
-        - 192.168.110.5-192.168.110.200
+        - 192.168.110.2-192.168.110.100
       gateway-ip: 192.168.110.1
       network-group: ARDANA
 
@@ -33,7 +33,7 @@
       tagged-vlan: false
       cidr: 192.168.245.0/24
       addresses:
-        - 192.168.245.5-192.168.245.200
+        - 192.168.245.2-192.168.245.100
       gateway-ip: 192.168.245.1
       network-group: MANAGEMENT
 


### PR DESCRIPTION
The subnet ranges configured in the input model for
the ARDANA-NET and MANAGEMENT-NET networks didn't match
those used in the heat template. This caused the newer
version of configuration processor to complain with the
following type of message:

```
ERR: Server ardana-ccp-c0-m1 (192.168.245.4) using
interface model ARDANA-INTERFACES does not have a
connection to a network which contains its address.
```
, which basically means that the addresses assigned
to servers in servers.yml (i.e. allocated by heat/openstack)
don't match the address ranges configured in the net_global.yml
file.

