### PR TITLE
openstack-ardana: ignore stack cleanup errors

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -196,8 +196,8 @@
                   for old_stack in $old_stacks_to_delete
                   do
                       # Need to resume the stack before deleting it, otherwise deletion will fail
-                      openstack --os-cloud $CLOUD_CONFIG_NAME stack resume --wait $old_stack
-                      openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait $old_stack
+                      openstack --os-cloud $CLOUD_CONFIG_NAME stack resume --wait $old_stack || :
+                      openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait $old_stack || :
                   done
               fi
           fi


### PR DESCRIPTION
Ignore errors encountered while cleaning up old stacks,
to avoid aborting an important job, such as the gating
job because of cleanup related issues.

This is hopefully just a temporary measure, until there
is a better strategy for planning engineering cloud
maintenance windows, which are currently impacting the
gating jobs too often.