### PR TITLE
openstack-ardana: update post-validation for storm.yml

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
@@ -17,7 +17,7 @@ S.5....T.  c /etc/kibana/kibana.yml
 .M...U...    /etc/monasca/agent
 .M...U...    /etc/monasca/agent/conf.d
 # permissions and owner changed by Monasca playbooks (bsc#1094971)
-SM5..U.T.  c /etc/storm/storm.yaml
+SM5....T.  c /etc/storm/storm.yaml
 .....UG..    /opt/kibana/optimize
 .M.......    /usr/lib/monasca/agent/custom_checks.d
 .M.......    /usr/lib/monasca/agent/custom_detect.d


### PR DESCRIPTION
The owner changes made by Ardana playbooks to the
/etc/storm/storm.yaml configuration file have been
fixed [1][2].

[1] https://bugzilla.suse.com/show_bug.cgi?id=1094971
[2] https://gerrit.suse.provo.cloud/4209

NOTE: this is only required by the dac-3cp openstack-ardana Job, which is currently failing because this post-validation check is obsolete.