### PR TITLE
Use ansible 2.6.2 from virtual environment for ardana CI

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -178,7 +178,6 @@
           CLOUD_CONFIG_NAME="$CLOUD_CONFIG_NAME"
           EOF
 
-          export ANSIBLE_HOST_KEY_CHECKING=False
           export ANSIBLE_KEEP_REMOTE_FILES=1
           # the name for the cloud defined in ~./config/openstack/clouds.yaml
 
@@ -285,6 +284,8 @@
               while read line; do echo "  - $line" >> ardana_net_vars.yml; done;
 
           cat ardana_net_vars.yml
+
+          source /opt/ansible/bin/activate
 
           ansible-playbook -v -i hosts ssh-keys.yml
           if [ -n "$gerrit_change_id" ] ; then

--- a/scripts/jenkins/ardana/ansible/ansible.cfg
+++ b/scripts/jenkins/ardana/ansible/ansible.cfg
@@ -1,0 +1,51 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+[defaults]
+
+# For faster ansible - see: http://mitogen.readthedocs.io/en/latest/ansible.html
+# Recommended if running ansible on high-latency (eg. nue<->provo)
+strategy_plugins = /opt/ansible/mitogen-0.2.2/ansible_mitogen/plugins/strategy
+strategy = mitogen_linear
+
+# Fact caching
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = ansible_facts
+fact_caching_timeout = 86400
+
+# Optimize ansible
+pipelining = True
+poll_interval = 5
+
+# Disable retry files
+retry_files_enabled = False
+
+# Default inventory file
+inventory = inventory
+host_key_checking = False
+
+# Set color options
+nocolor = 0
+
+# SSH timeout
+timeout = 120
+
+# Enable tasks profiling
+callback_whitelist = profile_tasks, timer
+
+# Use the YAML callback plugin
+stdout_callback = yaml

--- a/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
@@ -46,7 +46,7 @@
   - name: Record any failure of tempest
     set_fact:
       failures: "{{ failures + ['tempest'] }}"
-    when: tempest_run_result|failed
+    when: tempest_run_result is failed
 
   - name: Initialise array tracking post-deployment checks failures
     set_fact:
@@ -109,7 +109,7 @@
   - name: Check no rpm-owned files removed by deployment
     fail: msg="Found files removed by deployment:\n{{ rpm_verify_removed_files.stdout }}"
     when:
-      - "rpm_verify_removed_files.stdout | match('^missing ')"
+      - "rpm_verify_removed_files.stdout is match('^missing ')"
     ignore_errors: true
 
   - name: Record failure if rpm-owned files removed by deployment
@@ -117,7 +117,7 @@
       post_deploy_checks_failures:
         "{{ post_deploy_checks_failures + [ 'rpm-owned files removed by deployment' ] }}"
     when:
-      - "rpm_verify_removed_files.stdout | match('^missing ')"
+      - "rpm_verify_removed_files.stdout is match('^missing ')"
 
   - name: Check no rpm-owned files modified by deployment
     fail: msg="Found files modified by deployment:\n{{ rpm_verify_modified_files.stdout }}"
@@ -159,7 +159,7 @@
       post_deploy_checks_failures:
         "{{ post_deploy_checks_failures + [ 'Rogue files introduced by deployment' ] }}"
     when:
-      - rogue_files | failed
+      - rogue_files is failed
 
   - name: Remove temporary directory if not running in test mode and all checks succeeded
     become: yes


### PR DESCRIPTION
This is part of [SCRD-4003-Merge the automation scripts/tools used by QA and CI](https://jira.prv.suse.net/browse/SCRD-4003).

As QA is using using ansible 2.6.2 from within a virtual environment, this change applies the same approach to the CI.
It also adds a customized `ansible.cfg` with some optimizations, the same used for QA.

Tested in: https://ci.suse.de/job/openstack-ardana-flavio/5/