### PR TITLE
Add retry around broken build results

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana-testbuild-gerrit.yaml
@@ -76,7 +76,7 @@
           set -eux
           rm -rf ./automation-git
           git clone $git_automation_repo --branch $git_automation_branch automation-git
-          python automation-git/scripts/jenkins/ardana/gerrit/build_test_package.py
+          python -u automation-git/scripts/jenkins/ardana/gerrit/build_test_package.py
 
     publishers:
       - workspace-cleanup:

--- a/scripts/jenkins/ardana/gerrit/build_test_package.py
+++ b/scripts/jenkins/ardana/gerrit/build_test_package.py
@@ -110,9 +110,18 @@ def wait_for_build():
     while 'unknown' in sh.osc('results'):
         time.sleep(3)
     print("Waiting for build results")
-    results = sh.osc('results', '--watch')
-    if 'succeeded' not in results:
+    for attempt in range(3):
+        results = sh.osc('results', '--watch')
         print("Build results: %s" % results)
+        if 'broken' in results:
+            # Sometimes results --watch ends too soon, give it a few retries
+            # before actually failing
+            print("Sleeping for 10s before rechecking")
+            time.sleep(10)
+            continue
+        else:
+            break
+    if 'succeeded' not in results:
         print("Package build failed.")
         sys.exit(1)
 

--- a/scripts/jenkins/ardana/gerrit/build_test_package.py
+++ b/scripts/jenkins/ardana/gerrit/build_test_package.py
@@ -105,25 +105,28 @@ def create_test_project(develproject, testproject, repository):
     return testproject
 
 
-def wait_for_build():
-    print("Waiting for build to be scheduled")
-    while 'unknown' in sh.osc('results'):
-        time.sleep(3)
-    print("Waiting for build results")
-    for attempt in range(3):
-        results = sh.osc('results', '--watch')
-        print("Build results: %s" % results)
-        if 'broken' in results:
-            # Sometimes results --watch ends too soon, give it a few retries
-            # before actually failing
-            print("Sleeping for 10s before rechecking")
-            time.sleep(10)
-            continue
-        else:
-            break
-    if 'succeeded' not in results:
-        print("Package build failed.")
-        sys.exit(1)
+def wait_for_build(change, testproject):
+    package_name = project_map()[change.project]
+    print("Waiting for %s to build" % package_name)
+    with cd('%s/%s' % (testproject, package_name)):
+        while 'unknown' in sh.osc('results'):
+            print("Waiting for build to be scheduled")
+            time.sleep(3)
+        print("Waiting for build results")
+        for attempt in range(3):
+            results = sh.osc('results', '--watch')
+            print("Build results: %s" % results)
+            if 'broken' in results:
+                # Sometimes results --watch ends too soon, give it a few
+                # retries before actually failing
+                print("Sleeping for 10s before rechecking")
+                time.sleep(10)
+                continue
+            else:
+                break
+        if 'succeeded' not in results:
+            print("Package build failed.")
+            sys.exit(1)
 
 
 def create_test_package(change, develproject, testproject):
@@ -149,7 +152,6 @@ def create_test_package(change, develproject, testproject):
         sh.osc('service', 'disabledrun')
         sh.osc('add', glob.glob('%s*.obscpio' % package_name))
         sh.osc('commit', '-m', 'Testing change %s' % change.id)
-        wait_for_build()
 
 
 def cleanup(testproject):
@@ -168,9 +170,22 @@ def main():
     changes = [GerritChange(id) for id in change_ids]
     cleanup(testproject)
     testproject = create_test_project(develproject, testproject, repository)
+
+    # Create the test packages to be built
+    # NOTE(jhesketh): If necessary this could be done in a threadpool
     for change in changes:
         change.prep_workspace()
         create_test_package(change, develproject, testproject)
+
+    # Check all packages are built
+    # NOTE(jhesketh): this could be optimised to check packages in parallel,
+    # however the worst case scenario at the moment is
+    # "time for longest package" + "time for num_of_package checks" which isn't
+    # too much more than the minimum
+    # ("time for longest package" + "time for one check")
+    for change in changes:
+        wait_for_build(change,  testproject)
+
     cleanup(testproject)
 
 


### PR DESCRIPTION
Sometimes `osc results` returns 'broken' even when the build will eventually succeed. It isn't great to work around this, but for now add a sleep and recheck a few times before actually failing on transient errors.