### PR TITLE
openstack-ardana: fix ansible virtualenv call

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -203,6 +203,7 @@
           fi
 
           pushd automation-git/scripts/jenkins/ardana/ansible
+          source /opt/ansible/bin/activate
 
           # generate the heat template
           ansible-playbook -v generate-heat.yml \
@@ -280,8 +281,6 @@
               while read line; do echo "  - $line" >> ardana_net_vars.yml; done;
 
           cat ardana_net_vars.yml
-
-          source /opt/ansible/bin/activate
 
           ansible-playbook -v -i hosts ssh-keys.yml
           if [ -n "$gerrit_change_id" ] ; then


### PR DESCRIPTION
The ansible virtualenv must be entered before any ansible
commands are called.