### PR TITLE
openstack-ardana: reduce ansible verbosity

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -304,7 +304,7 @@
 
           # Run site.yml outside ansible for output streaming
           ssh $sshargs ardana@$DEPLOYER_IP "cd ~/scratch/ansible/next/ardana/ansible ; \
-               ansible-playbook -vvv -i hosts/verb_hosts site.yml"
+               ansible-playbook -v -i hosts/verb_hosts site.yml"
 
           # Run Update if required
           if [ -n "$update_cloudsource" -a "$update_cloudsource" != "$cloudsource" -o -n "$update_repositories" ]; then

--- a/scripts/jenkins/ardana/ansible/_update-clm.yml
+++ b/scripts/jenkins/ardana/ansible/_update-clm.yml
@@ -7,7 +7,7 @@
 
 - name: Run config-processor-run.yml playbook
   shell: |
-    ansible-playbook -vvv -i hosts/localhost -e encrypt="" -e rekey="" config-processor-run.yml
+    ansible-playbook -v -i hosts/localhost -e encrypt="" -e rekey="" config-processor-run.yml
   args:
     chdir: /var/lib/ardana/openstack/ardana/ansible
   become: true
@@ -15,7 +15,7 @@
 
 - name: Run ready-deployment.yml playbook
   shell: |
-    ansible-playbook -vvv -i hosts/localhost ready-deployment.yml
+    ansible-playbook -v -i hosts/localhost ready-deployment.yml
   args:
     chdir: /var/lib/ardana/openstack/ardana/ansible
   become: true

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -125,7 +125,7 @@
 
   - name: Run config-processor-run.yml playbook
     shell: |
-      ansible-playbook -vvv -i hosts/localhost -e encrypt="" -e rekey="" config-processor-run.yml
+      ansible-playbook -v -i hosts/localhost -e encrypt="" -e rekey="" config-processor-run.yml
   #    no_log: True
     register: out
     args:
@@ -135,7 +135,7 @@
 
   - name: Run ready-deployment.yml playbook
     shell: |
-      ansible-playbook -vvv -i hosts/localhost ready-deployment.yml
+      ansible-playbook -v -i hosts/localhost ready-deployment.yml
     args:
       chdir: /var/lib/ardana/openstack/ardana/ansible
     become: true

--- a/scripts/jenkins/ardana/ansible/reboot-node.yml
+++ b/scripts/jenkins/ardana/ansible/reboot-node.yml
@@ -17,7 +17,7 @@
 
 - name: Reboot node
   shell: |
-    ansible-playbook -vvv -i hosts/verb_hosts ardana-reboot.yml \
+    ansible-playbook -v -i hosts/verb_hosts ardana-reboot.yml \
       --limit {{ ansible_node }}
   args:
     chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
@@ -63,7 +63,7 @@
 
 - name: Run post-reboot actions on deployer
   shell: |
-    ansible-playbook -vvv -i hosts/verb_hosts _ardana-post-reboot.yml \
+    ansible-playbook -v -i hosts/verb_hosts _ardana-post-reboot.yml \
       --limit {{ ansible_node }}
   args:
     chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
@@ -74,7 +74,7 @@
   # Workaround for bsc#1091479 - start spark on all nodes after rebooting one node
 - name: Restart spark on all nodes to correct for bsc#1091479
   shell: |
-    ansible-playbook -vvv -i hosts/verb_hosts spark-start.yml
+    ansible-playbook -v -i hosts/verb_hosts spark-start.yml
   args:
     chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
   become: true

--- a/scripts/jenkins/ardana/ansible/reboot.yml
+++ b/scripts/jenkins/ardana/ansible/reboot.yml
@@ -35,7 +35,7 @@
 
   - name: Run a global service status check
     shell: |
-      ansible-playbook -vvv -i hosts/verb_hosts ardana-status.yml
+      ansible-playbook -v -i hosts/verb_hosts ardana-status.yml
     args:
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/tasks/main.yml
@@ -45,11 +45,6 @@
     virt_config: '{{ virt_config }}'
   register: heat_result
 
-- name: Print generated heat model
-  debug:
-    msg: '{{ heat_result.heat_template }}'
-    verbosity: 1
-
 - name: Generate heat orchestration template
   template:
     src: "heat-template.yaml"

--- a/scripts/jenkins/ardana/ansible/update-node.yml
+++ b/scripts/jenkins/ardana/ansible/update-node.yml
@@ -81,7 +81,7 @@
 
 - name: Update packages on the target node
   shell: |
-    ansible-playbook -vvv -i hosts/verb_hosts ardana-update-pkgs.yml \
+    ansible-playbook -v -i hosts/verb_hosts ardana-update-pkgs.yml \
       --limit {{ ansible_node }} \
       -e \
         "zypper_update_method={{ update_method }}
@@ -97,7 +97,7 @@
 
 - name: Get update status on the target node
   shell: |
-    ansible-playbook -vvv -i hosts/verb_hosts ardana-update-status.yml \
+    ansible-playbook -v -i hosts/verb_hosts ardana-update-status.yml \
       --limit {{ ansible_node }} \
       -e update_status_brief=true | grep "Pending update actions:"
   args:
@@ -127,7 +127,7 @@
 
 - name: Update services
   shell: |
-    ansible-playbook -vvv -i hosts/verb_hosts ardana-update.yml \
+    ansible-playbook -v -i hosts/verb_hosts ardana-update.yml \
       --limit {{ ansible_node }}
   args:
     chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible

--- a/scripts/jenkins/ardana/ansible/update.yml
+++ b/scripts/jenkins/ardana/ansible/update.yml
@@ -41,7 +41,7 @@
 
   - name: Run a global service status check
     shell: |
-      ansible-playbook -vvv -i hosts/verb_hosts ardana-status.yml
+      ansible-playbook -v -i hosts/verb_hosts ardana-status.yml
     args:
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true


### PR DESCRIPTION
Using -vvv is flooding the logs with ansible connection
information which has never proven useful in the past.
Reducing verbosity to make the output easier to decipher
(-v should be sufficient for most purposes).

Result: the size of the raw log file for a std-min job has been reduced from 30M to 20M