### PR TITLE
SCRD-4417 openstack-ardana: move heat stack management to separate job

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-heat.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-heat.yaml
@@ -1,0 +1,192 @@
+- job:
+    name: openstack-ardana-heat
+    description: |
+      Ardana heat stack management (create/delete/suspend stacks, clean up old stacks)
+    concurrent: false
+    # the selected node needs the cloud credentials
+    node: cloud-ardana-ci
+    wrappers:
+      - timestamps
+
+      - timeout:
+          timeout: 30
+          type: no-activity
+          abort: true
+          write-description: "Job aborted due to 30 minutes of inactivity"
+
+    logrotate:
+      numToKeep: 200
+      daysToKeep: 30
+
+    parameters:
+      - choice:
+          name: action
+          choices:
+            - cleanup
+            - create
+            - delete
+            - exclude
+          description: >-
+            The action to be performed:
+              - cleanup: run the build pool cleanup logic on a heat stack or on
+              the build pool itself
+              - create: create a new heat stack
+              - delete: delete a heat stack
+              - exclude: take a heat stack out of the build pool management and
+              prevent it from being deleted or suspended by the cleanup process
+
+            The heat_stack_name parameter value must be supplied if the create,
+            delete, or exclude action is selected. If the create or exclude
+            action is selected, the heat_template_file parameter value must also
+            be supplied.
+
+      - string:
+          name: heat_template_file
+          default: ''
+          description: >-
+            The heat orchestration template file describing the stack that must
+            be instantiated.
+
+      - string:
+          name: heat_stack_name
+          default: ''
+          description: >-
+            The name of the heat stack to be created, deleted, suspended,
+            reserved or released.
+
+      - string:
+          name: build_pool_name
+          default: ''
+          description: >-
+            Name of the build resource pool to be used for this job. When
+            supplied, the heat stack created by this job will be added to the
+            build pool and will be cleaned up automatically when the pool fills up.
+
+      - string:
+          name: build_pool_size
+          default: '0'
+          description: >-
+            The maximum number of heat stacks in the build_pool_name build pool
+            that can be kept running at any given time. When this number is exceeded,
+            older stacks in the pool will be deleted to make place for new ones.
+
+    builders:
+      - shell: |
+          set -ex
+
+          # the name for the cloud defined in ~./config/openstack/clouds.yaml
+          CLOUD_CONFIG_NAME=engcloud-cloud-ci
+
+          delete_heat_stack() {
+              stack_name=$1
+
+              # Resume stack before deletion, otherwise deleting it results in failure
+              openstack --os-cloud $CLOUD_CONFIG_NAME stack resume --wait $stack_name || :
+              openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait $stack_name && rc=$? || rc=$?
+              if [[ $rc != 0 ]]; then
+                  # Attempt a brute force type of cleanup (delete servers and volumes)
+                  openstack --os-cloud $CLOUD_CONFIG_NAME stack resource list --filter type=OS::Nova::Server \
+                    -f value -c physical_resource_id $stack_name |
+                    awk '{print "openstack --os-cloud '$CLOUD_CONFIG_NAME' server delete --wait "$1 }' | sh -x || :
+                  openstack --os-cloud $CLOUD_CONFIG_NAME stack resource list --filter type=OS::Cinder::Volume \
+                    -f value -c physical_resource_id $stack_name |
+                    awk '{print "openstack --os-cloud '$CLOUD_CONFIG_NAME' volume delete "$1 }' | sh -x || :
+                  openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait $stack_name && rc=$? || rc=$?
+                  if [[ $rc != 0 ]]; then
+                      # Usually, retrying after a short break works
+                      sleep 20
+                      openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait $stack_name && rc=$? || rc=$?
+                  fi
+              fi
+
+              return $rc
+          }
+
+          get_heat_stacks() {
+              filter=$1
+              # NOTE: cannot use --property status=<status> as a filter when --tags is also present
+              openstack --os-cloud $CLOUD_CONFIG_NAME stack list \
+                        --tags "$build_pool_name" \
+                         -f value -c 'Stack Name' -c 'Stack Status' \
+                        --sort 'creation_time:desc' |
+                        grep "$filter" || :
+          }
+
+          cleanup_heat_stacks() {
+              keep_no_old_stacks=$1
+              retcode=0
+
+              old_stacks_to_delete=$(get_heat_stacks SUSPEND_COMPLETE | cut -d' ' -f1 |
+                                     awk 'NR > '$keep_no_old_stacks' {print $1}')
+              if [[ -n $old_stacks_to_delete ]]; then
+                  for old_stack in $old_stacks_to_delete
+                  do
+                      delete_heat_stack $old_stack && rc=$? || rc=$?
+                      if [[ $rc != 0 ]]; then
+                          retcode=$rc
+                      fi
+                  done
+              fi
+
+              failed_stacks_to_delete=$(get_heat_stacks _FAILED | cut -d' ' -f1)
+              if [[ -n failed_stacks_to_delete ]]; then
+                  for failed_stack in $failed_stacks_to_delete
+                  do
+                      delete_heat_stack $failed_stack || :
+                  done
+              fi
+
+              return $rc
+          }
+
+          if [[ $action == "cleanup" ]]; then
+              if [[ -n $build_pool_name ]]; then
+                  # If a heat stack is supplied, clean it up by suspending it or deleting it,
+                  # depending on the build pool size
+                  if [[ -n $heat_stack_name ]]; then
+                      # First, check if the stack is hasn't been taken out of the build pool
+                      if [[ -n $(get_heat_stacks $heat_stack_name) ]]; then
+                          if (( $build_pool_size > 0 )); then
+                              openstack --os-cloud $CLOUD_CONFIG_NAME stack suspend --wait $heat_stack_name && rc=$? || rc=$?
+                              # If the suspend operation failed, try to delete the heat stack
+                              if [[ $rc != 0 ]]; then
+                                  delete_heat_stack $heat_stack_name
+                              fi
+                              exit $rc
+                          else
+                              delete_heat_stack $heat_stack_name
+                          fi
+                      fi
+                  else
+                      # Cleanup excess stacks and failed stacks
+                      cleanup_heat_stacks $build_pool_size
+                  fi
+              fi
+          elif [[ $action == "create" ]]; then
+              openstack --os-cloud $CLOUD_CONFIG_NAME stack create --timeout 10 --wait \
+                  -t "$heat_template_file"  \
+                  --tags "$build_pool_name" \
+                  $heat_stack_name && rc=$? || rc=$?
+              if [[ $rc != 0 ]]; then
+                  delete_heat_stack $heat_stack_name || :
+                  exit $rc
+              fi
+          elif [[ $action == "delete" ]]; then
+              delete_heat_stack $heat_stack_name
+          elif [[ $action == "exclude" ]]; then
+              # First, check if the stack is suspended
+              heat_stack=$(get_heat_stacks $heat_stack_name)
+              if [[ $heat_stack == *"SUSPEND_COMPLETE"* ]]; then
+                  # Updating a stack when it is suspended is not supported; it must be resumed first
+                  openstack --os-cloud $CLOUD_CONFIG_NAME stack resume --wait $heat_stack_name || :
+              fi
+              openstack --os-cloud $CLOUD_CONFIG_NAME stack update --tags '' \
+                  -t "$heat_template_file" $heat_stack_name
+          fi
+
+    publishers:
+      - workspace-cleanup:
+          clean-if:
+            - failure: false
+            - aborted: false
+            - unstable: false

--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -171,75 +171,76 @@
 
           cloudsource_url=http://provo-clouddata.cloud.suse.de/repos/x86_64/$cloudsource
           cloudsource_media_build=$( curl -s $cloudsource_url/media.1/build )
-          image_mirror_url=http://provo-clouddata.cloud.suse.de/images/openstack/x86_64
           echo cloudsource=$cloudsource
           echo cloudsource URL is $cloudsource_url
           echo media build version is $cloudsource_media_build
           echo
 
           set -ex
-          STACK_NAME=cloud-ci-openstack-ardana-${BUILD_NUMBER}
+          heat_stack_name=cloud-ci-openstack-ardana-${BUILD_NUMBER}
           if [ -n "${JOB_NAME}" ]; then
-              STACK_NAME=${STACK_NAME}-${JOB_NAME}
+              heat_stack_name=${heat_stack_name}-${JOB_NAME}
           fi
-          CLOUD_CONFIG_NAME=engcloud-cloud-ci
-          cat - > stack_env <<EOF
-          BUILD_POOL_NAME="$build_pool_name"
-          BUILD_POOL_SIZE="$build_pool_size"
-          STACK_NAME="$STACK_NAME"
-          CLOUD_CONFIG_NAME="$CLOUD_CONFIG_NAME"
-          EOF
 
           export ANSIBLE_KEEP_REMOTE_FILES=1
-          # the name for the cloud defined in ~./config/openstack/clouds.yaml
 
           # init the git tree
           git clone $git_automation_repo --branch $git_automation_branch automation-git
           if [ "$git_automation_repo" != "$git_input_model_repo" ]; then
               git clone $git_input_model_repo --branch $git_input_model_branch ardana-input-model-git
-              input_model_path="$PWD/ardana-input-model-git/${git_input_model_path}/${model}"
+              input_model_path="$WORKSPACE/ardana-input-model-git/${git_input_model_path}/${model}"
           else
-              input_model_path="$PWD/automation-git/${git_input_model_path}/${model}"
+              input_model_path="$WORKSPACE/automation-git/${git_input_model_path}/${model}"
           fi
+          rsync -av $input_model_path/* $WORKSPACE/input-model
 
           pushd automation-git/scripts/jenkins/ardana/ansible
           source /opt/ansible/bin/activate
 
           # generate the heat template
           ansible-playbook -v generate-heat.yml \
-            -e input_model_path="$input_model_path" \
-            -e heat_template_file="./heat-ardana-${model}.yaml"
+            -e input_model_path="$WORKSPACE/input-model" \
+            -e heat_template_file="$WORKSPACE/heat-ardana-${model}.yaml"
 
-          # Simple build pool management
-          if [[ -n $build_pool_name ]]; then
-              keep_no_old_stacks=$(( build_pool_size-1 ))
-              # NOTE: cannot use --property status=SUSPEND_COMPLETE as a filter when --tags is also present
-              old_stacks_to_delete=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack list \
-                                      --tags "$build_pool_name" \
-                                      -f value -c 'Stack Name' -c 'Stack Status' \
-                                      --sort 'creation_time:desc' |
-                                      grep SUSPEND_COMPLETE | cut -d' ' -f1 |
-                                      awk 'NR > '$keep_no_old_stacks' {print $1}')
-              if [[ -n $old_stacks_to_delete ]]; then
-                  for old_stack in $old_stacks_to_delete
-                  do
-                      # Need to resume the stack before deleting it, otherwise deletion will fail
-                      openstack --os-cloud $CLOUD_CONFIG_NAME stack resume --wait $old_stack || :
-                      openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait $old_stack || :
-                  done
-              fi
-          fi
+          # generate properties file
+          cat - > $WORKSPACE/heat_stack_env <<EOF
+          build_pool_name=$build_pool_name
+          build_pool_size=$build_pool_size
+          heat_stack_name=$heat_stack_name
+          heat_template_file=$WORKSPACE/heat-ardana-${model}.yaml
+          input_model_path=$WORKSPACE/input-model
+          EOF
 
-          openstack --os-cloud $CLOUD_CONFIG_NAME stack create --timeout 5 --wait \
-              -t heat-ardana-${model}.yaml  \
-              --tags "$build_pool_name" \
-              $STACK_NAME
+      - trigger-builds:
+        - project: openstack-ardana-heat
+          predefined-parameters: |
+            action=create
+          property-file: heat_stack_env
+          block: true
 
-          DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME admin-floating-ip -c output_value -f value)
-          NETWORK_MGMT_ID=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME mgmt-network-id -c output_value -f value)
-          sshargs="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-          # FIXME: Use cloud-init in the used image
-          sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 $sshargs root@${DEPLOYER_IP}
+      - trigger-builds:
+        - project: openstack-ardana-heat
+          predefined-parameters: |
+            action=cleanup
+            build_pool_name=$build_pool_name
+            build_pool_size=$build_pool_size
+          block: false
+
+      - shell: |
+          set +x
+          . $WORKSPACE/heat_stack_env
+
+          # the name for the cloud defined in ~./config/openstack/clouds.yaml
+          CLOUD_CONFIG_NAME=engcloud-cloud-ci
+          # mirror used to download images
+          image_mirror_url=http://provo-clouddata.cloud.suse.de/images/openstack/x86_64
+
+          set -ex
+
+          pushd automation-git/scripts/jenkins/ardana/ansible
+
+          DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name admin-floating-ip -c output_value -f value)
+          NETWORK_MGMT_ID=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name mgmt-network-id -c output_value -f value)
           cat << EOF > hosts
           [hosts]
           $DEPLOYER_IP ansible_user=root
@@ -250,10 +251,10 @@
           cat << EOF > ardana_net_vars.yml
           ---
           input_model_path: "$input_model_path"
-          deployer_mgmt_ip: $(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME admin-mgmt-ip -c output_value -f value)
+          deployer_mgmt_ip: $(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name admin-mgmt-ip -c output_value -f value)
           EOF
 
-          controller_mgmt_ips=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME controller-mgmt-ips -c output_value -f value|grep -o '[0-9.]*')
+          controller_mgmt_ips=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name controller-mgmt-ips -c output_value -f value|grep -o '[0-9.]*')
           if [ -n "$controller_mgmt_ips" ]; then
             echo "controller_mgmt_ips:" >> ardana_net_vars.yml
             for ip in $controller_mgmt_ips; do
@@ -263,7 +264,7 @@
             done
           fi
 
-          compute_mgmt_ips=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME compute-mgmt-ips -c output_value -f value|grep -o '[0-9.]*')
+          compute_mgmt_ips=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name compute-mgmt-ips -c output_value -f value|grep -o '[0-9.]*')
           if [ -n "$compute_mgmt_ips" ]; then
             echo "compute_mgmt_ips:" >> ardana_net_vars.yml
             for ip in $compute_mgmt_ips; do
@@ -281,6 +282,12 @@
               while read line; do echo "  - $line" >> ardana_net_vars.yml; done;
 
           cat ardana_net_vars.yml
+
+          sshargs="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+          # FIXME: Use cloud-init in the used image
+          sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 $sshargs root@${DEPLOYER_IP}
+
+          source /opt/ansible/bin/activate
 
           ansible-playbook -v -i hosts ssh-keys.yml
           if [ -n "$gerrit_change_id" ] ; then
@@ -335,38 +342,47 @@
               post-deploy-checks.yml
 
     publishers:
+      - trigger-parameterized-builds:
+        - project: openstack-ardana-heat
+          predefined-parameters: |
+            action=cleanup
+          property-file: heat_stack_env
+          condition: ALWAYS
+        - project: openstack-ardana-heat
+          predefined-parameters: |
+            action=cleanup
+            build_pool_name=$build_pool_name
+            build_pool_size=$build_pool_size
+          condition: ALWAYS
+
       - post-tasks:
         - matches:
-          - log-text: heat-ardana-
+          - log-text: DEPLOYER_IP
           script: |
-            . $WORKSPACE/stack_env
-            if [[ -n $BUILD_POOL_NAME ]] && (( $BUILD_POOL_SIZE == 0 )); then
-                openstack --os-cloud $CLOUD_CONFIG_NAME stack delete --wait \
-                      $STACK_NAME || :
-            else
-                DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $STACK_NAME deployer-ip-floating -c output_value -f value)
-                if [[ -n $BUILD_POOL_NAME ]]; then
-                    openstack --os-cloud $CLOUD_CONFIG_NAME stack suspend --wait \
-                          $STACK_NAME || :
-                fi
+            set +x
+            . $WORKSPACE/heat_stack_env
+            # the name for the cloud defined in ~./config/openstack/clouds.yaml
+            CLOUD_CONFIG_NAME=engcloud-cloud-ci
+
+            if [[ -z $build_pool_name ]] || (( $build_pool_size != 0 )); then
+                DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name admin-mgmt-ip -c output_value -f value)
                 echo "*****************************************************************"
                 echo ""
-                if [[ -n $BUILD_POOL_NAME ]]; then
-                  echo "** The installation stack has been suspended and will be removed "
+                if [[ -n $build_pool_name ]]; then
+                  echo "** The installation stack will be suspended and will be removed  "
                   echo "** automatically by one of the future job runs that is using the "
-                  echo "** same '$BUILD_POOL_NAME' build pool.                           "
+                  echo "** same '$build_pool_name' build pool.                           "
                   echo ""
                   echo "** To prevent future jobs from removing the installation, either "
-                  echo "** resume the stack or remove the '$BUILD_POOL_NAME' tag from it "
-                  echo "** by running:                                                   "
-                  echo ""
-                  echo "**   openstack stack update --tags '' $STACK_NAME                "
+                  echo "** resume the stack or take the stack out of the '$build_pool_name' "
+                  echo "** build pool by rebuilding the 'openstack-ardana-heat' job that "
+                  echo "** created it with the 'action' parameter set to 'exclude'.      "
                   echo ""
                 else
                   echo "** Installation remains available at                             "
                   echo "             ssh ardana@$DEPLOYER_IP                             "
                   echo ""
-                  echo "** Please do openstack stack delete $STACK_NAME when you're done."
+                  echo "** Please delete the $heat_stack_name stack manually when you're done."
                 fi
                 echo ""
                 echo "*****************************************************************"


### PR DESCRIPTION
Moves the heat stack management logic (creating and cleaning
up heat stacks) to its own Jenkins job and makes it more robust:
  * concurrency is disabled for the new job, to avoid overloading
  the engcloud with simultaneous heat requests and to allow the
  build pool management logic to run in a form of critical section.
  * having a separate job dealing with the engcloud will make it
  more obvious when there's a problem with it
  * the cleanup job is triggered after the main openstack-ardana
  job has completed. It will not block the main job and its failure
  status will not change the status of the main job
  * if a heat stack cannot be deleted, an alternative implementation
  which directly deletes servers and volumes is now available
  * the new openstack-ardana-heat job can be triggered manually
  to perform cleanup or to take a heat stack out of the build pool
  * this job will be transformed in a pipeline stage, when the
  openstack-ardana job is converted into a pipeline

Implements: https://jira.prv.suse.net/browse/SCRD-4417