### PR TITLE
Add a lonely node to upgrade-disruptive-ha

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-ha-template.yaml
@@ -21,6 +21,7 @@
             cloudsource=develcloud{previous_version}
             upgrade_cloudsource=develcloud{version}
             nodenumber={nodenumber}
+            nodenumberlonelynode=1
             want_nodesupgrade=1
             want_database_sql_engine={database_engine}
             want_trove_proposal=0


### PR DESCRIPTION
We attempt to build and use a lonely node during the disruptive HA job,
but we don't set a number of lonely nodes we require.