### PR TITLE
Make GM6/GM7 cloudsource more reliable

### DIFF
--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -52,13 +52,17 @@ function qacrowbarsetup_help
         Example:
             want_devel_repos=storage,virt
         Valid values: ha, storage, virt
-    want_cloud6_iso_path=path to search for Cloud 6 ISO image in
-        Search for Cloud 6 ISO image files in this path.
+    want_cloud6_iso_url=URL to use for downloading Cloud 6 ISO image
     want_cloud6_iso=ISO filename
         Name of Cloud 6 ISO image file.
-    want_cloud7_iso_path=path to search for Cloud 7 ISO image in
-        Search for Cloud 7 ISO image files in this path.
+    want_cloud7_iso_url=URL to use for downloading Cloud 7 ISO image
     want_cloud7_iso=ISO filename
         Name of Cloud 7 ISO image file.
+    want_cloud8_iso_url=URL to use for downloading Cloud 8 ISO image
+    want_cloud8_iso=ISO filename
+        Name of Cloud 8 ISO image file.
+    want_cloud9_iso_url=URL to use for downloading Cloud 9 ISO image
+    want_cloud9_iso=ISO filename
+        Name of Cloud 9 ISO image file.
 EOUSAGE
 }

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -314,12 +314,12 @@ function add_sdk_repo
     fi
 }
 
-function add_sap_repo
+function add_continuousdelivery_repo
 {
     local stage=
     [[ $TESTHEAD ]] && stage=":/Staging"
     # priority required to overwrite the default cloud6 packages
-    $zypper ar -p 92 -f http://$susedownload/ibs/Devel:/Cloud:/6:/SAP${stage}/SLE_12_SP1/ dc6sap
+    $zypper ar -p 92 -f http://$susedownload/ibs/Devel:/Cloud:/6:/SAP${stage}/SLE_12_SP1/ dc6cd
 }
 
 function add_ha_repo
@@ -1018,7 +1018,7 @@ EOF
         add_ha_repo
     fi
 
-    [[ $want_cd = 1 ]] && add_sap_repo
+    [[ $want_cd = 1 ]] && add_continuousdelivery_repo
 
     if [ -n "$deployceph" ] || [[ $want_external_ceph = 1 ]]; then
         add_suse_storage_repo


### PR DESCRIPTION
The fetching of ISOs was hardcoded to always sync from
download.suse.de/install. However the SUSE IT team is frequently
cleaning up that directories, which means ISO's that we rely on
are disappearing and breaking our CI. Any attempt at getting them
restored is time consuming. So instead we'll now host those isos
that we rely on on clouddata. Some refactoring and renaming of
parameters makes what is happening a bit more obvious.