### PR TITLE
openstack-ardana: add ardana-installer-ui rogue file exception

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-added-files-whitelist.txt
@@ -48,6 +48,9 @@
 # From tls-ansible/roles/tls-trust/tasks/install.yml
 /usr/share/pki/trust/anchors/ardana
 
+# From the Ardana installer UI (bsc#1104047)
+/usr/share/ardana/ardana-installer-ui/web/config.json
+
 # Standard (upstream) path for custom detection plugins for
 # monasca-agent i.e. if you've got agent plugins local to your site
 # you drop them in this directory.


### PR DESCRIPTION
A recent Ardana installer UI change caused the
/usr/share/ardana/ardana-installer-ui/web/config.json
file to be created and detected as a rogue RPM file.

This PR adds an exception to unblock the CI, while
the issue is being tracked by https://bugzilla.suse.com/show_bug.cgi?id=1104047.
