### PR TITLE
openstack-ardana: fix deployer IP message

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -365,7 +365,7 @@
             CLOUD_CONFIG_NAME=engcloud-cloud-ci
 
             if [[ -z $build_pool_name ]] || (( $build_pool_size != 0 )); then
-                DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name admin-mgmt-ip -c output_value -f value)
+                DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name admin-floating-ip -c output_value -f value)
                 echo "*****************************************************************"
                 echo ""
                 if [[ -n $build_pool_name ]]; then


### PR DESCRIPTION
Fixes the deployer IP message being displayed at the end
of a job run to reflect the floating IP value instead of
the management IP value.