### PR TITLE
github_pr: allow to skip TrustedSource filter

### DIFF
--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -33,6 +33,7 @@ template:
         config:
           status: unseen
       - type: TrustedSource
+        skippable: true
         config:
           users:
             *suse_cloud_user


### PR DESCRIPTION
Github_pr meanwhile allows to skip certain filters from
the config. This is useful when manually triggering
actions from a PR that would usually be filtered out.

Therefore filters can be marked as skippable.
Details in these commits of the github-pr repo:
 https://github.com/openSUSE/github-pr/commit/12965f424a6f18d71f4bc75ef88194d9772f75e2
 https://github.com/openSUSE/github-pr/commit/1f34fc2217c6eb8dac7f80e2669b21b378e999f7

Hint:
This will allow to trigger PR gating runs from external contributors using github_pr.