### PR TITLE
openstack-ardana: created jobs for Ardana 9

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8-suse.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8-suse.yaml
@@ -22,8 +22,8 @@
             - name: openstack-ardana
               predefined-parameters: |
                 model=std-min
-                cloudsource=SUSE-OpenStack-Cloud-8-Pool
-                repositories=SLES12-SP3-Pool,SLES12-SP3-Updates,SUSE-OpenStack-Cloud-8-Pool,SUSE-OpenStack-Cloud-8-Updates
+                cloudsource=GM8
+                repositories=SLES-Pool,SLES-Updates,Cloud-Pool,Cloud-Updates
                 tempest_run_filter=ci
                 build_pool_name=cloud-ardana-ci
                 build_pool_size=5

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -1,0 +1,35 @@
+- project:
+    name: cloud-ardana9-gating
+    version: 9
+    label: cloud-trigger
+    build_pool_name: cloud-ardana-ci
+    build_pool_size: 5
+    jobs:
+        - 'cloud-ardana{version}-gating'
+
+- project:
+    name: cloud-ardana9-x86_64
+    disabled: false
+    version: 9
+    arch: x86_64
+    tempest_run_filter: ci
+    build_pool_name: cloud-ardana-ci
+    build_pool_size: 5
+    jobs:
+        - 'cloud-ardana{version}-job-std-3cp-{arch}'
+        - 'cloud-ardana{version}-job-dac-3cp-{arch}'
+        - 'cloud-ardana{version}-job-std-min-{arch}'
+        - 'cloud-ardana{version}-job-std-split-{arch}'
+        - 'cloud-ardana{version}-job-std-3cp-devel-staging-updates-{arch}'
+        - 'cloud-ardana{version}-job-std-3cp-test-maintenance-updates-{arch}'
+
+- project:
+    name: cloud-ardana9-centos-x86_64
+    disabled: true
+    version: 9
+    arch: x86_64
+    tempest_run_filter: ci
+    build_pool_name: cloud-ardana-ci
+    build_pool_size: 5
+    jobs:
+        - 'cloud-ardana{version}-job-std-min-centos-{arch}'

--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -62,33 +62,50 @@
           description: >-
             This name reserves job environment and prevents deletion at the end.
 
-      - string:
+      - choice:
           name: cloudsource
-          default: 'SUSE-OpenStack-Cloud-8-devel-staging'
+          choices:
+            - stagingcloud8
+            - develcloud8
+            - GM8
+            - stagingcloud9
+            - develcloud9
           description: >-
-            This is used as input repository (from provo-clouddata) for testing
+            The cloud repository (from provo-clouddata) to be used for testing.
+            This value can take the following form:
+
+               stagingcloud<X> (Devel:Cloud:X:Staging)
+               develcloud<X> (Devel:Cloud:X)
+               GM<X> (official GM)
 
       - extended-choice:
           name: repositories
           type: multi-select
-          value: SLES12-SP3-Pool,SLES12-SP3-Updates,SLES12-SP3-Updates-test,SUSE-OpenStack-Cloud-8-Pool,SUSE-OpenStack-Cloud-8-Updates,SUSE-OpenStack-Cloud-8-Updates-test
+          value: SLES-Pool,SLES-Updates,SLES-Updates-test,Cloud-Pool,Cloud-Updates,Cloud-Updates-test
           visible-items: 6
           multi-select-delimiter: ','
-          default-value: SLES12-SP3-Pool,SLES12-SP3-Updates
+          default-value: SLES-Pool,SLES-Updates
           description: >-
-            Set of zypper repositories (from provo-clouddata) to be used during installation
+            Set of zypper repositories (from provo-clouddata) to be configured during installation
+            in addition to that indicated by the cloudsource parameter.
 
-      - string:
+      - choice:
           name: update_cloudsource
-          default: ''
+          choices:
+            -
+            - stagingcloud8
+            - develcloud8
+            - GM8
+            - stagingcloud9
+            - develcloud9
           description: >-
-            Repository to be used for update testing. Use a value different than
+            The cloud media (from provo-clouddata) to be used for update testing. Use a value different than
             cloudsource to enable update testing.
 
       - extended-choice:
           name: update_repositories
           type: multi-select
-          value: SLES12-SP3-Pool,SLES12-SP3-Updates,SLES12-SP3-Updates-test,SUSE-OpenStack-Cloud-8-Pool,SUSE-OpenStack-Cloud-8-Updates,SUSE-OpenStack-Cloud-8-Updates-test
+          value: SLES-Pool,SLES-Updates,SLES-Updates-test,Cloud-Pool,Cloud-Updates,Cloud-Updates-test
           visible-items: 6
           multi-select-delimiter: ','
           default-value: ''
@@ -169,11 +186,7 @@
       - shell: |
           set +x
 
-          cloudsource_url=http://provo-clouddata.cloud.suse.de/repos/x86_64/$cloudsource
-          cloudsource_media_build=$( curl -s $cloudsource_url/media.1/build )
           echo cloudsource=$cloudsource
-          echo cloudsource URL is $cloudsource_url
-          echo media build version is $cloudsource_media_build
           echo
 
           set -ex
@@ -199,8 +212,9 @@
 
           # generate the heat template
           ansible-playbook -v generate-heat.yml \
+            -e cloudsource="${cloudsource}" \
             -e input_model_path="$WORKSPACE/input-model" \
-            -e heat_template_file="$WORKSPACE/heat-ardana-${model}.yaml"
+            -e heat_template_file="$WORKSPACE/heat-ardana-${model}.yaml" \
 
           # generate properties file
           cat - > $WORKSPACE/heat_stack_env <<EOF
@@ -307,6 +321,7 @@
                                     "mktemp -d /tmp/ardana-job-rpm-verification.XXXXXXXX")
           ansible-playbook -v -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" \
                                        -e "verification_temp_dir=$verification_temp_dir" \
+                                       -e cloudsource="${cloudsource}" \
                                        init.yml
 
           # Run site.yml outside ansible for output streaming

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-dac-3cp-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-dac-3cp-template.yaml
@@ -18,7 +18,7 @@
           current-parameters: true
           predefined-parameters: |
             model=dac-3cp
-            cloudsource=SUSE-OpenStack-Cloud-{version}-devel-staging
+            cloudsource=stagingcloud{version}
             tempest_run_filter={tempest_run_filter}
             build_pool_name={build_pool_name}
             build_pool_size={build_pool_size}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-devel-staging-updates-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-devel-staging-updates-template.yaml
@@ -18,8 +18,8 @@
           current-parameters: true
           predefined-parameters: |
             model=std-3cp
-            cloudsource=SUSE-OpenStack-Cloud-{version}-devel
-            update_cloudsource=SUSE-OpenStack-Cloud-{version}-devel-staging
+            cloudsource=develcloud{version}
+            update_cloudsource=stagingcloud{version}
             tempest_run_filter={tempest_run_filter}
             build_pool_name={build_pool_name}
             build_pool_size={build_pool_size}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-template.yaml
@@ -18,7 +18,7 @@
           current-parameters: true
           predefined-parameters: |
             model=std-3cp
-            cloudsource=SUSE-OpenStack-Cloud-{version}-devel-staging
+            cloudsource=stagingcloud{version}
             tempest_run_filter={tempest_run_filter}
             build_pool_name={build_pool_name}
             build_pool_size={build_pool_size}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-test-maintenance-updates-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-3cp-test-maintenance-updates-template.yaml
@@ -18,9 +18,9 @@
           current-parameters: true
           predefined-parameters: |
             model=std-3cp
-            cloudsource=SUSE-OpenStack-Cloud-{version}-Pool
-            repositories=SLES12-SP3-Pool,SLES12-SP3-Updates,SUSE-OpenStack-Cloud-{version}-Pool,SUSE-OpenStack-Cloud-{version}-Updates
-            update_repositories=SLES12-SP3-Updates-test,SUSE-OpenStack-Cloud-{version}-Updates-test
+            cloudsource=GM{version}
+            repositories=SLES-Pool,SLES-Updates,Cloud-Pool,Cloud-Updates
+            update_repositories=SLES-Updates-test,Cloud-Updates-test
             tempest_run_filter={tempest_run_filter}
             build_pool_name={build_pool_name}
             build_pool_size={build_pool_size}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-centos-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-centos-template.yaml
@@ -19,7 +19,7 @@
           predefined-parameters: |
             model=std-min
             image_id_compute=centos73
-            cloudsource=SUSE-OpenStack-Cloud-8-devel-staging
+            cloudsource=stagingcloud{version}
             tempest_run_filter={tempest_run_filter}
             build_pool_name={build_pool_name}
             build_pool_size={build_pool_size}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-min-template.yaml
@@ -18,7 +18,7 @@
           current-parameters: true
           predefined-parameters: |
             model=std-min
-            cloudsource=SUSE-OpenStack-Cloud-{version}-devel-staging
+            cloudsource=stagingcloud{version}
             tempest_run_filter={tempest_run_filter}
             build_pool_name={build_pool_name}
             build_pool_size={build_pool_size}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-std-split-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-std-split-template.yaml
@@ -18,7 +18,7 @@
           current-parameters: true
           predefined-parameters: |
             model=std-split
-            cloudsource=SUSE-OpenStack-Cloud-{version}-devel-staging
+            cloudsource=stagingcloud{version}
             tempest_run_filter={tempest_run_filter}
             build_pool_name={build_pool_name}
             build_pool_size={build_pool_size}

--- a/scripts/jenkins/ardana/ansible/generate-heat.yml
+++ b/scripts/jenkins/ardana/ansible/generate-heat.yml
@@ -21,4 +21,5 @@
   gather_facts: False
 
   roles:
+    - cloud-common
     - heat-generator

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -2,6 +2,8 @@
 - name: Initialize the Deployer
   hosts: hosts
   gather_facts: False
+  roles:
+    - cloud-common
 
   vars_files:
     - ardana_net_vars.yml
@@ -69,10 +71,10 @@
 
   # osconfig-ansible should take care of installing the repositories itself,
   # it's just that it won't auto accept the Devel key, so do that now
-  - name: Import Devel:Cloud:8 key
+  - name: Import Devel:Cloud:X key
     shell: |
-      kf=/srv/www/suse-12.3/x86_64/repos/Cloud/repodata/repomd.xml.key
-      [ -r $kf ] || kf=/srv/www/suse-12.3/x86_64/repos/Cloud/content.key
+      kf={{ repository_path[cloud_release] }}/x86_64/repos/Cloud/repodata/repomd.xml.key
+      [ -r $kf ] || kf={{ repository_path[cloud_release] }}/x86_64/repos/Cloud/content.key
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@{{ item }} "cat >/tmp/cloud.key && rpm --import /tmp/cloud.key && rm /tmp/cloud.key" < $kf
     with_items:
       - "{{ controller_mgmt_ips|default([]) }}"

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -3,26 +3,27 @@
   hosts: hosts
   gather_facts: False
 
-  vars:
-    clouddata_server: provo-clouddata.cloud.suse.de
-    download_suse_server: download.suse.de
-    cloudsource: SUSE-OpenStack-Cloud-8-devel-staging
-    repositories: SLES12-SP3-Pool,SLES12-SP3-Updates
-    arch: x86_64
-    repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
-    cloudsource_url: "{{ repos_url }}/{{ cloudsource }}"
-    test_repository_url: ''
+  roles:
+  - cloud-common
 
   tasks:
 
-  - name: Initialize repositories
+  - name: Initialize repository variables
     set_fact:
       repos_dict: {}
+      repository_list: []
+
+  - name: Replace repository mnemonics
+    set_fact:
+      repository_list: "{{ repository_list+
+        [repository_mnemonics[cloud_release][item]|default(item)] }}"
+    with_items: "{{ repositories.split(',')|unique|list }}"
+    when: repositories != ''
 
   - name: Parse repositories
     set_fact:
       repos_dict: "{{ repos_dict|default({})|combine({item: item}) }}"
-    with_items: "{{ repositories.split(',')|unique|list }}"
+    with_items: "{{ repository_list }}"
     when: repositories != ''
 
   - name: Add Cloud to repository list
@@ -30,24 +31,30 @@
       # Use a consistent name for the Cloud media install repo so that we
       # don't have to account for development versus production repos in the
       # playbooks
-      repos_dict: "{{ {'Cloud': cloudsource}|combine(repos_dict) }}"
-    when: cloudsource != ''
+      repos_dict: "{{ {'Cloud': cloud_repository}|combine(repos_dict) }}"
+
+  - name: Check cloud srv directory
+    stat:
+      path: "{{ repository_path[cloud_release] }}/x86_64/repos/Cloud/"
+    register: cloud_srv_dir_stats
 
   - name: Check srv directories
     stat:
-      path: "/srv/www/suse-12.3/x86_64/repos/{{ item.key }}"
+      path: "{{ repository_path[cloud_release] }}/x86_64/repos/{{ item.key }}"
     register: srv_dir_stats
     with_dict: "{{ repos_dict }}"
 
   - name: Create srv directories
     file:
       state: directory
-      path: "/srv/www/suse-12.3/x86_64/repos/{{ item.item.key }}"
+      path: "{{ repository_path[cloud_release] }}/x86_64/repos/{{ item.item.key }}"
       mode: 0755
     when: not item.stat.exists
     with_items:
       - "{{ srv_dir_stats.results }}"
 
+  # NOTE: we rsync only once, to avoid bringing in new cloudsource media contents
+  # during subsequent runs
   - name: Rsync Cloud repo contents
     command: >
       rsync
@@ -57,16 +64,16 @@
         --fuzzy
         --delay-updates
         --delete-delay
-        'rsync://{{ clouddata_server }}/cloud/repos/x86_64/{{ cloudsource }}/'
-        '/srv/www/suse-12.3/x86_64/repos/Cloud/'
-    when: cloudsource != ''
+        'rsync://{{ clouddata_server }}/cloud/repos/x86_64/{{ cloud_repository }}/'
+        '{{ repository_path[cloud_release] }}/x86_64/repos/Cloud/'
+    when: not cloud_srv_dir_stats.stat.exists
 
   - name: Mount zypper repos
     mount:
       state: mounted
       fstype: nfs
       opts: ro,nosuid,rsize=8192,wsize=8192,hard,intr,nolock,x-systemd.automount,noauto
-      name: /srv/www/suse-12.3/x86_64/repos/{{ item.item.key }}
+      name: "{{ repository_path[cloud_release] }}//x86_64/repos/{{ item.item.key }}"
       src: "{{ clouddata_server }}:/srv/nfs/repos/x86_64/{{ item.item.value }}"
     when: item.item.key != 'Cloud'
     with_items:
@@ -74,7 +81,7 @@
 
   - name: Add zypper repos
     zypper_repository:
-      repo: "/srv/www/suse-12.3/x86_64/repos/{{ item.item.key }}"
+      repo: "{{ repository_path[cloud_release] }}/x86_64/repos/{{ item.item.key }}"
       name: "{{ item.item.key }}"
     register: added_repos
     with_items:
@@ -111,7 +118,6 @@
     get_url:
       url: "{{ cloudsource_url }}/media.1/build"
       dest: /etc/ardana/media-build-version
-    when: cloudsource != ''
 
   - name: Add build information to /etc/motd
     shell: |
@@ -122,9 +128,8 @@
       media_build_version=$(cat /etc/ardana/media-build-version)
       echo "Built from: {{ cloudsource_url }}" >>/etc/motd
       echo "Media build version: $media_build_version" >>/etc/motd
-    when: cloudsource != ''
 
   - name: Add repos information to /etc/motd
     shell: |
-      echo "Configured repositories: {{ repositories }}" >>/etc/motd
+      echo "Configured repositories: {{ repository_list|join(', ') }}" >>/etc/motd
     when: repositories != ''

--- a/scripts/jenkins/ardana/ansible/roles/cloud-common/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/cloud-common/defaults/main.yml
@@ -1,0 +1,61 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+clouddata_server: provo-clouddata.cloud.suse.de
+download_suse_server: download.suse.de
+cloudsource: stagingcloud8
+repositories: SLES-Pool,SLES-Updates
+arch: x86_64
+repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
+
+test_repository_url: ''
+
+# The cloud release is encoded in the cloudsource value
+cloud_release: "cloud{{ cloudsource[-1] }}"
+
+# Media/repositories mapped by the cloudsource value
+cloudsource_repos:
+  stagingcloud8: SUSE-OpenStack-Cloud-8-devel-staging
+  develcloud8: SUSE-OpenStack-Cloud-8-devel
+  GM8: SUSE-OpenStack-Cloud-8-official
+  stagingcloud9: SUSE-OpenStack-Cloud-9-devel-staging
+  develcloud9: SUSE-OpenStack-Cloud-9-devel
+  GM9: SUSE-OpenStack-Cloud-9-official
+
+cloud_repository: "{{ cloudsource_repos[cloudsource] }}"
+cloudsource_url: "{{ repos_url }}/{{ cloud_repository }}"
+
+# Release independent provo-clouddata repository mnemonics accepted by the Jenkins job
+repository_mnemonics:
+  cloud8:
+    SLES-Pool: SLES12-SP3-Pool
+    SLES-Updates: SLES12-SP3-Updates
+    SLES-Updates-test: SLES12-SP3-Updates-test
+    Cloud-Pool: SUSE-OpenStack-Cloud-8-Pool
+    Cloud-Updates: SUSE-OpenStack-Cloud-8-Updates
+    Cloud-Updates-test: SUSE-OpenStack-Cloud-8-Updates-test
+  cloud9:
+    SLES-Pool: SLES12-SP4-Pool
+    SLES-Updates: SLES12-SP4-Updates
+    SLES-Updates-test: SLES12-SP4-Updates-test
+    Cloud-Pool: SUSE-OpenStack-Cloud-9-Pool
+    Cloud-Updates: SUSE-OpenStack-Cloud-9-Updates
+    Cloud-Updates-test: SUSE-OpenStack-Cloud-9-Updates-test
+
+repository_path:
+  cloud8: /srv/www/suse-12.3
+  cloud9: /srv/www/suse-12.4

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/defaults/main.yml
@@ -15,6 +15,27 @@
 #
 ---
 
+# Versioned virtualized configuration artifacts
+virt_artifacts:
+  cloud8:
+    sles_distro_id: sles12sp3-x86_64
+    rhel_distro_id: rhel73-x86_64
+    sles_image: cleanvm-jeos-SLE12SP3
+    rhel_image: centos73
+    clm_flavor: cloud-ardana-job-compute
+    controller_flavor: cloud-ardana-job-controller
+    compute_flavor: cloud-ardana-job-compute
+    disk_size: 30
+  cloud9:
+    sles_distro_id: sles12sp4-x86_64
+    rhel_distro_id: rhel73-x86_64
+    sles_image: cleanvm-jeos-SLE12SP4
+    rhel_image: centos73
+    clm_flavor: cloud-ardana-job-compute
+    controller_flavor: cloud-ardana-job-controller
+    compute_flavor: cloud-ardana-job-compute
+    disk_size: 30
+
 # Exhaustive list of service components required by the CLM node.
 # When service components that are not in this list are hosted
 # by an Ardana node, that node is considered either a controller node
@@ -39,15 +60,15 @@ clm_service_components:
   - ntp-client
 
 virt_config:
-  sles_distro_id: sles12sp3-x86_64
-  rhel_distro_id: rhel73-x86_64
+  sles_distro_id: '{{ virt_artifacts[cloud_release].sles_distro_id }}'
+  rhel_distro_id: '{{ virt_artifacts[cloud_release].rhel_distro_id }}'
   clm_service_components: '{{ clm_service_components }}'
-  clm_flavor: '{{ clm_flavor|default("cloud-ardana-job-compute") }}'
-  controller_flavor: '{{ controller_flavor|default("cloud-ardana-job-controller") }}'
-  compute_flavor: '{{ compute_flavor|default("cloud-ardana-job-compute") }}'
-  sles_image: '{{ sles_image|default("cleanvm-jeos-SLE12SP3") }}'
-  rhel_image: '{{ rhel_image|default("centos75") }}'
-  disk_size: '{{ disk_size|default(30) }}'
+  clm_flavor: '{{ clm_flavor|default(virt_artifacts[cloud_release].clm_flavor) }}'
+  controller_flavor: '{{ controller_flavor|default(virt_artifacts[cloud_release].controller_flavor) }}'
+  compute_flavor: '{{ compute_flavor|default(virt_artifacts[cloud_release].compute_flavor) }}'
+  sles_image: '{{ sles_image|default(virt_artifacts[cloud_release].sles_image) }}'
+  rhel_image: '{{ rhel_image|default(virt_artifacts[cloud_release].rhel_image) }}'
+  disk_size: '{{ disk_size|default(virt_artifacts[cloud_release].disk_size) }}'
   flavors: '{{ flavors|default([]) }}'
   images: '{{ images|default([]) }}'
   disks: '{{ disks|default([]) }}'

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/vars/standard.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/vars/standard.yml
@@ -37,18 +37,23 @@ clm_service_components:
 clm_flavor: cloud-ardana-job-compute
 controller_flavor: cloud-ardana-job-controller
 compute_flavor: cloud-ardana-job-compute
-sles_image: cleanvm-jeos-SLE12SP3
-rhel_image: centos75
+sles_images:
+  cloud8: cleanvm-jeos-SLE12SP3
+  cloud9: cleanvm-jeos-SLE12SP4
+sles_image: "{{ sles_images[cloud_release] }}"
+rhel_image: centos73
 disk_size: 30
 
 images:
   CONTROLLER-ROLE: '{{ sles_image }}'
   STD-CONTROLLER-ROLE: '{{ sles_image }}'
   STD-COMPUTE-ROLE:
-      sles12sp3-x86_64: '{{ sles_image }}'
+      sles12sp3-x86_64: '{{ sles_images["cloud8"] }}'
+      sles12sp4-x86_64: '{{ sles_images["cloud9"] }}'
       rhel73-x86_64: '{{ rhel_image }}'
   COMPUTE-ROLE:
-      sles12sp3-x86_64: '{{ sles_image }}'
+      sles12sp3-x86_64: '{{ sles_images["cloud8"] }}'
+      sles12sp4-x86_64: '{{ sles_images["cloud9"] }}'
       rhel73-x86_64: '{{ rhel_image }}'
 
 flavors:

--- a/scripts/jenkins/ardana/ansible/update-node.yml
+++ b/scripts/jenkins/ardana/ansible/update-node.yml
@@ -1,5 +1,5 @@
 ---
-# Need to enable allowVendorChange to allow packages to be updated to D:C:8 and D:C:8:S
+# Need to enable allowVendorChange to allow packages to be updated to D:C:X and D:C:X:S
 - name: Enable allowVendorChange on the host
   shell: |
     ansible '{{ ansible_node }}' -b -a \
@@ -8,9 +8,9 @@
     chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
   become: true
   become_user: ardana
-  when: cloudsource in ['SUSE-OpenStack-Cloud-8-devel', 'SUSE-OpenStack-Cloud-8-devel-staging']
+  when: cloudsource is search("stagingcloud.*") or cloudsource is search("develcloud.*")
 
-# Need to change repo type to yast2 to allow packages to be updated to D:C:8 and D:C:8:S
+# Need to change repo type to yast2 to allow packages to be updated to D:C:X and D:C:X:S
 - name: Change Cloud repo type to yast2
   shell: |
     ansible '{{ ansible_node }}' -b -a \
@@ -19,7 +19,7 @@
     chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
   become: true
   become_user: ardana
-  when: cloudsource in ['SUSE-OpenStack-Cloud-8-devel', 'SUSE-OpenStack-Cloud-8-devel-staging']
+  when: cloudsource is search("stagingcloud.*") or cloudsource is search("develcloud.*")
 
 # Accounting for the update scenario which starts from a point
 # where the update helper playbooks are not yet present (i.e.


### PR DESCRIPTION
Updates the previous `cloudsource` ansible variable
in the Ardana deployment automation playbooks to
closer resemble the `cloudsoure` parameter used by
mkcloud jobs. The `cloudsource` variable values will now
encode both the cloud version and media:

 - a stagingcloud\<X\> value corresponds to Devel:Cloud:X:Staging
 media
 - a develcloud\<X\> value corresponds to Devel:Cloud:X media
 - a GM\<X\> value corresponds to the official GM media (not
 yet available for Cloud9)

All the Ardana deployment playbooks have been updated to
differentiate between cloud releases and new jobs have been 
created for cloud 9.