### PR TITLE
Remove unmaintained medias from mediacheck

### DIFF
--- a/jenkins/ci.suse.de/cloud-mediacheck.yaml
+++ b/jenkins/ci.suse.de/cloud-mediacheck.yaml
@@ -15,19 +15,17 @@
           type: user-defined
           name: project
           values:
-            - Devel:Cloud:6/SLE_12_SP1
-            - Devel:Cloud:6:Appliances/SLE_12_SP1
             - Devel:Cloud:7/SLE_12_SP2
-            - Devel:Cloud:7:Mitaka/SLE_12_SP2
             - Devel:Cloud:8/SLE_12_SP3/SOC
             - Devel:Cloud:8/SLE_12_SP3/HOS
             - Devel:Cloud:8/SLE_12_SP3/CROWBAR
             - Devel:Cloud:9/SLE_12_SP4/SOC
             - Devel:Cloud:9/SLE_12_SP4/CROWBAR
-            - Devel:Cloud:8:Ocata/SLE_12_SP3
             - SUSE:SLE-12-SP3:Update:Products:Cloud8/SLE_12_SP3/SOC
             - SUSE:SLE-12-SP3:Update:Products:Cloud8/SLE_12_SP3/HOS
             - SUSE:SLE-12-SP3:Update:Products:Cloud8/SLE_12_SP3/CROWBAR
+            - SUSE:SLE-12-SP4:Update:Products:Cloud9/SLE_12_SP4/SOC
+            - SUSE:SLE-12-SP4:Update:Products:Cloud9/SLE_12_SP4/CROWBAR
       - axis:
           type: user-defined
           name: subproject
@@ -43,8 +41,6 @@
       combination-filter: |
         (
           [
-            "Devel:Cloud:6",
-            "Devel:Cloud:6/SLE_12_SP1",
             "Devel:Cloud:7/SLE_12_SP2",
             "Devel:Cloud:8/SLE_12_SP3/SOC",
             "Devel:Cloud:8/SLE_12_SP3/HOS",


### PR DESCRIPTION
Cloud6 == EOL
Mitaka/Ocata == only for CF CI, no longer in use

Add Cloud9/SUSE missing media check