### PR TITLE
openstack-ardana: remove the need for the sshpass package

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/sshpass.sh
+++ b/scripts/jenkins/ardana/ansible/files/sshpass.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Usage, e.g.:
+#
+#    SSHPASS=myrootpass sshpass ssh-copy-id root@myserver
+#
+
+
+# This script functions both as the SSH wrapper and the SSH_ASKPASS script
+# at the same time
+if [ -n "$SSH_ASKPASS_PASSWORD" ]; then
+    cat <<< "$SSH_ASKPASS_PASSWORD"
+else
+    SSH_ASKPASS_PASSWORD="$SSHPASS"
+    export SSH_ASKPASS_PASSWORD
+
+    sshopts="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oServerAliveInterval=20 -oConnectTimeout=5  -oNumberOfPasswordPrompts=1"
+    sshcmd=$1
+
+    shift
+
+    DISPLAY=dummydisplay:0 SSH_ASKPASS=$0 setsid $sshcmd $sshopts "$@"
+fi

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -45,13 +45,14 @@
       [ -f ~/.ssh/id_rsa ] || ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
 
   - name: Copy root key to non-deployer nodes
-    shell: |
-      sshpass -p linux ssh-copy-id -o ConnectionAttempts=120 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no {{ item }}
+    script: files/sshpass.sh ssh-copy-id {{ item }}
     with_items:
       - "{{ controller_mgmt_ips|default([]) }}"
       - "{{ compute_mgmt_ips|default([]) }}"
     ignore_errors: True
     when: item != "" and item != deployer_mgmt_ip
+    environment:
+      SSHPASS: linux
 
   - name: Create ardana user/group on non-deployer nodes
     shell: |

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -11,7 +11,6 @@
     arch: x86_64
     repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
     cloudsource_url: "{{ repos_url }}/{{ cloudsource }}"
-    sshpass_repo: "http://download.suse.de/ibs/NON_Public:/infrastructure/SUSE_SLE_12_SP3_Update/"
     test_repository_url: ''
 
   tasks:
@@ -87,29 +86,12 @@
       name: "Cloud-Test"
     when: test_repository_url != ''
 
-  - name: Repo for sshpass
-    zypper_repository:
-      repo: "{{ sshpass_repo }}"
-      disable_gpg_check: yes
-      name: sshpass
-
   # Refresh all repos
   - name: Refresh zypper repositories
     zypper_repository:
       repo: '*'
       auto_import_keys: yes
       runrefresh: yes
-
-  - name: Install sshpass
-    zypper:
-      name: 'sshpass'
-      state: present
-
-  - name: Remove Repo for sshpass
-    zypper_repository:
-      repo: "{{ sshpass_repo }}"
-      name: sshpass
-      state: absent
 
   - name: Install ardana pattern
     zypper:


### PR DESCRIPTION
The functionality provided by the sshpass package is
replaced by a simple script which essentially provides
the same functionality (some bits take from mkcloud-common.sh).

This way, we remove the need to install a special repository
for the sshpass package and all intermittent failures associated
with this repository.