### PR TITLE
openstack-ardana: fix workspace cleanup

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -407,3 +407,4 @@
             - failure: false
             - aborted: false
             - unstable: false
+            - success: false


### PR DESCRIPTION
The openstack-ardana-heat cleanup job is triggered, even after a
successful job, to suspend the heat stack used by the main
openstack-ardana job. The cleanup job needs access to the
workspace used by the main job, to pass parameters via
a properties file, so the workspace used by the main job
mustn't be deleted in case of success.