### PR TITLE
github_pr: config for ardana self gating for automation PRs

### DIFF
--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -11,6 +11,10 @@ template:
     stable: &mkcloud_automation_stable
       <<: *mkcloud_automation_standard
       cloudsource: GM7+up
+  ardana_parameters: &ardana_automation_parameters
+    standard: &ardana_automation_standard
+      label: cloud-trigger
+      # define more static or default parameters here
   user:
     suse_cloud_user: &suse_cloud_user
       - SUSE-Cloud
@@ -39,6 +43,24 @@ template:
             *suse_cloud_user
           teams:
             *suse_cloud_team
+      - type: FileMatch
+        config:
+          inverse: true
+          paths:
+            -  !ruby/regexp '/scripts\/jenkins\/ardana\//'
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: pending
+              message: Queued automation PR gating
+          - type: JenkinsJobTriggerArdana
+            parameters:
+              detail_logging: true
+              job_name: cloud-ardana8-gating
+              job_cmd: "../jenkins/jenkins-job-trigger"
+              job_parameters:
+                *ardana_automation_parameters
+
       - type: FileMatch
         config:
           paths:

--- a/scripts/github_pr/interactions/ia_cloud.rb
+++ b/scripts/github_pr/interactions/ia_cloud.rb
@@ -57,6 +57,13 @@ module GithubPR
     end
   end
 
+  class JenkinsJobTriggerArdanaAction < JenkinsJobTriggerMkcloudAction
+    # inherit from JenkinsJobTriggerAction in case we need a different extra_parameters function
+    # github_pr is the string that lets openstack-mkcloud do the self gating, if
+    #   the ardana jobs are not adapted in the same way, we might need to set the correct
+    #   extra parameters here (overwrite the function)
+  end
+
   class JenkinsJobTriggerMkcloudCCTAction < JenkinsJobTriggerMkcloudAction
     CLOUDSOURCE = {
       "master" => "develcloud8",


### PR DESCRIPTION
This configuration change to the github_pr config for the
automation repo will allow to trigger ardana self gating jobs
for PRs to autmation that affect only ardana based deployments.

DO NOT MERGE YET
Please see the comments. You most likely need to adapt the parameters that are used to configure the ardana build.
@stefannica Please take over this PR, or find someone to take this over and get it ready.

@jesusaurus This is how we filter PRs and trigger the corresponding jobs.