### PR TITLE
qa_opesntack: upgrade the distribution

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -73,6 +73,11 @@ function addopensuseleaprepos {
     $zypper ar --refresh "$repomirror/update/leap/$VERSION/oss/" Leap-$VERSION-oss-update
 }
 
+function distribution_upgrade {
+    $zypper dist-upgrade --auto-agree-with-licenses
+}
+
+
 # setup repos
 VERSION=11
 REPO=SLE_11_SP3
@@ -144,6 +149,8 @@ fi
 
 if [ -z "$skip_reposetup" ]; then
     $addrepofunc
+    # Upgrade the distribution after adding the repositories
+    distribution_upgrade
 fi
 
 # install maintenance updates


### PR DESCRIPTION
After installing the repositories, we upgrade the distribution.
This can fix some problems when the VM (like in the case of
cleanvm) have some packages versions that are not expected.

This fix the cleanvm current problem, when a downgrade of
python-base package is required before installing the Cloud
patterns.