### PR TITLE
Ignore ERROR_FOR_DIVISION_BY_ZERO value in glance/scrubber.log

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3864,7 +3864,9 @@ function oncontroller_testsetup
         iscloudver 6plus && configargs=""
         su - glance -s /bin/sh -c "/usr/bin/glance-scrubber $configargs" \
             || complain 113 "Glance scrubber doesn't work properly"
-        grep -v glance_store /var/log/glance/scrubber.log | grep ERROR \
+        # ERROR_FOR_DIVISION_BY_ZERO is part of MySQL server mode
+        # this is logged into glance/scrubber.log if DEBUG is enabled
+        grep -v glance_store /var/log/glance/scrubber.log | grep -v ERROR_FOR_DIVISION_BY_ZERO | grep ERROR \
             && complain 114 "Unexpected errors in glance-scrubber logs"
     fi
 


### PR DESCRIPTION
The value is not an error, it's part of MySQL server mode.
It is only seen in glance/scrubber.log if DEBUG mode is enabled.

See end of https://ci.suse.de/job/openstack-mkcloud/128449/console - the build fails because the check finds ERROR_FOR_DIVISION_BY_ZERO
