### PR TITLE
openstack-ardana: make proper use of ansible inventory and group_vars

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -262,14 +262,9 @@
 
           DEPLOYER_IP=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name admin-floating-ip -c output_value -f value)
           NETWORK_MGMT_ID=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name mgmt-network-id -c output_value -f value)
-          cat << EOF > hosts
-          [hosts]
-          $DEPLOYER_IP ansible_user=root
-          EOF
+          sed -i "s/^ardana-virt.*/ardana-virt      ansible_host=$DEPLOYER_IP/g" inventory
 
-          cat hosts
-
-          cat << EOF > ardana_net_vars.yml
+          cat << EOF > host_vars/ardana-virt.yml
           ---
           input_model_path: "$input_model_path"
           deployer_mgmt_ip: $(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name admin-mgmt-ip -c output_value -f value)
@@ -277,7 +272,7 @@
 
           controller_mgmt_ips=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name controller-mgmt-ips -c output_value -f value|grep -o '[0-9.]*')
           if [ -n "$controller_mgmt_ips" ]; then
-            echo "controller_mgmt_ips:" >> ardana_net_vars.yml
+            echo "controller_mgmt_ips:" >> host_vars/ardana-virt.yml
             for ip in $controller_mgmt_ips; do
                 cat << EOF >> ardana_net_vars.yml
               - $ip
@@ -287,22 +282,22 @@
 
           compute_mgmt_ips=$(openstack --os-cloud $CLOUD_CONFIG_NAME stack output show $heat_stack_name compute-mgmt-ips -c output_value -f value|grep -o '[0-9.]*')
           if [ -n "$compute_mgmt_ips" ]; then
-            echo "compute_mgmt_ips:" >> ardana_net_vars.yml
+            echo "compute_mgmt_ips:" >> host_vars/ardana-virt.yml
             for ip in $compute_mgmt_ips; do
-                cat << EOF >> ardana_net_vars.yml
+                cat << EOF >> host_vars/ardana-virt.yml
               - $ip
           EOF
             done
           fi
 
           # Get the IP addresses of the dns servers from the mgmt network
-          echo "mgmt_dnsservers:" >> ardana_net_vars.yml
+          echo "mgmt_dnsservers:" >> host_vars/ardana-virt.yml
           openstack --os-cloud $CLOUD_CONFIG_NAME port list --network $NETWORK_MGMT_ID \
                     --device-owner network:dhcp -f value -c 'Fixed IP Addresses' | \
               sed -e "s/^ip_address='\(.*\)', .*$/\1/" | \
-              while read line; do echo "  - $line" >> ardana_net_vars.yml; done;
+              while read line; do echo "  - $line" >> host_vars/ardana-virt.yml; done;
 
-          cat ardana_net_vars.yml
+          cat host_vars/ardana-virt.yml
 
           sshargs="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
           # FIXME: Use cloud-init in the used image
@@ -310,26 +305,21 @@
 
           source /opt/ansible/bin/activate
 
-          ansible-playbook -v -i hosts ssh-keys.yml
+          ansible-playbook -v ssh-keys.yml
           if [ -n "$gerrit_change_ids" ] ; then
               test_repository=http://download.suse.de/ibs/${homeproject//:/:\/}:/ardana-ci-${gerrit_change_ids//,/-}/standard
-              ansible-playbook -v -i hosts -e "build_url=$BUILD_URL" \
-                                           -e "cloudsource=${cloudsource}" \
-                                           -e "repositories='${repositories}'" \
-                                           -e "test_repository_url=${test_repository}" \
-                                           repositories.yml
-          else
-              ansible-playbook -v -i hosts -e "build_url=$BUILD_URL" \
-                                           -e "cloudsource=${cloudsource}" \
-                                           -e "repositories='${repositories}'" \
-                                           repositories.yml
           fi
+          ansible-playbook -v -e "build_url=$BUILD_URL" \
+                              -e "cloudsource=${cloudsource}" \
+                              -e "repositories='${repositories}'" \
+                              -e "test_repository_url=${test_repository}" \
+                              repositories.yml
           verification_temp_dir=$(ssh $sshargs root@$DEPLOYER_IP \
                                     "mktemp -d /tmp/ardana-job-rpm-verification.XXXXXXXX")
-          ansible-playbook -v -i hosts -e "deployer_floating_ip=$DEPLOYER_IP" \
-                                       -e "verification_temp_dir=$verification_temp_dir" \
-                                       -e cloudsource="${cloudsource}" \
-                                       init.yml
+          ansible-playbook -v -e "deployer_floating_ip=$DEPLOYER_IP" \
+                              -e "verification_temp_dir=$verification_temp_dir" \
+                              -e cloudsource="${cloudsource}" \
+                              init.yml
 
           # Run site.yml outside ansible for output streaming
           ssh $sshargs ardana@$DEPLOYER_IP "cd ~/scratch/ansible/next/ardana/ansible ; \
@@ -339,25 +329,25 @@
           if [ -n "$update_cloudsource" -a "$update_cloudsource" != "$cloudsource" -o -n "$update_repositories" ]; then
 
               # Run pre-update checks
-              ansible-playbook -v -i hosts \
+              ansible-playbook -v \
                   -e "image_mirror_url=${image_mirror_url}" \
                   -e "tempest_run_filter=${tempest_run_filter}" \
                   pre-update-checks.yml
 
-              ansible-playbook -v -i hosts \
+              ansible-playbook -v \
                   -e "build_url=$BUILD_URL" \
                   -e "cloudsource=${update_cloudsource}" \
                   -e "repositories='${update_repositories}'" \
                   repositories.yml
 
-              ansible-playbook -v -i hosts \
+              ansible-playbook -v \
                   -e "cloudsource=${update_cloudsource}" \
                   -e "update_method=${update_method}" \
                   update.yml
           fi
 
           # Run post-deploy checks
-          ansible-playbook -v -i hosts \
+          ansible-playbook -v \
               -e "image_mirror_url=${image_mirror_url}" \
               -e "tempest_run_filter=${tempest_run_filter}" \
               -e "verification_temp_dir=$verification_temp_dir" \

--- a/scripts/jenkins/ardana/ansible/generate-heat.yml
+++ b/scripts/jenkins/ardana/ansible/generate-heat.yml
@@ -21,5 +21,4 @@
   gather_facts: False
 
   roles:
-    - cloud-common
     - heat-generator

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -15,6 +15,11 @@
 #
 ---
 
+cloudsource: stagingcloud8
+
+# The cloud release is encoded in the cloudsource value
+cloud_release: "cloud{{ cloudsource[-1] }}"
+
 ntp_servers:
   - ntp.suse.de
   - ntp0.suse.de

--- a/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
@@ -17,15 +17,11 @@
 
 clouddata_server: provo-clouddata.cloud.suse.de
 download_suse_server: download.suse.de
-cloudsource: stagingcloud8
 repositories: SLES-Pool,SLES-Updates
 arch: x86_64
 repos_url: "http://{{ clouddata_server }}/repos/{{ arch }}"
 
 test_repository_url: ''
-
-# The cloud release is encoded in the cloudsource value
-cloud_release: "cloud{{ cloudsource[-1] }}"
 
 # Media/repositories mapped by the cloudsource value
 cloudsource_repos:

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -1,22 +1,18 @@
 ---
 - name: Initialize the Deployer
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
-  roles:
-    - cloud-common
 
   vars_files:
-    - ardana_net_vars.yml
     - vars/main.yml
 
   tasks:
   - name: Write deployer info to /etc/motd
-    become: yes
     shell: |
       echo "DEPLOYER_IP={{ deployer_floating_ip | default(None) }}" >> /etc/motd
 
   - name: Grow 1st partition filesystem
-    become: yes
     shell: |
       /usr/sbin/growpart /dev/vda 1 && /sbin/resize2fs /dev/vda1
     ignore_errors: True
@@ -82,7 +78,6 @@
     when: item != "" and item != deployer_mgmt_ip
 
   - name: Grow 1st partition filesystem on non-deployer nodes
-    become: yes
     shell: |
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no  root@{{ item }} "/usr/sbin/growpart /dev/vda 1 && /sbin/resize2fs /dev/vda1"
     ignore_errors: True

--- a/scripts/jenkins/ardana/ansible/inventory
+++ b/scripts/jenkins/ardana/ansible/inventory
@@ -24,6 +24,9 @@ ardana-scale    ansible_host=10.84.48.51
 [deployer_nue]
 ardana-qa4      ansible_host=10.162.66.12
 
+[deployer_virt]
+ardana-virt
+
 [ses_prv]
 ses-prv       ansible_host=10.84.88.251
 
@@ -55,3 +58,6 @@ ses_nue
 [qe_all:children]
 prv_all
 nue_all
+
+[virt_all:children]
+deployer_virt

--- a/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/post-deploy-checks.yml
@@ -1,10 +1,10 @@
 ---
 - name: Post deployment checks
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
 
   vars_files:
-    - ardana_net_vars.yml
     - vars/main.yml
 
   tasks:
@@ -20,16 +20,6 @@
       chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
     become: true
     become_user: ardana
-
-  - name: Stop irrelevant services to survive tempest
-    shell: |
-      ansible-playbook -v -i hosts/verb_hosts logging-stop.yml
-      ansible-playbook -v -i hosts/verb_hosts monasca-transform-stop.yml
-    args:
-      chdir: /var/lib/ardana/scratch/ansible/next/ardana/ansible
-    become: true
-    become_user: ardana
-    when: tempest_run_filter != ""
 
   - name: Run tempest
     shell: |

--- a/scripts/jenkins/ardana/ansible/pre-deploy-checks.yml
+++ b/scripts/jenkins/ardana/ansible/pre-deploy-checks.yml
@@ -1,11 +1,9 @@
 - name: Take snapshot of files not owned by a package prior to deployment
-  become: yes
   failed_when: false
   shell: |
     find /usr -print0 | xargs -0 rpm -qf | grep "is not owned" \
       > "{{ pre_deploy_unowned_files }}"
 
 - name: Take snapshot of modified/deleted rpm-owned files prior to deployment
-  become: yes
   shell: rpm -Va > "{{ pre_deploy_rpm_verification }}"
   failed_when: false

--- a/scripts/jenkins/ardana/ansible/pre-update-checks.yml
+++ b/scripts/jenkins/ardana/ansible/pre-update-checks.yml
@@ -1,10 +1,10 @@
 ---
 - name: Pre update checks
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
 
   vars_files:
-    - ardana_net_vars.yml
     - vars/main.yml
 
   tasks:

--- a/scripts/jenkins/ardana/ansible/reboot.yml
+++ b/scripts/jenkins/ardana/ansible/reboot.yml
@@ -1,10 +1,8 @@
 ---
 - name: Reboot all nodes
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
-  vars_files:
-    - ardana_net_vars.yml
-    - vars/main.yml
 
   tasks:
 

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -1,10 +1,8 @@
 ---
 - name: Setup repositories on the deployer node
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
-
-  roles:
-  - cloud-common
 
   tasks:
 

--- a/scripts/jenkins/ardana/ansible/ssh-keys.yml
+++ b/scripts/jenkins/ardana/ansible/ssh-keys.yml
@@ -1,11 +1,11 @@
 ---
 - name: Setup SSH keys
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
 
   tasks:
   - name:  Write available ssh keys to people can login
-    become: yes
     lineinfile:
       dest: /root/.ssh/authorized_keys
       line: "{{ item }}"

--- a/scripts/jenkins/ardana/ansible/test-post-deployment-checks.yml
+++ b/scripts/jenkins/ardana/ansible/test-post-deployment-checks.yml
@@ -16,7 +16,8 @@
 
 ---
 - name: Test post-deployment checks
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
   vars:
     rpm_verification_test_mode:

--- a/scripts/jenkins/ardana/ansible/update.yml
+++ b/scripts/jenkins/ardana/ansible/update.yml
@@ -1,10 +1,8 @@
 ---
 - name: Install package updates on all nodes
-  hosts: hosts
+  hosts: ardana-virt
+  remote_user: root
   gather_facts: False
-  vars_files:
-    - ardana_net_vars.yml
-    - vars/main.yml
 
   vars:
     update_method: update


### PR DESCRIPTION
Switch to using the ansible inventory and group_vars instead of generating
a dedicated host file and ardana_net_vars variable file and keeping common
variables in a cloud-common role.