### PR TITLE
pr trigger: enable debug

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -75,4 +75,4 @@
               ;;
           esac
 
-          ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_cloud.yaml
+          ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugfilterchain --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_cloud.yaml

--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -77,4 +77,4 @@
               ;;
           esac
 
-          ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_crowbar.yaml
+          ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugfilterchain --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_crowbar.yaml

--- a/jenkins/ci.suse.de/cloud-suse-cloud-specs.yaml
+++ b/jenkins/ci.suse.de/cloud-suse-cloud-specs.yaml
@@ -50,4 +50,4 @@
             ;;
           esac
 
-          ${ghpr} -a trigger-prs --mode "$mode" --debugratelimit --config ${automationrepo}/scripts/github_pr/github_cloud-specs.yaml
+          ${ghpr} -a trigger-prs --mode "$mode" --debugfilterchain --debugratelimit --config ${automationrepo}/scripts/github_pr/github_cloud-specs.yaml


### PR DESCRIPTION
When a PR failed to receive a response from the pr trigger it was not
possible to see what was going on. Enabling debug fixes that.

Example run with it enabled:
https://ci.suse.de/view/Cloud/view/Trigger/job/cloud-automation-pr-trigger/111345/console