### PR TITLE
make log parser plugin ignore more things

### DIFF
--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -61,8 +61,9 @@ ok /Re-reading the partition table failed/
 # https://bugzilla.suse.com/show_bug.cgi?id=1031131
 ok /dracut-install: ERROR: installing .*dracut-fsck-help.txt/
 
+# https://bugzilla.suse.com/show_bug.cgi?id=1105496
 # https://bugzilla.redhat.com/show_bug.cgi?id=1312188
-ok /(libvirtd|virtlogd)\[\d+\]: End of file while reading data: Input\/output error/
+ok /(libvirtd|virtlogd)\[\d+\]: .*End of file while reading data: Input\/output error/
 
 ok /^suse\/(repodata|setup\/descr)\/appdata-failed\.(xml|html)\.(gz|xz|bz2)$/
 

--- a/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
+++ b/scripts/jenkins/log-parser/openstack-mkcloud-rules.txt
@@ -51,6 +51,7 @@ warning /This is not necessarily an error/
 warning /(?i)warning/
 
 ok /^\+ \/\S+\/github-status\.rb /
+ok /^\+ \/\S+\/github_pr\.rb /
 ok /Loading robots.txt; please ignore errors/
 ok /update-alternatives: .*ruby_parse_extract_error/
 


### PR DESCRIPTION
Ignore github_pr.rb false positive, and weird libvirtd errors.

The automatic CI tests will not test this properly, so will have to test via https://github.com/SUSE/cloud/blob/master/docs/CI/keep-jenkins-green/jobs/openstack-mkcloud-log-parser-test.md