### PR TITLE
github pr: Set status when pr owner has no permission

### DIFF
--- a/scripts/github_pr/github_cloud-specs.yaml
+++ b/scripts/github_pr/github_cloud-specs.yaml
@@ -25,6 +25,11 @@ template:
             *suse_user
           teams:
             *suse_cloud_specs_team
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: error
+              message: Owner of the source repo for this PR lacks permission
         whitelist_handler:
           - type: RunHelperAndSetStatus
             parameters:

--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -39,6 +39,11 @@ template:
             *suse_cloud_user
           teams:
             *suse_cloud_team
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: error
+              message: Owner of the source repo for this PR lacks permission
       - type: FileMatch
         config:
           paths:
@@ -71,6 +76,11 @@ template:
             *suse_cloud_user
           teams:
             *suse_cloud_team
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: error
+              message: Owner of the source repo for this PR lacks permission
         whitelist_handler:
           - type: SetStatus
             parameters:

--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -30,6 +30,11 @@ template:
             *suse_crowbar_user
           teams:
             *crowbar_team
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: error
+              message: Owner of the source repo for this PR lacks permission
         whitelist_handler:
           - type: SetStatus
             parameters:
@@ -56,6 +61,11 @@ template:
             *suse_crowbar_user
           teams:
             *crowbar_team
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: error
+              message: Owner of the source repo for this PR lacks permission
         whitelist_handler:
           - type: SetStatus
             parameters:


### PR DESCRIPTION
Otherwise this shows no indication on Github that the PR was processed.