### PR TITLE
Don't assign nodes to ceilometer-swift-proxy-middleware in qa scenarios

### DIFF
--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1a.yaml
@@ -162,10 +162,7 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
+      ceilometer-swift-proxy-middleware: []
 - barclamp: aodh
   deployment:
     elements:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1b.yaml
@@ -171,10 +171,7 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
+      ceilometer-swift-proxy-middleware: []
 
 - barclamp: manila
   attributes:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
@@ -183,10 +183,7 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
+      ceilometer-swift-proxy-middleware: []
 
 - barclamp: monasca
   attributes:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -210,10 +210,7 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
+      ceilometer-swift-proxy-middleware: []
 - barclamp: aodh
   deployment:
     elements:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -222,10 +222,7 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
+      ceilometer-swift-proxy-middleware: []
 
 - barclamp: manila
   attributes:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8a.yaml
@@ -219,10 +219,7 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
+      ceilometer-swift-proxy-middleware: []
 
 - barclamp: monasca
   attributes:

--- a/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
@@ -214,10 +214,7 @@ proposals:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
+      ceilometer-swift-proxy-middleware: []
 - barclamp: aodh
   deployment:
     elements:


### PR DESCRIPTION
This role is optional and requires swift to be installed otherwise gives and error.

See bug #1105616