### PR TITLE
openstack-ardana: fix recent errors

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -285,7 +285,7 @@
           if [ -n "$controller_mgmt_ips" ]; then
             echo "controller_mgmt_ips:" >> host_vars/ardana-virt.yml
             for ip in $controller_mgmt_ips; do
-                cat << EOF >> ardana_net_vars.yml
+                cat << EOF >> host_vars/ardana-virt.yml
               - $ip
           EOF
             done

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Import virtual configuration
   include_vars:
     file: '{{ virt_config_file }}'
-  when: virt_config_file is defined
+  when: virt_config_file is defined and virt_config_file != ''
 
 - name: Import input model
   load_input_model:


### PR DESCRIPTION
Fixes two recently introduced errors:
- leftover reference to the old ardana_net_vars.yml file
that causes the SSH keys to no longer be installed properly
on the controller nodes and the deployment to fail with an
'SSH Error: data could not be sent to the remote host' failure,
introduced by #2652
- use of an empty virtual configuration file value when caasp
is not enabled, which was not handled properly by the heat generator,
introduced by #2605 
