### PR TITLE
Avoid jenkins-job-builder 2.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ suseinstall:
 	sudo zypper install perl-JSON-XS perl-libxml-perl python-pip libvirt-python
 
 genericinstall:
-	sudo pip install -U 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder requests
+	sudo pip install -U 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder!=2.3.0 requests
 	git clone https://github.com/SUSE-Cloud/roundup && \
 	cd roundup && \
 	./configure && \


### PR DESCRIPTION
That seems to fail in test mode with a weird error. lets skip it
for now.