### PR TITLE
Add supportutils-plugin-suse-openstack-cloud to list of rhel packages

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/files/enable-centos-rpms-on-rhel/roles/deployer-rhel-repo/vars/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/files/enable-centos-rpms-on-rhel/roles/deployer-rhel-repo/vars/main.yml
@@ -185,3 +185,4 @@ rhel_repo_rpms_list:
   - openstack-freezer-scheduler
   - python-python-logstash
   - python-monascaclient
+  - supportutils-plugin-suse-openstack-cloud


### PR DESCRIPTION
This change adds `supportutils-plugin-suse-openstack-cloud` as it is missing on the RHEL repository.