### PR TITLE
Run openstack-ardana on automation PRs

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -58,6 +58,12 @@
               - on failure
 
       - string:
+          name: github_pr
+          description: >-
+            String is a ':' separated list of these values:
+            $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context
+
+      - string:
           name: git_automation_repo
           default: https://github.com/SUSE-Cloud/automation.git
           description: >-

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -46,6 +46,17 @@ pipeline {
       }
     }
 
+    stage('automation PR support') {
+      steps {
+        sh '''
+          if [ -n "$github_pr" ] ; then
+            cd automation-git
+            exec scripts/jenkins/ardana/pr-update.sh
+          fi
+        '''
+      }
+    }
+
     stage('parallel one') {
       // abort all stages if one of them fails
       failFast true
@@ -326,6 +337,11 @@ pipeline {
           fi
         '''
       }
+      sh '''
+        if [ -n "$github_pr" ] ; then
+          automation-git/scripts/ardana/pr-success.sh
+        fi
+      '''
     }
     failure {
       lock(resource: 'cloud-ECP-API') {
@@ -336,6 +352,11 @@ pipeline {
           fi
         '''
       }
+      sh '''
+        if [ -n "$github_pr" ] ; then
+          automation-git/scripts/ardana/pr-failure.sh
+        fi
+      '''
     }
   }
 }

--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -11,6 +11,11 @@ template:
     stable: &mkcloud_automation_stable
       <<: *mkcloud_automation_standard
       cloudsource: GM7+up
+  ardana_parameters: &ardana_automation_parameters
+    standard: &ardana_automation_standard
+      label: cloud-ardana-ci
+    stable:
+      *ardana_automation_standard
   user:
     suse_cloud_user: &suse_cloud_user
       - SUSE-Cloud
@@ -46,6 +51,23 @@ template:
               message: Owner of the source repo for this PR lacks permission
       - type: FileMatch
         config:
+          inverse: true
+          paths:
+            -  !ruby/regexp '/scripts\/jenkins\/ardana\//'
+        blacklist_handler:
+          - type: SetStatus
+            parameters:
+              status: pending
+              message: Queued automation PR gating
+          - type: JenkinsJobTriggerArdana
+            parameters:
+              detail_logging: true
+              job_name: openstack-ardana
+              job_cmd: "../jenkins/jenkins-job-trigger"
+              job_parameters:
+                <<: *ardana_automation_parameters
+      - type: FileMatch
+        config:
           paths:
             -  !ruby/regexp '/scripts\/(mkcloud|qa_crowbarsetup\.sh|lib\/.*)$/'
             -  !ruby/regexp '/scripts\/jenkins\/log-parser\//'
@@ -53,7 +75,7 @@ template:
           - type: SetStatus
             parameters:
               status: success
-              message: mkcloud gating not applicable
+              message: gating not applicable
         whitelist_handler:
           - type: SetStatus
             parameters:

--- a/scripts/github_pr/interactions/ia_cloud.rb
+++ b/scripts/github_pr/interactions/ia_cloud.rb
@@ -72,4 +72,15 @@ module GithubPR
       para
     end
   end
+
+  class JenkinsJobTriggerArdanaAction < JenkinsJobTriggerMkcloudAction
+    # Start by inheriting from JenkinsJobTriggerMkcloudAction to use its
+    # extra_parameters, but if we need to modify the extra_parameters then we
+    # should change to inherit JenkinsJobTriggerAction directly.
+    #
+    # github_pr is the string that lets openstack-mkcloud do the self gating, if
+    #   the ardana jobs are not adapted in the same way, we might need to set the correct
+    #   extra parameters here (overwrite the function)
+  end
+
 end

--- a/scripts/jenkins/ardana/pr-failure.sh
+++ b/scripts/jenkins/ardana/pr-failure.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source scripts/jenkins/github-pr/parse.rc
+github_context=suse/ardana
+if [[ $github_pr_context ]] ; then
+    github_context=$github_context/$github_pr_context
+fi
+
+ghprrepo=~/github.com/openSUSE/github-pr
+ghpr=${ghprrepo}/github_pr.rb
+ghpr_paras="--org ${github_org} --repo ${github_repo} --sha $github_pr_sha --context $github_context"
+
+$ghpr --action set-status --debugratelimit $ghpr_paras --status "failure" --targeturl $BUILD_URL --message "PR gating failed"

--- a/scripts/jenkins/ardana/pr-success.sh
+++ b/scripts/jenkins/ardana/pr-success.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source scripts/jenkins/github-pr/parse.rc
+github_context=suse/ardana
+if [[ $github_pr_context ]] ; then
+    github_context=$github_context/$github_pr_context
+fi
+
+ghprrepo=~/github.com/openSUSE/github-pr
+ghpr=${ghprrepo}/github_pr.rb
+ghpr_paras="--org ${github_org} --repo ${github_repo} --sha $github_pr_sha --context $github_context"
+
+$ghpr --action set-status --debugratelimit $ghpr_paras --status "success" --targeturl $BUILD_URL --message "PR gating succeeded"

--- a/scripts/jenkins/ardana/pr-update.sh
+++ b/scripts/jenkins/ardana/pr-update.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source scripts/jenkins/github-pr/parse.rc
+github_context=suse/ardana
+if [[ $github_pr_context ]] ; then
+    github_context=$github_context/$github_pr_context
+fi
+
+ghprrepo=~/github.com/openSUSE/github-pr
+ghpr=${ghprrepo}/github_pr.rb
+ghpr_paras="--org ${github_org} --repo ${github_repo} --sha $github_pr_sha --context $github_context"
+
+echo "testing PR: https://github.com/$github_pr_repo/pull/$github_pr_id"
+
+# check for newer PRs
+if ! $ghpr --action is-latest-sha $ghpr_paras --pr $github_pr_id ; then
+    $ghpr --action set-status $ghpr_paras --status "error" --targeturl $BUILD_URL --message "SHA1 mismatch, newer commit exists"
+    exit 1
+fi
+$ghpr --action set-status $ghpr_paras --status "pending" --targeturl $BUILD_URL --message "Started PR gating"
+
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git fetch origin $github_pr_sha
+git checkout -B ardana-ci FETCH_HEAD
+git clean  # remove files deleted from git
+

--- a/scripts/jenkins/github-pr/parse.rc
+++ b/scripts/jenkins/github-pr/parse.rc
@@ -1,0 +1,13 @@
+#!/bin/false
+## This file must be sourced so that the calling process can access the variables
+
+# error if github_pr is unset
+${github_pr:?}
+
+github_opts=(${github_pr//:/ })
+github_pr_repo=${github_opts[0]}
+github_pr_id=${github_opts[1]}
+github_pr_sha=${github_opts[2]}
+github_pr_context=${github_opts[4]}
+github_org=${github_pr_repo%/*}
+github_repo=${github_pr_repo##*/}

--- a/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
+++ b/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
@@ -119,17 +119,13 @@ function mkcloudgating_trap()
 
 ## mkcloud github PR gating
 if [[ $github_pr ]] ; then
-    github_opts=(${github_pr//:/ })
-    github_pr_repo=${github_opts[0]}
-    github_pr_id=${github_opts[1]}
-    github_pr_sha=${github_opts[2]}
-    github_pr_context=${github_opts[4]}
+    # split $github_pr into multiple variables
+    source ${automationrepo}/scripts/jenkins/github-pr/parse.rc
+
     github_context=suse/mkcloud
     if [[ $github_pr_context ]] ; then
       github_context=$github_context/$github_pr_context
     fi
-    github_org=${github_pr_repo%/*}
-    github_repo=${github_pr_repo##*/}
     ghpr_paras="--org ${github_org} --repo ${github_repo} --sha $github_pr_sha --context $github_context"
 
     echo "testing PR: https://github.com/$github_pr_repo/pull/$github_pr_id"


### PR DESCRIPTION
Add a filter to the github_pr cloud config to run the openstack-ardana job when pull requests are proposed to the automation project.

Also, move the bulk of both openstack-ardana and openstack-mkcloud to scripts within the automation project so that changes to the jobs can be self-gating.