### PR TITLE
Fix qa_devstack for leap 15.0

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-devstack.yaml
+++ b/jenkins/ci.opensuse.org/openstack-devstack.yaml
@@ -23,7 +23,7 @@
     builders:
       - update-automation
       - shell: |
-          sudo /usr/local/sbin/freshvm cleanvm openSUSE-Leap-42.3
+          sudo /usr/local/sbin/freshvm cleanvm openSUSE-Leap-15.0
           sleep 100
 
           set -u


### PR DESCRIPTION
Upstream devstack still defaults to Python 3.5, but we need either
python 3.4 or 3.6, so set the variable appropriately.