### PR TITLE
Add jenkins-job-triggerc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 jenkins/*.config.xml
 jenkins/*.cred
+scripts/jenkins/jenkins-job-triggerc
 scripts/jenkins/*.config.xml
 scripts/jenkins/*.cred
 


### PR DESCRIPTION
This commit adds an entry scripts/jenkins/jenkins-job-triggerc to
.gitignore. This file is created during `make test` execution. So, we
don't need to manage this file by a git repo.