### PR TITLE
Adjust scenarios for change of default database backend

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
+++ b/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
@@ -2,6 +2,7 @@
 proposals:
 - barclamp: database
   attributes:
+    sql_engine: postgresql
   deployment:
     elements:
       database-server:

--- a/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
@@ -36,6 +36,7 @@ proposals:
       - @@compute2@@
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
@@ -117,6 +117,7 @@ proposals:
       - "@@controller2@@"
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud7/cloud7-ironic-swift-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-swift-ha.yml
@@ -117,6 +117,7 @@ proposals:
       - "@@controller2@@"
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -38,6 +38,7 @@ proposals:
       - "@@controller3@@"
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
@@ -39,6 +39,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -87,6 +87,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -39,6 +39,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -33,6 +33,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3.yaml
@@ -58,6 +58,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
@@ -56,6 +56,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8a.yaml
@@ -39,6 +39,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8b.yaml
@@ -33,6 +33,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
@@ -33,6 +33,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -38,6 +38,7 @@ proposals:
       - "@@controller3@@"
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -39,6 +39,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -87,6 +87,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -39,6 +39,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -33,6 +33,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-3.yaml
@@ -59,6 +59,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -56,6 +56,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8a.yaml
@@ -39,6 +39,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         shared:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8b.yaml
@@ -33,6 +33,7 @@ proposals:
 
 - barclamp: database
   attributes:
+    sql_engine: postgresql
     ha:
       storage:
         mode: drbd


### PR DESCRIPTION
The default database backend for Cloud 7 will soon change from
"postgresql" to "mariadb". In order to keep the scenarios deployable
with GA as well as with GA+Updates after the changed default, we're
forcing the backend to "postgresql" in the crowbar batch files for now.

Many of the batch files are still taylored for postgresql anyway (e.g.
using two-node cluster with and without drbd)