### PR TITLE
Enable swift explicitly for qa scenarios

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -15,7 +15,7 @@
       It will wipe all machines in the selected cloud!
 
     wrappers:
-      - mkphyscloud-qa-build-name-wrapper 
+      - mkphyscloud-qa-build-name-wrapper
     publishers:
       - mkphyscloud-qa-common-publishers
 
@@ -53,14 +53,14 @@
           name: automation_repo
           default: github.com/$repo_owner/automation#$branch
           description: Mandatory, automation repo URL
-      
+
       - string:
           name: networkingplugin
           default: linuxbridge
           description: |
                networking plugin to be used by Neutron. Available options are: openvswitch:gre, vlan, vxlan / linuxbridge:vlan
 
-      - string: 
+      - string:
           name: networkingmode
           default: vlan
           description: networking mode to be used by Neutron. Available options are gre, vlan, vxlan
@@ -222,6 +222,8 @@
           export want_node_aliases=controller=3,compute-kvm=2,storage-swift=2 ;
           export networkingplugin=$networkingplugin ;
           export networkingmode=$networkingmode ;
+          export want_swift=1 ;
+          export cephvolumenumber=1 ;
           export scenario=\"/root/scenario.yml\" ;
           export commands=\"$commands\" "'
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1b.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1b.yaml
@@ -17,7 +17,7 @@
       It will wipe all machines in the selected cloud!
 
     wrappers:
-      - mkphyscloud-qa-build-name-wrapper 
+      - mkphyscloud-qa-build-name-wrapper
     publishers:
       - mkphyscloud-qa-common-publishers
 
@@ -59,7 +59,7 @@
       - string:
           name: networkingplugin
           default: linuxbridge
-          description: | 
+          description: |
               networking plugin to be used by Neutron. Available options are: openvswitch:gre, vlan, vxlan / linuxbridge:vlan
 
       - string:
@@ -202,6 +202,8 @@
           export want_node_roles=controller=3,compute=4 ;
           export networkingplugin=$networkingplugin ;
           export networkingmode=$networkingmode ;
+          export want_swift=1 ;
+          export cephvolumenumber=1 ;
           export scenario=\"/root/scenario.yml\" ;
           export commands=\"$commands\" "'
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -15,7 +15,7 @@
         - glance (storage swift)
         - nova: ssl, libvirt migration enabled, shared storage, kvm kernel samepage merging, 1 KVM
         - cinder: Local file
-        - neutron: linuxbridge or OVS 
+        - neutron: linuxbridge or OVS
         - manila: NetApp backend (we expect that a vserver 'cloud-manila-svm' is available on the 'netapp-n1-e0m.cloud.suse.de' server)
 
       Warning: It will wipe all machines!
@@ -76,12 +76,12 @@
       - string:
           name: netapp_server
           default: netapp-n1-e0m.cloud.suse.de
-          description: Mandatory, the name of the NetApp Storage backend server 
+          description: Mandatory, the name of the NetApp Storage backend server
 
       - string:
           name: netapp_vserver
           default: cloud-manila-svm
-          description: Mandatory, the name of the NetApp Storage backend vserver 
+          description: Mandatory, the name of the NetApp Storage backend vserver
 
       - string:
           name: tempest
@@ -194,7 +194,7 @@
           # check that netapp backend server is available
           ping -c 3 $netapp_server || ret=$?
 
-          if [ $ret != 0 ] ; then 
+          if [ $ret != 0 ] ; then
             echo "netapp server is unavailable!"
             exit 1
           fi
@@ -244,6 +244,8 @@
           export netapp_server=$netapp_server ;
           export netapp_vserver=$netapp_vserver ;
           export networkingplugin=$networkingplugin ;
+          export want_swift=1 ;
+          export cephvolumenumber=1 ;
           export networkingmode=$networkingmode ;
           export commands=\"$commands\" "'
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2b.yaml
@@ -197,6 +197,8 @@
           export shared_storage_ip=$shared_storage_ip
           export want_node_aliases=controller=3,computekvm=2,computevmw=1 ;
           export want_node_roles=controller=3,compute=4 ;
+          export want_swift=1 ;
+          export cephvolumenumber=1 ;
           export scenario=\"/root/scenario.yml\" ;
           export vcenter_ip=$vcenter_ip ;
           export vcenter_user="Administrator@vsphere.local" ;

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8a.yaml
@@ -11,12 +11,12 @@
         - Shared device for DB and rabbit
         - Swift
         - Neutron: linuxbridge or OVS
-        - Monasca 
+        - Monasca
 
       It will wipe all machines in the selected cloud!
 
     wrappers:
-      - mkphyscloud-qa-build-name-wrapper 
+      - mkphyscloud-qa-build-name-wrapper
     publishers:
       - mkphyscloud-qa-common-publishers
 
@@ -202,6 +202,8 @@
           export want_node_aliases=controller=3,compute-kvm=1,storage-swift=2,monasca-server=1 ;
           export networkingplugin=$networkingplugin ;
           export networkingmode=$networkingmode ;
+          export want_swift=1 ;
+          export cephvolumenumber=1 ;
           export scenario=\"/root/scenario.yml\" ;
           export commands=\"$commands\" "'
 


### PR DESCRIPTION
The commit https://github.com/SUSE-Cloud/automation/commit/ffce9054527be9d3750305049e80203b0c96c2c0 made it necessary to explicitly enable swift in mkcloud, even though crowbar batch already contains swift.

This broke qa scenarios where swift was used for storage.