### PR TITLE
qa_crowbarsetup: wait longer for initial chef run

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3966,7 +3966,7 @@ function oncontroller_testsetup
 
     local ssh_target="$ssh_user@$vmip"
 
-    wait_for 40 5 "timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $ssh_target true" "SSH key to be copied to VM"
+    wait_for 60 5 "timeout -k 20 10 ssh -o UserKnownHostsFile=/dev/null $ssh_target true" "SSH key to be copied to VM"
 
     if ! ssh $ssh_target curl $test_internet_url ; then
         complain 95 could not reach internet


### PR DESCRIPTION
On machines with low RAM (32GB in total) the initial chef
run takes slightly longer, so we didn't wait enough half the time.
Increasing the timeout fixes the issue.