### PR TITLE
Switch Cloud9 HA jobs to use ssl

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -30,6 +30,7 @@
     tempestoptions: -s -t
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: ceph
+    want_all_ssl: 0
     jobs:
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -40,6 +40,7 @@
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: ceph
     database_engine: postgresql
+    want_all_ssl: 0
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -40,6 +40,7 @@
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: swift
     database_engine: mysql
+    want_all_ssl: 0
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -25,7 +25,6 @@
         - 'cloud-mkcloud{version}-job-magnum-{arch}'
         - 'cloud-mkcloud{version}-job-monasca-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
-        - 'cloud-mkcloud{version}-job-ssl-{arch}'
 - project:
     name: cloud-mkcloud9-ha-x86_64
     disabled: false
@@ -38,6 +37,7 @@
     label: openstack-mkcloud-ha-x86_64
     storage_method_ha: swift
     database_engine: mysql
+    want_all_ssl: 1
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
@@ -80,4 +80,3 @@
         - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
         - 'cloud-mkcloud{version}-job-magnum-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
-        - 'cloud-mkcloud{version}-job-ssl-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -25,6 +25,7 @@
             crowbar_networkingmode=team
             storage_method={storage_method_ha}
             hacloud=1
+            want_all_ssl={want_all_ssl}
             mkcloudtarget=all_noreboot
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-{arch}


### PR DESCRIPTION
The HA+SSL combination isn't very well tested in our CI, but it
is the more common scenario that customers / PoCs are using. For
example the SAP Cloud Project is requiring this combination, but
also other users are choosing this combination. Hence we should
be testing it.

For now only switch Cloud9. Switching more once we have more
testing passes.