### PR TITLE
Update batch scenarios to match schema

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
@@ -37,11 +37,12 @@ proposals:
 - barclamp: database
   attributes:
     sql_engine: postgresql
-    ha:
-      storage:
-        mode: drbd
-        drbd:
-          size: 5
+    postgresql:
+      ha:
+        storage:
+          mode: drbd
+          drbd:
+            size: 5
   deployment:
     elements:
       database-server:

--- a/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-basic-ha.yml
@@ -118,11 +118,12 @@ proposals:
 - barclamp: database
   attributes:
     sql_engine: postgresql
-    ha:
-      storage:
-        mode: drbd
-        drbd:
-          size: 5
+    postgresql:
+      ha:
+        storage:
+          mode: drbd
+          drbd:
+            size: 5
   deployment:
     elements:
       database-server:

--- a/scripts/scenarios/cloud7/cloud7-ironic-swift-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-ironic-swift-ha.yml
@@ -118,11 +118,12 @@ proposals:
 - barclamp: database
   attributes:
     sql_engine: postgresql
-    ha:
-      storage:
-        mode: drbd
-        drbd:
-          size: 5
+    postgresql:
+      ha:
+        storage:
+          mode: drbd
+          drbd:
+            size: 5
   deployment:
     elements:
       database-server:


### PR DESCRIPTION
Recently `ha` subtree was moved below `postgresql` as part of migration
from postgresql to mariadb. Some batches were not updated to match the
new schema.