### PR TITLE
Added support for Horizon on ardana_qe_tests role

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/horizon.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/horizon.sh.j2
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Wrapper script to execute horizon selenium integration tests
+# within the venv
+#
+# Usage: horizon.sh
+
+set -o pipefail
+
+VENV={{ ardana_qe_test_venv }}
+STESTR={{  ardana_qe_test_venv }}/bin/stestr
+
+# Activate the virtual environment
+source ${VENV}/bin/activate
+
+# Run horizon tests.
+cd {{ ardana_qe_tests_dir }}/ardana-qa-tests/horizon/
+
+ip=`grep public-KEY-API-extapi /etc/hosts | awk {'print $1'}`
+url="https://$ip/"
+adminpwd=`grep OS_PASSWORD ~/service.osrc | sed -e 's#.*=\(\)#\1#'`
+demopwd=`grep -ri keystone_demo_pwd ~/scratch/ansible/next/ardana/ansible/group_vars | sed -e 's#.*_pwd: \(\)#\1#'`
+
+sed  -i 's|^\(dashboard_url=\)\(.*\)|\1'$url'|' openstack_dashboard/test/integration_tests/horizon.conf
+sed  -i "s/\(admin_password *= *\).*/\1$adminpwd/" openstack_dashboard/test/integration_tests/horizon.conf
+sed  -i "s/\(password *= *\).*/\1$demopwd/" openstack_dashboard/test/integration_tests/horizon.conf
+
+${STESTR} init
+${STESTR} run -t ./ --concurrency=1 | tee {{ ardana_qe_test_log }}
+${STESTR} last --subunit > {{ ardana_qe_test_subunit }}

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/horizon.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/horizon.yml
@@ -1,0 +1,19 @@
+---
+
+ardana_qe_test_venv_requires:
+  - 'pymysql'
+  - 'python-subunit'
+  - 'selenium'
+  - 'django'
+  - 'nose'
+  - 'tox'
+  - 'stestr'
+  - 'oslo_utils'
+  - 'oslo_config'
+  - 'xvfbwrapper'
+
+ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
+ardana_qe_test_get_results_cmds:
+  passed: 'grep ok {{ ardana_qe_test_log }} | wc -l'
+  failed: 'grep FAILED {{ ardana_qe_test_log }} | wc -l'
+  ran: 'grep -e "FAILED\|ok" {{ ardana_qe_test_log }} | wc -l'


### PR DESCRIPTION
These are the wrapper files helps to run Horizon Selenium integration tests located at http://git.suse.provo.cloud/cgit/ardana/ardana-qa-tests/tree/ardana-qa-tests/horizon 