### PR TITLE
Run openstack-mkcloud job on changes to its script

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -417,19 +417,12 @@
           write-description: "Job aborted due to 60 minutes of inactivity."
 
     builders:
+      - update-automation
       - shell: |
-          set -ex
-
-          export automationrepo=~/github.com/SUSE-Cloud/automation
-
-          # automation bootstrapping
-          if ! [ -e ${automationrepo}/scripts/jenkins/update_automation ] ; then
-            rm -rf ${automationrepo}
-            curl https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation | bash
+          if [[ $github_pr ]] ; then
+            exec ${automationrepo}/scripts/jenkins/mkcloud/openstack-mkcloud.prep.sh
           fi
-          # fetch the latest automation updates
-          ${automationrepo}/scripts/jenkins/update_automation
-
+      - shell: |
           # run the builder script in the automation repo
           exec ${automationrepo}/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
 

--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -50,7 +50,7 @@ template:
         config:
           paths:
             -  !ruby/regexp '/scripts\/(mkcloud|qa_crowbarsetup\.sh|lib\/.*)$/'
-            -  !ruby/regexp '/scripts\/jenkins\/log-parser\//'
+            -  !ruby/regexp '/scripts\/jenkins\/(log-parser|mkcloud)\//'
         blacklist_handler:
           - type: SetStatus
             parameters:

--- a/scripts/jenkins/mkcloud/openstack-mkcloud.prep.sh
+++ b/scripts/jenkins/mkcloud/openstack-mkcloud.prep.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -x
+shopt -s extglob
+
+# emptying the workspace
+mkdir -p empty
+rsync -r --delete empty/ ./
+
+# split $github_pr into multiple variables
+source ${automationrepo}/scripts/jenkins/github-pr/parse.rc
+
+# Support for automation self-gating
+if [[ "$github_pr_repo" = "SUSE-Cloud/automation" ]]; then
+    automationrepo_orig=$automationrepo
+    automationrepo=$WORKSPACE/automation-git
+
+    mkdir -p $automationrepo
+    rsync -a ${automationrepo_orig%/}/ $automationrepo/
+    pushd $automationrepo
+    ghremote=origin
+    git config --get-all remote.${ghremote}.fetch | grep -q pull || \
+        git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
+    git fetch $ghremote 2>&1 | grep -v '\[new ref\]' || :
+    git checkout -t $ghremote/pr/$github_pr_id
+    git config user.email cloud-devel+jenkins@suse.de
+    git config user.name "Jenkins User"
+    echo "we merge to always test what will end up in master"
+    git merge master -m temp-merge-commit
+    # Show latest commit in log to see what's really tested.
+    # Include a unique indent so that the log parser plugin
+    # can ignore the output and avoid false positives.
+    git --no-pager show | sed 's/^/|@| /'
+    popd
+fi


### PR DESCRIPTION
In #2709 we moved the bulk of the openstack-mkcloud job to a script
within the automation repo, but that new script was not added to
the file filter for the openstack-mkcloud job. Add the new script
directory to the file filter so that the openstack-mkcloud job runs
on changes to its builder script.

Depends on work from #2713 and #2687