### PR TITLE
syncSLErepos: Create destination directory before rsyncing

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -172,6 +172,7 @@ for servicepack in 4 3 2 1; do
         echo ================== Updating SLE 12 SP$servicepack for $arch
 
         destdir_install=/srv/nfs/install/suse-${chef_version}/$arch/install/
+        mkdir -p $destdir_install
         if [ -z "$sync_from_ibs" ]; then
             $rsync $install_source/SLP/SLE-$version-Server-GM/$arch/DVD1/ $destdir_install
         else


### PR DESCRIPTION
In case the install/suse-12.X directory wasn't created, rsync
skipped the syncing because the parent of the destination didn't
exist. Make sure that is always the case by creating the destdir
beforehand explicitly.