### PR TITLE
Check for presence of specific migration.

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2226,7 +2226,7 @@ function custom_configuration
         database)
             if [[ $hacloud = 1 ]] ; then
                 if [[ "$want_database_sql_engine" != "mysql" ]] ; then
-                    if iscloudver 7 ; then
+                    if [ -e "/opt/dell/chef/data_bags/crowbar/migrate/database/109_separate_db_roles.rb" ]; then
                         proposal_set_value database default "['attributes']['database']['postgresql']['ha']['storage']['mode']" "'drbd'"
                         proposal_set_value database default "['attributes']['database']['postgresql']['ha']['storage']['drbd']['size']" "$drbd_database_size"
                     else
@@ -2236,7 +2236,8 @@ function custom_configuration
                 fi
                 # For SOC7 we introduced transitional role called mysql-server that's gonna be used during the upgrade
                 # Users deploying SOC7 with MariaDB must use this one and not database-server
-                if iscloudver 7 && [[ "$want_database_sql_engine" == "mysql" ]] ; then
+                if iscloudver 7 && [[ "$want_database_sql_engine" == "mysql" ]] && \
+                    [ -e "/opt/dell/chef/data_bags/crowbar/migrate/database/109_separate_db_roles.rb" ]; then
                     proposal_set_value database default "['deployment']['database']['elements']['mysql-server']" "['cluster:$clusternamedata']"
                 else
                     proposal_set_value database default "['deployment']['database']['elements']['database-server']" "['cluster:$clusternamedata']"


### PR DESCRIPTION
This was removed in commit 6e230ec9fb2f555fce0fb9f1a74e0a8c2e882df5,
but removal would break GM installations, since the migration is
delivered via maintenance update.

Fix after merging https://github.com/SUSE-Cloud/automation/pull/2721