### PR TITLE
cloud-ardana-job-gerrit: override default votes

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -21,6 +21,7 @@
                 comment-contains-value: '^suse_recheck$'
             - comment-added-contains-event:
                 comment-contains-value: '^recheck$'
+          override-votes: true
           gerrit-build-successful-verified-value: 1
           skip-vote:
               notbuilt: true


### PR DESCRIPTION
This is needed for gerrit-build-successful-verified-value:1 to have any
effect. By default the Jenkins Gerrit trigger plugin doesn't vote in
Gerrit, we want it to do that for this job.