### PR TITLE
Take a PR URL to trigger only from it

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -3,6 +3,15 @@
     node: cloud-trigger
 
     parameters:
+      - string:
+          name: prurl
+          default: None
+          description: |
+            Only process this one PR with mode "all", irrespective of the below
+            mode selection.
+            Example:
+            https://github.com/SUSE-Cloud/automation/pull/0/commits/0000
+
       - choice:
           name: mode
           choices:
@@ -74,5 +83,10 @@
               repos="--only --org ${repositories%/*} --repo ${repositories##*/}"
               ;;
           esac
+
+          if [ $prurl ]; then
+            buildmode=all
+            repos="$repos --this $prurl"
+          fi
 
           ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugfilterchain --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_cloud.yaml


### PR DESCRIPTION
When something fails and a repo has many open PRs triggering all of them
won't work as jenkins rejects creation of too many jobs.