### PR TITLE
Remove broken ardana trigger for PRs in this repo

### DIFF
--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -13,9 +13,6 @@ template:
       cloudsource: GM7+up
   ardana_parameters: &ardana_automation_parameters
     standard: &ardana_automation_standard
-      label: cloud-ardana-ci
-    stable:
-      *ardana_automation_standard
   user:
     suse_cloud_user: &suse_cloud_user
       - SUSE-Cloud
@@ -49,23 +46,6 @@ template:
             parameters:
               status: error
               message: Owner of the source repo for this PR lacks permission
-      - type: FileMatch
-        config:
-          inverse: true
-          paths:
-            -  !ruby/regexp '/scripts\/jenkins\/ardana\//'
-        blacklist_handler:
-          - type: SetStatus
-            parameters:
-              status: pending
-              message: Queued automation PR gating
-          - type: JenkinsJobTriggerArdana
-            parameters:
-              detail_logging: true
-              job_name: openstack-ardana
-              job_cmd: "../jenkins/jenkins-job-trigger"
-              job_parameters:
-                <<: *ardana_automation_parameters
       - type: FileMatch
         config:
           paths:


### PR DESCRIPTION
It misses the necessary parameters and the lockable resource. It
prevents triggering crowbar for a commit that would match both
FileMatches.

This partially reverts
4a23690202b2989c5590305ec78d158387ea094e
from https://github.com/SUSE-Cloud/automation/pull/2687