### PR TITLE
Fix automation-pr-trigger job default parameter

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -5,7 +5,7 @@
     parameters:
       - string:
           name: prurl
-          default: None
+          default:
           description: |
             Only process this one PR with mode "all", irrespective of the below
             mode selection.


### PR DESCRIPTION
None is not a magic key word for the empty string, use nothing instead.