### PR TITLE
SCRD-4983 openstack-ardana: reuse the workspace for pipeline jobs

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-bootstrap.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-bootstrap.yaml
@@ -134,5 +134,6 @@
             branches:
               - ${git_automation_branch}
             browser: auto
+            wipe-workspace: false
       script-path: ${jenkinsfile_path}
       lightweight-checkout: false

--- a/jenkins/ci.suse.de/openstack-ardana-tempest.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tempest.yaml
@@ -118,5 +118,6 @@
             branches:
               - ${git_automation_branch}
             browser: auto
+            wipe-workspace: false
       script-path: ${jenkinsfile_path}
       lightweight-checkout: false

--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -88,6 +88,7 @@
             branches:
               - ${git_automation_branch}
             browser: auto
+            wipe-workspace: false
       script-path: ${jenkinsfile_path}
       lightweight-checkout: false
 

--- a/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
@@ -167,5 +167,6 @@
             branches:
               - ${git_automation_branch}
             browser: auto
+            wipe-workspace: false
       script-path: ${jenkinsfile_path}
       lightweight-checkout: false

--- a/jenkins/ci.suse.de/openstack-ardana.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana.yaml
@@ -300,5 +300,6 @@
             branches:
               - ${git_automation_branch}
             browser: auto
+            wipe-workspace: false
       script-path: ${jenkinsfile_path}
       lightweight-checkout: false


### PR DESCRIPTION
Reuse the workspace on the master Jenkins node when checking
out the Jenkinsfile contents from the automation repo, to avoid
flooding GitHub with too many API requests.