### PR TITLE
openstack-ardana: support cloud9 repository paths

### DIFF
--- a/scripts/jenkins/ardana/ansible/ardana-update.yml
+++ b/scripts/jenkins/ardana/ansible/ardana-update.yml
@@ -19,6 +19,7 @@
 - name: Update ardana
   hosts: ardana-{{ qe_env }}
   remote_user: ardana
+  gather_facts: True
   vars:
     task: "update"
 

--- a/scripts/jenkins/ardana/ansible/bootstrap-deployer-vm.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-deployer-vm.yml
@@ -19,6 +19,7 @@
 - name: Bootstrap deployer VM
   hosts: ardana-{{ qe_env }}
   remote_user: root
+  gather_facts: True
   vars:
     task: "deploy"
 

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -20,6 +20,9 @@ cloudsource: stagingcloud8
 # The cloud release is encoded in the cloudsource value
 cloud_release: "cloud{{ cloudsource[-1] }}"
 
+suse_release: "suse-{{ ansible_distribution_version }}"
+local_repos_base_dir: "/srv/www/{{ suse_release }}/{{ ansible_architecture }}/repos"
+
 ntp_servers:
   - ntp.suse.de
   - ntp0.suse.de

--- a/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
@@ -51,7 +51,3 @@ repository_mnemonics:
     Cloud-Pool: SUSE-OpenStack-Cloud-9-Pool
     Cloud-Updates: SUSE-OpenStack-Cloud-9-Updates
     Cloud-Updates-test: SUSE-OpenStack-Cloud-9-Updates-test
-
-repository_path:
-  cloud8: /srv/www/suse-12.3
-  cloud9: /srv/www/suse-12.4

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -2,7 +2,7 @@
 - name: Initialize the Deployer
   hosts: ardana-{{ ardana_env }}
   remote_user: root
-  gather_facts: False
+  gather_facts: True
 
   vars_files:
     - vars/main.yml
@@ -63,8 +63,8 @@
   # it's just that it won't auto accept the Devel key, so do that now
   - name: Import Devel:Cloud:X key
     shell: |
-      kf={{ repository_path[cloud_release] }}/x86_64/repos/Cloud/repodata/repomd.xml.key
-      [ -r $kf ] || kf={{ repository_path[cloud_release] }}/x86_64/repos/Cloud/content.key
+      kf={{ local_repos_base_dir }}/Cloud/repodata/repomd.xml.key
+      [ -r $kf ] || kf={{ local_repos_base_dir }}/Cloud/content.key
       ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@{{ item }} "cat >/tmp/cloud.key && rpm --import /tmp/cloud.key && rm /tmp/cloud.key" < $kf
     with_items:
       - "{{ controller_mgmt_ips|default([]) }}"

--- a/scripts/jenkins/ardana/ansible/repositories.yml
+++ b/scripts/jenkins/ardana/ansible/repositories.yml
@@ -2,7 +2,7 @@
 - name: Setup repositories on the deployer node
   hosts: ardana-{{ ardana_env }}
   remote_user: root
-  gather_facts: False
+  gather_facts: True
 
   tasks:
 
@@ -33,19 +33,19 @@
 
   - name: Check cloud srv directory
     stat:
-      path: "{{ repository_path[cloud_release] }}/x86_64/repos/Cloud/"
+      path: "{{ local_repos_base_dir }}/Cloud/"
     register: cloud_srv_dir_stats
 
   - name: Check srv directories
     stat:
-      path: "{{ repository_path[cloud_release] }}/x86_64/repos/{{ item.key }}"
+      path: "{{ local_repos_base_dir }}/{{ item.key }}"
     register: srv_dir_stats
     with_dict: "{{ repos_dict }}"
 
   - name: Create srv directories
     file:
       state: directory
-      path: "{{ repository_path[cloud_release] }}/x86_64/repos/{{ item.item.key }}"
+      path: "{{ local_repos_base_dir }}/{{ item.item.key }}"
       mode: 0755
     when: not item.stat.exists
     with_items:
@@ -68,7 +68,7 @@
         --delay-updates
         --delete-delay
         'rsync://{{ clouddata_server }}/cloud/repos/x86_64/{{ cloud_repository }}/'
-        '{{ repository_path[cloud_release] }}/x86_64/repos/Cloud/'
+        '{{ local_repos_base_dir }}/Cloud/'
     when: not cloud_srv_dir_stats.stat.exists
 
   - name: Mount zypper repos
@@ -76,7 +76,7 @@
       state: mounted
       fstype: nfs
       opts: ro,nosuid,rsize=8192,wsize=8192,hard,intr,nolock,x-systemd.automount,noauto
-      name: "{{ repository_path[cloud_release] }}//x86_64/repos/{{ item.item.key }}"
+      name: "{{ local_repos_base_dir }}/{{ item.item.key }}"
       src: "{{ clouddata_server }}:/srv/nfs/repos/x86_64/{{ item.item.value }}"
     when: item.item.key != 'Cloud'
     with_items:
@@ -84,7 +84,7 @@
 
   - name: Add zypper repos
     zypper_repository:
-      repo: "{{ repository_path[cloud_release] }}/x86_64/repos/{{ item.item.key }}"
+      repo: "{{ local_repos_base_dir }}/{{ item.item.key }}"
       name: "{{ item.item.key }}"
     register: added_repos
     with_items:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/run_ardana_plays.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/run_ardana_plays.yml
@@ -151,12 +151,12 @@
     - not (ansible_openstack_rhel_plays | default({})) is failed
     - rhel_enabled
 
-- name: Import Devel:Cloud:8 key when source is devel[-staging]
+- name: Import Devel:Cloud:X key when cloudsource is staging or devel
   command: "ansible {{ item }} resources"
   args:
     chdir: "{{ ardana_scratch_path }}"
   with_items:
-    - "-m copy -a 'src=/srv/www/suse-12.3/x86_64/repos/Cloud/content.key dest=/tmp/'"
+    - "-m copy -a 'src={{ local_repos_base_dir }}/Cloud/content.key dest=/tmp/'"
     - "-b -a 'rpm --import /tmp/content.key'"
   when: "'devel' in cloud_source"
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_update/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_update/defaults/main.yml
@@ -27,7 +27,6 @@ cloud_maint_updates_list: "{{ cloud_maint_updates.split(',') if cloud_maint_upda
 sles_maint_updates_list: "{{ sles_maint_updates.split(',') if sles_maint_updates is defined and sles_maint_updates | length > 0 else [] }}"
 
 update_nfs_repo_server: "{{ cloud_media_server }}:/dist/ibs/SUSE:/Maintenance:/"
-local_repos_base_dir: "/srv/www/suse-12.3/x86_64/repos"
 
 ardana_openstack_path: "~/openstack/ardana/ansible"
 ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"

--- a/scripts/jenkins/ardana/ansible/roles/bootstrap_deployer/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/bootstrap_deployer/defaults/main.yml
@@ -50,4 +50,3 @@ sles_maint_updates_list: "{{ sles_maint_updates.split(',') if sles_maint_updates
 
 update_nfs_repo_server: "{{ cloud_media_server }}:/dist/ibs/SUSE:/Maintenance:/"
 nfs_repo_server: "{{ clouddata_server }}:/srv/nfs/repos/x86_64"
-local_repos_base_dir: "/srv/www/suse-12.3/x86_64/repos"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
@@ -22,9 +22,14 @@
 
 - include_tasks: set_announcement.yml
 
+- name: Find cloud build file
+  shell: |
+    find /srv/www/*/x86_64/repos/*Cloud*/ -name build
+  register: cloud_build_file
+
 - name: Get media build version
   slurp:
-    src: "/srv/www/suse-12.3/x86_64/repos/Cloud/media.1/build"
+    src: "{{ cloud_build_file.stdout }}"
   register: cloud_media_build_version
   failed_when: false
   when:

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: Get build version
   slurp:
-    src: "/srv/www/suse-12.3/x86_64/repos/Cloud/media.1/build"
+    src: "{{ local_repos_base_dir }}/Cloud/media.1/build"
   register: build_version
 
 - name: Send results to OpenStack-Health

--- a/scripts/jenkins/ardana/ansible/run-ardana-deploy-plays.yml
+++ b/scripts/jenkins/ardana/ansible/run-ardana-deploy-plays.yml
@@ -19,6 +19,7 @@
 - name: Drop intput model and run Ardana playbooks
   hosts: ardana-{{ qe_env }}
   remote_user: ardana
+  gather_facts: True
   vars:
     task: "deploy"
 

--- a/scripts/jenkins/ardana/ansible/run-ardana-qe-tests.yml
+++ b/scripts/jenkins/ardana/ansible/run-ardana-qe-tests.yml
@@ -19,6 +19,7 @@
 - name: Run '{{ test_name }}' test and collect results
   hosts: ardana-{{ qe_env }}
   remote_user: ardana
+  gather_facts: True
   vars:
     task: "ardana-qe-tests"
 

--- a/scripts/jenkins/ardana/ansible/run-ardana-tempest.yml
+++ b/scripts/jenkins/ardana/ansible/run-ardana-tempest.yml
@@ -19,6 +19,7 @@
 - name: Run ardana tempest and collect results
   hosts: ardana-{{ qe_env }}
   remote_user: ardana
+  gather_facts: True
   vars:
     task: "tempest"
 


### PR DESCRIPTION
Adds support for differentiated cloud8/cloud9 root
repository path. Previously, the root path was hardcoded
to `/srv/www/suse-12.3`, which didn't match the SLES12_SP4
based path used for cloud9.