### PR TITLE
Add CI jobs for Devel:Cloud:9:Rocky

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -25,6 +25,9 @@
         - 'cloud-mkcloud{version}-job-magnum-{arch}'
         - 'cloud-mkcloud{version}-job-monasca-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
+        # temporary jobs for testing Devel:Cloud:9:Rocky:
+        - 'cloud-mkcloud{version}-job-2nodes-rocky-{arch}'
+        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-rocky-{arch}'
 - project:
     name: cloud-mkcloud9-ha-x86_64
     disabled: false
@@ -45,6 +48,8 @@
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-agent-{arch}'
+        # temporary job for testing Devel:Cloud:9:Rocky:
+        - 'cloud-mkcloud{version}-job-ha-rocky-{arch}'
 - project:
     name: cloud-mkcloud9-tempestfull-x86_64
     disabled: false

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-rocky-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-2nodes-rocky-template.yaml
@@ -1,0 +1,29 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-2nodes-rocky-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: 'H 2 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=rockycloud{version}
+            nodenumber=2
+            mkcloudtarget=all_batch
+            tempestoptions={tempestoptions}
+            label={label}
+            scenario=cloud{version}-2nodes-default.yml
+            want_node_aliases=controller=1,compute-kvm=1
+            job_name=cloud-mkcloud{version}-job-2nodes-rocky-{arch}
+

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-rocky-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-rocky-template.yaml
@@ -1,0 +1,28 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-4nodes-linuxbridge-rocky-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: 'H 2 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=rockycloud{version}
+            nodenumber=4
+            networkingplugin=linuxbridge
+            crowbar_networkingmode=team
+            tempestoptions={tempestoptions}
+            mkcloudtarget=all
+            label={label}
+            job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-rocky-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-rocky-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-rocky-template.yaml
@@ -1,0 +1,31 @@
+- job-template:
+    name: 'cloud-mkcloud{version}-job-ha-rocky-{arch}'
+    node: cloud-trigger
+    disabled: '{obj:disabled}'
+
+    triggers:
+      - timed: '11 2 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 7
+
+    builders:
+      - trigger-builds:
+        - project: openstack-mkcloud
+          condition: SUCCESS
+          block: true
+          current-parameters: true
+          predefined-parameters: |
+            TESTHEAD=1
+            cloudsource=rockycloud{version}
+            nodenumber={nodenumber}
+            networkingmode=vxlan
+            tempestoptions={tempestoptions}
+            crowbar_networkingmode=team
+            storage_method={storage_method_ha}
+            hacloud=1
+            want_all_ssl={want_all_ssl}
+            mkcloudtarget=all_noreboot
+            label={label}
+            job_name=cloud-mkcloud{version}-job-ha-rocky-{arch}


### PR DESCRIPTION
These CI jobs let us test the Devel:Cloud:9:Rocky packages for defects
introduced by the switch to upstream's stable/rocky branch without needlessly
breaking the regular Devel:Cloud:9 CI (i.e. Crowbar changes will still be able
to pass CI without additional CI breakage due to Rocky related changes). Once
we've gotten these jobs green, we can introduce the stable/rocky packages to
Devel:Cloud:9 and revert this commit.