### PR TITLE
SCRD-4999 openstack-ardana: gerrit top-level pipeline job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -63,15 +63,15 @@
 
 
 - project:
-    name: cloud-ardana9-std-min-gerrit-x86_64
+    name: cloud-ardana9-gerrit-x86_64
     disabled: false
     version: 9
     arch: x86_64
+    build_pool: cloud-ardana-gerrit-slot
     model: std-min
+    tempest_run_filter: ci
     develproject: Devel:Cloud:9:Staging
     repository: SLE_12_SP4
     branch: master
-    tempest_run_filter: ci
-    build_pool: cloud-ardana-gerrit-slot
     jobs:
-        - 'cloud-ardana{version}-job-{model}-gerrit-{arch}'
+        - 'cloud-ardana{version}-job-gerrit-{arch}'

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -1,0 +1,49 @@
+/**
+ * The openstack-ardana-gerrit Jenkins Pipeline
+ */
+
+pipeline {
+  // skip the default checkout, because we want to use a custom path
+  options {
+    skipDefaultCheckout()
+  }
+
+  agent {
+    node {
+      label 'cloud-trigger'
+    }
+  }
+
+  stages {
+
+    stage('validate commit message') {
+      steps {
+        script {
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${gerrit_change_ids}"
+        }
+        echo 'TBD: trigger commit message validator job...'
+      }
+    }
+
+    stage('integration test') {
+      steps {
+        lock(resource: null, label: "$build_pool", variable: 'ardana_env', quantity: 1) {
+          script {
+            def slaveJob = build job: 'openstack-ardana', parameters: [
+              string(name: 'ardana_env', value: "$ardana_env"),
+              string(name: 'cleanup', value: "on success"),
+              string(name: 'gerrit_change_ids', value: "$gerrit_change_ids"),
+              string(name: 'git_automation_repo', value: "$git_automation_repo"),
+              string(name: 'git_automation_branch', value: "$git_automation_branch"),
+              string(name: 'model', value: "$model"),
+              string(name: 'cloudsource', value: "$cloudsource"),
+              string(name: 'tempest_run_filter', value: "$tempest_run_filter"),
+              string(name: 'develproject', value: "$develproject"),
+              string(name: 'repository', value: "$repository")
+            ], propagate: true, wait: true
+          }
+        }
+      }
+    }
+  }
+}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -1,10 +1,6 @@
 - job-template:
-    name: 'cloud-ardana{version}-job-{model}-gerrit-{arch}'
-    properties:
-      - lockable-resources:
-          label: "{build_pool}"
-          var-name: "ardana_env"
-          number: 1
+    name: 'cloud-ardana{version}-job-gerrit-{arch}'
+    project-type: pipeline
     concurrent: true
     node: cloud-trigger
     disabled: '{obj:disabled}'
@@ -78,18 +74,83 @@
       numToKeep: -1
       daysToKeep: 14
 
-    builders:
-      - trigger-builds:
-        - project: openstack-ardana
-          condition: SUCCESS
-          block: true
-          current-parameters: true
-          predefined-parameters: |
-            ardana_env=${{ardana_env}}
-            cleanup=on success
-            gerrit_change_ids=${{GERRIT_CHANGE_NUMBER}}
-            develproject={develproject}
-            repository={repository}
-            model={model}
-            cloudsource=stagingcloud{version}
-            tempest_run_filter={tempest_run_filter}
+    parameters:
+
+      - string:
+          name: git_automation_repo
+          default: https://github.com/SUSE-Cloud/automation.git
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: master
+          description: >-
+            The git automation branch
+
+      - string:
+          name: jenkinsfile_path
+          default: jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+          description: >-
+            The location of the Jenkinsfile defining the pipeline
+
+      - string:
+          name: build_pool
+          default: '{build_pool}'
+          description: >-
+            The lockable resource pool (label) to use for jobs triggered by this pipeline
+
+      - string:
+          name: gerrit_change_ids
+          default: '${{GERRIT_CHANGE_NUMBER}}'
+          description: >-
+            A comma separated list of IDs for changes in gerrit.suse.provo.cloud
+            to test.
+
+      - string:
+          name: model
+          default: '{model}'
+          description: >-
+            The Input Model to use from the input model git repository / branch / path.
+
+      - string:
+          name: cloudsource
+          default: 'stagingcloud{version}'
+          description: >-
+            The cloud repository (from provo-clouddata) to be used for testing.
+            This value can take the following form:
+
+               stagingcloud<X> (Devel:Cloud:X:Staging)
+               develcloud<X> (Devel:Cloud:X)
+               GM<X> (official GM)
+
+      - string:
+          name: tempest_run_filter
+          default: '{tempest_run_filter}'
+          description: >-
+            Name of the filter file to use for tempest. Use an empty value to
+            skip running tempest.
+
+      - string:
+          name: develproject
+          default: '{develproject}'
+          description: >-
+            Project in IBS to link against when creating a test project for a
+            change proposal.
+
+      - string:
+          name: repository
+          default: '{repository}'
+          description: >-
+            Name of the repository in IBS against which to build the test packages.
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${{git_automation_repo}}
+            branches:
+              - ${{git_automation_branch}}
+            browser: auto
+            wipe-workspace: false
+      script-path: ${{jenkinsfile_path}}
+      lightweight-checkout: false


### PR DESCRIPTION
Implements a top-level pipeline job for Gerrit for Ardana:
 - calls the openstack-ardana pipeline job as a downstream job
 - is a placeholder for all upcoming validation stages to be performed
 on a single Gerrit change:
    - commit validator
    - unit-testing targeting specific repositories
    - other tests
