### PR TITLE
Disable Trove proposal for Cloud 9 jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9-suse.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9-suse.yaml
@@ -32,6 +32,7 @@
                 mkcloudtarget=all_batch
                 scenario=cloud9-2nodes-default.yml
                 want_node_aliases=controller=1,compute-kvm=1
+                want_trove_proposal=0
                 label=openstack-mkcloud-SLE12-x86_64
                 job_name=susecloud9: OVS
             - name: openstack-mkcloud
@@ -43,6 +44,7 @@
                 nodenumber=4
                 networkingplugin=linuxbridge
                 mkcloudtarget=all
+                want_trove_proposal=0
                 label=openstack-mkcloud-SLE12-x86_64
                 job_name=susecloud9: linuxbridge
       - multijob:
@@ -61,5 +63,6 @@
                 storage_method=swift
                 hacloud=1
                 mkcloudtarget=all_noreboot
+                want_trove_proposal=0
                 label=openstack-mkcloud-SLE12-x86_64
                 job_name=susecloud9: HA vxlan

--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -2,6 +2,7 @@
     name: cloud-mkcloud9-gating
     version: 9
     previous_version: 8
+    want_trove_proposal: 0
     label: cloud-trigger
     jobs:
         - 'cloud-mkcloud{version}-gating'
@@ -14,6 +15,7 @@
     tempestoptions: --smoke
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: mysql
+    want_trove_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
@@ -38,6 +40,7 @@
     storage_method_ha: swift
     database_engine: mysql
     want_all_ssl: 1
+    want_trove_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
@@ -53,6 +56,7 @@
     arch: x86_64
     tempestoptions: --parallel
     label: openstack-mkcloud-SLE12-x86_64
+    want_trove_proposal: 0
     jobs:
          - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'
          - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}'
@@ -63,6 +67,7 @@
     arch: x86_64
     label: openstack-mkcloud-SLE12-SP2-x86_64
     tempestoptions: --smoke
+    want_trove_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-uefi-{arch}'
 - project:
@@ -73,6 +78,7 @@
     arch: aarch64
     label: openstack-mkcloud-SLE12-{arch}
     tempestoptions: --smoke
+    want_trove_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -385,6 +385,11 @@
           default: '1'
           description: set to 0 to not deploy aodh
 
+      - string:
+          name: want_trove_proposal
+          default:
+          description: set to 0 to not deploy trove
+
       ################################################
       # misc
 


### PR DESCRIPTION
By default, the Trove proposal is enabled in mkcloud. Since we
are planning to entirely remove Trove in Cloud 9, this commit
disables Trove deployment as a first step. This should also
fix the failing Trove tests currently plaguing HA jobs by not
running them anymore.