### PR TITLE
Use -x with bash for Jenkins scripts

### DIFF
--- a/jenkins/ci.opensuse.org/macros.yaml
+++ b/jenkins/ci.opensuse.org/macros.yaml
@@ -2,7 +2,7 @@
     name: update-automation
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           [ -e ~/bin/update_automation ] || mkdir -p ~/bin && wget -O ~/bin/update_automation https://raw.github.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation && chmod a+x ~/bin/update_automation
           # fetch the latest automation updates
           update_automation
@@ -12,7 +12,7 @@
     name: gerrit-git-prep
     builders:
       - shell: |
-          #!/bin/bash -e
+          #!/bin/bash -xe
 
           #
           # NOTE(toabctl): The script is basically a copy of:

--- a/jenkins/ci.opensuse.org/openstack-submit.yaml
+++ b/jenkins/ci.opensuse.org/openstack-submit.yaml
@@ -10,7 +10,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           case $openstack_project in
             Master)
               echo "Master project, skip job, do not fail (e.g. for Master project)"

--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
@@ -10,10 +10,10 @@
     builders:
       - gerrit-git-prep
       - shell: |
-          #!/bin/bash -e
+          #!/bin/bash -xe
           rpm -qa|grep '\(renderspec\|pymod2pkg\)'
 
-          set -eux
+          set -u
 
           osc_timed="timeout 20m osc"
 

--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-update.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-update.yaml
@@ -8,7 +8,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           export OSCAPI="https://api.opensuse.org"
           export OBS_PROJECT="Cloud:OpenStack:Upstream:{release}"
           export RELEASE="{release}"

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-rally-test.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-rally-test.yaml
@@ -65,8 +65,7 @@
           condition-expression: ${ENV,var="run_rally_test"}
           steps: 
           - shell: |
-              #!/bin/bash
-              set -x
+              #!/bin/bash -x
               # Create artifacts dir
               export artifacts_dir=$WORKSPACE/.artifacts
               rm -rf $artifacts_dir
@@ -101,8 +100,7 @@
           condition-expression: ${ENV,var="run_failover_test"}
           steps:
           - shell: |
-              #!/bin/bash
-              set -x
+              #!/bin/bash -x
               export artifacts_dir=$WORKSPACE/.artifacts
               rm -rf $artifacts_dir
               mkdir -p $artifacts_dir

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -160,7 +160,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1b.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1b.yaml
@@ -148,7 +148,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           export admin=crowbar$hw_number;
           export cloud=qa$hw_number;
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -176,7 +176,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
           netapp_server=$netapp_server

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2c.yaml
@@ -159,7 +159,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
           netapp_server=$netapp_server

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-3.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-3.yaml
@@ -152,7 +152,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           export admin=crowbar$hw_number;
           export cloud=qa$hw_number;
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-6a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-6a.yaml
@@ -142,7 +142,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8a.yaml
@@ -150,7 +150,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8b.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8b.yaml
@@ -155,7 +155,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-9.yaml
@@ -144,7 +144,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-cct.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-cct.yaml
@@ -70,7 +70,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           set +e;
           admin=crowbar$hw_number;
           cloud=qa$hw_number;

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-horizon-tests.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-horizon-tests.yaml
@@ -40,7 +40,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number;
           cloud=qa$hw_number;
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-pacemaker-cts.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-pacemaker-cts.yaml
@@ -41,7 +41,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number
           cloud=qa$hw_number
           

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-defcore.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-defcore.yaml
@@ -39,7 +39,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number;
           cloud=qa$hw_number;
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-full.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-full.yaml
@@ -44,7 +44,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number;
           cloud=qa$hw_number;
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-smoke.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-tempest-smoke.yaml
@@ -52,7 +52,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number;
           cloud=qa$hw_number;
 

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-upgrade-ui.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-test-upgrade-ui.yaml
@@ -65,7 +65,7 @@
 
     builders:
       - shell: |
-          #!/bin/bash
+          #!/bin/bash -x
           admin=crowbar$hw_number;
           cloud=qa$hw_number;
           result=0

--- a/scripts/github_pr/suse.cloud-specs.helper.sh
+++ b/scripts/github_pr/suse.cloud-specs.helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 #
 # small helper to run tox on a PR with github_pr

--- a/scripts/jenkins/ardana/ansible/jenkins/ardana-deploy.yml
+++ b/scripts/jenkins/ardana/ansible/jenkins/ardana-deploy.yml
@@ -113,7 +113,7 @@
           description: Notify RocketChat when deployment starts/finishes.
     builders:
       - shell: |-
-          #!/bin/bash
+          #!/bin/bash -x
 
           export ANSIBLE_FORCE_COLOR=true
 

--- a/scripts/jenkins/ardana/ansible/jenkins/ardana-iverify.yml
+++ b/scripts/jenkins/ardana/ansible/jenkins/ardana-iverify.yml
@@ -57,7 +57,7 @@
           name: rc_notify
     builders:
       - shell: |-
-          #!/bin/bash
+          #!/bin/bash -x
 
           export ANSIBLE_FORCE_COLOR=true
           ansible-playbook run-ardana-iverify.yml -e "qe_env=$qe_env rc_notify=$rc_notify"

--- a/scripts/jenkins/ardana/ansible/jenkins/ardana-ses-integration.yml
+++ b/scripts/jenkins/ardana/ansible/jenkins/ardana-ses-integration.yml
@@ -62,7 +62,7 @@
           name: rc_notify
     builders:
       - shell: |-
-          #!/bin/bash
+          #!/bin/bash -x
 
           export ANSIBLE_FORCE_COLOR=true
           

--- a/scripts/jenkins/ardana/ansible/jenkins/ardana-tempest.yml
+++ b/scripts/jenkins/ardana/ansible/jenkins/ardana-tempest.yml
@@ -82,7 +82,7 @@
           name: rc_notify
     builders:
       - shell: |-
-          #!/bin/bash
+          #!/bin/bash -x
 
           export ANSIBLE_FORCE_COLOR=true
           

--- a/scripts/jenkins/ardana/ansible/jenkins/ardana-update.yml
+++ b/scripts/jenkins/ardana/ansible/jenkins/ardana-update.yml
@@ -65,7 +65,7 @@
           name: rc_notify
     builders:
       - shell: |-
-          #!/bin/bash
+          #!/bin/bash -x
 
           export ANSIBLE_FORCE_COLOR=true
           

--- a/scripts/jenkins/ardana/pr-failure.sh
+++ b/scripts/jenkins/ardana/pr-failure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 source scripts/jenkins/github-pr/parse.rc
 github_context=suse/ardana

--- a/scripts/jenkins/ardana/pr-success.sh
+++ b/scripts/jenkins/ardana/pr-success.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 source scripts/jenkins/github-pr/parse.rc
 github_context=suse/ardana

--- a/scripts/jenkins/ardana/pr-update.sh
+++ b/scripts/jenkins/ardana/pr-update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 source scripts/jenkins/github-pr/parse.rc
 github_context=suse/ardana

--- a/scripts/jenkins/track-upstream-internal.sh
+++ b/scripts/jenkins/track-upstream-internal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 PROJECTSOURCE=IBS/${project}
 
 # needs .oscrc with user,pass,trusted_prj

--- a/scripts/jenkins/track-upstream.sh
+++ b/scripts/jenkins/track-upstream.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 PROJECTSOURCE=OBS/${project}
 COMPONENT=$component
 


### PR DESCRIPTION
Its the default in our Jenkins if you don't specify a different
interpreter via shebang. This fixes those cases and stand alone files.