### PR TITLE
Remove duplication of automationrepo environment

### DIFF
--- a/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
+++ b/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
@@ -8,11 +8,6 @@ mkdir -p $artifacts_dir
 touch $artifacts_dir/.ignore
 export log_dir=$artifacts_dir/mkcloud_log
 
-if [ -d $WORKSPACE/automation-git ] ; then
-    # If we're testing a pull request, use our custom checkout
-    automationrepo=$WORKSPACE/automation-git
-fi
-
 jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
 export ghprrepo=~/github.com/openSUSE/github-pr
 export ghpr=${ghprrepo}/github_pr.rb


### PR DESCRIPTION
The job executing the script already sets this.

This was omitted from 10eb9b5559100cdb65b3c59e1671026113f8276f to not
trigger the broken job that it fixed.