### PR TITLE
manila: by default turn off manila input-model change

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -40,7 +40,7 @@ service_component_groups:
     - neutron-client
     - nova-client
     - swift-client
-    - manila-client
+    #- manila-client
   CORE:
     - ntp-server
     - ip-cluster
@@ -83,7 +83,7 @@ service_component_groups:
     - octavia-api
     - octavia-health-manager
     - ops-console-web
-    - manila-api
+    #- manila-api
   DBMQ:
     - mysql
     - rabbitmq
@@ -131,7 +131,7 @@ service_component_groups:
     - neutron-metadata-agent
     - neutron-openvswitch-agent
     - neutron-lbaasv2-agent
-    - manila-share
+    #- manila-share
 
 
 


### PR DESCRIPTION
Commented out manila input-model change.

**Reference**: https://github.com/SUSE/cloud-specs/blob/master/specs/cloud8/manila.rst (Manila Spec)
_Manila will NOT be included by default in green field installs and reference input models. Instead, manual steps will be documented for those wishing to enable Manila in their configuration post-install._