### PR TITLE
Test devstack with IPv4 and IPv6

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-devstack.yaml
+++ b/jenkins/ci.opensuse.org/openstack-devstack.yaml
@@ -1,5 +1,14 @@
-- job:
-    name: 'openstack-devstack'
+- project:
+    name: openstack-devstack
+    jobs:
+      - 'openstack-devstack-{ipversion}':
+          ipversion: ipv4
+      - 'openstack-devstack-{ipversion}':
+          ipversion: ipv6
+
+- job-template:
+    name: 'openstack-devstack-{ipversion}'
+    id: 'openstack-devstack-{ipversion}'
     node: cloud-cleanvm
     description: |
       Job to periodically run devstack against the latest openSUSE release.
@@ -30,7 +39,7 @@
           set +ex
 
           scp ~/github.com/SUSE-Cloud/automation/scripts/jenkins/qa_devstack.sh root@cleanvm:
-          ssh root@cleanvm "bash -x ~/qa_devstack.sh"
+          ssh root@cleanvm "bash -x ~/qa_devstack.sh {ipversion}"
           ret=$?
           if [ "$ret" != 0 ] ; then
               virsh shutdown cleanvm
@@ -39,7 +48,7 @@
               virsh destroy cleanvm
               find /mnt/cleanvmbackup -mtime +5 -type f | xargs --no-run-if-empty rm
               # backup /dev/vg0/cleanvm disk image
-              file=/mnt/cleanvmbackup/${BUILD_NUMBER}-devstack.raw.gz
+              file=/mnt/cleanvmbackup/$BUILD_NUMBER-devstack.raw.gz
               time gzip -c1 /dev/vg0/cleanvm > $file
               du $file
               exit 1

--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# We can pass an argument to the function to configure ipv6
+# Use ipv4 by default so we are backwards compatible
+SVC_IP_VERSION=4
+[[ $1 == "ipv6" ]] && SVC_IP_VERSION=6
+
 ##########################################################################
 # Setup devstack and run Tempest
 ##########################################################################
@@ -183,7 +188,11 @@ VERBOSE_NO_TIMESTAMP=True
 
 NOVNC_FROM_PACKAGE=True
 RECLONE=yes
+
+IP_VERSION=4+6
+SERVICE_IP_VERSION=$SVC_IP_VERSION
 HOST_IP=127.0.0.1
+HOST_IPV6=::1
 LOGFILE=stack.sh.log
 LOGDAYS=1
 SCREEN_LOGDIR=/opt/stack/logs


### PR DESCRIPTION
IPv6 is required for the next cloud versions and we are still not
testing it.

This patch creates two jobs, one to deploy devstack with ipv4 and
other with an ipv6 control planes, and run tempest on them.

Devstack doesn't support dual stack in the control plane.

It also enables ipv4 and ipv6 for the dataplane in neutron

Ref:
https://github.com/SUSE/cloud-specs/pull/249
https://github.com/SUSE/cloud-specs/pull/129