### PR TITLE
Adding SES ansible plays for configuring single node SES for ccp

### DIFF
--- a/ccp/ses-ansible/README.md
+++ b/ccp/ses-ansible/README.md
@@ -1,0 +1,29 @@
+ses-ansible
+===========
+
+Playbook and role for deploying SUSE Enterprise Storage 5 (SES 5) on a target
+node.
+
+## Usage:
+
+With the inventory already in place containing one node named `ses`, run the
+playbook:
+
+```bash
+cat inventory
+ses ansible_ssh_host=192.168.10.11 ansible_ssh_user=root
+
+ansible-playbook ses-install.yml
+```
+
+During the installation a system reboot may occur, in that case, after
+rebooting rerun the playbook.
+
+## Notes:
+
+* For now it only supports a single node deployment, this is intended only for
+QA/tests/development.
+* By default all disks, besides the OS disk, will be zapped and used as OSD. If
+3 or more OSD disks are present, ceph will be configured with `default pool replicas = min(3, <number of OSDs>)`,
+otherwise `default pool replicas = 1`.
+* Take a look at `roles/ses/defaults/main.yml` and `roles/setup_ses_configs/defaults/main.yml` for variables that can be overriden.

--- a/ccp/ses-ansible/inventory
+++ b/ccp/ses-ansible/inventory
@@ -1,0 +1,1 @@
+ses ansible_ssh_host=192.168.122.61 ansible_ssh_user=root

--- a/ccp/ses-ansible/roles/ses/defaults/main.yml
+++ b/ccp/ses-ansible/roles/ses/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+ses_version: 5
+ses_deepsea_minions: "*"
+ses_zap_disks: False
+ses_repo_server: "http://provo-clouddata.cloud.suse.de"
+
+ses_osd_pool_default_pg_num: 64
+radosgw_keystone: False
+
+# Set DEV_ENV true if need to setup cluster with less than 3 nodes
+ses_dev_env_setting: True
+
+# OpenStack configs
+
+# Flag to indicate whether create pools/keys for openstack services or not?
+ses_openstack_config: False
+ses_openstack_glance_pool:
+  name: glance
+  pg_num: "{{ ses_osd_pool_default_pg_num }}"
+ses_openstack_cinder_pool:
+  name: cinder
+  pg_num: "{{ ses_osd_pool_default_pg_num }}"
+ses_openstack_nova_pool:
+  name: nova
+  pg_num: "{{ ses_osd_pool_default_pg_num }}"
+ses_openstack_cinder_backup_pool:
+  name: backups
+  pg_num: "{{ ses_osd_pool_default_pg_num }}"
+ses_openstack_pools:
+  - "{{ ses_openstack_glance_pool }}"
+  - "{{ ses_openstack_cinder_pool }}"
+  - "{{ ses_openstack_nova_pool }}"
+  - "{{ ses_openstack_cinder_backup_pool }}"
+ses_openstack_keys:
+  - { name: client.glance, key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_glance_pool.name }}", mode: "0600", acls: [] }
+  - { name: client.cinder, key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_pool.name }}, allow rwx pool={{ ses_openstack_nova_pool.name }}, allow rwx pool={{ ses_openstack_glance_pool.name }}", mode: "0600", acls: []  }
+  - { name: client.cinder_backup, key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_backup_pool.name }}", mode: "0600", acls: [] }

--- a/ccp/ses-ansible/roles/ses/files/policy.cfg
+++ b/ccp/ses-ansible/roles/ses/files/policy.cfg
@@ -1,0 +1,38 @@
+# {{ ansible_managed }}
+
+## Cluster Assignment
+cluster-ceph/cluster/*.sls
+
+## Roles
+# ADMIN
+role-master/cluster/*.sls
+role-admin/cluster/*.sls
+
+# MON
+role-mon/cluster/*.sls
+
+# MGR (mgrs are usually colocated with mons)
+role-mgr/cluster/*.sls
+
+# MDS
+role-mds/cluster/*.sls
+
+# IGW
+role-igw/cluster/*.sls
+
+# RGW
+role-rgw/cluster/*.sls
+
+# NFS
+role-ganesha/cluster/*.sls
+
+# openATTIC
+role-openattic/cluster/*.sls
+
+# COMMON
+config/stack/default/global.yml
+config/stack/default/ceph/cluster.yml
+
+## Profiles
+profile-default/cluster/*.sls
+profile-default/stack/default/ceph/minions/*.yml

--- a/ccp/ses-ansible/roles/ses/handlers/main.yml
+++ b/ccp/ses-ansible/roles/ses/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Restart and enable salt-minion
+  service:
+    name: salt-minion
+    state: restarted
+    enabled: yes
+
+- name: Restart and enable salt-master
+  service:
+    name: salt-master
+    state: restarted
+    enabled: yes

--- a/ccp/ses-ansible/roles/ses/tasks/deepsea_setup.yml
+++ b/ccp/ses-ansible/roles/ses/tasks/deepsea_setup.yml
@@ -1,0 +1,104 @@
+---
+
+- name: Install deepsea
+  package:
+    name: "deepsea"
+
+- name: Drop deepsea config(s)
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: "master_minion.sls.j2"
+      dest:  "/srv/pillar/ceph/master_minion.sls"
+    - src: "deepsea_minions.sls.j2"
+      dest: "/srv/pillar/ceph/deepsea_minions.sls"
+
+- name: "Ensure DEV_ENV setting in globals"
+  lineinfile:
+    dest: "/srv/pillar/ceph/stack/global.yml"
+    state: present
+    create: yes
+    regexp: "^DEV_ENV"
+    line: "DEV_ENV: {{ ses_dev_env_setting | lower }}"
+    owner: salt
+    group: salt
+    mode: 0644
+
+- name: Run stage 0 - prepare
+  command: "salt-run state.orch ceph.stage.prep"
+  register: stage0
+  changed_when: false
+  ignore_errors: yes
+
+- name: Show stage 0 (salt-run state.orch ceph.stage.prep) results
+  debug:
+    var: stage0.stdout_lines
+    verbosity: 1
+
+- name: Run stage 1 - discovery
+  command: "salt-run state.orch ceph.stage.discovery"
+  register: stage1
+  changed_when: false
+
+- name: show stage 1 (salt-run state.orch ceph.stage.discovery) results
+  debug:
+    var: stage1.stdout_lines
+    verbosity: 1
+
+- name: Drop policy file
+  copy:
+    src: "policy.cfg"
+    dest: "/srv/pillar/ceph/proposals/policy.cfg"
+
+- name: Drop config for single node deployment
+  template:
+    src: "global.conf.j2"
+    dest: "/srv/salt/ceph/configuration/files/ceph.conf.d/global.conf"
+
+- name: Chanage RGW default port
+  replace:
+    dest: "/srv/salt/ceph/configuration/files/rgw.conf"
+    regexp: 'port=80"$'
+    replace: 'port=8080"'
+
+- name: Run stage 2 - configure
+  command: "salt-run state.orch ceph.stage.configure"
+  register: stage2
+  changed_when: false
+
+- name: Show stage 2 (salt-run state.orch ceph.stage.configure) results
+  debug:
+    var: stage2.stdout_lines
+    verbosity: 1
+
+- name: Run stage 3 - deployment
+  environment:
+    DEV_ENV: true
+  command: "salt-run state.orch ceph.stage.deploy"
+  register: stage3
+  changed_when: false
+
+- name: show stage 3 (salt-run state.orch ceph.stage.deploy) results
+  debug:
+    var: stage3.stdout_lines
+    verbosity: 1
+
+- name: Run stage 4 - services
+  command: "salt-run state.orch ceph.stage.services"
+  register: stage4
+  changed_when: false
+  failed_when:
+    - stage4.rc != 0
+    - stage4.stdout.find('lrbd has been enabled, and is dead') == -1 # Do not fail on known cosmetic issue https://www.suse.com/support/kb/doc/?id=7018668
+
+- name: Show stage 4 (salt-run state.orch ceph.stage.services) results
+  debug:
+    var: stage4.stdout_lines
+    verbosity: 1
+
+- name: run iscsi workaround
+  command: salt-run state.orch ceph.stage.iscsi
+  when:
+    - stage4.stdout.find('lrbd has been enabled, and is dead') != -1  # Implement workaround of the cosmetic issue https://www.suse.com/support/kb/doc/?id=7018668
+

--- a/ccp/ses-ansible/roles/ses/tasks/main.yml
+++ b/ccp/ses-ansible/roles/ses/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+
+- import_tasks: pre_setup.yml
+
+- import_tasks: zap_disks.yml
+  when: ses_zap_disks
+
+- import_tasks: salt_setup.yml
+
+- import_tasks: deepsea_setup.yml
+
+- import_tasks: openstack_config.yml
+  when: ses_openstack_config
+  tags:
+    - openstack_config

--- a/ccp/ses-ansible/roles/ses/tasks/openstack_config.yml
+++ b/ccp/ses-ansible/roles/ses/tasks/openstack_config.yml
@@ -1,0 +1,46 @@
+---
+- name: Create openstack pool(s)
+  command: "ceph osd pool create {{ item.name }} {{ item.pg_num }}"
+  with_items: "{{ ses_openstack_pools | unique }}"
+  changed_when: false
+  failed_when: false
+
+- name: Associate openstack pool(s) to application rbd
+  command: "ceph osd pool application enable {{ item.name }} rbd"
+  with_items: "{{ ses_openstack_pools | unique }}"
+  changed_when: false
+
+- name: Create openstack key(s)
+  shell: "ceph-authtool -C /etc/ceph/ceph.{{ item.name }}.keyring --name {{ item.name }} --add-key {{ item.key }} --cap mon \"{{ item.mon_cap|default('') }}\" --cap osd \"{{ item.osd_cap|default('') }}\" --cap mds \"{{ item.mds_cap|default('') }}\""
+  args:
+    creates: "/etc/ceph/ceph.{{ item.name }}.keyring"
+  with_items: "{{ ses_openstack_keys }}"
+  changed_when: false
+
+- name: Check if openstack key(s) already exist(s)
+  command: "ceph auth get {{ item.name }}"
+  changed_when: false
+  failed_when: false
+  with_items: "{{ ses_openstack_keys }}"
+  register: openstack_key_exist
+
+- name: Add openstack key(s) to ceph
+  command: "ceph auth import -i /etc/ceph/ceph.{{ item.0.name }}.keyring"
+  changed_when: false
+  with_together:
+    - "{{ ses_openstack_keys }}"
+    - "{{ openstack_key_exist.results }}"
+  when: item.1.rc != 0
+
+- name: Get ses conf options
+  shell: grep 'fsid\|mon_host\|mon_initial\|network' /etc/ceph/ceph.conf | awk '{ print $3}'
+  register: conf_options
+
+- name: Get ceph conf/key file contents
+  slurp:
+    src: "/etc/ceph/{{ item }}"
+  with_items:
+    - "ceph.client.cinder.keyring"
+    - "ceph.client.cinder_backup.keyring"
+    - "ceph.client.glance.keyring"
+  register: ceph_files

--- a/ccp/ses-ansible/roles/ses/tasks/pre_setup.yml
+++ b/ccp/ses-ansible/roles/ses/tasks/pre_setup.yml
@@ -1,0 +1,42 @@
+---
+
+- name: "Ensure host in /etc/hosts"
+  lineinfile:
+    dest: "/etc/hosts"
+    line: "{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - "{{ ansible_default_ipv4.address }}	{{ ansible_hostname }}"
+    - "::1	{{ ansible_hostname }}"
+
+- name: "Count number of disk devices"
+  shell: |
+    lsblk -n -o type | awk 'BEGIN{count=0} $1=="disk" {count++} END{print count}'
+  register: ses_node_disks_count_result
+
+- name: "Set SES node disk count fact"
+  set_fact:
+    ses_node_disks_count: "{{ ses_node_disks_count_result.stdout | int }}"
+
+- name: "Ensure NTP installed"
+  package:
+    name: ntp
+    state: present
+
+- name: Ensure NTP is enabled
+  service:
+    name: "ntpd"
+    state: started
+    enabled: yes
+
+- name: Ensure SES repos present
+  zypper_repository:
+    name: "{{ item.name }}"
+    repo: "{{ item.repo }}"
+  with_items:
+    - name: "SUSE-Enterprise-Storage-{{ ses_version }}-Pool"
+      repo: "{{ ses_repo_server }}/repos/x86_64/SUSE-Enterprise-Storage-{{ ses_version }}-Pool/"
+    - name: "SUSE-Enterprise-Storage-{{ ses_version }}-Updates"
+      repo: "{{ ses_repo_server }}/repos/x86_64/SUSE-Enterprise-Storage-{{ ses_version }}-Updates/"

--- a/ccp/ses-ansible/roles/ses/tasks/salt_setup.yml
+++ b/ccp/ses-ansible/roles/ses/tasks/salt_setup.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Install salt-master and minion
+  package:
+    name: "{{ item }}"
+  with_items:
+    - "salt-master"
+    - "salt-minion"
+  notify:
+    - Restart and enable salt-minion
+    - Restart and enable salt-master
+
+- name: Drop salt configuration
+  template:
+    src: "master.conf.j2"
+    dest: "/etc/salt/minion.d/master.conf"
+  notify:
+    - Restart and enable salt-minion
+
+- meta: flush_handlers
+
+- name: "Wait for salt-minion to initialize"
+  pause:
+    seconds: 5
+
+- name: Accept salt keys
+  command: "salt-key --accept-all -y"
+  changed_when: false

--- a/ccp/ses-ansible/roles/ses/tasks/zap_disks.yml
+++ b/ccp/ses-ansible/roles/ses/tasks/zap_disks.yml
@@ -1,0 +1,66 @@
+---
+
+- name: Get ceph data partitions
+  shell: |
+    blkid -o device -t PARTLABEL="ceph data"
+  failed_when: false
+  register: ceph_data_partition_to_erase_path
+
+- name: Get ceph block partitions
+  shell: |
+    blkid -o device -t PARTLABEL="ceph block"
+  failed_when: false
+  register: ceph_block_partition_to_erase_path
+
+- name: Get ceph journal partitions
+  shell: |
+    blkid -o device -t PARTLABEL="ceph journal"
+  failed_when: false
+  register: ceph_journal_partition_to_erase_path
+
+- name: Get ceph db partitions
+  shell: |
+    blkid -o device -t PARTLABEL="ceph block.db"
+  failed_when: false
+  register: ceph_db_partition_to_erase_path
+
+- name: Get ceph wal partitions
+  shell: |
+    blkid -o device -t PARTLABEL="ceph block.wal"
+  failed_when: false
+  register: ceph_wal_partition_to_erase_path
+
+- name: Create combined_devices_list
+  set_fact:
+    combined_devices_list: "{{ ceph_data_partition_to_erase_path.stdout_lines +
+                               ceph_block_partition_to_erase_path.stdout_lines +
+                               ceph_journal_partition_to_erase_path.stdout_lines +
+                               ceph_db_partition_to_erase_path.stdout_lines +
+                               ceph_wal_partition_to_erase_path.stdout_lines }}"
+
+- name: Resolve parent device
+  shell: echo /dev/$(lsblk -no pkname "{{ item }}")
+  register: tmp_resolved_parent_device
+  with_items:
+    - "{{ combined_devices_list }}"
+
+- name: Create resolved_parent_device
+  set_fact:
+    resolved_parent_device: "{{ tmp_resolved_parent_device.results | map(attribute='stdout') | list | unique }}"
+  when: combined_devices_list | length > 0
+
+- name: Zap ceph journal/block db/block wal partitions
+  shell: |
+    # if the disk passed is a raw device AND the boot system disk
+    if parted -s "{{ item }}" print | grep -sq boot; then
+      echo "Looks like {{ item }} has a boot partition,"
+      echo "if you want to delete specific partitions point to the partition instead of the raw device"
+      echo "Do not use your system disk!"
+      exit 1
+    fi
+    sgdisk -Z "{{ item }}"
+    dd if=/dev/zero of="{{ item }}" bs=1M count=200
+    udevadm settle --timeout=600
+  with_items:
+    - "{{ resolved_parent_device }}"
+  when: combined_devices_list | length > 0

--- a/ccp/ses-ansible/roles/ses/templates/deepsea_minions.sls.j2
+++ b/ccp/ses-ansible/roles/ses/templates/deepsea_minions.sls.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+deepsea_minions: '{{ ses_deepsea_minions }}'

--- a/ccp/ses-ansible/roles/ses/templates/global.conf.j2
+++ b/ccp/ses-ansible/roles/ses/templates/global.conf.j2
@@ -1,0 +1,26 @@
+# {{ ansible_managed }}
+
+mon_max_pg_per_osd = 1500 # do not set the max limit
+# mon_pg_warn_max_per_osd = 1500 # pre-luminuous-release
+osd crush chooseleaf type = 0 # set OSD as failure domain
+mon pg warn max object skew = -1
+mon allow pool delete = true
+{% if ses_node_disks_count|int > 3 %}
+osd pool default size = {{ [3, ses_node_disks_count -2] | min }}
+{% else %}
+osd pool default size = 1
+{% endif %}
+
+{% if radosgw_keystone %}
+[client.rgw.{{ ansible_hostname }}]
+rgw keystone url = {{ lookup('env', 'OS_AUTH_URL') }}
+rgw keystone admin user = {{ lookup('env', 'OS_USERNAME') }}
+rgw keystone admin password = {{ lookup('env', 'OS_PASSWORD') }}
+rgw keystone admin project = {{ lookup('env', 'OS_PROJECT_NAME') }}
+rgw keystone admin domain = {{ lookup('env', 'OS_USER_DOMAIN_NAME') }}
+rgw keystone api version = {{ lookup('env', 'OS_IDENTITY_API_VERSION') }}
+rgw keystone accepted roles = admin,Member,_member_
+rgw keystone accepted admin roles = admin
+rgw keystone revocation interval = 0
+rgw keystone verify ssl = false
+{% endif %}

--- a/ccp/ses-ansible/roles/ses/templates/master.conf.j2
+++ b/ccp/ses-ansible/roles/ses/templates/master.conf.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+master: {{ ansible_hostname }}

--- a/ccp/ses-ansible/roles/ses/templates/master_minion.sls.j2
+++ b/ccp/ses-ansible/roles/ses/templates/master_minion.sls.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+master_minion: {{ ansible_hostname }}

--- a/ccp/ses-ansible/roles/setup_ses_configs/defaults/main.yml
+++ b/ccp/ses-ansible/roles/setup_ses_configs/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+ses_config_path: "/tmp/ses_config"
+radosgw_keystone: False

--- a/ccp/ses-ansible/roles/setup_ses_configs/tasks/main.yml
+++ b/ccp/ses-ansible/roles/setup_ses_configs/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Ensure ses config directory exist
+  file:
+    path: "{{ ses_config_path }}"
+    state: directory
+  when:
+    - ses_openstack_config
+
+- name: Drop ceph conf and keys
+  copy:
+    dest: "{{ ses_config_path }}/{{ item.item }}"
+    content: "{{ item.content | b64decode }}"
+    mode: 0644
+  with_items:
+    - "{{ hostvars['ses'].ceph_files.results }}"
+  when:
+    - ses_openstack_config
+
+- name: Generate ses-config.yml
+  template:
+    src: ses-config.yml.j2
+    dest: "{{ ses_config_path }}/ses_config.yml"
+  when:
+    - ses_openstack_config

--- a/ccp/ses-ansible/roles/setup_ses_configs/templates/ses-config.yml.j2
+++ b/ccp/ses-ansible/roles/setup_ses_configs/templates/ses-config.yml.j2
@@ -1,0 +1,28 @@
+ses_cluster_configuration:
+  ses_cluster_name: ceph
+{% if radosgw_keystone %}
+  ses_radosgw_url: "http://{{ hostvars['ses'].ansible_default_ipv4.address }}:8080/swift/v1"
+{% endif %}
+
+  conf_options:
+      ses_fsid: {{ hostvars['ses'].conf_options.stdout_lines.0 }}
+      ses_mon_initial_members: {{ hostvars['ses'].conf_options.stdout_lines.1 }}
+      ses_mon_host: {{ hostvars['ses'].conf_options.stdout_lines.2 }}
+      ses_public_network: {{ hostvars['ses'].conf_options.stdout_lines.3 }}
+      ses_cluster_network: {{ hostvars['ses'].conf_options.stdout_lines.4 }}
+  cinder:
+      rbd_store_pool: cinder
+      rbd_store_pool_user: cinder
+      keyring_file_name: ceph.client.cinder.keyring
+  cinder-backup:
+      rbd_store_pool: backups
+      rbd_store_pool_user: cinder_backup
+      keyring_file_name: ceph.client.cinder_backup.keyring
+ # Nova uses the cinder user to access the nova pool, cinder pool
+ # So all we need here is the nova pool name.
+  nova:
+      rbd_store_pool: nova
+  glance:
+      rbd_store_pool: glance
+      rbd_store_pool_user: glance
+      keyring_file_name: ceph.client.glance.keyring

--- a/ccp/ses-ansible/ses-install.yml
+++ b/ccp/ses-ansible/ses-install.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Install SES 5
+  hosts: ses
+  become: yes
+  roles:
+    - ses
+
+- name: Get SES configs
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - roles/ses/defaults/main.yml
+  roles:
+    - role: setup_ses_configs
+      tags:
+        - openstack_config


### PR DESCRIPTION
This repository initial code based is copied from Flavio Ramalho QA setup
playbooks.

Adding new sub directory, ccp, to house CCP related automation logic.
CCP will require some changes that's why added new SES ansible tree under ccp
codebase.

Changes added to setup DEV_ENV variable, ipv6 local entry in /etc/hosts,
workaround to bypass max pg per OSD error and calculate number of replicas
based on disk devices.

Incorporated recent changes made in Flavio's ses-ansible.