### PR TITLE
openstack-ardana: fix commit message validator

### DIFF
--- a/scripts/jenkins/gitlint.ini
+++ b/scripts/jenkins/gitlint.ini
@@ -8,7 +8,7 @@ line-length=80
 words=wip,WIP
 
 [title-match-regex]
-regex=^SCRD-.*|.*\((bsc#[1-9]+\s?)+\)$
+regex=^SCRD-.*|.*\((bsc#[0-9]+\s?)+\)$
 
 [body-max-line-length]
 line-length=80


### PR DESCRIPTION
Fixes the bugzilla ID regex enforced by the commit message
validator.