### PR TITLE
Don't use ceph for cloud7 ha jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -38,7 +38,7 @@
     nodenumber_controller: 2
     tempestoptions: --smoke
     label: openstack-mkcloud-ha-x86_64
-    storage_method_ha: ceph
+    storage_method_ha: swift
     database_engine: postgresql
     want_all_ssl: 0
     jobs:


### PR DESCRIPTION
Since Cloud 7 needs 3 node HA cluster now (the default database switched
to galera), we don't have enough nodes left for deploying ceph (needs at
least 3 osd nodes). Switch the job to deploy swift.