### PR TITLE
openstack-ardana: Add filter to enable features according to cloudsource

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -1,0 +1,25 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+when_staging: "{{ cloud_source | default(cloudsource) is match('.*staging.*') }}"
+when_staging_or_devel: "{{ cloud_source | default(cloudsource) is match('.*(staging|devel).*') }}"
+when_cloud8: "{{ cloud_source | default(cloudsource) is match('.*8.*') }}"
+when_cloud9: "{{ cloud_source | default(cloudsource) is match('.*9.*') }}"
+
+versioned_features:
+  manila:
+    enabled: "{{ when_staging }}"

--- a/scripts/jenkins/ardana/ansible/init.yml
+++ b/scripts/jenkins/ardana/ansible/init.yml
@@ -80,6 +80,13 @@
       - "{{ compute_mgmt_ips|default([]) }}"
     when: item != "" and item != deployer_mgmt_ip
 
+  - name: Remove manila from input model when manila not enabled
+    replace:
+      path: "{{ input_model_path }}/data/control_plane.yml"
+      regexp: '(.*manila.*)'
+      replace: '#\1'
+    when: not versioned_features['manila'].enabled
+
   - name: Initialize target Model from "{{ input_model_path }}"
     synchronize:
       src: "{{ input_model_path }}/"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/control_plane.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/control_plane.yml
@@ -65,7 +65,7 @@
           allocation-policy: any
 {%     endif %}
           service-components:
-{%     for service_component in ns.service_components|unique|sort %}
+{%     for service_component in ns.service_components|unique|sort if (versioned_features[service_component.split('-')[0]]|default(dict()))['enabled']|default(true) %}
             - {{ service_component }}
 {%     endfor %}
 {%   endfor %}


### PR DESCRIPTION
Following @stefannica idea in [1] this change adds a filter for
disabling/enabling/tracking features depending of the cloudsource value.

For now it is enabling manila only for staging builds.

1. https://github.com/SUSE-Cloud/automation/pull/2772