### PR TITLE
openstack-ardana: update monasca RPM file permissions check

### DIFF
--- a/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
+++ b/scripts/jenkins/ardana/ansible/files/rpm-verify-modification-whitelist.txt
@@ -19,7 +19,8 @@ S.5....T.  c /etc/kibana/kibana.yml
 # permissions and owner changed by Monasca playbooks (bsc#1094971)
 SM5....T.  c /etc/storm/storm.yaml
 .....UG..    /opt/kibana/optimize
-.M.......    /usr/lib/monasca/agent/custom_checks.d
+# permissions and owner changed by Monasca playbooks (bsc#1094873)
+.....UG..    /usr/lib/monasca/agent/custom_checks.d
 .M.......    /usr/lib/monasca/agent/custom_detect.d
 S.5....T.    /usr/lib/systemd/system/apache2.service
 S.5....T.    /usr/lib/systemd/system/rabbitmq-server.service


### PR DESCRIPTION
Update the whitelist maintained for the post-deploy RPM
file modification check to account for monasca-ansible patch
https://gerrit.suse.provo.cloud/4210/, which changed the
/usr/lib/monasca/agent/custom_checks.d file permissions from
root:root to monasca-agent:monasca.