### PR TITLE
shebang for python script gerrit2obs-name.py

### DIFF
--- a/scripts/jenkins/ardana/gerrit/gerrit2obs-name.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit2obs-name.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
without this the script cant be called and track-upstream-internal.sh
fails