### PR TITLE
trackupstream: Do not trigger on ref update

### DIFF
--- a/jenkins/ci.suse.de/ardana-trigger-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trigger-trackupstream.yaml
@@ -1,12 +1,12 @@
 - job:
     name: 'ardana-trigger-trackupstream'
 
+    concurrent: false # It's not a good idea to try to do the same update twice.
     triggers:
       - gerrit:
           server-name: 'gerrit.suse.provo.cloud'
           trigger-on:
             - change-merged-event
-            - ref-updated-event
           skip-vote:
               notbuilt: true
           projects:


### PR DESCRIPTION
Also make concurrent=false explicit.

I tested triggering on both ref update and change merge. While a change
merge always results in a ref update, a run triggered by the ref update
won't comment on the change that got merged. Not triggering on a ref
update will miss a direct push to the branch without a review.
Triggering on both will run the job twice, which is a bit of waste as we
require review.

This job can always be manually triggered.