### PR TITLE
Remove freezer-ui plugin from trackupstream jobs

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -36,7 +36,6 @@
             - openstack-heat-gbp
             - openstack-heat-templates
             - openstack-horizon-plugin-designate-ui
-            - openstack-horizon-plugin-freezer-ui
             - openstack-horizon-plugin-gbp-ui
             - openstack-horizon-plugin-ironic-ui
             - openstack-horizon-plugin-neutron-fwaas-ui
@@ -123,7 +122,6 @@
             ].contains(component) ||
             [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Ocata:Staging" ].contains(project) &&
             [
-              "openstack-horizon-plugin-freezer-ui",
               "openstack-horizon-plugin-neutron-fwaas-ui",
               "openstack-horizon-plugin-neutron-vpnaas-ui",
               "openstack-neutron-vsphere",


### PR DESCRIPTION
openstack-horizon-plugin-freezer-ui is available in
Cloud:OpenStack:{Pike,Queens,Rocky,Master}:Upstream so we don't need to
run trackupstream for it. It's currently failing the trackupstream job
for Queens and Rocky Staging because it is missing from those projects.