### PR TITLE
Remove vpnaas-ui plugin from trackupstream jobs

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -41,7 +41,6 @@
             - openstack-horizon-plugin-ironic-ui
             - openstack-horizon-plugin-neutron-fwaas-ui
             - openstack-horizon-plugin-neutron-lbaas-ui
-            - openstack-horizon-plugin-neutron-vpnaas-ui
             - openstack-horizon-plugin-manila-ui
             - openstack-horizon-plugin-magnum-ui
             - openstack-horizon-plugin-monasca-ui
@@ -125,7 +124,6 @@
             [
               "openstack-horizon-plugin-freezer-ui",
               "openstack-horizon-plugin-neutron-fwaas-ui",
-              "openstack-horizon-plugin-neutron-vpnaas-ui",
               "openstack-neutron-vsphere",
             ].contains(component) ||
             [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Pike:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Rocky:Staging" ].contains(project) &&


### PR DESCRIPTION
openstack-horizon-plugin-vpnaas-ui is available in
Cloud:OpenStack:Upstream:{Master,Pike,Queens,Rocky} and so doesn't need
to use the trackupstream job. It seems to have been inadvertently copied
from Cloud:OpenStack:Master to Cloud:Openstack:Rocky:Staging but that
package in C:O:M just links to C:O:U:M and does not have a _service
file, which now causes the trackupstream job to fail.