### PR TITLE
keystone_password: Increase crowbar batch timeout

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4230,13 +4230,13 @@ y = YAML.load(ARGF)
 y['proposals'].first['attributes']['admin'] ||= {}
 y['proposals'].first['attributes']['admin']['password'] = '$updated_password'
 puts y.to_yaml" > /root/keystone-test-pw-update.yaml
-    safely crowbar batch --timeout 900 build < /root/keystone-test-pw-update.yaml
+    safely crowbar batch --timeout 1500 build < /root/keystone-test-pw-update.yaml
     safely oncontroller test_keystone_password
     cat /root/keystone-test-pw-update.yaml | ruby -ryaml -e "
 y = YAML.load(ARGF)
 y['proposals'].first['attributes']['admin']['password'] = '$old_password'
 puts y.to_yaml" > /root/keystone-test-pw-reset.yaml
-    safely crowbar batch --timeout 900 build < /root/keystone-test-pw-reset.yaml
+    safely crowbar batch --timeout 1500 build < /root/keystone-test-pw-reset.yaml
 }
 
 function onadmin_have_salt_barclamp


### PR DESCRIPTION
In an HA deployment a chef-client run can take around 10 minutes on a
single node. As the crowbar needs to wait for existing chef-client runs
to finish before the new chef-client run for applying the keystone
barclamp can be triggered we need to increase the timeout of the crowbar
batch call to have enough time for 2 chef-client runs + some safety
margin. This commit increases the timeout from 15 to 25 minutes.