### PR TITLE
Avoid the need for python-sh on trigger slaves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ suseinstall:
 	sudo zypper install perl-JSON-XS perl-libxml-perl python-pip libvirt-python
 
 genericinstall:
-	sudo pip install -U 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder requests sh
+	sudo pip install -U 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder requests
 	git clone https://github.com/SUSE-Cloud/roundup && \
 	cd roundup && \
 	./configure && \

--- a/scripts/jenkins/ardana/gerrit/build_test_package.py
+++ b/scripts/jenkins/ardana/gerrit/build_test_package.py
@@ -20,6 +20,9 @@ import requests
 
 import sh
 
+sys.path.append(os.path.dirname(__file__))
+from gerrit_project_map import gerrit_project_map  # noqa: E402
+
 GERRIT_URL = 'https://gerrit.suse.provo.cloud'
 
 # We use a more complex regex that matches both formats of Depends-On so that
@@ -51,14 +54,6 @@ def find_dependency_headers(message):
     # Reverse the order so that we process the oldest Depends-On first
     dependencies.reverse()
     return dependencies
-
-
-def gerrit_project_map():
-    # Used for mapping gerrit project names onto OBS package names
-    map_file = os.path.join(os.path.dirname(__file__), 'project-map.json')
-    with open(map_file) as map:
-        project_map = json.load(map)
-    return project_map
 
 
 @contextlib.contextmanager

--- a/scripts/jenkins/ardana/gerrit/gerrit2obs-name.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit2obs-name.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(__file__))
-from build_test_package import gerrit_project_map  # noqa: E402
+from gerrit_project_map import gerrit_project_map  # noqa: E402
 
 
 def main():

--- a/scripts/jenkins/ardana/gerrit/gerrit_project_map.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit_project_map.py
@@ -1,0 +1,10 @@
+import json
+import os
+
+
+def gerrit_project_map():
+    # Used for mapping gerrit project names onto OBS package names
+    map_file = os.path.join(os.path.dirname(__file__), 'project-map.json')
+    with open(map_file) as map:
+        project_map = json.load(map)
+    return project_map

--- a/scripts/jenkins/ardana/gerrit/project-map2project-regexp.py
+++ b/scripts/jenkins/ardana/gerrit/project-map2project-regexp.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(__file__))
-from build_test_package import gerrit_project_map  # noqa: E402
+from gerrit_project_map import gerrit_project_map  # noqa: E402
 
 
 def main():


### PR DESCRIPTION
Move the function gerrit_project_map into its own module, so it can
avoid the imports from the rest of its old location.