### PR TITLE
allocpool: chomp the pid value

### DIFF
--- a/scripts/mkcloudhost/allocpool
+++ b/scripts/mkcloudhost/allocpool
@@ -24,6 +24,7 @@ foreach my $d (@dirs) {
         sysopen my $fh, $a, O_RDWR|O_CREAT or die "cant create $a";
         flock $fh, LOCK_EX or next;
         my $num = <$fh>;
+        chomp($num);
         if($num && $num=~m/^\d{1,5}$/) {
                 my $signalled=kill(0, $num);
                 diag "PID file had $num";


### PR DESCRIPTION
If not chomped the following grep will fail if the PID
ends with a new line character and a job will fail to start.