### PR TITLE
Treat /proc/X/cmdline as a text file

### DIFF
--- a/scripts/mkcloudhost/allocpool
+++ b/scripts/mkcloudhost/allocpool
@@ -29,7 +29,7 @@ foreach my $d (@dirs) {
                 my $signalled=kill(0, $num);
                 diag "PID file had $num";
                 if($signalled) {
-                        if(!$ENV{CHECKPROC} || `grep $ENV{CHECKPROC} /proc/$num/cmdline` == 0) {
+                        if(!$ENV{CHECKPROC} || `grep -a $ENV{CHECKPROC} /proc/$num/cmdline` == 0) {
                                 diag "someone else owns $a and is alive";
                                 next;
                         }


### PR DESCRIPTION
See `Argument "Binary file /proc/6780/cmdline matches\n" isn't numeric in numeric eq (==) at /root/github.com/SUSE-Cloud/automation/scripts/mkcloudhost/allocpool line 32, <$fh> line 1`

in https://ci.suse.de/job/openstack-mkcloud/135373/console