### PR TITLE
openstack-ardana: re-add heat stack create/delete job

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-heat.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-heat.yaml
@@ -1,0 +1,93 @@
+- job:
+    name: openstack-ardana-heat
+    project-type: pipeline
+    concurrent: true
+    wrappers:
+      - timestamps
+      - timeout:
+          timeout: 300
+          type: no-activity
+          abort: true
+          write-description: "Job aborted due to 180 minutes of inactivity"
+
+    logrotate:
+      numToKeep: 2000
+      daysToKeep: 300
+
+    properties:
+      - authorization:
+          cloud:
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-delete
+            - job-discover
+            - job-read
+            - job-workspace
+            - run-delete
+            - run-update
+            - scm-tag
+          anonymous:
+            - job-read
+
+    parameters:
+      - string:
+          name: ardana_env
+          default: ''
+          description: >-
+            The virtual environment identifier. This field should be set to a
+            value that will uniquely identify the heat stack.
+
+            WARNING: if a heat stack associated with the supplied ardana_env already
+            exists, it will be replaced if this job is launched to create it.
+
+      - choice:
+          name: heat_action
+          choices:
+            -
+            - create
+            - delete
+          description: >-
+            The action to be performed:
+              - create: create a new heat stack
+              - delete: delete a heat stack
+
+            If the create action is selected, a heat template file is required, which can only
+            be supplied by running this job as a downstream job or indicating a preexisting workspace.
+
+      - string:
+          name: git_automation_repo
+          default: https://github.com/SUSE-Cloud/automation.git
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: master
+          description: >-
+            The git automation branch
+
+      - string:
+          name: reuse_node
+          default: ''
+          description: >-
+            The Jenkins agent where this job must run. Used by upstream jobs to
+            force a job to reuse the same node.
+
+      - string:
+          name: reuse_workspace
+          default: ''
+          description: >-
+            The Jenkins workspace that this job must reuse. Used by upstream jobs to
+            force a job to use the same workspace.
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${git_automation_repo}
+            branches:
+              - ${git_automation_branch}
+            browser: auto
+            wipe-workspace: false
+      script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
+      lightweight-checkout: false

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -1,0 +1,93 @@
+/**
+ * The openstack-ardana-heat Jenkins Pipeline
+ *
+ * This jobs automates creating/deleting heat stacks.
+ */
+pipeline {
+
+  // skip the default checkout, because we want to use a custom path
+  options {
+    skipDefaultCheckout()
+  }
+
+  agent {
+    node {
+      label reuse_node ? reuse_node : "cloud-ardana-ci"
+      customWorkspace ardana_env ? "${JOB_NAME}-${ardana_env}" : "${JOB_NAME}-${BUILD_NUMBER}"
+    }
+  }
+
+  stages {
+    stage('Setup workspace') {
+      steps {
+        cleanWs()
+
+        // If the job is set up to reuse an existing workspace, replace the
+        // current workspace with a symlink to the reused one.
+        // NOTE: even if we specify the reused workspace as the
+        // customWorkspace variable value, Jenkins will refuse to reuse a
+        // workspace that's already in use by one of the currently running
+        // jobs and will just create a new one.
+        sh '''
+          if [ -n "${reuse_workspace}" ]; then
+            rmdir "${WORKSPACE}"
+            ln -s "${reuse_workspace}" "${WORKSPACE}"
+          fi
+        '''
+
+        script {
+          if (ardana_env == '') {
+            error("Empty 'ardana_env' parameter value.")
+          }
+          if (heat_action == '') {
+            error("Empty 'heat_action' parameter value.")
+          }
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${heat_action} ${ardana_env}"
+          if (reuse_workspace == '') {
+            if (heat_action == 'create') {
+              error("This job needs to be called by an upstream job to create a heat stack.")
+            }
+            sh('git clone $git_automation_repo --branch $git_automation_branch automation-git')
+            sh('''
+              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+              ansible_playbook load-job-params.yml
+            ''')
+          }
+        }
+      }
+    }
+    stage('Delete heat stack') {
+      steps {
+        // Run the monitoring bits outside of the ECP-API lock, and lock the
+        // ECP API only while actually deleting the stack
+        sh('''
+          source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+          ansible_playbook heat-stack.yml -e @input.yml -e heat_action='monitor'
+        ''')
+        lock(resource: 'cloud-ECP-API') {
+          sh('''
+            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+            ansible_playbook heat-stack.yml -e @input.yml -e heat_action='delete' -e monitor_stack_after_delete=False
+          ''')
+        }
+        sh('''
+          source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+          ansible_playbook heat-stack.yml -e @input.yml -e heat_action='monitor'
+        ''')
+      }
+    }
+    stage('Create heat stack') {
+      when {
+        expression { heat_action == 'create' }
+      }
+      steps {
+        lock(resource: 'cloud-ECP-API') {
+          sh('''
+            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+            ansible_playbook heat-stack.yml -e @input.yml
+          ''')
+        }
+      }
+    }
+  }
+}

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -91,11 +91,13 @@ pipeline {
 
     stage('Create heat stack') {
       steps {
-        lock(resource: 'cloud-ECP-API') {
-          sh('''
-            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-            ansible_playbook heat-stack.yml -e @input.yml
-          ''')
+        script {
+          def slaveJob = build job: 'openstack-ardana-heat', parameters: [
+            string(name: 'ardana_env', value: "$ardana_env"),
+            string(name: 'heat_action', value: "create"),
+            string(name: 'reuse_node', value: "${NODE_NAME}"),
+            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+          ], propagate: true, wait: true
         }
       }
     }
@@ -130,11 +132,13 @@ pipeline {
       """
     }
     failure {
-      lock(resource: 'cloud-ECP-API') {
-        sh('''
-          source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-          ansible_playbook heat-stack.yml -e @input.yml -e heat_action=delete
-        ''')
+      script {
+        def slaveJob = build job: 'openstack-ardana-heat', parameters: [
+          string(name: 'ardana_env', value: "$ardana_env"),
+          string(name: 'heat_action', value: "delete"),
+          string(name: 'reuse_node', value: "${NODE_NAME}"),
+          string(name: 'reuse_workspace', value: "${WORKSPACE}")
+        ], propagate: false, wait: false
       }
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -221,25 +221,25 @@ pipeline {
     always {
       archiveArtifacts artifacts: '.artifacts/**/*', allowEmptyArchive: true
       script{
-        if (cleanup == "always") {
-          lock(resource: 'cloud-ECP-API') {
-            sh('''
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook heat-stack.yml -e @input.yml -e heat_action=delete
-            ''')
-          }
+        if (cleanup == "always" && cloud_type == "virtual") {
+          def slaveJob = build job: 'openstack-ardana-heat', parameters: [
+            string(name: 'ardana_env', value: "$ardana_env"),
+            string(name: 'heat_action', value: "delete"),
+            string(name: 'reuse_node', value: "${NODE_NAME}"),
+            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+          ], propagate: false, wait: false
         }
       }
     }
     success {
       script {
-        if (cleanup == "on success") {
-          lock(resource: 'cloud-ECP-API') {
-            sh('''
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook heat-stack.yml -e @input.yml -e heat_action=delete
-            ''')
-          }
+        if (cleanup == "on success" && cloud_type == "virtual") {
+          def slaveJob = build job: 'openstack-ardana-heat', parameters: [
+            string(name: 'ardana_env', value: "$ardana_env"),
+            string(name: 'heat_action', value: "delete"),
+            string(name: 'reuse_node', value: "${NODE_NAME}"),
+            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+          ], propagate: false, wait: false
         }
       }
       sh '''
@@ -250,13 +250,13 @@ pipeline {
     }
     failure {
       script {
-        if (cleanup == "on failure") {
-          lock(resource: 'cloud-ECP-API') {
-            sh('''
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook heat-stack.yml -e @input.yml -e heat_action=delete
-            ''')
-          }
+        if (cleanup == "on failure" && cloud_type == "virtual") {
+          def slaveJob = build job: 'openstack-ardana-heat', parameters: [
+            string(name: 'ardana_env', value: "$ardana_env"),
+            string(name: 'heat_action', value: "delete"),
+            string(name: 'reuse_node', value: "${NODE_NAME}"),
+            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+          ], propagate: false, wait: false
         }
       }
       sh '''

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/delete.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/delete.yml
@@ -15,14 +15,7 @@
 #
 ---
 
-- name: Ensure stack is not in a pending state before deleting it
-  command: |
-    openstack --os-cloud {{ os_cloud }} stack show {{ heat_stack_name }} \
-      -c stack_status -f value
-  register: stack_status
-  retries: 100
-  until: "'IN_PROGRESS' not in stack_status.stdout"
-  delay: 10
+- include_tasks: monitor.yml
 
 - block:
     - name: Delete stack '{{ heat_stack_name }}'
@@ -31,7 +24,6 @@
         name: "{{ heat_stack_name }}"
         state: absent
         api_timeout: "{{ api_timeout }}"
-      when: "'DELETE_COMPLETE' not in stack_status.stdout"
   rescue:
     - name: Force delete stack resources when delete failed
       shell: |
@@ -68,12 +60,5 @@
       delay: 5
 
   always:
-    - name: Wait until stack '{{ heat_stack_name }}' is completely deleted
-      command: |
-        openstack --os-cloud {{ os_cloud }} stack show {{ heat_stack_name }} \
-          -c stack_status -f value
-      register: stack_status
-      retries: 100
-      until: "'DELETE_COMPLETE' not in stack_status.stdout"
-      delay: 10
-      failed_when: False
+    - include_tasks: monitor.yml
+      when: monitor_stack_after_delete

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/main.yml
@@ -22,8 +22,15 @@
   register: get_stack
   failed_when: false
 
+- include_tasks: monitor.yml
+  when:
+    - get_stack.stdout != ''
+    - heat_action == 'monitor'
+
 - include_tasks: delete.yml
-  when: get_stack.stdout != ''
+  when:
+    - get_stack.stdout != ''
+    - heat_action != 'monitor'
 
 - include_tasks: create.yml
   when: "heat_action == 'create'"

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/monitor.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/monitor.yml
@@ -15,9 +15,13 @@
 #
 ---
 
-os_cloud: "engcloud-cloud-ci"
-heat_action: "create"
-api_timeout: "600"
+- name: Monitor stack until deleted or not in a pending state
+  command: |
+    openstack --os-cloud {{ os_cloud }} stack show {{ heat_stack_name }} \
+      -c stack_status -f value
+  register: stack_status
+  retries: 100
+  until: "'IN_PROGRESS' not in stack_status.stdout and 'DELETE_COMPLETE' not in stack_status.stdout"
+  delay: 10
+  failed_when: "stack_status.rc != 0 and 'Stack not found' not in stack_status.stderr"
 
-heat_stack_name: "openstack-ardana-{{ ardana_env }}"
-monitor_stack_after_delete: True


### PR DESCRIPTION
Moves the logic dealing with long operations involving creating/deleting
heat stacks in the ECP cloud back to a separate Jenkins job, `openstack-ardana-heat`.
The advantages of having this handled in a separate job:
 - ECP infrastructure related failures can be monitored separately
 - the job can be run manually to cleanup stacks left over from previous
 openstack-ardana pipeline runs
 - cleaning up a heat stack during the post-build actions of other jobs
 (e.g. openstack-ardana) can be triggered and run without blocking the
 upstream job, which means that upstream jobs can finish earlier and
 report the result faster
 - last but not least, the job can be reused by other pipelines which
 need to manage heat stacks, for example a job that automates creating a
 SES cluster

The heat stack management tasks protected by the ECP-API resource
lock have also been reduced to those that actually create or delete
heat stacks, while the monitoring tasks are executed outside this
lock. This effectively reduces the time that jobs spend waiting
for the ECP-API resource to become available.