### PR TITLE
Add and persist ilo route for qe env.

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
@@ -81,6 +81,7 @@
 {%   if 'MANAGEMENT' in network_group.component_endpoints %}
 {%     if bm_info is defined %}
 {%       set _ = ns.routes.append('OCTAVIA-MGMT-NET') %}
+{%       set _ = ns.routes.append('ILO') %}
 {%     else %}
 {%       for neutron_ng in scenario.network_groups if 'NEUTRON-VLAN' in neutron_ng.component_endpoints %}
 {%         set _ = ns.routes.append('NEUTRON-%s-VLAN-NET'|format(neutron_ng.name|upper)) %}
@@ -95,6 +96,7 @@
 {%     endfor  %}
 {%   endif %}
 
+{% if network_group.name != 'ILO' %}
       load-balancers:
 {%   if 'INTERNAL-API' in network_group['component_endpoints'] %}
 
@@ -225,4 +227,5 @@
 {%   else %}
       tags: []
 {%   endif %}
+{% endif %}
 {% endfor %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
@@ -42,3 +42,7 @@ network_groups:
     tagged_vlan: true
     component_endpoints:
       - NEUTRON-VXLAN
+
+  - name: ILO
+    hostname_suffix: ilo
+    component_endpoints: []


### PR DESCRIPTION
- Currently ilo route is hard coded into qcow2 image for each qe environment and it being removed during network restart through site.yml.
- This change will add and persist the ilo route through input model.