### PR TITLE
mkcloud: Remove trove from cloud9 testing

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -121,6 +121,11 @@
               "openstack-rally",
               "openstack-tempest",
             ].contains(component) ||
+            [ "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging" ].contains(project) &&
+            [
+              "openstack-trove",
+              "openstack-horizon-plugin-trove-ui",
+            ].contains(component) ||
             [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Ocata:Staging" ].contains(project) &&
             [
               "openstack-horizon-plugin-freezer-ui",

--- a/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
@@ -8,8 +8,6 @@ proposals:
       - @@controller@@
 - barclamp: rabbitmq
   attributes:
-    trove:
-      enabled: true
   deployment:
     elements:
       rabbitmq-server:
@@ -152,12 +150,6 @@ proposals:
       ceilometer-server:
       - @@controller@@
       ceilometer-swift-proxy-middleware:
-      - @@controller@@
-- barclamp: trove
-  attributes:
-  deployment:
-    elements:
-      trove-server:
       - @@controller@@
 - barclamp: magnum
   attributes:

--- a/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
@@ -205,12 +205,6 @@ proposals:
       manila-share:
       - @@controller1@@
       - @@controller2@@
-- barclamp: trove
-  attributes:
-  deployment:
-    elements:
-      trove-server:
-      - @@controller1@@
 - barclamp: magnum
   attributes:
     cert:


### PR DESCRIPTION
It is being retired for Cloud9 after being deprecated for some time.