### PR TITLE
mkcloud: rabbitmq notifications needed with ceilometer

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2296,6 +2296,12 @@ function custom_configuration
             if ! iscloudver 9plus && ! [[ $want_trove_proposal = 0 ]]; then
                 proposal_set_value rabbitmq default "['attributes']['rabbitmq']['trove']['enabled']" true
             fi
+
+            if iscloudver 7plus && ! [[ $want_ceilometer_proposal = 0 ]]; then
+                if crowbar rabbitmq proposal show default | grep -q enable_notifications; then
+                    proposal_set_value rabbitmq default "['attributes']['rabbitmq']['client']['enable_notifications']" true
+                fi
+            fi
         ;;
         dns)
             [ "$want_multidnstest" = 1 ] || return 0


### PR DESCRIPTION
In order to add a check to the ceilometer proposal that notifications
are enabled, we need to enable it in the CI env. With the change
https://github.com/crowbar/crowbar-openstack/pull/1792 we need
to prep the proposal accordingly to enable notifications in the
rabbitmq proposal if ceilometer is being deployed