### PR TITLE
openstack-ardana: don't reuse workspace to cleanup heat stacks

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -135,9 +135,7 @@ pipeline {
       script {
         def slaveJob = build job: 'openstack-ardana-heat', parameters: [
           string(name: 'ardana_env', value: "$ardana_env"),
-          string(name: 'heat_action', value: "delete"),
-          string(name: 'reuse_node', value: "${NODE_NAME}"),
-          string(name: 'reuse_workspace', value: "${WORKSPACE}")
+          string(name: 'heat_action', value: "delete")
         ], propagate: false, wait: false
       }
     }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -224,9 +224,7 @@ pipeline {
         if (cleanup == "always" && cloud_type == "virtual") {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
-            string(name: 'heat_action', value: "delete"),
-            string(name: 'reuse_node', value: "${NODE_NAME}"),
-            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+            string(name: 'heat_action', value: "delete")
           ], propagate: false, wait: false
         }
       }
@@ -236,9 +234,7 @@ pipeline {
         if (cleanup == "on success" && cloud_type == "virtual") {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
-            string(name: 'heat_action', value: "delete"),
-            string(name: 'reuse_node', value: "${NODE_NAME}"),
-            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+            string(name: 'heat_action', value: "delete")
           ], propagate: false, wait: false
         }
       }
@@ -253,9 +249,7 @@ pipeline {
         if (cleanup == "on failure" && cloud_type == "virtual") {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
-            string(name: 'heat_action', value: "delete"),
-            string(name: 'reuse_node', value: "${NODE_NAME}"),
-            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+            string(name: 'heat_action', value: "delete")
           ], propagate: false, wait: false
         }
       }


### PR DESCRIPTION
The `openstack-ardana-heat` Jenkins job builds triggered as post
build actions to clean up heat stacks must not reuse the workspace
from their parent jobs because they are running asynchronously
and the parent workspace may no longer be available.

This error has affected at least one job run so far: https://ci.suse.de/job/openstack-ardana-heat/61/