### PR TITLE
openstack-ardana: do not store host keys on known_hosts

### DIFF
--- a/scripts/jenkins/ardana/ansible/ansible.cfg
+++ b/scripts/jenkins/ardana/ansible/ansible.cfg
@@ -49,3 +49,9 @@ callback_whitelist = profile_tasks, timer
 
 # Use the YAML callback plugin
 stdout_callback = yaml
+
+
+[ssh_connection]
+
+# Do not save host keys on SSH known_hosts
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null


### PR DESCRIPTION
Ansible is storing host keys on ssh known_hosts files wich cause issues when the same IP is used for different hosts (virtual envs [1]).

This change adds `UserKnownHostsFile=/dev/null` to ansible ssh_args
so those host keys won't be stored.

1. https://ci.suse.de/job/openstack-ardana-vcloud/733/console