### PR TITLE
openstack-ardana: disable ansible mitogen plugin

### DIFF
--- a/scripts/jenkins/ardana/ansible/ansible.cfg
+++ b/scripts/jenkins/ardana/ansible/ansible.cfg
@@ -18,8 +18,8 @@
 
 # For faster ansible - see: http://mitogen.readthedocs.io/en/latest/ansible.html
 # Recommended if running ansible on high-latency (eg. nue<->provo)
-strategy_plugins = /opt/ansible/mitogen-0.2.2/ansible_mitogen/plugins/strategy
-strategy = mitogen_linear
+#strategy_plugins = /opt/ansible/mitogen-0.2.2/ansible_mitogen/plugins/strategy
+#strategy = mitogen_linear
 
 # Fact caching
 gathering = smart


### PR DESCRIPTION
Comment out ansible mitogen plugin on ansible config to make sure it
is/isn't affecting some CI failure cases.