### PR TITLE
openstack-ardana: reimplement shared workspaces

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-bootstrap-clm.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-bootstrap-clm.yaml
@@ -105,13 +105,6 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
-      - string:
-          name: reuse_workspace
-          default: ''
-          description: >-
-            The Jenkins workspace that this job must reuse. Used by upstream jobs to
-            force a job to use the same workspace.
-
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-heat.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-heat.yaml
@@ -53,7 +53,7 @@
               - delete: delete a heat stack
 
             If the create action is selected, a heat template file is required, which can only
-            be supplied by running this job as a downstream job or indicating a preexisting workspace.
+            be supplied by running this job as a downstream job.
 
       - string:
           name: git_automation_repo
@@ -73,13 +73,6 @@
           description: >-
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
-
-      - string:
-          name: reuse_workspace
-          default: ''
-          description: >-
-            The Jenkins workspace that this job must reuse. Used by upstream jobs to
-            force a job to use the same workspace.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/openstack-ardana-pcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-pcloud.yaml
@@ -105,13 +105,6 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
-      - string:
-          name: reuse_workspace
-          default: ''
-          description: >-
-            The Jenkins workspace that this job must reuse. Used by upstream jobs to
-            force a job to use the same workspace.
-
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-tempest.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tempest.yaml
@@ -96,13 +96,6 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
-      - string:
-          name: reuse_workspace
-          default: ''
-          description: >-
-            The Jenkins workspace that this job must reuse. Used by upstream jobs to
-            force a job to use the same workspace.
-
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -73,13 +73,6 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
-      - string:
-          name: reuse_workspace
-          default: ''
-          description: >-
-            The Jenkins workspace that this job must reuse. Used by upstream jobs to
-            force a job to use the same workspace.
-
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
@@ -134,13 +134,6 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
-      - string:
-          name: reuse_workspace
-          default: ''
-          description: >-
-            The Jenkins workspace that this job must reuse. Used by upstream jobs to
-            force a job to use the same workspace.
-
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -1,5 +1,5 @@
 /**
- * The openstack-ardana-physical Jenkins Pipeline
+ * The openstack-ardana-pcloud Jenkins Pipeline
  *
  * This jobs creates an fresh VM on the specified HW environment
  * that can be used to deploy an Ardana input model which is either
@@ -8,44 +8,40 @@
 
 pipeline {
 
-  // skip the default checkout, because we want to use a custom path
   options {
+    // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
   }
 
   agent {
     node {
       label reuse_node ? reuse_node : "cloud-ardana-ci"
-      customWorkspace ardana_env ? "${JOB_NAME}-${ardana_env}" : "${JOB_NAME}-${BUILD_NUMBER}"
+      // Use a single workspace for all job runs, to avoid cluttering the
+      // worker node
+      customWorkspace "${JOB_NAME}"
     }
   }
 
   stages {
     stage('Setup workspace') {
       steps {
-        cleanWs()
-
-        // If the job is set up to reuse an existing workspace, replace the
-        // current workspace with a symlink to the reused one.
-        // NOTE: even if we specify the reused workspace as the
-        // customWorkspace variable value, Jenkins will refuse to reuse a
-        // workspace that's already in use by one of the currently running
-        // jobs and will just create a new one.
-        sh '''
-          if [ -n "${reuse_workspace}" ]; then
-            rmdir "${WORKSPACE}"
-            ln -s "${reuse_workspace}" "${WORKSPACE}"
-          fi
-        '''
-
         script {
           if (ardana_env == '') {
             error("Empty 'ardana_env' parameter value.")
           }
-          currentBuild.displayName = "#${BUILD_NUMBER} ${ardana_env}"
-          if (reuse_workspace == '') {
-            sh('git clone $git_automation_repo --branch $git_automation_branch automation-git')
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
+          // Use a shared workspace folder for all jobs running on the same
+          // target 'ardana_env' cloud environment
+          env.SHARED_WORKSPACE = sh (
+            returnStdout: true,
+            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
+          ).trim()
+          if (reuse_node == '') {
             sh('''
+              rm -rf $SHARED_WORKSPACE
+              mkdir -p $SHARED_WORKSPACE
+              cd $SHARED_WORKSPACE
+              git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
               ansible_playbook load-job-params.yml
             ''')
@@ -57,6 +53,7 @@ pipeline {
     stage('Generate input model') {
       steps {
         sh('''
+          cd $SHARED_WORKSPACE
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook generate-input-model.yml -e @input.yml
         ''')
@@ -66,6 +63,7 @@ pipeline {
     stage('Start deployer VM') {
       steps {
         sh('''
+          cd $SHARED_WORKSPACE
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook start-deployer-vm.yml -e @input.yml
         ''')
@@ -75,6 +73,7 @@ pipeline {
     stage('Setup SSH access') {
       steps {
         sh('''
+          cd $SHARED_WORKSPACE
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook setup-ssh-access.yml -e @input.yml
         ''')
@@ -84,12 +83,15 @@ pipeline {
 
   post {
     always {
-        archiveArtifacts artifacts: '.artifacts/**/*', allowEmptyArchive: true
+        // archiveArtifacts doesn't support absolute paths, so we have to to this instead
+        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
+        sh 'rm ${BUILD_NUMBER}.artifacts'
     }
     success{
       sh """
       set +x
-      cd automation-git/scripts/jenkins/ardana/ansible
+      cd $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible
       echo "
 *****************************************************************
 ** The deployer for ${ardana_env} is reachable at

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
@@ -6,49 +6,42 @@
 
 pipeline {
 
-  // skip the default checkout, because we want to use a custom path
   options {
+    // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
   }
 
   agent {
     node {
       label reuse_node ? reuse_node : "cloud-ardana-ci"
-      customWorkspace ardana_env ? "${JOB_NAME}-${ardana_env}" : "${JOB_NAME}-${BUILD_NUMBER}"
+      // Use a single workspace for all job runs, to avoid cluttering the
+      // worker node
+      customWorkspace "${JOB_NAME}"
     }
   }
 
   stages {
     stage('Setup workspace') {
       steps {
-        cleanWs()
-
-        // If the job is set up to reuse an existing workspace, replace the
-        // current workspace with a symlink to the reused one.
-        // NOTE: even if we specify the reused workspace as the
-        // customWorkspace variable value, Jenkins will refuse to reuse a
-        // workspace that's already in use by one of the currently running
-        // jobs and will just create a new one.
-        sh '''
-          if [ -n "${reuse_workspace}" ]; then
-            rmdir "${WORKSPACE}"
-            ln -s "${reuse_workspace}" "${WORKSPACE}"
-          fi
-        '''
-
         script {
           if (ardana_env == '') {
             error("Empty 'ardana_env' parameter value.")
           }
-          currentBuild.displayName = "#${BUILD_NUMBER} ${ardana_env}"
-          if (reuse_workspace == '') {
-            sh('git clone $git_automation_repo --branch $git_automation_branch automation-git')
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
+          // Use a shared workspace folder for all jobs running on the same
+          // target 'ardana_env' cloud environment
+          env.SHARED_WORKSPACE = sh (
+            returnStdout: true,
+            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
+          ).trim()
+          if (reuse_node == '') {
             sh('''
+              rm -rf $SHARED_WORKSPACE
+              mkdir -p $SHARED_WORKSPACE
+              cd $SHARED_WORKSPACE
+              git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
               ansible_playbook load-job-params.yml
-            ''')
-            sh('''
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
               ansible_playbook setup-ssh-access.yml -e @input.yml
             ''')
           }
@@ -59,13 +52,14 @@ pipeline {
     stage('Run Tempest') {
       steps {
         sh('''
+          cd $SHARED_WORKSPACE
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook run-tempest.yml -e @input.yml
         ''')
       }
       post {
         always {
-          junit testResults: '.artifacts/*.xml', allowEmptyResults: true
+          junit testResults: "${SHARED_WORKSPACE}/.artifacts/*.xml", allowEmptyResults: true
         }
       }
     }
@@ -73,7 +67,10 @@ pipeline {
 
   post {
     always {
-        archiveArtifacts artifacts: '.artifacts/**/*', allowEmptyArchive: true
+        // archiveArtifacts doesn't support absolute paths, so we have to to this instead
+        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
+        sh 'rm ${BUILD_NUMBER}.artifacts'
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
@@ -12,46 +12,29 @@ pipeline {
 
   agent {
     node {
-      label reuse_node ? reuse_node : "openstack-trackupstream"
+      label "openstack-trackupstream"
     }
   }
 
   stages {
-    stage('setup workspace and environment') {
+    stage('Setup workspace') {
       steps {
         cleanWs()
-
-        // If the job is set up to reuse an existing workspace, replace the
-        // current workspace with a symlink to the reused one.
-        // NOTE: even if we specify the reused workspace as the
-        // customWorkspace variable value, Jenkins will refuse to reuse a
-        // workspace that's already in use by one of the currently running
-        // jobs and will just create a new one.
-        sh '''
-          if [ -n "${reuse_workspace}" ]; then
-            rmdir "${WORKSPACE}"
-            ln -s "${reuse_workspace}" "${WORKSPACE}"
-          fi
-        '''
-
         script {
+          if (gerrit_change_ids == '') {
+            error("Empty 'gerrit_change_ids' parameter value.")
+          }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${gerrit_change_ids}"
           env.test_repository_url = sh (
             returnStdout: true,
             script: '''
               echo http://download.suse.de/ibs/${homeproject//:/:\\/}:/ardana-ci-${gerrit_change_ids//,/-}/standard/${homeproject}:ardana-ci-${gerrit_change_ids//,/-}.repo
             '''
-          )
+          ).trim()
+          sh('''
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+          ''')
         }
-      }
-    }
-
-    stage('clone automation repo') {
-      when {
-        expression { reuse_workspace == '' }
-      }
-      steps {
-        sh 'git clone $git_automation_repo --branch $git_automation_branch automation-git'
       }
     }
 

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -7,44 +7,40 @@
  */
 pipeline {
 
-  // skip the default checkout, because we want to use a custom path
   options {
+    // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
   }
 
   agent {
     node {
       label reuse_node ? reuse_node : "cloud-ardana-ci"
-      customWorkspace ardana_env ? "${JOB_NAME}-${ardana_env}" : "${JOB_NAME}-${BUILD_NUMBER}"
+      // Use a single workspace for all job runs, to avoid cluttering the
+      // worker node
+      customWorkspace "${JOB_NAME}"
     }
   }
 
   stages {
     stage('Setup workspace') {
       steps {
-        cleanWs()
-
-        // If the job is set up to reuse an existing workspace, replace the
-        // current workspace with a symlink to the reused one.
-        // NOTE: even if we specify the reused workspace as the
-        // customWorkspace variable value, Jenkins will refuse to reuse a
-        // workspace that's already in use by one of the currently running
-        // jobs and will just create a new one.
-        sh '''
-          if [ -n "${reuse_workspace}" ]; then
-            rmdir "${WORKSPACE}"
-            ln -s "${reuse_workspace}" "${WORKSPACE}"
-          fi
-        '''
-
         script {
           if (ardana_env == '') {
             error("Empty 'ardana_env' parameter value.")
           }
-          currentBuild.displayName = "#${BUILD_NUMBER} ${ardana_env}"
-          if (reuse_workspace == '') {
-            sh('git clone $git_automation_repo --branch $git_automation_branch automation-git')
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
+          // Use a shared workspace folder for all jobs running on the same
+          // target 'ardana_env' cloud environment
+          env.SHARED_WORKSPACE = sh (
+            returnStdout: true,
+            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
+          ).trim()
+          if (reuse_node == '') {
             sh('''
+              rm -rf $SHARED_WORKSPACE
+              mkdir -p $SHARED_WORKSPACE
+              cd $SHARED_WORKSPACE
+              git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
               ansible_playbook load-job-params.yml
             ''')
@@ -61,6 +57,7 @@ pipeline {
           }
           steps {
             sh('''
+              cd $SHARED_WORKSPACE
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
               ansible_playbook generate-input-model.yml -e @input.yml
             ''')
@@ -72,6 +69,7 @@ pipeline {
           }
           steps {
             sh('''
+              cd $SHARED_WORKSPACE
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
               ansible_playbook clone-input-model.yml -e @input.yml
             ''')
@@ -83,6 +81,7 @@ pipeline {
     stage('Generate heat template') {
       steps {
         sh('''
+          cd $SHARED_WORKSPACE
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook generate-heat-template.yml -e @input.yml
         ''')
@@ -97,8 +96,7 @@ pipeline {
             string(name: 'heat_action', value: "create"),
             string(name: 'git_automation_repo', value: "$git_automation_repo"),
             string(name: 'git_automation_branch', value: "$git_automation_branch"),
-            string(name: 'reuse_node', value: "${NODE_NAME}"),
-            string(name: 'reuse_workspace', value: "${WORKSPACE}")
+            string(name: 'reuse_node', value: "${NODE_NAME}")
           ], propagate: true, wait: true
         }
       }
@@ -107,6 +105,7 @@ pipeline {
     stage('Setup SSH access') {
       steps {
         sh('''
+          cd $SHARED_WORKSPACE
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook setup-ssh-access.yml -e @input.yml
         ''')
@@ -116,12 +115,15 @@ pipeline {
 
   post {
     always {
-        archiveArtifacts artifacts: '.artifacts/**/*', allowEmptyArchive: true
+        // archiveArtifacts doesn't support absolute paths, so we have to to this instead
+        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
+        sh 'rm ${BUILD_NUMBER}.artifacts'
     }
     success{
       sh """
       set +x
-      cd automation-git/scripts/jenkins/ardana/ansible/ansible_facts
+      cd $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/ansible_facts
       echo "
 *****************************************************************
 ** The virtual environment is reachable at
@@ -132,14 +134,6 @@ pipeline {
 *****************************************************************
       "
       """
-    }
-    failure {
-      script {
-        def slaveJob = build job: 'openstack-ardana-heat', parameters: [
-          string(name: 'ardana_env', value: "$ardana_env"),
-          string(name: 'heat_action', value: "delete")
-        ], propagate: false, wait: false
-      }
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -95,6 +95,8 @@ pipeline {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
             string(name: 'heat_action', value: "create"),
+            string(name: 'git_automation_repo', value: "$git_automation_repo"),
+            string(name: 'git_automation_branch', value: "$git_automation_branch"),
             string(name: 'reuse_node', value: "${NODE_NAME}"),
             string(name: 'reuse_workspace', value: "${WORKSPACE}")
           ], propagate: true, wait: true

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -224,7 +224,9 @@ pipeline {
         if (cleanup == "always" && cloud_type == "virtual") {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
-            string(name: 'heat_action', value: "delete")
+            string(name: 'heat_action', value: "delete"),
+            string(name: 'git_automation_repo', value: "$git_automation_repo"),
+            string(name: 'git_automation_branch', value: "$git_automation_branch")
           ], propagate: false, wait: false
         }
       }
@@ -234,7 +236,9 @@ pipeline {
         if (cleanup == "on success" && cloud_type == "virtual") {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
-            string(name: 'heat_action', value: "delete")
+            string(name: 'heat_action', value: "delete"),
+            string(name: 'git_automation_repo', value: "$git_automation_repo"),
+            string(name: 'git_automation_branch', value: "$git_automation_branch")
           ], propagate: false, wait: false
         }
       }
@@ -249,7 +253,9 @@ pipeline {
         if (cleanup == "on failure" && cloud_type == "virtual") {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
-            string(name: 'heat_action', value: "delete")
+            string(name: 'heat_action', value: "delete"),
+            string(name: 'git_automation_repo', value: "$git_automation_repo"),
+            string(name: 'git_automation_branch', value: "$git_automation_branch")
           ], propagate: false, wait: false
         }
       }

--- a/scripts/jenkins/ardana/jenkins-helper.sh
+++ b/scripts/jenkins/ardana/jenkins-helper.sh
@@ -14,13 +14,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
+SHARED_WORKSPACE=${SHARED_WORKSPACE:-"$PWD"}
 ANSIBLE_VENV=${ANSIBLE_VENV:-"/opt/ansible"}
-AUTOMATION_DIR=${AUTOMATION_DIR:-"automation-git"}
+AUTOMATION_DIR=${AUTOMATION_DIR:-"$SHARED_WORKSPACE/automation-git"}
 
 
 function ansible_playbook {
   set +x
+  export WORKSPACE=$SHARED_WORKSPACE
   export ANSIBLE_FORCE_COLOR=true
   source $ANSIBLE_VENV/bin/activate
   if [[ "$PWD" != *scripts/jenkins/ardana/ansible ]]; then


### PR DESCRIPTION
The openstack-ardana pipeline job uses the idea of a shared
workspace: a common folder shared by the openstack-ardana job with
all downstream jobs targeting the same `ardana_env` virtual or physical
cloud setup. This mechanism was previously implemented by manipulating
the Jenkins `WORKSPACE` locations, replacing them in downstream jobs with
symbolic links pointing to the main job's Jenkins workspace - a hack which
was causing some issues with the Jenkins server's job management.

This commit reimplements the shared workspace mechanism: a `SHARED_WORKSPACE`
location uniquely associated with every `ardana_env` cloud setup is managed
and shared by jobs independently of their Jenkins workspaces. This approach also
 simplifies the implementation:
 - the shared workspace location is now only determined by the `ardana_env`
   value and doesn't need to be passed as a parameter between jobs
 - all builds belonging to the same job can use a single `WORKSPACE` location,
   because that location will basically not be used at all, with the following
   exceptions:
   - the openstack-ardana-gerrit job, which isn't tied to a single `ardana_env` value
   - the openstack-ardana-heat job, which may be triggered to run asynchronously
     from its parent job and needs a backup location where it can store its files
     in case the shared workspace is invalidated by other jobs

