### PR TITLE
openstack-ardana: fix Jenkins artifacts name

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
@@ -74,9 +74,9 @@ pipeline {
   post {
     always {
         // archiveArtifacts doesn't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
-        sh 'rm ${BUILD_NUMBER}.artifacts'
+        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
+        sh 'rm ${BUILD_NUMBER}'
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -84,9 +84,9 @@ pipeline {
   post {
     always {
         // archiveArtifacts doesn't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
-        sh 'rm ${BUILD_NUMBER}.artifacts'
+        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
+        sh 'rm ${BUILD_NUMBER}'
     }
     success{
       sh """

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
@@ -63,10 +63,10 @@ pipeline {
   post {
     always {
         // archiveArtifacts and junit don't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
+        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
         junit testResults: "${BUILD_NUMBER}/.artifacts/*.xml", allowEmptyResults: true
-        sh 'rm ${BUILD_NUMBER}.artifacts'
+        sh 'rm ${BUILD_NUMBER}'
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -116,9 +116,9 @@ pipeline {
   post {
     always {
         // archiveArtifacts doesn't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
-        sh 'rm ${BUILD_NUMBER}.artifacts'
+        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
+        sh 'rm ${BUILD_NUMBER}'
     }
     success{
       sh """

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -227,9 +227,9 @@ pipeline {
   post {
     always {
         // archiveArtifacts doesn't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE}/.artifacts ${BUILD_NUMBER}.artifacts'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}.artifacts/**/*", allowEmptyArchive: true
-        sh 'rm ${BUILD_NUMBER}.artifacts'
+        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
+        sh 'rm ${BUILD_NUMBER}'
       script{
         if (cleanup == "always" && cloud_type == "virtual") {
           def slaveJob = build job: 'openstack-ardana-heat', parameters: [


### PR DESCRIPTION
Use a consistent name for the root folder where Jenkins artifacts are
stored: `.artifacts` instead of `$BUILD_NUMER.artifacts`.