### PR TITLE
openstack-ardana: several small fixes

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -16,7 +16,7 @@
 ---
 
 heat_stack_name: "openstack-ardana-{{ ardana_env }}"
-heat_template_file: "{{ workspace_path }}/heat-stack-{{ (model is defined and model != '') | ternary(model, scenario_name) }}.yml"
+heat_template_file: "{{ workspace_path }}/heat-stack-{{ (scenario_name is defined and scenario_name != '') | ternary(scenario_name, model) }}.yml"
 os_cloud: "engcloud-cloud-ci"
 
 

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -19,7 +19,11 @@ when_staging: "{{ cloud_source | default(cloudsource) is match('.*staging.*') }}
 when_staging_or_devel: "{{ cloud_source | default(cloudsource) is match('.*(staging|devel).*') }}"
 when_cloud8: "{{ cloud_source | default(cloudsource) is match('.*8.*') }}"
 when_cloud9: "{{ cloud_source | default(cloudsource) is match('.*9.*') }}"
+when_cloud9M3: "{{ cloud_source | default(cloudsource) is match('cloud9M3') }}"
 
 versioned_features:
   manila:
     enabled: "{{ when_staging }}"
+  # FIXME: Remove this entry when bsc#1110414 fixed
+  fix_ardana_ssh_keyscan:
+    enabled: "{{ when_cloud9M3 }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
@@ -23,6 +23,8 @@ ardana_openstack_playbooks:
   - "ready-deployment.yml"
 
 ardana_scratch_playbooks:
+  - play: "ardana-ssh-keyscan.yml"
+    when: "{{ is_physical_deploy and when_cloud9 }}"
   - play: "wipe_disks.yml -e automate=true"
     when: "{{ is_physical_deploy }}"
   - play: "site.yml"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
@@ -34,6 +34,14 @@
   register: vrrp
   when: is_physical_deploy
 
+# FIXME: Remove task when bsc#1110414 fixed
+- name: Workaround for bug bsc#1110414
+  replace:
+    path: "~/openstack/ardana/ansible/roles/ardana-ssh-keyscan/tasks/main.yml"
+    regexp: '"\$'
+    replace: '"'
+  when: versioned_features.fix_ardana_ssh_keyscan.enabled
+
 - name: Commit changes
   shell: |
     git add -A

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/reimage_nodes.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/reimage_nodes.yml
@@ -23,7 +23,7 @@
     chdir: "{{ ardana_openstack_path }}"
 
 - name: Get list of SLES nodes to reimage
-  shell: 'cobbler profile list | grep "sles12sp3-x86_64-" | cut -d"-" -f3'
+  shell: 'cobbler profile list | grep "sles12sp{{ ansible_distribution_release }}-x86_64-" | cut -d"-" -f3'
   become: yes
   register: ardana_sles_nodes
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -29,6 +29,15 @@ ardana_qe_test_script: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.sh"
 ardana_qe_test_venv: "{{ ardana_qe_base_dir }}/{{ test_name }}/venv"
 ardana_qe_test_venv_requires: []
 
+ardana_qe_tests_requires_state: "present"
+ardana_qe_tests_requires:
+  - "gcc"
+  - "python-devel"
+
+sles_sdk_repos:
+  - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
+  - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
+
 ardana_qe_test_run_filters: "{{ role_path }}/files/run_filters/{{ test_name }}"
 
 ardana_qe_tests_admin_osrc_values:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/main.yml
@@ -22,6 +22,8 @@
 
 - include_tasks: read_group_vars.yml
 
+- include_tasks: qe_test_requires.yml
+
 - include_tasks: prepare_test_env.yml
 
 - include_tasks: setup_os_resources.yml
@@ -36,6 +38,12 @@
       vars:
         os_resource_state: "absent"
       when: os_resources_requires | length
+
+      # NOTE: Removing SLE-SDK repos and packages required for ardana-qe-tests
+      # as they were affecting maintenance updates
+    - include_tasks: qe_test_requires.yml
+      vars:
+        ardana_qe_tests_requires_state: "absent"
 
     - name: Fail if any '{{ test_name }}' test has failed
       fail:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/prepare_test_env.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/prepare_test_env.yml
@@ -30,36 +30,6 @@
     force: yes
     version: "{{ ardana_qe_tests_branch }}"
 
-- name: Install SLES-SDK repos
-  zypper_repository:
-    name: "{{ item }}"
-    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item }}/"
-    runrefresh: yes
-    priority: 9999
-  loop:
-    - "SLE12-SP3-SDK-Pool"
-    - "SLE12-SP3-SDK-Updates"
-  become: yes
-
-- name: Install requirements for QE automated tests
-  zypper:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "gcc"
-    - "python-devel"
-    - "java-1_8_0-openjdk-headless"
-  become: yes
-
-- name: Remove SLES-SDK repos
-  zypper_repository:
-    name: "{{ item }}"
-    state: absent
-  with_items:
-    - "SLE12-SP3-SDK-Pool"
-    - "SLE12-SP3-SDK-Updates"
-  become: yes
-
 - name: Ensure test virtual environment exists when required
   pip:
     name: "{{ item }}"
@@ -85,5 +55,3 @@
     dest: "{{ ardana_qe_test_work_dir }}/run_filters/"
     mode: "0640"
   when: "ardana_qe_test_run_filters is exists"
-
-

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/qe_test_requires.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/qe_test_requires.yml
@@ -1,0 +1,34 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- name: Ensure SLES-SDK repos {{ ardana_qe_tests_requires_state }}
+  zypper_repository:
+    name: "{{ item }}"
+    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item }}/"
+    runrefresh: yes
+    priority: 9999
+    state: "{{ ardana_qe_tests_requires_state }}"
+  loop: "{{ sles_sdk_repos }}"
+  become: yes
+
+- name: Ensure requirements for ardana-qe-tests {{ ardana_qe_tests_requires_state }}
+  zypper:
+    name: "{{ item }}"
+    state: "{{ ardana_qe_tests_requires_state }}"
+  loop: "{{ ardana_qe_tests_requires }}"
+  become: yes

--- a/scripts/jenkins/ardana/ansible/roles/bootstrap_ardana/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/bootstrap_ardana/defaults/main.yml
@@ -23,7 +23,7 @@ cobbler_requires:
     url: "http://{{ sles_media_server }}/install/SLE-12-SP3-Server-GM/SLE-12-SP3-Server-DVD-x86_64-GM-DVD1.iso"
     download_when: "{{ cloud_release == 'cloud8' }}"
   - name: "sles12sp4.iso"
-    url: "http://{{ sles_media_server }}/install/SLE-12-SP4-Server-Beta4/SLE-12-SP4-Server-DVD-x86_64-Beta4-DVD1.iso"
+    url: "http://{{ sles_media_server }}/install/SLE-12-SP4-Server-RC1/SLE-12-SP4-Server-DVD-x86_64-RC1-DVD1.iso"
     download_when: "{{ cloud_release == 'cloud9' }}"
   - name: "rhel7.iso"
     url: "http://10.84.144.252/compute_iso/RHEL-7.3-20170728-Server-x86_64-dvd.iso"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
@@ -44,7 +44,7 @@ tempest_run_filter: "smoke"
 os_health_server: "10.86.0.167"
 os_health_url: "http://{{ os_health_server }}/#/job/{{ os_health_build_name }}"
 os_health_url_msg: "[{{ os_health_url }}]({{ os_health_url }})"
-os_health_build_name: "{{ lookup('env', 'BUILD_DISPLAY_NAME') | default('NA', true) }}"
+os_health_build_name: "{{ lookup('env', 'BUILD_DISPLAY_NAME') | default('NA', true) | replace(': ', '-') | replace('#', '') }}"
 
 ansible_log_url: "{{ lookup('env', 'BUILD_URL') }}artifact/.artifacts/ansible.log"
 ansible_log_url_msg: "[{{ ansible_log_url }}]({{ ansible_log_url }})"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -21,7 +21,7 @@ clouddata_server: "provo-clouddata.cloud.suse.de"
 subunit2sql_venv: "/opt/subunit2sql"
 os_health_server: "10.86.0.167"
 os_health_url: "http://{{ os_health_server }}/#/job/{{ os_health_build_name }}"
-os_health_build_name: "{{ lookup('env', 'BUILD_DISPLAY_NAME') | default('NA', true)  | replace(' ', '-') }}"
+os_health_build_name: "{{ lookup('env', 'BUILD_DISPLAY_NAME') | default('NA', true) | replace(': ', '-') | replace('#', '') }}"
 os_service_name: "{{ test_name.split('_')[0] }}"
 
 sles_sdk_repos:

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -23,6 +23,10 @@ os_health_server: "10.86.0.167"
 os_health_url: "http://{{ os_health_server }}/#/job/{{ os_health_build_name }}"
 os_health_build_name: "{{ lookup('env', 'BUILD_DISPLAY_NAME') | default('NA', true) | replace(': ', '-') | replace('#', '') }}"
 os_service_name: "{{ test_name.split('_')[0] }}"
+os_health_requires_state: "present"
+os_health_requires:
+  - "gcc"
+  - "python-devel"
 
 sles_sdk_repos:
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
@@ -15,34 +15,10 @@
 #
 ---
 
+- include_tasks: os_health_requires.yml
+
 - name: Gather variables for '{{ task }}'
   include_vars: "{{ task }}.yml"
-
-- name: Ensure SLES-SDK repos present
-  zypper_repository:
-    name: "{{ item }}"
-    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item }}/"
-    runrefresh: yes
-    priority: 9999
-  loop: "{{ sles_sdk_repos }}"
-  become: yes
-
-- name: Ensure requirements for subunit2sql installed
-  zypper:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "gcc"
-    - "python-devel"
-  become: yes
-
-- name: Ensure SLES-SDK repos absent
-  zypper_repository:
-    name: "{{ item }}"
-    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item }}/"
-    state: absent
-  loop: "{{ sles_sdk_repos }}"
-  become: yes
 
 - name: Setup subunit2sql
   pip:
@@ -60,3 +36,9 @@
   shell: |
     {{ subunit2sql_venv }}/bin/subunit2sql --database-connection mysql+pymysql://subunit:subunit@{{ os_health_server }}/subunit \
       --run_meta "{{ os_health_metadata | join(',') }}" --artifacts "{{ jenkins_artifacts_url }}" {{ test_results_subunit }}
+
+# NOTE: Removing SLE-SDK repos and packages required for subunit2sql
+# as they were affecting maintenance updates
+- include_tasks: os_health_requires.yml
+  vars:
+    os_health_requires_state: "absent"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
@@ -1,0 +1,34 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- name: Ensure SLES-SDK repos {{ os_health_requires_state }}
+  zypper_repository:
+    name: "{{ item }}"
+    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item }}/"
+    runrefresh: yes
+    priority: 9999
+    state: "{{ os_health_requires_state }}"
+  loop: "{{ sles_sdk_repos }}"
+  become: yes
+
+- name: Ensure requirements for subunit2sql {{ os_health_requires_state }}
+  zypper:
+    name: "{{ item }}"
+    state: "{{ os_health_requires_state }}"
+  loop: "{{ os_health_requires }}"
+  become: yes


### PR DESCRIPTION
This PR addresses the following issues on the ardana automation playbooks.

- When running openstack-ardana job the default is to use the input model
  from ardana repository (model parameter is set and scenario_name is
  empty).
  For the heat template file name the same logic is used, whici is use
  the model variable and only use scenario_name when its defined and not
  empty.
- The SLE-SDK repos and packges installed by send_to_os_health and
  ardana-qe-tests roles were affecting maintenance updates.
  This change address this issue by making sure those repos/packages
  are removed after its use.
- Add workaround for bug bsc#1110414 present on `cloud9M3`.
  Applying this workaround is controlled by the versioned_features variable.
- Cloud 9 sets `host_key_checking = True` on ansible.cfg which requires
  accepting the host keys when is the firt time running the playbook on a
  new host. The keys are also automatically added to known hosts when
  running site.yml which calls ardana-ssh-keyscan.yml playbook.  
  For hardware deployments we need to run wipe_disks.yml before site.yml
  and as wipe_disks.yml does not call ardana-ssh-keyscan.yml it get stuck
  waiting for input to accept the ssh keys.  
  This change adds ardana-ssh-keyscan.yml to the list of playbooks that
  are ran for cloud9 hardware deployment so we make sure the hosts keys are
  on known hosts file before running wipe_disks.yml
- Build names containing `space` and `#` are not accepted by
  OpenStack-Health. This changes remove the `#` from the build name
  and replaces `space` with `-`.
- The task to select nodes for bm-reimage was using a static value
  to grep for the nodes (sles12sp3) which does not work for cloud9 (sp4).
  This change uses a variable from ansible facts to select the correct
  sp value.