### PR TITLE
openstack-ardana: use workspace symlink for artifacts

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
@@ -26,9 +26,7 @@ pipeline {
   agent {
     node {
       label reuse_node ? reuse_node : "cloud-ardana-ci"
-      // Use a single workspace for all job runs, to avoid cluttering the
-      // worker node
-      customWorkspace "${JOB_NAME}"
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
 
@@ -50,6 +48,10 @@ pipeline {
             sh('''
               rm -rf $SHARED_WORKSPACE
               mkdir -p $SHARED_WORKSPACE
+
+              # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
+              ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
+
               cd $SHARED_WORKSPACE
               git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
@@ -73,10 +75,8 @@ pipeline {
 
   post {
     always {
-        // archiveArtifacts doesn't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
-        sh 'rm ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+        cleanWs()
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -16,9 +16,7 @@ pipeline {
   agent {
     node {
       label reuse_node ? reuse_node : "cloud-ardana-ci"
-      // Use a single workspace for all job runs, to avoid cluttering the
-      // worker node
-      customWorkspace "${JOB_NAME}"
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
 
@@ -40,6 +38,10 @@ pipeline {
             sh('''
               rm -rf $SHARED_WORKSPACE
               mkdir -p $SHARED_WORKSPACE
+
+              # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
+              ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
+
               cd $SHARED_WORKSPACE
               git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
@@ -83,10 +85,8 @@ pipeline {
 
   post {
     always {
-        // archiveArtifacts doesn't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
-        sh 'rm ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+        cleanWs()
     }
     success{
       sh """

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
@@ -14,9 +14,7 @@ pipeline {
   agent {
     node {
       label reuse_node ? reuse_node : "cloud-ardana-ci"
-      // Use a single workspace for all job runs, to avoid cluttering the
-      // worker node
-      customWorkspace "${JOB_NAME}"
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
 
@@ -38,6 +36,10 @@ pipeline {
             sh('''
               rm -rf $SHARED_WORKSPACE
               mkdir -p $SHARED_WORKSPACE
+
+              # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
+              ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
+
               cd $SHARED_WORKSPACE
               git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
@@ -62,11 +64,9 @@ pipeline {
 
   post {
     always {
-        // archiveArtifacts and junit don't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
-        junit testResults: "${BUILD_NUMBER}/.artifacts/*.xml", allowEmptyResults: true
-        sh 'rm ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+        junit testResults: ".artifacts/*.xml", allowEmptyResults: true
+        cleanWs()
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -15,9 +15,7 @@ pipeline {
   agent {
     node {
       label reuse_node ? reuse_node : "cloud-ardana-ci"
-      // Use a single workspace for all job runs, to avoid cluttering the
-      // worker node
-      customWorkspace "${JOB_NAME}"
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
 
@@ -39,6 +37,10 @@ pipeline {
             sh('''
               rm -rf $SHARED_WORKSPACE
               mkdir -p $SHARED_WORKSPACE
+
+              # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
+              ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
+
               cd $SHARED_WORKSPACE
               git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
@@ -115,10 +117,8 @@ pipeline {
 
   post {
     always {
-        // archiveArtifacts doesn't support absolute paths, so we have to to this instead
-        sh 'ln -s ${SHARED_WORKSPACE} ${BUILD_NUMBER}'
-        archiveArtifacts artifacts: "${BUILD_NUMBER}/.artifacts/**/*", allowEmptyArchive: true
-        sh 'rm ${BUILD_NUMBER}'
+        archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+        cleanWs()
     }
     success{
       sh """


### PR DESCRIPTION
The `junit` and `archiveArtifacts` pipeline plugins don't support
absolute paths, which means they can only take in files that are
in the Jenkins `WORKSPACE` folder. Using a dedicated workspace for
every job run, which is cleaned up at the end, and creating symlinks
there from the shared workspace solves this problem.