### PR TITLE
Delete the Ardana Testbuild Project after 30days

### DIFF
--- a/scripts/jenkins/ardana/gerrit/build_test_package.py
+++ b/scripts/jenkins/ardana/gerrit/build_test_package.py
@@ -293,6 +293,9 @@ class OBSProject:
                   (self.obs_test_project_name, self.obs_linked_project))
             sh.osc('-A', 'https://api.suse.de', 'api', '-T', meta.name,
                    '/source/%s/_meta' % self.obs_test_project_name)
+            sh.osc('-A', 'https://api.suse.de', 'deleterequest',
+                   self.obs_test_project_name, '--accept-in-hours', 720,
+                   '-m', 'Auto delete after 30 days.')
 
     def add_test_package(self, package):
         """


### PR DESCRIPTION
Currently no job deletes the Ardana Testbuild Projects but we should do
some cleanups.