### PR TITLE
openstack-ardana: add ardana-qa-tests to openstack-ardana pipeline

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-qa-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-qa-tests.yaml
@@ -1,0 +1,132 @@
+- job:
+    name: openstack-ardana-qa-tests
+    project-type: pipeline
+    concurrent: true
+    wrappers:
+      - timestamps
+      - timeout:
+          timeout: 300
+          type: no-activity
+          abort: true
+          write-description: "Job aborted due to 180 minutes of inactivity"
+
+    logrotate:
+      numToKeep: 2000
+      daysToKeep: 300
+
+    properties:
+      - authorization:
+          cloud:
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-delete
+            - job-discover
+            - job-read
+            - job-workspace
+            - run-delete
+            - run-update
+            - scm-tag
+          anonymous:
+            - job-read
+
+    parameters:
+      - string:
+          name: ardana_env
+          default: ''
+          description: >-
+            The virtual or hardware environment identifier. This field should either
+            be set to one of the values associated with the known hardware environments
+            (e.g. qe101), or to a value that will identify the created virtual environment.
+
+            WARNING: if a virtual environment associated with the supplied ardana_env already
+            exists, it will be replaced.
+
+      - extended-choice:
+          name: test_list
+          type: multi-select
+          visible-items: 10
+          multi-select-delimiter: ','
+          default-value: ''
+          value: >-
+            iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,
+            heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,
+            nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,
+            barbican-functional,horizon,horizon_integration-tests,freezer,keystone-soapui,
+            remove_compute_node,add_compute_node,tempest_cleanup
+          description: >-
+            Select tests to run
+
+      - string:
+          name: test_branch
+          default: master
+          description: >-
+            ardana-qa-tests repository branch
+
+      - string:
+          name: run_filter
+          default: ''
+          description: >-
+            test run filter
+
+      - bool:
+          name: dpdk
+          default: false
+          description: >-
+            (neutron) DPDK enabled/disabled
+
+      - choice:
+          name: dpdk_br
+          choices:
+            - br-dpdk0
+            - br-dpdkbond0
+          description: >-
+            (neutron) dpdk bond interface name
+
+      - bool:
+          name: octavia
+          default: false
+          description: >-
+            (neutron) OCTAVIA enabled/disabled
+
+      - bool:
+          name: esx
+          default: false
+          description: >-
+            ESX compute enabled/disabled
+
+      - bool:
+          name: rc_notify
+          default: true
+          description: >-
+            Notify RocketChat about job status
+
+      - string:
+          name: git_automation_repo
+          default: https://github.com/SUSE-Cloud/automation.git
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: master
+          description: >-
+            The git automation branch
+
+      - string:
+          name: reuse_node
+          default: ''
+          description: >-
+            The Jenkins agent where this job must run. Used by upstream jobs to
+            force a job to reuse the same node.
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${git_automation_repo}
+            branches:
+              - ${git_automation_branch}
+            browser: auto
+            wipe-workspace: false
+      script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
+      lightweight-checkout: false

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
@@ -1,0 +1,78 @@
+/**
+ * The openstack-ardana-qa-tests Jenkins Pipeline
+ *
+ * This job runs ardana-qa-tests on a pre-deployed CLM cloud.
+ */
+
+pipeline {
+
+  options {
+    // skip the default checkout, because we want to use a custom path
+    skipDefaultCheckout()
+    timestamps()
+  }
+
+  agent {
+    node {
+      label reuse_node ? reuse_node : "cloud-ardana-ci"
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
+    }
+  }
+
+  stages {
+    stage('Setup workspace') {
+      steps {
+        script {
+          if (ardana_env == '') {
+            error("Empty 'ardana_env' parameter value.")
+          }
+          if (test_list == '') {
+            error("Empty 'test_list' parameter value.")
+          }
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
+          // Use a shared workspace folder for all jobs running on the same
+          // target 'ardana_env' cloud environment
+          env.SHARED_WORKSPACE = sh (
+            returnStdout: true,
+            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
+          ).trim()
+          if (reuse_node == '') {
+            sh('''
+               rm -rf "$SHARED_WORKSPACE"
+               mkdir -p "$SHARED_WORKSPACE"
+
+               # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
+               ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
+
+               cd $SHARED_WORKSPACE
+               git clone $git_automation_repo --branch $git_automation_branch automation-git
+               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+               ansible_playbook load-job-params.yml
+               ansible_playbook setup-ssh-access.yml -e @input.yml
+            ''')
+          }
+          def test_list = env.test_list.split(',')
+          for (test in test_list) {
+            catchError {
+              stage(test) {
+                sh("""
+                  cd \$SHARED_WORKSPACE
+                  source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+                  ansible_playbook run-ardana-qe-tests.yml -e @input.yml \
+                                                           -e test_name=$test
+                """)
+              }
+            }
+            archiveArtifacts artifacts: ".artifacts/**/${test}*", allowEmptyArchive: true
+            junit testResults: ".artifacts/${test}.xml", allowEmptyResults: true
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -223,7 +223,25 @@ pipeline {
       }
     }
 
-    stage ('Deploy CaaSP') {
+    stage('Run QA tests') {
+      when {
+        expression { qa_test_list != '' }
+      }
+      steps {
+        script {
+          def slaveJob = build job: 'openstack-ardana-qa-tests', parameters: [
+            string(name: 'ardana_env', value: "$ardana_env"),
+            string(name: 'test_list', value: "$qa_test_list"),
+            string(name: 'rc_notify', value: "$rc_notify"),
+            string(name: 'git_automation_repo', value: "$git_automation_repo"),
+            string(name: 'git_automation_branch', value: "$git_automation_branch"),
+            string(name: 'reuse_node', value: "${NODE_NAME}")
+          ], propagate: true, wait: true
+        }
+      }
+    }
+
+    stage('Deploy CaaSP') {
       when {
         expression { want_caasp == 'true' }
       }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -149,6 +149,21 @@
             Name of the filter file to use for tempest. Use an empty value to
             skip running tempest.
 
+      - extended-choice:
+          name: qa_test_list
+          type: multi-select
+          visible-items: 10
+          multi-select-delimiter: ','
+          default-value: ''
+          value: >-
+            iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,
+            heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,
+            nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,
+            barbican-functional,horizon,horizon_integration-tests,freezer,keystone-soapui,
+            remove_compute_node,add_compute_node,tempest_cleanup
+          description: >-
+            Select QA tests to run. Use an empty value to skip running QA tests.
+
       - string:
           name: extra_repos
           default: ''

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -17,6 +17,7 @@
 
 # The cloud release is encoded in the cloudsource value
 cloud_release: "cloud{{ cloudsource | regex_search('\\d') }}"
+clouddata_server: "provo-clouddata.cloud.suse.de"
 rhel_enabled: "{{ rhel_computes is defined and rhel_computes | int > 0 }}"
 
 workspace_path: "{{ lookup('env', 'WORKSPACE') | default('.', true) }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/README.md
@@ -45,7 +45,7 @@ Try to use predefined ansible variables whenever possible. Example:
 
 6. Create the file `vars/<test_name>.yml` to define specific variables for the test, this is like its the configuration file.
 
-* The following variables must be defined on it:
+* The following variables should be defined on it:
     * `ardana_qe_test_get_failed_cmd`: a bash command used to get a list of tests that failed from its execution log.
 
         Example for iverify:
@@ -63,16 +63,7 @@ Try to use predefined ansible variables whenever possible. Example:
         ardana_qe_test_get_failed_cmd: "grep -e '^iverify.*\\.\\.\\..*FAIL' {{ ardana_qe_test_log }} || echo 'None'"
         ```
 
-    * `ardana_qe_test_get_results_cmds`: a list of bash commands to get the number of tests that passed, failed and ran from its execution log.
-
-        Example for iverify:
-
-        ```sh
-        ardana_qe_test_get_results_cmds:
-          passed: "grep -e '^iverify.*\\.\\.\\..*ok' {{ ardana_qe_test_log }} | wc -l"
-          failed: "grep -e '^iverify.*\\.\\.\\..*FAIL' {{ ardana_qe_test_log }} | wc -l"
-          ran: "grep -e '^iverify.*\\.\\.\\..*' {{ ardana_qe_test_log }} | wc -l"
-        ```
+    * `ardana_qe_test_timeout`: define a specific timeout for the test in minutes (defaults to 120).
 
     * If the test requires the creation OpenStack resources you must define `os_resources_requires` variable with the resources needed. Example:
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -25,6 +25,7 @@ ardana_qe_tests_branch: "{{ tests_branch | default('master') }}"
 ardana_qe_test_log: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.log"
 ardana_qe_test_subunit: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.subunit"
 ardana_qe_test_script: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.sh"
+ardana_qe_test_timeout: 120
 
 ardana_qe_test_venv: "{{ ardana_qe_base_dir }}/{{ test_name }}/venv"
 ardana_qe_test_venv_requires: []
@@ -58,3 +59,7 @@ os_resource_test_auth:
     password: "secret"
     project: "{{ os_resource_prefix }}-project"
     role: "Member"
+
+subunit2junit_venv: "~/subunit2junit"
+subunit_html_results: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.html"
+subunit_xml_results: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.xml"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/convert_subunit.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/convert_subunit.yml
@@ -13,16 +13,23 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+
 ---
 
-test_results_subunit: "/opt/stack/tempest/logs/testrepository_region1.subunit"
+- name: Ensure virtualenv with subunit2junit
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{{ subunit2junit_venv }}"
+  loop:
+    - "junitxml"
+    - "python-subunit"
 
-os_health_build_name: "{{ ardana_env }}_tempest_{{ tempest_run_filter }}"
+- name: Generate xml subunit results
+  shell: "{{ subunit2junit_venv }}/bin/subunit2junitxml {{ ardana_qe_test_subunit }} > {{ subunit_xml_results }}"
+  changed_when: false
+  failed_when: false
 
-os_health_metadata:
-  - "build_uuid:`uuidgen`"
-  - "project:openstack/tempest/{{ tempest_run_filter }}""
-  - "ardana_env:{{ ardana_env }}"
-  - "build_name:{{ os_health_build_name }}"
-  - "openstack_service:{{ tempest_run_filter }}"
-  - "build_version:{{ cloud_media_build_version.content | b64decode }}"
+- name: Generate html subunit results
+  shell: "subunit2html {{ ardana_qe_test_subunit }} {{ subunit_html_results }}"
+  changed_when: false
+  failed_when: false

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/main.yml
@@ -32,6 +32,15 @@
 - block:
     - include_tasks: run_test.yml
   always:
+    - name: Fail if the test timed out
+      fail:
+        msg: |
+          Timed out waiting for '{{ ardana_qe_test_script }}' to finish after
+          {{ ardana_qe_test_timeout }} minutes.
+      when: test_output.rc == 124
+
+    - include_tasks: convert_subunit.yml
+
     - include_tasks: process_test_results.yml
 
     - include_tasks: setup_os_resources.yml

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/prepare_test_env.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/prepare_test_env.yml
@@ -55,3 +55,13 @@
     dest: "{{ ardana_qe_test_work_dir }}/run_filters/"
     mode: "0640"
   when: "ardana_qe_test_run_filters is exists"
+
+- name: Ensure previous result/log deleted
+  file:
+    path: "{{ item }}"
+    state: "absent"
+  loop:
+    - "{{ ardana_qe_test_log }}"
+    - "{{ ardana_qe_test_subunit }}"
+    - "{{ subunit_html_results }}"
+    - "{{ subunit_xml_results }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/process_test_results.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/process_test_results.yml
@@ -21,21 +21,20 @@
     chdir: "{{ ardana_qe_test_work_dir }}"
   register: ardana_qe_failed_tests
 
-- name: Process '{{ test_name }}' results
-  shell: "{{ ardana_qe_test_get_results_cmds[item] }}"
-  args:
-    chdir: "{{ ardana_qe_test_work_dir }}"
-  loop: "{{ ardana_qe_test_get_results_cmds.keys() }}"
-  register: test_results_processed
-
-- name: Store test results
-  set_fact:
-    ardana_qe_test_results: "{{ ardana_qe_test_results | default({}) | combine({item.item: item.stdout}) }}"
-  loop: "{{ test_results_processed.results }}"
-  loop_control:
-    label: "{{ item.item }}: {{ item.stdout }}"
-
 - name: Check if subunit output is available
   stat:
     path: "{{ ardana_qe_test_subunit }}"
   register: subunit
+
+- name: Get '{{ test_name }}' results from subunit
+  command: "{{ subunit2junit_venv }}/bin/subunit-stats {{ ardana_qe_test_subunit }}"
+  failed_when: false
+  register: test_results
+
+- name: Process test results from subunit
+  set_fact:
+    ardana_qe_test_results: "{{ ardana_qe_test_results | default({}) | combine({item.split()[0] | lower: item.split()[-1]}) }}"
+  when: "'tests' in item"
+  loop: "{{ test_results.stdout_lines }}"
+  loop_control:
+    label: "{{ item.split()[0] | lower }}: {{ item.split()[-1] }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/run_test.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/run_test.yml
@@ -16,5 +16,9 @@
 ---
 
 - name: Run test '{{ test_name }}'
-  command: "{{ ardana_qe_test_script }} {{ ardana_qe_test_script_args | default('') }} \
-    {{ run_filter_file | default('') }}"
+  command: |
+    timeout {{ ardana_qe_test_timeout}}m {{ ardana_qe_test_script }} \
+    {{ ardana_qe_test_script_args | default('') }} \
+    {{ run_filter_file | default('') }}
+  register: test_output
+  changed_when: false

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-cli-func.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-cli-func.yml
@@ -27,11 +27,6 @@ ardana_qe_test_venv_requires:
 
 ardana_qe_test_get_failed_cmd: "grep -B1 -- '------' {{ ardana_qe_test_log }} |
   awk -F '\n' 'ln ~ /^$/ { ln = \"matched\"; print $1 } $1 ~ /^--$/ { ln = \"\" }'"
-ardana_qe_test_get_results_cmds:
-  passed: "awk '/- Passed:/ { print $3 }' {{ ardana_qe_test_log }} "
-  failed: "awk '/- Failed:/ { print $3 }' {{ ardana_qe_test_log }}"
-  ran: "awk '/^Ran:/ { print $2 }' {{ ardana_qe_test_log }}"
-  skipped: "awk '/- Skipped:/ { print $3 }' {{ ardana_qe_test_log }}"
 
 test_run_filter: "{{ run_filter | default('smoke', true) }}"
 run_concurrency: 0

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-functional.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-functional.yml
@@ -81,12 +81,7 @@ ardana_qe_tests_dir: "{{ ardana_qe_test_work_dir }}"
 ardana_qe_tests_branch: "stable/pike"
 ardana_qe_test_get_failed_cmd: "grep -B1 -- '------' {{ ardana_qe_test_log }} |
   awk -F '\n' 'ln ~ /^$/ { ln = \"matched\"; print $1 } $1 ~ /^--$/ { ln = \"\" }'"
-ardana_qe_test_get_results_cmds:
-  passed: "awk '/- Passed:/ { print $3 }' {{ ardana_qe_test_log }} "
-  failed: "awk '/- Failed:/ { print $3 }' {{ ardana_qe_test_log }}"
-  ran: "awk '/^Ran:/ { print $2 }' {{ ardana_qe_test_log }}"
-  skipped: "awk '/- Skipped:/ { print $3 }' {{ ardana_qe_test_log }}"
-
+  
 ardana_qe_test_venv_requires:
   - 'os-testr'
 ardana_qe_test_run_filters: "{{ role_path }}/files/run_filters/"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/ceilometer.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/ceilometer.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/ceilometer_capacity_management.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/ceilometer_capacity_management.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/cinder-parallel.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/cinder-parallel.yml
@@ -1,9 +1,21 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
 ardana_qe_test_venv_requires:
   - 'python-subunit'
 
 ardana_qe_test_get_failed_cmd: "grep Pas {{ ardana_qe_test_log }} | grep -v 'Failed:  0' || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  passed: "grep Pas {{ ardana_qe_test_log }} | grep 'Failed:  0' | wc -l"
-  failed: "grep Pas {{ ardana_qe_test_log }} | grep -v 'Failed:  0' | wc -l"
-  ran: "grep Pas {{ ardana_qe_test_log }} | grep Pas | wc -l"
-

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/cinder.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/cinder.yml
@@ -1,6 +1,18 @@
-ardana_qe_test_get_failed_cmd: "grep Passed {{ ardana_qe_test_log }} | grep -v 'Failed:  0' || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  passed: "grep Passed {{ ardana_qe_test_log }} | grep 'Failed:  0' | wc -l"
-  failed: "grep Passed {{ ardana_qe_test_log }} | grep -v 'Failed:  0' | wc -l"
-  ran: "grep Passed {{ ardana_qe_test_log }} | grep Passed | wc -l"
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
 
+ardana_qe_test_get_failed_cmd: "grep Passed {{ ardana_qe_test_log }} | grep -v 'Failed:  0' || echo 'None'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/freezer.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/freezer.yml
@@ -20,7 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  failed: "grep Failed: {{ ardana_qe_test_log }} | cut -c12-13"
-  ran: "grep Ran: {{ ardana_qe_test_log }} | cut -c6-7"
-  passed: "grep Passed: {{ ardana_qe_test_log }} | cut -c12-13"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/getput.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/getput.yml
@@ -1,3 +1,20 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
 # The way getput reports test results is one line per test so in this case we have
 # 6 lines and any failures are reported as a non-zero value in column 11. This
 # almost never happens and the more interesting value is the IOPS which in
@@ -9,9 +26,3 @@ ardana_qe_test_venv_requires:
 
 # if (( `grep 1k xxx | grep put | awk '{print $10}'|cut -f1 -d'.'` < 40 )); then grep 1k xxx|grep put; fi
 ardana_qe_test_get_failed_cmd: "cat {{ ardana_qe_test_log }} | grep FAIL || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran:    "cat {{ ardana_qe_test_log }} | egrep -v 'Test|FAIL' | wc -l"
-  failed: "cat {{ ardana_qe_test_log }} | grep FAIL | wc -l || echo 'None'"
-  passed: "expr `egrep -v 'Test|FAIL' {{ ardana_qe_test_log }} | wc -l` - \
-                `grep FAIL {{ ardana_qe_test_log }} | wc -l`"
-

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/heat.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/heat.yml
@@ -20,7 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  failed: "grep Failed: {{ ardana_qe_test_log }} | cut -c12-13"
-  ran: "grep Ran: {{ ardana_qe_test_log }} | cut -c6-7"
-  passed: "grep Passed: {{ ardana_qe_test_log }} | cut -c12-13"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/horizon.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/horizon.yml
@@ -1,3 +1,18 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
 ---
 
 ardana_qe_test_venv_requires:
@@ -13,7 +28,3 @@ ardana_qe_test_venv_requires:
   - 'xvfbwrapper'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  passed: 'grep ok {{ ardana_qe_test_log }} | wc -l'
-  failed: 'grep FAILED {{ ardana_qe_test_log }} | wc -l'
-  ran: 'grep -e "FAILED\|ok" {{ ardana_qe_test_log }} | wc -l'

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/iverify.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/iverify.yml
@@ -16,8 +16,3 @@
 ---
 
 ardana_qe_test_get_failed_cmd: "grep -e '^iverify.*\\.\\.\\..*FAIL' {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  passed: "grep -e '^iverify.*\\.\\.\\..*ok' {{ ardana_qe_test_log }} | wc -l"
-  failed: "grep -e '^iverify.*\\.\\.\\..*FAIL' {{ ardana_qe_test_log }} | wc -l"
-  ran: "grep -e '^iverify.*\\.\\.\\..*' {{ ardana_qe_test_log }} | wc -l"
-  skipped: "grep -e '^iverify.*\\.\\.\\..*SKIP' {{ ardana_qe_test_log }} | wc -l"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/logging.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/logging.yml
@@ -25,8 +25,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} | cut -d. -f2-7"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran: {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed: {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed: {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped: {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/magnum.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/magnum.yml
@@ -20,7 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  failed: "grep Failed: {{ ardana_qe_test_log }} | cut -c12-13"
-  ran: "grep Ran: {{ ardana_qe_test_log }} | cut -c6-7"
-  passed: "grep Passed: {{ ardana_qe_test_log }} | cut -c12-13"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/monasca.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/monasca.yml
@@ -20,7 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} | cut -d. -f2-7"
-ardana_qe_test_get_results_cmds:
-  failed: "grep Failed: {{ ardana_qe_test_log }} | cut -c12-13"
-  ran: "grep Ran: {{ ardana_qe_test_log }} | cut -c6-7"
-  passed: "grep Passed: {{ ardana_qe_test_log }} | cut -c12-13"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
@@ -1,3 +1,18 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
 ---
 
 ardana_qe_test_venv_requires:
@@ -12,8 +27,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  passed: 'grep ok {{ ardana_qe_test_log }} | wc -l'
-  failed: 'grep FAILED {{ ardana_qe_test_log }} | wc -l'
-  ran: 'grep -e "FAILED\|ok" {{ ardana_qe_test_log }} | wc -l'
-  skipped: 'grep -e "SKIPPED" {{ ardana_qe_test_log }} | wc -l'

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova-attach.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova-attach.yml
@@ -1,9 +1,21 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
 ardana_qe_test_venv_requires:
   - 'python-subunit'
 
 ardana_qe_test_get_failed_cmd: "grep Pas {{ ardana_qe_test_log }} | grep -v 'Failed:  0' || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  passed: "grep Pas {{ ardana_qe_test_log }} | grep 'Failed:  0' | wc -l"
-  failed: "grep Pas {{ ardana_qe_test_log }} | grep -v 'Failed:  0' | wc -l"
-  ran: "grep Pas {{ ardana_qe_test_log }} | grep Pas | wc -l"
-

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_flavor.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_flavor.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_image.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_image.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_migrate.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_migrate.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_server.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_server.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_services.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_services.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_volume.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/nova_volume.yml
@@ -20,8 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  ran: "grep Ran {{ ardana_qe_test_log }} | awk '{print $2}'"
-  passed: "grep Passed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  failed: "grep Failed {{ ardana_qe_test_log }} | awk '{print $3}'"
-  skipped: "grep Skipped {{ ardana_qe_test_log }} | awk '{print $3}'"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/tempest_cleanup.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/tempest_cleanup.yml
@@ -20,7 +20,3 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
-ardana_qe_test_get_results_cmds:
-  failed: "grep Failed: {{ ardana_qe_test_log }} | cut -c12-13"
-  ran: "grep Ran: {{ ardana_qe_test_log }} | cut -c6-7"
-  passed: "grep Passed: {{ ardana_qe_test_log }} | cut -c12-13"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
@@ -34,6 +34,7 @@ rc_channel_id_query: "json.channels[?name=='{{ rc_channels[ardana_env] }}']._id"
 rc_deploy_announcement_file: "~/deploy_finished-{{ ardana_env }}.rc"
 
 rc_msg_title: "{{ rc_task | upper }} {{ rc_action }}"
+rc_msg_color: "{{ 'danger' if rc_state == 'Failed' else 'good' if rc_state == 'Success' else '#BDC3C7' }}"
 
 # IVerify vars
 iverify_failed_tests:

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
@@ -38,10 +38,11 @@
     validate_certs: no
     protocol: "{{ rc_protocol }}"
     attachments:
-      - color: "{{ 'danger' if rc_state == 'Failed' else 'good' if rc_state == 'Success' else 'warning' }}"
+      - color: "{{ rc_msg_color }}"
         title: "{{ rc_msg_title }}"
         title_link: "{{ lookup('env', 'BUILD_URL') }}console"
         text:
+        collapsed: "{{ rc_att_colapsed | default(False) }}"
         fields: "{{ rc_msg_fields_started if rc_action == 'started' else rc_msg_fields_finished }}"
   ignore_errors: True
   delegate_to: localhost

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/ardana-qe-tests.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/ardana-qe-tests.yml
@@ -15,6 +15,12 @@
 #
 ---
 ardana_qe_test_log_url: "{{ lookup('env', 'BUILD_URL') }}artifact/.artifacts/{{ test_name }}.log"
+ardana_qe_test_log_url_msg: "[{{ ardana_qe_test_log_url }}]({{ ardana_qe_test_log_url }})"
+
+rc_att_colapsed: True
+
+rc_msg_color: "{{ 'danger' if (rc_state == 'Failed' and ardana_qe_test_results is not defined) else '#BDC3C7' if rc_state == 'Started' else _test_msg_color }}"
+_test_msg_color: "{{ (ardana_qe_test_results is defined and ardana_qe_test_results.failed | int > 0) | ternary('warning', 'good') }}"
 
 rc_announcement_started: "Running ardana-qe-tests({{ test_name }}) test"
 rc_announcement_finished: "{{ rc_previous_announcement.content | b64decode if rc_previous_announcement.content is defined else 'NA' }}"
@@ -23,7 +29,7 @@ rc_msg_title: "ardana-qe-tests({{ test_name }}) {{ rc_action }}"
 
 rc_msg_fields_started:
   - title: Started by
-    value: "{{ lookup('env', 'BUILD_URL') | default(lookup('env', 'USER'), true) }}"
+    value: "{{ jenkins_build_url_msg  }}"
     short: False
   - title: Deployer
     value: "{{ hostvars[ardana_env].ansible_host }}"
@@ -31,13 +37,13 @@ rc_msg_fields_started:
 
 _rc_msg_fields_finished:
   - title: Started by
-    value: "{{ lookup('env', 'BUILD_URL') | default(lookup('env', 'USER'), true) }}"
+    value: "{{ jenkins_build_url_msg }}"
     short: False
   - title: Deployer
     value: "{{ hostvars[ardana_env].ansible_host }}"
     short: True
-  - title: Ran
-    value: "{{ ardana_qe_test_results.ran if ardana_qe_test_results is defined else 'Not available' }}"
+  - title: Total
+    value: "{{ ardana_qe_test_results.total if ardana_qe_test_results is defined else 'Not available' }}"
     short: True
   - title: Passed
     value: "{{ ardana_qe_test_results.passed if ardana_qe_test_results is defined else 'Not available' }}"
@@ -46,18 +52,18 @@ _rc_msg_fields_finished:
     value: "{{ ardana_qe_test_results.failed if ardana_qe_test_results is defined else 'Not available' }}"
     short: True
   - title: Skipped
-    value: "{{ ardana_qe_test_results.skipped if ardana_qe_test_results is defined and 'skipped' in ardana_qe_test_results else 'Not available' }}"
+    value: "{{ ardana_qe_test_results.skipped if ardana_qe_test_results is defined else 'Not available' }}"
     short: True
   - title: Failed tests
-    value: "{{ ardana_qe_failed_tests.stdout if ardana_qe_failed_tests is defined else 'Not available' }}"
+    value: "{{ ardana_qe_failed_tests.stdout if ardana_qe_failed_tests is defined else 'Timeout' if test_output is defined and test_output.rc == 124 else 'Not available' }}"
     short: False
   - title: Log
-    value: "{{ ardana_qe_test_log_url if lookup('env', 'BUILD_URL') else 'Not available' }}"
+    value: "{{ ardana_qe_test_log_url_msg if lookup('env', 'BUILD_URL') else 'Not available' }}"
     short: False
 
 _rc_os_health_msg:
   - title: OpenStack-Health
-    value: "{{ os_health_url }}"
+    value: "[{{ os_health_url }}]({{ os_health_url }})"
     short: False
 
 rc_msg_fields_finished: "{{ _rc_msg_fields_finished + _rc_os_health_msg if subunit is defined and subunit.stat.exists else _rc_msg_fields_finished }}"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -19,9 +19,9 @@ jenkins_artifacts_url: "{{ lookup('env', 'BUILD_URL') + 'artifact/.artifacts/' i
 clouddata_server: "provo-clouddata.cloud.suse.de"
 
 subunit2sql_venv: "/opt/subunit2sql"
+subunit2sql_bin: "{{ subunit2sql_venv }}/bin/subunit2sql"
 os_health_server: "10.86.0.167"
 os_health_url: "http://{{ os_health_server }}/#/job/{{ os_health_build_name }}"
-os_health_build_name: "{{ lookup('env', 'BUILD_DISPLAY_NAME') | default('NA', true) | replace(': ', '-') | replace('#', '') }}"
 os_service_name: "{{ test_name.split('_')[0] }}"
 os_health_requires_state: "present"
 os_health_requires:

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/install_subunit2sql.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/install_subunit2sql.yml
@@ -1,0 +1,27 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- include_tasks: os_health_requires.yml
+
+- name: Setup subunit2sql
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{{ subunit2sql_venv }}"
+  loop:
+    - "subunit2sql"
+    - "pymysql"
+  become: yes

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
@@ -15,19 +15,16 @@
 #
 ---
 
-- include_tasks: os_health_requires.yml
+- name: Check if subunit2sql installed
+  stat:
+    path: "{{ subunit2sql_bin }}"
+  register: _subunit2sql
+
+- include_tasks: install_subunit2sql.yml
+  when: not _subunit2sql.stat.exists
 
 - name: Gather variables for '{{ task }}'
   include_vars: "{{ task }}.yml"
-
-- name: Setup subunit2sql
-  pip:
-    name: "{{ item }}"
-    virtualenv: "{{ subunit2sql_venv }}"
-  with_items:
-    - "subunit2sql"
-    - "pymysql"
-  become: yes
 
 - include_tasks: get_cloud_build_version.yml
   when: cloud_media_build_version is not defined or 'content' not in cloud_media_build_version
@@ -43,3 +40,4 @@
 - include_tasks: os_health_requires.yml
   vars:
     os_health_requires_state: "absent"
+  when: not _subunit2sql.stat.exists

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
@@ -33,9 +33,10 @@
   when: cloud_media_build_version is not defined or 'content' not in cloud_media_build_version
 
 - name: Send results to OpenStack-Health
-  shell: |
+  command: |
     {{ subunit2sql_venv }}/bin/subunit2sql --database-connection mysql+pymysql://subunit:subunit@{{ os_health_server }}/subunit \
       --run_meta "{{ os_health_metadata | join(',') }}" --artifacts "{{ jenkins_artifacts_url }}" {{ test_results_subunit }}
+  changed_when: false
 
 # NOTE: Removing SLE-SDK repos and packages required for subunit2sql
 # as they were affecting maintenance updates

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/vars/ardana-qe-tests.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/vars/ardana-qe-tests.yml
@@ -17,9 +17,11 @@
 
 test_results_subunit: "{{ ardana_qe_test_subunit }}"
 
+os_health_build_name: "{{ ardana_env }}_qa-tests_{{ test_name }}"
+
 os_health_metadata:
   - "build_uuid:`uuidgen`"
-  - "project:openstack/{{ test_name }}"
+  - "project:openstack/qa_tests/{{ test_name }}"
   - "ardana_env:{{ ardana_env }}"
   - "build_name:{{ os_health_build_name }}"
   - "openstack_service:{{ os_service_name.split('-')[0] | lower }}"

--- a/scripts/jenkins/ardana/ansible/run-ardana-qe-tests.yml
+++ b/scripts/jenkins/ardana/ansible/run-ardana-qe-tests.yml
@@ -13,25 +13,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-
 ---
 
 - name: Run '{{ test_name }}' test and collect results
-  hosts: ardana-{{ qe_env }}
+  hosts: "{{ ardana_env }}"
   remote_user: ardana
   gather_facts: True
   vars:
     task: "ardana-qe-tests"
-
-  vars_prompt:
-    - name: "qe_env"
-      prompt: "Target envinroment to run tests"
-      private: no
-      when: qe_env not defined
-    - name: "test_name"
-      prompt: "Test to run"
-      private: no
-      when: test_name not defined
 
   pre_tasks:
     - include_role:
@@ -52,17 +41,28 @@
             rc_action: "finished"
             rc_state: "Failed"
           when: rc_notify
+
         - name: Stop if something failed
           fail:
             msg: "{{ task }} failed."
       always:
+        - name: Load ardana_qe_tests role variables (remove when https://github.com/ansible/ansible/issues/21890 fixed)
+          include_vars: "roles/ardana_qe_tests/defaults/main.yml"
+
         - include_role:
             name: jenkins_artifacts
+          vars:
+            jenkins_artifacts_to_collect:
+              - "{{ ardana_qe_test_log }}"
+              - "{{ subunit_html_results }}"
+              - "{{ subunit_xml_results }}"
           when: lookup("env", "WORKSPACE")
 
         - include_role:
             name: send_to_os_health
-          when: subunit.stat.exists
+          when:
+            - subunit is defined
+            - subunit.stat.exists
 
   post_tasks:
     - include_role:


### PR DESCRIPTION
This PR cover necessary changes to support running ardana-qa-tests from jenkins, and adding it to the main openstack-ardana pipeline. Those changes include:

- some minor changes on the messages sent to rocketchat regarding
  ardana-qe-tests.
- update ardana-qe-tests to use the same structure used on
  other playbooks since https://github.com/SUSE-Cloud/automation/pull/2766. 
- changes the way test results are processed, instead of requiring each test to
  grep the log for results, now the test results are taken from the subunit
  output for all tests.
- introduces a new variable `ardana_qe_test_timeout` which can be
  used to define a timeout for running the test. By default it is set to
  120 minutes.
- check if subunit2sql is already installed before running tasks to
  install it.
- adds support for runnig ardana-qa-tests from jenkins.
  It also adds an option to run run those tests from the main
  openstack-ardana pipeline, howevever with less options. For a more
  cutomized run, the downstream job should be used.
