### PR TITLE
openstack-ardana-gerrit: make cloud8 job non-voting

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -101,5 +101,6 @@
     branch: stable/pike
     develproject: Devel:Cloud:8:Staging
     repository: SLE_12_SP3
+    voting: 0
     jobs:
         - '{ardana_gerrit_job}'

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -18,7 +18,7 @@
             - comment-added-contains-event:
                 comment-contains-value: '^recheck$'
           override-votes: true
-          gerrit-build-successful-verified-value: 1
+          gerrit-build-successful-verified-value: '{voting|1}'
           skip-vote:
               notbuilt: true
           projects:


### PR DESCRIPTION
The cloud8 Ardana Gerrit job is currently only checking the
commit message. It shouldn't vote V+1 on Gerrit changes without
running integration tests, because this may cause breaking changes
to be merged before Zuul has a chance to invalidate them.