### PR TITLE
openstack-ardana: enable timestamps in Ardana pipeline logs

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
+    timestamps()
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   // skip the default checkout, because we want to use a custom path
   options {
     skipDefaultCheckout()
+    timestamps()
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
+    timestamps()
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
+    timestamps()
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
+    timestamps()
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
   // skip the default checkout, because we want to use a custom path
   options {
     skipDefaultCheckout()
+    timestamps()
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
+    timestamps()
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
+    timestamps()
     // reserve a resource if instructed to do so, otherwise use a dummy resource
     // and a zero quantity to fool Jenkins into thinking it reserved a resource when in fact it didn't
     lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',


### PR DESCRIPTION
Enables logging timestamps for all Ardana pipeline jobs.

The result can be seen here, for example: https://ci.suse.de/job/openstack-ardana-vcloud/925/console
The timestamps plugin also allows settings to be configured directly in the URL (e.g. https://ci.suse.de/job/openstack-ardana-vcloud/925/timestamps/?time=yy-mm-dd%20HH:mm:ss&appendLog&locale=en_US )

NOTE: there's a known Jenkins issue that prevents the timestamps plugin from displaying timestamps in the Blue Ocean UI: https://issues.jenkins-ci.org/browse/JENKINS-44195