### PR TITLE
Avoid expected errors in sourced shell file

### DIFF
--- a/scripts/jenkins/github-pr/parse.rc
+++ b/scripts/jenkins/github-pr/parse.rc
@@ -2,12 +2,12 @@
 ## This file must be sourced so that the calling process can access the variables
 
 # error if github_pr is unset
-${github_pr:?}
+github_pr="${github_pr:?}"
 
 github_opts=(${github_pr//:/ })
 github_pr_repo=${github_opts[0]}
 github_pr_id=${github_opts[1]}
 github_pr_sha=${github_opts[2]}
-github_pr_context=${github_opts[4]}
+github_pr_context=${github_opts[4]:-}
 github_org=${github_pr_repo%/*}
 github_repo=${github_pr_repo##*/}


### PR DESCRIPTION
These were not found as they were not fatal without set -eu .

Avoid trying to find an executable named as the content of
$github_pr when its not empty, only error when its empty.

Avoid an unset variable error, the context may be set to the empty
string.