### PR TITLE
Make devstack work with IPv6

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -17,7 +17,7 @@ DEVSTACK_DIR="/opt/stack/devstack"
 
 # This allows testing with an unmerged change included. An
 # empty variable disables that behavior
-PENDING_REVIEW="576798"
+PENDING_REVIEW="605983"
 
 set -ex
 


### PR DESCRIPTION
Once the Leap 15 support is merged in devstack upstream

https://review.openstack.org/#/c/576798/

we need this patch to make it work with IPv6

https://review.openstack.org/#/c/605983/

The job testing Leap 15 and IPv6 requires python3 and meanwhile is not added upstream is being tested in our CI
https://ci.opensuse.org/view/OpenStack/job/openstack-devstack-ipv6/

