### PR TITLE
Remove ardana-extensions-example from trackupstream

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -24,7 +24,6 @@
             - ardana-db
             - ardana-designate
             - ardana-extensions-dcn
-            - ardana-extensions-example
             - ardana-extensions-nsx
             - ardana-freezer
             - ardana-glance

--- a/scripts/jenkins/ardana/gerrit/project-map.json
+++ b/scripts/jenkins/ardana/gerrit/project-map.json
@@ -2,7 +2,6 @@
   "ardana-ansible": "ardana-ansible",
   "ardana-input-model": "ardana-input-model",
   "ardana-extensions-dcn": "ardana-extensions-dcn",
-  "ardana-extensions-example": "ardana-extensions-example",
   "ardana-extensions-nsx": "ardana-extensions-nsx",
   "ardana-extensions-ses": "ardana-ses",
   "ardana-qa-ansible": "ardana-qa-ansible",


### PR DESCRIPTION
The package isn't used anymore and we removed it from the product.