### PR TITLE
openstack-ardana: fixes for ardana-qa-tests

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
@@ -37,14 +37,11 @@ pipeline {
             script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
           ).trim()
           if (reuse_node == '') {
+            // Resort to the backup dedicated workspace if this job is running as
+            // a standalone job allowing users to run several tests in parallel
+            // targeting the same environment.
+            env.SHARED_WORKSPACE = "$WORKSPACE"
             sh('''
-               rm -rf "$SHARED_WORKSPACE"
-               mkdir -p "$SHARED_WORKSPACE"
-
-               # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
-               ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
-
-               cd $SHARED_WORKSPACE
                git clone $git_automation_repo --branch $git_automation_branch automation-git
                source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
                ansible_playbook load-job-params.yml

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -252,7 +252,9 @@ pipeline {
 
     stage('Run QA tests') {
       when {
-        expression { qa_test_list != '' }
+        // For extended-choice parameter we also need to check if the variable
+        // is defined
+        expression { env.qa_test_list != null && qa_test_list != '' }
       }
       steps {
         script {

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -15,7 +15,7 @@
 #
 ---
 
-ardana_qe_base_dir: "{{ ansible_user_dir }}/ardana-qe"
+ardana_qe_base_dir: "~/ardana-qe"
 ardana_qe_test_work_dir: "{{ ardana_qe_base_dir }}/{{ test_name }}"
 ardana_qe_tests_dir: "{{ ardana_qe_base_dir }}/ardana-qa-tests"
 ardana_qe_tests_git_repo: "http://git.suse.provo.cloud"


### PR DESCRIPTION
- Extended-choice parameters are not defined when the job is automatically
  triggerd. So, we need to check if the variable is defined before using
  it.
- Using `ansible_user_dir` variable from ansible facts to reference the
  ardana home directory is not realiable as if there are facts cached from
  a previous playbook ran as root `ansible_user_dir` is set to root.
- If the openstack-ardana-qa-tests job is running as a standalone job
  use dedicated workspace to allow users to run several tests in parallel
  targeting the same environment.