### PR TITLE
openstack-ardana: switch Gerrit CI to demo input model for Cloud 9

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -2,6 +2,7 @@
     name: cloud-ardana8-gating
     ardana_gating_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
+    model: std-min
     version: 8
     label: cloud-trigger
     jobs:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -2,6 +2,7 @@
     name: cloud-ardana9-gating
     ardana_gating_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
+    model: demo
     version: 9
     label: cloud-trigger
     jobs:
@@ -10,6 +11,7 @@
 - project:
     name: cloud-ardana9-job-std-3cp-x86_64
     ardana_job: '{name}'
+    disabled: true
     ardana_env: cloud-ardana-ci-slot
     model: std-3cp
     triggers:
@@ -20,6 +22,7 @@
 - project:
     name: cloud-ardana9-job-dac-3cp-x86_64
     ardana_job: '{name}'
+    disabled: true
     ardana_env: cloud-ardana-ci-slot
     model: dac-3cp
     triggers:
@@ -30,7 +33,18 @@
 - project:
     name: cloud-ardana9-job-std-min-x86_64
     ardana_job: '{name}'
+    disabled: true
     ardana_env: cloud-ardana-ci-slot
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana9-job-demo-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    model: demo
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -39,6 +53,7 @@
 - project:
     name: cloud-ardana9-job-std-split-x86_64
     ardana_job: '{name}'
+    disabled: true
     ardana_env: cloud-ardana-ci-slot
     model: std-split
     triggers:
@@ -63,5 +78,6 @@
     name: cloud-ardana9-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
+    model: demo
     jobs:
         - '{ardana_gerrit_job}'

--- a/jenkins/ci.suse.de/templates/cloud-ardana-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-gating-template.yaml
@@ -21,7 +21,7 @@
       - shell: |
           echo starttime=$(date +%s) > build_start_time
       - trigger-builds:
-         - project: cloud-ardana{version}-job-std-min-x86_64
+         - project: cloud-ardana{version}-job-{model}-x86_64
            condition: SUCCESS
            block: true
            predefined-parameters: |


### PR DESCRIPTION
Monasca is going to be broken for a while in Cloud 9, until all
the needed monasca packages are ported to Rocky. In the meantime,
we still need to maintain a working CI, so disabling monasca for
all Cloud 9 Ardana CI jobs (switching to `demo` as an input model,
which has monasca disabled) is a fair compromise.
    
This commit also disables all Ardana Cloud9 CI jobs that are using
input models including monasca, for the same reasons.

Reverting this change is tracked by https://jira.suse.de/browse/SCRD-5371