### PR TITLE
Add interface for deployer to reach to public endpoints

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/standard.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/standard.yml
@@ -24,6 +24,8 @@ interface_models:
           - MANAGEMENT
       - network_groups:
           - ARDANA
+      - forced_network_groups:
+          - EXTERNAL-API
 
   - name: CONTROLLER
     service_groups:


### PR DESCRIPTION
With standard scenario, standalone deployer cannot reach to the public endpoints (external-api network) and that is require for some of the qa tests. Adding an interface to external-api network solves this issue.

Tested - https://ci.suse.de/job/openstack-ardana/966/console