### PR TITLE
Store tempest results on devstack jobs

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-devstack.yaml
+++ b/jenkins/ci.opensuse.org/openstack-devstack.yaml
@@ -53,6 +53,17 @@
               du $file
               exit 1
           fi
+          scp root@cleanvm:/opt/stack/results.html .
+          scp root@cleanvm:/opt/stack/results.xml .
 
     wrappers:
       - timestamps
+
+    publishers:
+      - archive:
+          artifacts: results.html
+          allow-empty-results: true
+
+      - junit:
+          results: results.xml
+          allow-empty-results: true

--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -242,4 +242,14 @@ tox -e smoke
 EOF
 fi
 
+h_echo_header "Store tempest results"
+pip install junitxml
+sudo -u stack -i <<EOF
+cd /opt/stack
+if [ -f devstack.subunit ]; then
+    subunit2html devstack.subunit
+    subunit2junitxml devstack.subunit > results.xml
+fi
+EOF
+
 exit 0


### PR DESCRIPTION
It's much better for debugging to store the tempest results in html. 
Also, it stores the tests in junit format, leveraging the Junit plugin in tempest to show the test results, this way you can see the exact number of tests failing from the job itself.