### PR TITLE
openstack-ardana: set ardana branch based on cloud release

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-qa-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-qa-tests.yaml
@@ -58,10 +58,11 @@
             Select tests to run
 
       - string:
-          name: test_branch
-          default: master
+          name: ardana_qa_tests_branch
+          default: ''
           description: >-
-            ardana-qa-tests repository branch
+            ardana-qa-tests repository branch. If empty the branch is set based
+            on the cloud release version (cloud8: stable/pike, cloud9: master)
 
       - string:
           name: run_filter

--- a/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
@@ -51,9 +51,10 @@
 
       - string:
           name: git_input_model_branch
-          default: master
+          default: ''
           description: >-
-            The git repository branch to use for input models
+            The git repository branch to use for input models. If empty the branch is set based
+            on the cloud release version (cloud8: stable/pike, cloud9: master)
 
       - string:
           name: git_input_model_path

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -64,9 +64,10 @@
 
       - string:
           name: git_input_model_branch
-          default: '{branch|master}'
+          default: '{branch|}'
           description: >-
-            The git repository branch to use for input models
+            The git repository branch to use for input models. If empty the branch is set based
+            on the cloud release version (cloud8: stable/pike, cloud9: master)
 
       - string:
           name: git_input_model_path

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -17,6 +17,10 @@
 
 # The cloud release is encoded in the cloudsource value
 cloud_release: "cloud{{ cloudsource | regex_search('\\d') }}"
+cloud_git_branch:
+  cloud8: "stable/pike"
+  cloud9: "master"
+
 clouddata_server: "provo-clouddata.cloud.suse.de"
 rhel_enabled: "{{ rhel_computes is defined and rhel_computes | int > 0 }}"
 

--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -16,13 +16,13 @@
 ---
 
 heat_stack_name: "openstack-ardana-{{ ardana_env }}"
-heat_template_file: "{{ workspace_path }}/heat-stack-{{ (scenario_name is defined and scenario_name != '') | ternary(scenario_name, model) }}.yml"
+heat_template_file: "{{ workspace_path }}/heat-stack-{{ scenario_name | default(model) }}.yml"
 os_cloud: "engcloud-cloud-ci"
 
 
 want_caasp: False
-virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name != '' else '' }}"
-virt_config_file: "{{ (virt_config_name is defined and virt_config_name != '') | ternary(virt_config_name, virt_config_file_name) }}"
+virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
+virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 
 cli_stack_queries:
   - "admin-floating-ip"

--- a/scripts/jenkins/ardana/ansible/load-job-params.yml
+++ b/scripts/jenkins/ardana/ansible/load-job-params.yml
@@ -31,6 +31,7 @@
         create: yes
         line: "{{ (item.key == 'bool') | ternary(bool_line, default_line) }}"
       with_dict: "{{ jjb.0[jjb_type].parameters }}"
+      when: lookup('env', item.value.name)
       loop_control:
         label: "{{ item.value.name }}"
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -20,7 +20,11 @@ ardana_qe_test_work_dir: "{{ ardana_qe_base_dir }}/{{ test_name }}"
 ardana_qe_tests_dir: "{{ ardana_qe_base_dir }}/ardana-qa-tests"
 ardana_qe_tests_git_repo: "http://git.suse.provo.cloud"
 ardana_qe_tests_git_url: "{{ ardana_qe_tests_git_repo }}/ardana/ardana-qa-tests.git"
-ardana_qe_tests_branch: "{{ tests_branch | default('master') }}"
+
+# cloudsource is not required for QA tests, so we set a 'dummy' cloudsource
+# value based on the SLES SP version
+cloudsource: "{{ (ansible_distribution_release == '3') | ternary('8', '9') }}"
+ardana_qa_tests_branch: "{{ cloud_git_branch[cloud_release] }}"
 
 ardana_qe_test_log: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.log"
 ardana_qe_test_subunit: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.subunit"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/prepare_test_env.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/prepare_test_env.yml
@@ -28,7 +28,7 @@
     repo: "{{ ardana_qe_tests_git_url }}"
     dest: "{{ ardana_qe_tests_dir }}"
     force: yes
-    version: "{{ ardana_qe_tests_branch }}"
+    version: "{{ ardana_qa_tests_branch }}"
 
 - name: Ensure test virtual environment exists when required
   pip:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/barbican-cli-func.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/barbican-cli-func.sh.j2
@@ -28,7 +28,7 @@ $VENV_FOLDER/bin/pip install -r test-requirements.txt
 $PYTHON setup.py install
 
 #Workaround for bug 1084362 for upstream pike-cloud8
-if [[ "{{ ardana_qe_tests_branch }}" = *"pike"* ]]; then
+if [[ "{{ ardana_qa_tests_branch }}" = *"pike"* ]]; then
     git grep -l '2018-02' | xargs sed -i 's/2018-02/2021-02/g'
 fi
 if [ ! -d {{ ardana_qe_tests_dir }}/.testrepository ]; then

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-cli-func.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-cli-func.yml
@@ -18,10 +18,6 @@
 ardana_qe_tests_git_url: "{{ ardana_qe_tests_git_repo }}/openstack/python-barbicanclient"
 ardana_qe_tests_dir: "{{ ardana_qe_test_work_dir }}"
 
-#For now setting this to stable/pike. We need to update this based on the cloud
-# release version as part of the framework.
-ardana_qe_tests_branch: "stable/pike"
-
 ardana_qe_test_venv_requires:
   - 'os-testr'
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-functional.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/barbican-functional.yml
@@ -76,12 +76,9 @@ ca_bundle: /etc/ssl/ca-bundle.pem
 ardana_qe_tests_git_url: "{{ ardana_qe_tests_git_repo }}/openstack/barbican"
 ardana_qe_tests_dir: "{{ ardana_qe_test_work_dir }}"
 
-#For now setting this to stable/pike. We need to update this based on the cloud
-# release version as part of the framework.
-ardana_qe_tests_branch: "stable/pike"
 ardana_qe_test_get_failed_cmd: "grep -B1 -- '------' {{ ardana_qe_test_log }} |
   awk -F '\n' 'ln ~ /^$/ { ln = \"matched\"; print $1 } $1 ~ /^--$/ { ln = \"\" }'"
-  
+
 ardana_qe_test_venv_requires:
   - 'os-testr'
 ardana_qe_test_run_filters: "{{ role_path }}/files/run_filters/"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_clone/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_clone/defaults/main.yml
@@ -16,6 +16,6 @@
 ---
 
 git_input_model_repo: "git://git.suse.provo.cloud/ardana/ardana-input-model.git"
-git_input_model_branch: "master"
+git_input_model_branch: "{{ cloud_git_branch[cloud_release] }}"
 git_input_model_path: "2.0/ardana-ci"
 git_input_model_dest: "/tmp/ardana-input-model"


### PR DESCRIPTION
Currently the ardana branch used for cloning input model and ardana-qa-tests is manually set on the jenkins job.
This change allows the ardana branch to be automatically set based on the cloud release (cloud8: stablb/pike, cloud9: master) when the branch parameter on the jenkins job is empty.

This change also change the behavior when loading parameters from jenkins jobs to the playbooks, currently all parameters are loaded, with this change only the non-empty parameters will be loaded.