### PR TITLE
openstack-ardana: playbook must fail if any tempest test failed

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
@@ -25,3 +25,8 @@
 
 - include_tasks: post_defcore.yml
   when: tempest_run_filter == 'defcore'
+
+- name: Fail if any tempest test has failed
+  fail:
+    msg: "{{ tempest_results_processed.results.3.stdout }} tests failed."
+  when: tempest_results_processed.results.3.stdout | int > 0


### PR DESCRIPTION
Added a task to fail if any tempest test fails, so the job calling the
tempest playbook will report a failure when there at least one tempest
test that failed.