### PR TITLE
openstack-ardana: make entry-scale-kvm work with virtual clouds

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/tasks/main.yml
@@ -70,7 +70,7 @@
 - name: Update input model disks to accomodate virtio_blk
   replace:
     dest: '{{ item.src }}'
-    regexp: '/dev/sd([a-f])'
+    regexp: '/dev/sd([a-z])'
     replace: '/dev/vd\1'
   with_filetree: '{{ input_model_path }}'
   loop_control:

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
@@ -42,6 +42,9 @@ Example:
 The input model described by the `roles/ardana_input_model_generator/vars/templates/standard.yml` scenario template will
 be generated in the `/path/to/input-model` output path.
 
+In addition to the mentioned parameters and to those specific for each scenario template, there are also
+a few [global parameters](#global-parameters) that can be used to further customize the generated input model.
+
 ## Input Model Templates
 
 This section describes the template categories that the input model generator combines to create an input model:
@@ -296,6 +299,15 @@ TBD
 
 TBD
 
+### Hardware templates
+
+## Global parameters
+
+The following optional parameters may be supplied as ansible external variables to control various
+aspects of the generated input model:
+
+* `designate_backend` : controls the designate backend configured for the input model. May be set to
+either `bind` (default) or `powerdns`.
 
 # Limitations
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -20,6 +20,9 @@ qe_ardana_bm_info_dir: "/tmp/ardana-bm-info"
 
 template_file_name: "{{ scenario[item ~ '_template'] }}.yml"
 
+# Backend for designate: powerdns or bind
+designate_backend: bind
+
 service_component_groups:
   CLM:
     - lifecycle-manager
@@ -43,7 +46,7 @@ service_component_groups:
   CORE:
     - ntp-server
     - ip-cluster
-    - bind
+    - "{{ designate_backend }}"
     - memcached
     - barbican-api
     - barbican-worker

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
@@ -203,7 +203,9 @@
 {%     endif %}
 {%   endfor %}
 
-{%  if 'SWPAC' in service_group.service_components or 'SWOBJ' in service_group.service_components %}
+{%  if 'SWPAC' in service_group.service_components or
+       'SWOBJ' in service_group.service_components or
+       'CORE'  in service_group.service_components %}
     device-groups:
 {%   for service_component in service_group['service_components'] %}
 {%     if service_component == 'SWPAC' %}
@@ -235,9 +237,17 @@
           attrs:
             rings:
               - object-0
+{%     elif service_component == 'CORE' %}
+{%       set ns.drive_idx = ns.drive_idx+1 %}
+
+      - name: cinder-volume
+        devices:
+          - name: /dev/sd{{ drive_letters[ns.drive_idx] }}
+        consumer:
+          name: cinder
 {%     endif %}
 {%   endfor %}
-{%  endif %}
+{% endif %}
 
 {% endfor %}
 {% endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
@@ -68,8 +68,8 @@
         - swift-account
         - swift-object
         - swift-rsync
-{%   elif bm_info is defined and 'EXTERNAL-API' in network_group.component_endpoints %}
-        - bind-ext
+{%   elif 'EXTERNAL-API' in network_group.component_endpoints %}
+        - {{ designate_backend }}-ext
 {%   else %}
         []
 {%   endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
@@ -25,10 +25,10 @@
 {%  if bm_info is defined %}
 {{ bm_info.networks[network_group.name|replace('-', '_')|lower] | to_nice_yaml(indent=2) | indent(6, True) }}
 {%-  else -%}
-{%   if network_group['tagged_vlan'] %}
+{%   if network_group['tagged_vlan']|default(False) %}
       vlanid: {{ ns.net_id }}
 {%   endif %}
-      tagged-vlan: {{ network_group['tagged_vlan']|lower }}
+      tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
       cidr: 192.168.{{ ns.net_id }}.0/24
       gateway-ip: 192.168.{{ ns.net_id }}.1
 {%  endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -30,8 +30,10 @@
 {% else %}
         neutron_provider_networks:
 {% set ns = namespace(mgmt_net_id=0, physnet_id=0, net_id=30, vlan_id=100+scenario.network_groups|length) %}
-{% for network_group in scenario.network_groups if 'MANAGEMENT' in network_group.component_endpoints %}
-{%   set ns.mgmt_net_id = loop.index0+100 %}
+{% for network_group in scenario.network_groups %}
+{%   if 'MANAGEMENT' in network_group.component_endpoints %}
+{%     set ns.mgmt_net_id = loop.index0+100 %}
+{%   endif %}
 {% endfor  %}
 {% for network_group in scenario.network_groups %}
 {%   if 'NEUTRON-VLAN' in network_group.component_endpoints %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/servers.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/servers.yml
@@ -15,12 +15,16 @@
 #
 ---
 {% set ns = namespace(clm_net_id=0, server_idx=0) %}
-{% for network_group in scenario['network_groups'] if 'CLM' in network_group['component_endpoints'] %}
-{%   set ns.clm_net_id = loop.index0+100 %}
-{% endfor  %}
-{% if ns.clm_net_id == 0  %}
-{%   for network_group in scenario['network_groups'] if 'MANAGEMENT' in network_group['component_endpoints'] %}
+{% for network_group in scenario['network_groups'] %}
+{%   if 'CLM' in network_group['component_endpoints'] %}
 {%     set ns.clm_net_id = loop.index0+100 %}
+{%   endif %}
+{% endfor %}
+{% if ns.clm_net_id == 0  %}
+{%   for network_group in scenario['network_groups'] %}
+{%     if 'MANAGEMENT' in network_group['component_endpoints'] %}
+{%       set ns.clm_net_id = loop.index0+100 %}
+{%     endif %}
 {%   endfor  %}
 {% endif %}
   product:
@@ -35,9 +39,6 @@
 {%   for idx in range(service_group['member_count']|int) %}
 {%     set server_id = "%s-%04d"|format(service_group.name, idx+1) %}
     - id: {{ bm_info.servers[ns.server_idx].id if bm_info is defined else server_id }}
-{% if bm_info is not defined %}
-      hostname: {{ scenario['cloud_name'] }}-{{ bm_info.servers[ns.server_idx].id if bm_info is defined else server_id }}
-{% endif %}
       ip-addr: 192.168.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.{{ bm_info.networks.bm_subnet_start + ns.server_idx if bm_info is defined else ns.server_idx + 100 }}
       role: {{ service_group.name|upper }}-ROLE
       server-group: RACK{{ (idx%3)+1 }}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
@@ -33,7 +33,7 @@ network_groups:
 
   - name: EXTERNAL-VM
     hostname_suffix: extvm
-    tagged_vlan: false
+    tagged_vlan: true
     component_endpoints:
       - NEUTRON-EXT
 


### PR DESCRIPTION
Input model generator fixes required to make the `entry-scale-kvm`
scenario to also work with ECP virtual cloud deployments in addition
to physical ones:
  - added the missing `cinder-volume` device group to all generated
  input models, without which the `cinder-volume` service wasn't
  provisioned
  - extended the range covered by the `/dev/sd*` to `/dev/vd*`
  replacement to allow more devices to be used
  - added a `designate_backend` parameter to the input model
  generator, with `bind` and `powerdns` as possible values,
  to control which designate backend is deployed in generated
  input models
  - added the `bind-ext` component endpoint to the EXTERNAL-API
  network group, to enable designate to be tested the same as with
  bare-metal deployments
  - switched the EXTERNAL-VM network in the `compact` network template
  to be VLAN tagged, to be aligned to the bare-metal deployment and
  also to fix the error of attaching two native networks (EXTERNAL-VM
  and MANAGEMENT) to the same bond interface on controller and compute
  nodes
  - fixed a couple of input model generator bugs responsible for
  using the wrong subnet to allocate server IPs
  - removed unused hardcoded hostnames from servers

This will enable the QA team to use virtual cloud deployments to run
the same scenarios as those being currently used for physical clouds.
