### PR TITLE
openstack-ardana: display deployer IP more often

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
@@ -61,6 +61,14 @@ pipeline {
               ansible_playbook load-job-params.yml
             ''')
           }
+          env.DEPLOYER_IP = sh (
+            returnStdout: true,
+            script: '''
+              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+                $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+            '''
+          ).trim()
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
         }
       }
     }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -82,6 +82,16 @@ pipeline {
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook setup-ssh-access.yml -e @input.yml
         ''')
+        script {
+          env.DEPLOYER_IP = sh (
+            returnStdout: true,
+            script: '''
+              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+                $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+            '''
+          ).trim()
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
+        }
       }
     }
   }
@@ -97,15 +107,6 @@ pipeline {
       cleanWs()
     }
     success{
-      script {
-        env.DEPLOYER_IP = sh (
-          returnStdout: true,
-          script: '''
-            grep -oP "${ardana_env}\s+ansible_host=\K[0-9\.]+" \
-              $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
-          '''
-        ).trim()
-      }
       echo """
 ******************************************************************************
 ** The deployer for the '${ardana_env}' physical environment is reachable at:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -97,17 +97,22 @@ pipeline {
       cleanWs()
     }
     success{
-      sh """
-      set +x
-      cd $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible
-      echo "
-*****************************************************************
-** The deployer for ${ardana_env} is reachable at
+      script {
+        env.DEPLOYER_IP = sh (
+          returnStdout: true,
+          script: '''
+            grep -oP "${ardana_env}\s+ansible_host=\K[0-9\.]+" \
+              $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+          '''
+        ).trim()
+      }
+      echo """
+******************************************************************************
+** The deployer for the '${ardana_env}' physical environment is reachable at:
 **
-**        ssh root@\$(awk '/^${ardana_env}/{print \$2}' inventory | cut -d'=' -f2)
+**        ssh root@${DEPLOYER_IP}
 **
-*****************************************************************
-      "
+******************************************************************************
       """
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
@@ -48,6 +48,14 @@ pipeline {
                ansible_playbook setup-ssh-access.yml -e @input.yml
             ''')
           }
+          env.DEPLOYER_IP = sh (
+            returnStdout: true,
+            script: '''
+              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+                $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+            '''
+          ).trim()
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
           def test_list = env.test_list.split(',')
           for (test in test_list) {
             catchError {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
@@ -50,6 +50,14 @@ pipeline {
               ansible_playbook setup-ssh-access.yml -e @input.yml
             ''')
           }
+          env.DEPLOYER_IP = sh (
+            returnStdout: true,
+            script: '''
+              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+                $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+            '''
+          ).trim()
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
         }
       }
     }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -121,6 +121,16 @@ pipeline {
           source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
           ansible_playbook setup-ssh-access.yml -e @input.yml
         ''')
+        script {
+          env.DEPLOYER_IP = sh (
+            returnStdout: true,
+            script: '''
+              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+                $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+            '''
+          ).trim()
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
+        }
       }
     }
   }
@@ -136,15 +146,6 @@ pipeline {
       cleanWs()
     }
     success{
-      script {
-        env.DEPLOYER_IP = sh (
-          returnStdout: true,
-          script: '''
-            grep -oP "${ardana_env}\s+ansible_host=\K[0-9\.]+" \
-              $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
-          '''
-        ).trim()
-      }
       echo """
 ******************************************************************************
 ** The deployer for the '${ardana_env}' virtual environment is reachable at:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -136,18 +136,23 @@ pipeline {
       cleanWs()
     }
     success{
-      sh """
-      set +x
-      cd $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/ansible_facts
-      echo "
-*****************************************************************
-** The virtual environment is reachable at
+      script {
+        env.DEPLOYER_IP = sh (
+          returnStdout: true,
+          script: '''
+            grep -oP "${ardana_env}\s+ansible_host=\K[0-9\.]+" \
+              $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+          '''
+        ).trim()
+      }
+      echo """
+******************************************************************************
+** The deployer for the '${ardana_env}' virtual environment is reachable at:
 **
-**        ssh root@\$(awk '/admin-floating-ip/{getline; print \$2}' localhost | sed -e 's/^"//' -e 's/"\$//')
+**        ssh root@${DEPLOYER_IP}
 **
-** Please delete openstack-ardana-${ardana_env} stack manually when you're done.
-*****************************************************************
-      "
+** Please delete the 'openstack-ardana-${ardana_env}' stack manually when you're done.
+******************************************************************************
       """
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -101,6 +101,7 @@ pipeline {
 
               // Load the environment variables set by the downstream job
               env.DEPLOYER_IP = slaveJob.buildVariables.DEPLOYER_IP
+              currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
               echo """
 ******************************************************************************
 ** The deployer for the '${ardana_env}' physical environment is reachable at:
@@ -144,6 +145,7 @@ pipeline {
 
               // Load the environment variables set by the downstream job
               env.DEPLOYER_IP = slaveJob.buildVariables.DEPLOYER_IP
+              currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
               echo """
 ******************************************************************************
 ** The deployer for the '${ardana_env}' virtual environment is reachable at:


### PR DESCRIPTION
Updates the pipeline jobs to display the IP address
where the deployer can be reached immediately after
the preparation of the virtual/physical environment,
as well as at the end of the pipeline, also showing
instructions on how to cleanup the virtual cloud.

This change will also change the build name itself
to show the IP, as soon as it becomes available.