### PR TITLE
Replace rsync.opensuse.org

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -294,7 +294,7 @@ done
 if [ $SITE = "nue" ]; then
     # repos we need for our test automation (jenkins-swarm-client, github-status, jt_sync, cct)
     for obsrepo in devel:/languages:/ruby:/extensions/SLE_12 devel:/tools:/building/SLE_12_SP3 ; do
-        rsync_with_create rsync://rsync.opensuse.org/buildservice-repos/$obsrepo/ /srv/nfs/repos/repositories/$obsrepo/
+        rsync_with_create rsync://ftp.gwdg.de/pub/opensuse/repositories/$obsrepo/ /srv/nfs/repos/repositories/$obsrepo/
     done
 
     # this one is always failing - we need to ignore that otherwise the lock file remains stuck


### PR DESCRIPTION
rsync.opensuse.org is down since a month without a ETA for a replacement
so let's use a working rsync server.

See https://status.opensuse.org/incidents/166