### PR TITLE
openstack-ardana: wait for cloud nodes to start

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -86,6 +86,16 @@
 
   tasks:
     - block:
+        - name: Wait for cloud nodes to be accessible
+          delegate_to: localhost
+          wait_for:
+            host: "{{ ansible_ssh_host }}"
+            port: 22
+            search_regex: OpenSSH
+            state: started
+            delay: 10
+            timeout: 300
+
         - name: Grow 1st partition filesystem
           shell: |
             /usr/sbin/growpart /dev/vda 1 && /sbin/resize2fs /dev/vda1

--- a/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
+++ b/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
@@ -76,6 +76,16 @@
 
   tasks:
     - block:
+        - name: Wait for deployer to be accessible
+          delegate_to: localhost
+          wait_for:
+            host: "{{ ansible_host }}"
+            port: 22
+            search_regex: OpenSSH
+            state: started
+            delay: 10
+            timeout: 300
+
         - include_role:
             name: ssh_keys
       rescue:


### PR DESCRIPTION
Before attempting to provision any of the target Ardana cloud nodes,
the ansible playbooks must first wait for those nodes to complete
the startup procedure (i.e. wait for the SSH service to start),
otherwise connectivity errors may occur.

This problem is easily reproducible with simpler input models, like
'minimal', which complete the virtual cloud creation quickly and
thus don't allow the deployer node enough time to complete the
startup process.