### PR TITLE
Fix install job when only cloud or sles MU defined

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/templates/maint_updates.yml.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/templates/maint_updates.yml.j2
@@ -19,8 +19,8 @@
   hosts: resources
   become: yes
   vars:
-    cloud_maint_updates_list: {{ cloud_maint_updates_list | to_yaml if cloud_maint_updates | length else [] }}
-    sles_maint_updates_list: {{ sles_maint_updates_list | to_yaml if sles_maint_updates | length else [] }}
+    cloud_maint_updates_list: {{ cloud_maint_updates_list | to_yaml if cloud_maint_updates is defined and cloud_maint_updates | length else [] }}
+    sles_maint_updates_list: {{ sles_maint_updates_list | to_yaml if sles_maint_updates is defined and sles_maint_updates | length else [] }}
     sles_sp: {{ (cloud_release == 'cloud8') | ternary('3', '4') }}
     cloud_release: {{ cloud_release }}
 {% raw %}


### PR DESCRIPTION
Current deployment job is failing when we only define cloud or sles MU as empty parameter is not being added into input.yml file.
e.g https://ci.suse.de/view/Cloud/view/Builds/job/openstack-ardana/1003/console

This PR solves the issue by checking if cloud and sles mu parameter is defined when setting up MU repos.

Tested in baremetal and virtual environments:
https://ci.suse.de/view/Cloud/view/Builds/job/openstack-ardana/1012/
https://ci.suse.de/job/openstack-ardana/1016/console