### PR TITLE
Fix devstack job in ci.opensuse.org

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -243,13 +243,11 @@ EOF
 fi
 
 h_echo_header "Store tempest results"
-pip install junitxml
 sudo -u stack -i <<EOF
 cd /opt/stack
-if [ -f devstack.subunit ]; then
-    subunit2html devstack.subunit
-    subunit2junitxml devstack.subunit > results.xml
-fi
+pip install junitxml
+subunit2html devstack.subunit
+subunit2junitxml devstack.subunit > results.xml
 EOF
 
 exit 0


### PR DESCRIPTION
Previous commit allowed the devstack jobs to use some jenkins
plugins to store and report the test results.
However, there were several mistakes, mainly for rushing things :(.

The junitxml dependency has to be added to the VM were devstack is
running. Also, the if block to check for the file `subunit `can be avoided
since we want to fail the build if it doesn't exist.

Signed-off-by: aojeagarcia <aojeagarcia@suse.com>