### PR TITLE
Increased timeout for service-ansible-playbook on ardana_qe_tests role

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/service-ansible-playbooks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/service-ansible-playbooks.yml
@@ -15,6 +15,7 @@
 #
 ---
 
+ardana_qe_test_timeout: 300
 ardana_qe_test_venv_requires:
   - 'python-subunit'
   - 'stestr'


### PR DESCRIPTION
In order to let service-ansible-playbooks testing to run completely, I increase timeout to 5 hours