### PR TITLE
Disable freezer for Cloud9 generated models

### DIFF
--- a/scripts/jenkins/ardana/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-cloud.yml
@@ -38,13 +38,16 @@
 
   tasks:
     - block:
-        - name: Remove manila from input model when manila not enabled
+        - name: Remove versioned features from input model when not enabled
           replace:
             path: "{{ input_model_path }}/data/control_plane.yml"
-            regexp: '(.*manila.*)'
+            regexp: '(.*{{ item }}.*)'
             replace: '#\1'
-          when: not versioned_features['manila'].enabled
+          when: not versioned_features[item].enabled
           delegate_to: localhost
+          loop:
+            - manila
+            - freezer
 
         - name: Ardana log stream at
           debug:

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -24,6 +24,8 @@ when_cloud9M3: "{{ cloud_source | default(cloudsource) is match('cloud9M3') }}"
 versioned_features:
   manila:
     enabled: "{{ when_staging }}"
+  freezer:
+    enabled: "{{ when_cloud8 }}"
   # FIXME: Remove this entry when bsc#1110414 fixed
   fix_ardana_ssh_keyscan:
     enabled: "{{ when_cloud9M3 }}"


### PR DESCRIPTION
Jira: SCRD-5330

Freezer is not available for the Rocky release that Cloud9 is based
upon, so only enable the freezer service in generated input models
for Cloud8.