### PR TITLE
Fix pip junitxml installation and remove review

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -17,7 +17,7 @@ DEVSTACK_DIR="/opt/stack/devstack"
 
 # This allows testing with an unmerged change included. An
 # empty variable disables that behavior
-PENDING_REVIEW="605983"
+PENDING_REVIEW=""
 
 set -ex
 
@@ -243,9 +243,9 @@ EOF
 fi
 
 h_echo_header "Store tempest results"
+pip install junitxml
 sudo -u stack -i <<EOF
 cd /opt/stack
-pip install junitxml
 subunit2html devstack.subunit
 subunit2junitxml devstack.subunit > results.xml
 EOF


### PR DESCRIPTION
It turns out that junitxml needs root privileges to be installed.

In addition, we remove the pending patch from the variable since it was merged upstream

Signed-off-by: aojeagarcia <aojeagarcia@suse.com>