### PR TITLE
ipv6: first attempt at want_ipv6 option

### DIFF
--- a/scripts/lib/ipv6/network.json
+++ b/scripts/lib/ipv6/network.json
@@ -1,0 +1,332 @@
+{
+    "attributes": {
+        "network": {
+            "conduit_map": [
+                {
+                    "conduit_list": {
+                        "intf0": {
+                            "if_list": [
+                                "1g1",
+                                "1g2"
+                            ]
+                        },
+                        "intf1": {
+                            "if_list": [
+                                "1g1",
+                                "1g2"
+                            ]
+                        },
+                        "intf2": {
+                            "if_list": [
+                                "1g1",
+                                "1g2"
+                            ]
+                        }
+                    },
+                    "pattern": "team/.*/.*"
+                },
+                {
+                    "conduit_list": {
+                        "intf0": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        },
+                        "intf1": {
+                            "if_list": [
+                                "?1g2"
+                            ]
+                        },
+                        "intf2": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        }
+                    },
+                    "pattern": "dual/.*/.*"
+                },
+                {
+                    "conduit_list": {
+                        "intf0": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        },
+                        "intf1": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        },
+                        "intf2": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        }
+                    },
+                    "pattern": "single/.*/.*"
+                },
+                {
+                    "conduit_list": {
+                        "intf0": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        },
+                        "intf1": {
+                            "if_list": [
+                                "1g1"
+                            ]
+                        },
+                        "intf2": {
+                            "if_list": [
+                                "1g1"
+                            ]
+                        }
+                    },
+                    "pattern": ".*/.*/.*"
+                },
+                {
+                    "conduit_list": {
+                        "intf0": {
+                            "if_list": [
+                                "1g1"
+                            ]
+                        },
+                        "intf1": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        },
+                        "intf2": {
+                            "if_list": [
+                                "?1g1"
+                            ]
+                        }
+                    },
+                    "pattern": "mode/1g_adpt_count/role"
+                }
+            ],
+            "enable_rx_offloading": true,
+            "enable_tx_offloading": true,
+            "interface_map": [
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:01",
+                        "0000:00/0000:00:03"
+                    ],
+                    "pattern": "PowerEdge R610"
+                },
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:01.1/0000:01:00.0",
+                        "0000:00/0000:00:01.1/0000.01:00.1",
+                        "0000:00/0000:00:01.0/0000:02:00.0",
+                        "0000:00/0000:00:01.0/0000:02:00.1"
+                    ],
+                    "pattern": "PowerEdge R620"
+                },
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:01",
+                        "0000:00/0000:00:03"
+                    ],
+                    "pattern": "PowerEdge R710"
+                },
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:04",
+                        "0000:00/0000:00:02"
+                    ],
+                    "pattern": "PowerEdge C6145"
+                },
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:03.0/0000:01:00.0",
+                        "0000:00/0000:00:03.0/0000:01:00.1",
+                        "0000:00/0000:00:1c.4/0000:06:00.0",
+                        "0000:00/0000:00:1c.4/0000:06:00.1"
+                    ],
+                    "pattern": "PowerEdge R730xd"
+                },
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:1c",
+                        "0000:00/0000:00:07",
+                        "0000:00/0000:00:09",
+                        "0000:00/0000:00:01"
+                    ],
+                    "pattern": "PowerEdge C2100"
+                },
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:01",
+                        "0000:00/0000:00:03",
+                        "0000:00/0000:00:07"
+                    ],
+                    "pattern": "C6100"
+                },
+                {
+                    "bus_order": [
+                        "0000:00/0000:00:01",
+                        "0000:00/0000:00:02"
+                    ],
+                    "pattern": "product"
+                }
+            ],
+            "mode": "single",
+            "networks": {
+                "admin": {
+                    "add_bridge": false,
+                    "broadcast": "",
+                    "conduit": "intf0",
+                    "mtu": 1500,
+                    "netmask": "64",
+                    "ranges": {
+                        "admin": {
+                            "end": "fd00:0:0:3:5054:ff:fe77:7771",
+                            "start": "fd00:0:0:3:5054:ff:fe77:7770"
+                        },
+                        "dhcp": {
+                            "end": "fd00:0:0:3::80",
+                            "start": "fd00:0:0:3::21"
+                        },
+                        "host": {
+                            "end": "fd00:0:0:3::160",
+                            "start": "fd00:0:0:3::81"
+                        },
+                        "switch": {
+                            "end": "fd00:0:0:3::250",
+                            "start": "fd00:0:0:3::241"
+                        }
+                    },
+                    "router": "fd00:0:0:3::1",
+                    "router_pref": 10,
+                    "subnet": "fd00:0:0:3::0",
+                    "use_vlan": false,
+                    "vlan": 100
+                },
+                "bmc": {
+                    "add_bridge": false,
+                    "broadcast": "",
+                    "conduit": "bmc",
+                    "netmask": "64",
+                    "ranges": {
+                        "host": {
+                            "end": "fd00:0:0:3::240",
+                            "start": "fd00:0:0:3::162"
+                        }
+                    },
+                    "subnet": "fd00:0:0:3::0",
+                    "use_vlan": false,
+                    "vlan": 100
+                },
+                "bmc_vlan": {
+                    "add_bridge": false,
+                    "broadcast": "",
+                    "conduit": "intf2",
+                    "netmask": "64",
+                    "ranges": {
+                        "host": {
+                            "end": "fd00:0:0:3::161",
+                            "start": "fd00:0:0:3::161"
+                        }
+                    },
+                    "subnet": "fd00:0:0:3::0",
+                    "use_vlan": true,
+                    "vlan": 100
+                },
+                "nova_fixed": {
+                    "add_bridge": false,
+                    "add_ovs_bridge": false,
+                    "bridge_name": "br-fixed",
+                    "broadcast": "",
+                    "conduit": "intf1",
+                    "netmask": "64",
+                    "ranges": {
+                        "dhcp": {
+                            "end": "fd00:0:0:2::254",
+                            "start": "fd00:0:0:2::1"
+                        }
+                    },
+                    "router": "fd00:0:0:2::1",
+                    "router_pref": 20,
+                    "subnet": "fd00:0:0:2::0",
+                    "use_vlan": true,
+                    "vlan": 500
+                },
+                "nova_floating": {
+                    "add_bridge": false,
+                    "add_ovs_bridge": false,
+                    "bridge_name": "br-public",
+                    "broadcast": "",
+                    "conduit": "intf1",
+                    "netmask": "65",
+                    "ranges": {
+                        "host": {
+                            "end": "fd00:0:0:1:8000::254",
+                            "start": "fd00:0:0:1:8000::129"
+                        }
+                    },
+                    "subnet": "fd00:0:0:1:8000::0",
+                    "use_vlan": true,
+                    "vlan": 300
+                },
+                "os_sdn": {
+                    "add_bridge": false,
+                    "broadcast": "64",
+                    "conduit": "intf1",
+                    "mtu": 1500,
+                    "netmask": "64",
+                    "ranges": {
+                        "host": {
+                            "end": "fd00:0:0:7::254",
+                            "start": "fd00:0:0:7::10"
+                        }
+                    },
+                    "subnet": "fd00:0:0:7::0",
+                    "use_vlan": true,
+                    "vlan": 400
+                },
+                "public": {
+                    "add_bridge": false,
+                    "broadcast": "",
+                    "conduit": "intf1",
+                    "netmask": "64",
+                    "ranges": {
+                        "host": {
+                            "end": "fd00:0:0:1::127",
+                            "start": "fd00:0:0:1::2"
+                        }
+                    },
+                    "router": "fd00:0:0:1::1",
+                    "router_pref": 5,
+                    "subnet": "fd00:0:0:1::0",
+                    "use_vlan": true,
+                    "vlan": 300
+                },
+                "storage": {
+                    "add_bridge": false,
+                    "broadcast": "",
+                    "conduit": "intf1",
+                    "mtu": 1500,
+                    "netmask": "64",
+                    "ranges": {
+                        "host": {
+                            "end": "fd00:0:0:4::239",
+                            "start": "fd00:0:0:4::10"
+                        }
+                    },
+                    "subnet": "fd00:0:0:4::0",
+                    "use_vlan": true,
+                    "vlan": 200
+                }
+            },
+            "start_up_delay": 30,
+            "teaming": {
+                "miimon": 100,
+                "mode": 1,
+                "xmit_hash_policy": "layer2"
+            }
+        }
+    }
+}

--- a/scripts/lib/mkcloud-onhost.sh
+++ b/scripts/lib/mkcloud-onhost.sh
@@ -26,13 +26,9 @@ function onhost_setup_portforwarding
         mkdir -p $boot_mkcloud_d
         if [[ ${want_ipv6} == 0 ]]; then
             net_end=".0/24"
-            ip_wrap_left=''
-            ip_wrap_right=''
             iptables="iptables"
         else
             net_end=":/64"
-            ip_wrap_left='['
-            ip_wrap_right=']'
             iptables="ip6tables"
         fi
         $sudo tee $boot_mkcloud_d_cloud >/dev/null <<EOS
@@ -68,7 +64,7 @@ for port in 22 80 443 5000 7630; do
         host_port_offset=\$(( \$host - \$offset ))
         iptables_unique_rule PREROUTING -t nat -p tcp \\
             --dport \$(( $cloud_port_offset + \$port + \$host_port_offset )) \\
-            -j DNAT --to-destination ${ip_wrap_left}${net_admin}${ip_sep}\$host${ip_wrap_right}:\$port
+            -j DNAT --to-destination $(wrap_ip "${net_admin}${ip_sep}\$host"):\$port
     done
 done
 

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -56,11 +56,15 @@ mkcconf=mkcloud.config
 rm -f $mkcconf # we dont want to source old info in the line below
 
 : ${virtualcloud:=virtual}
-: ${net_admin:=192.168.124}
+#: ${net_admin:=192.168.124}
+if (( $want_ipv6 > 0 )); then
+    echo ">>> WARNING: IPv6 (want_ipv6) is under active development <<<"
+    : ${net_admin:='fd00:0:0:3'}
+else
+    : ${net_admin:=192.168.124}
+fi
 setcloudnetvars $virtualcloud
 : ${forwardmode:=nat}
-: ${adminnetmask:=255.255.248.0}
-: ${ironicnetmask:=255.255.255.0}
 : ${nodenumber:=2}
 # expect to have this many physical machines attached via $mkch_physcloudif
 # these replace virtual machines, so we start less VMs
@@ -225,7 +229,7 @@ function onhost_supportconfig
             timeout 600 supportconfig | wc &
             wait
         '
-        $scp root@$adminip:/var/log/*tbz $artifacts_dir/
+        $scp root@$(wrap_ip $adminip):/var/log/*tbz $artifacts_dir/
     fi
 }
 
@@ -354,8 +358,8 @@ EOF
     env|grep -e ^debug_ -e ^pre_ -e ^vlan_ -e ^want_ -e ^net_ -e ^nodenumber -e ^clusterconfig -e ^ironicnetmask | sort >> $mkcconf
 
     cp -a $mkcconf $artifacts_dir/
-    $scp -r $SCRIPTS_DIR $mkcconf root@$adminip:
-    [[ $need_scenario = 1 ]] && $scp $scenario_path root@$adminip:
+    $scp -r $SCRIPTS_DIR $mkcconf root@$(wrap_ip $adminip):
+    [[ $need_scenario = 1 ]] && $scp $scenario_path root@$(wrap_ip $adminip):
     ssh $sshopts root@$adminip "echo `hostname` > cloud ; . ./$(basename $SCRIPTS_DIR)/qa_crowbarsetup.sh ; $@"
     return $?
 }
@@ -602,7 +606,7 @@ function lonelynode_nfs_server
 function prepareinstcrowbar
 {
     echo "connecting to crowbar admin server at $adminip"
-    ! [ -e crowbar.patch ] || $scp crowbar.patch root@$adminip:
+    ! [ -e crowbar.patch ] || $scp crowbar.patch root@$(wrap_ip $adminip):
     onadmin prepareinstallcrowbar
     return $?
 }
@@ -619,7 +623,7 @@ function scp_install_chef_suse_override
     if [ -e "$install_chef_suse_override" ]; then
         ssh root@$adminip "mv /opt/dell/bin/install-chef-suse.sh{,.orig}"
         $scp -p "$install_chef_suse_override" \
-            root@$adminip:/opt/dell/bin/install-chef-suse.sh
+            root@$(wrap_ip $adminip):/opt/dell/bin/install-chef-suse.sh
         ssh root@$adminip "chmod +x /opt/dell/bin/install-chef-suse.sh"
     fi
 }
@@ -629,7 +633,7 @@ function instcrowbar
     scp_install_chef_suse_override
     onadmin installcrowbar
     local ret=$?
-    $scp root@$adminip:$crowbar_install_log "$artifacts_dir/"
+    $scp root@$(wrap_ip $adminip):$crowbar_install_log "$artifacts_dir/"
     return $ret
 }
 
@@ -639,7 +643,7 @@ function instcrowbarfromgit
     safely rsync -av --exclude ".git" --exclude ".ci-tracking" ./crowbar root@$adminip:/root/
     onadmin installcrowbarfromgit
     local ret=$?
-    $scp root@$adminip:$crowbar_install_log "$artifacts_dir/"
+    $scp root@$(wrap_ip $adminip):$crowbar_install_log "$artifacts_dir/"
     return $ret
 }
 
@@ -811,14 +815,14 @@ function testsetup
 {
     onadmin testsetup
     local ret=$?
-    $scp root@$adminip:tempest*.log "$artifacts_dir/"
+    $scp root@$(wrap_ip $adminip):tempest*.log "$artifacts_dir/"
 
     # Register the cloud in Rally and import the results
     if [[ $rally_server && -f $artifacts_dir/tempest.subunit.log ]] ; then
         local title=$(testname)
         local type=$(testtype)
 
-        $scp root@$adminip:.openrc "$artifacts_dir/"
+        $scp root@$(wrap_ip $adminip):.openrc "$artifacts_dir/"
         local tmpdir=`ssh $sshopts rally@$rally_server "mktemp -d rally-XXXXXX"`
         $scp "$artifacts_dir/tempest.subunit.log" "$artifacts_dir/.openrc" rally@$rally_server:$tmpdir
         ssh $sshopts rally@$rally_server "
@@ -938,11 +942,11 @@ function qa_test
         git clone https://$ghsc/qa-openstack-cli.git
     fi
     popd
-    rsync -av ~/$ghsc/qa-openstack-cli root@$adminip:
+    rsync -av ~/$ghsc/qa-openstack-cli root@$(wrap_ip $adminip):
     onadmin qa_test
     ret=$?
 
-    $scp -r root@$adminip:qa_test.logs/ $artifacts_dir/
+    $scp -r root@$(wrap_ip $adminip):qa_test.logs/ $artifacts_dir/
     return $ret
 }
 
@@ -951,7 +955,7 @@ function crowbarbackup
     safely onadmin crowbarbackup "$@"
     local btargetdir=${artifacts_dir:-.}
     mkdir -p "$btargetdir"
-    safely $scp root@$adminip:/tmp/backup-crowbar.tar.gz "$btargetdir"
+    safely $scp root@$(wrap_ip $adminip):/tmp/backup-crowbar.tar.gz "$btargetdir"
 }
 
 function crowbarrestore
@@ -962,7 +966,7 @@ function crowbarrestore
         complain 56 "No crowbar backup tarball found."
     fi
     onhost_reset_admin
-    safely $scp "$btarball" root@$adminip:/tmp/
+    safely $scp "$btarball" root@$(wrap_ip $adminip):/tmp/
     safely onadmin crowbarrestore "$@"
 }
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -970,7 +970,7 @@ function onadmin_prepareinstallcrowbar
     [[ $forcephysicaladmin ]] || lsmod | grep -q ^virtio_blk || complain 25 "this script should be run in the crowbar admin VM"
     [[ $want_ssl_keys ]] && ! [[ -e /root/cloud-keys/ ]] && rsync -a "$want_ssl_keys/" /root/cloud-keys/
     [[ $want_rootpw = linux ]] || echo -e "$want_rootpw\n$want_rootpw" | passwd
-    echo configure static IP and absolute + resolvable hostname ${crowbar_name}.$cloudfqdn gw:$net.1
+    echo configure static IP and absolute + resolvable hostname ${crowbar_name}.$cloudfqdn gw:$net${ip_sep}1
     # We want to use static networking which needs a static resolv.conf .
     # The SUSE sysconfig/ifup scripts drop DNS-servers received from DHCP
     # when switching from DHCP to static.
@@ -980,15 +980,25 @@ function onadmin_prepareinstallcrowbar
 NAME='eth0'
 STARTMODE='auto'
 BOOTPROTO='static'
+EOF
+    if (( ${want_ipv6} > 0 )); then
+        cat >> /etc/sysconfig/network/ifcfg-eth0 <<EOF
+IPV6INIT=yes
+IPV6ADDR='$adminip/$adminnetmask'
+IPV6_DEFAULTGW='${net_admin}${ip_sep}1'
+EOF
+    else
+        cat >> /etc/sysconfig/network/ifcfg-eth0 <<EOF
 IPADDR='$adminip'
 NETMASK='255.255.255.0'
-BROADCAST='$net.255'
+BROADCAST='$net${ip_sep}255'
 EOF
+    fi
     ifdown br0
     rm -f /etc/sysconfig/network/ifcfg-br0
     routes_file=/etc/sysconfig/network/routes
     if ! [ -e $routes_file ] || ! grep -q "^default" $routes_file; then
-        echo "default $net.1 - -" > $routes_file
+        echo "default $net${ip_sep}1 - -" > $routes_file
     fi
     echo "${crowbar_name}.$cloudfqdn" > /etc/HOSTNAME
     hostname `cat /etc/HOSTNAME`
@@ -1064,6 +1074,12 @@ EOF
     local netfile="/etc/crowbar/network.json"
 
     local netfilepatch=`basename $netfile`.patch
+
+    if (( $want_ipv6 > 0 )); then
+        cp $netfile ${netfile}.orig-v4
+        cp $scripts_lib_dir/ipv6/network.json $netfile
+    fi
+
     if [ -e ~/$netfilepatch ]; then
         ensure_packages_installed patch
         patch -p1 $netfile < ~/$netfilepatch
@@ -1079,13 +1095,28 @@ EOF
     # to revert https://github.com/crowbar/barclamp-network/commit/a85bb03d7196468c333a58708b42d106d77eaead
     sed -i.netbak1 -e 's/192\.168\.126/192.168.122/g' $netfile
 
-    sed -i.netbak -e 's/"conduit": "bmc",$/& "router": "192.168.124.1",/' \
-        -e "s/192.168.124/$net/g" \
-        -e "s/192.168.130/$net_sdn/g" \
-        -e "s/192.168.125/$net_storage/g" \
-        -e "s/192.168.127/$net_ceph/g" \
-        -e "s/192.168.123/$net_fixed/g" \
-        -e "s/192.168.122/$net_public/g" \
+    if (( $want_ipv6 > 0 )); then
+        sed -i.netbak -e 's/"conduit": "bmc",$/& "router": "fd00:0:0:3::1",/' \
+            -e "s/fd00:0:0:3:/$net${ip_sep}/g" \
+            -e "s/fd00:0:0:7:/$net_sdn${ip_sep}/g" \
+            -e "s/fd00:0:0:4:/$net_storage${ip_sep}/g" \
+            -e "s/fd00:0:0:5:/$net_ceph${ip_sep}/g" \
+            -e "s/fd00:0:0:2:/$net_fixed${ip_sep}/g" \
+            -e "s/fd00:0:0:1:/$net_public${ip_sep}/g" \
+            -e "s/fd00:0:0:3:5054:ff:fe77:7770/$adminip/g" \
+            -e "s/fd00:0:0:3:5054:ff:fe77:7771/$admin_end_range/g" \
+            $netfile
+    else
+        sed -i.netbak -e 's/"conduit": "bmc",$/& "router": "192.168.124.1",/' \
+            -e "s/192.168.124./$net${ip_sep}/g" \
+            -e "s/192.168.130./$net_sdn${ip_sep}/g" \
+            -e "s/192.168.125./$net_storage${ip_sep}/g" \
+            -e "s/192.168.127./$net_ceph${ip_sep}/g" \
+            -e "s/192.168.123./$net_fixed${ip_sep}/g" \
+            -e "s/192.168.122./$net_public${ip_sep}/g" \
+            $netfile
+    fi
+    sed -i.netbak.vlan \
         -e "s/ 200/ $vlan_storage/g" \
         -e "s/ 600/ $vlan_ceph/g" \
         -e "s/ 300/ $vlan_public/g" \
@@ -1120,6 +1151,12 @@ EOF
     fi
 
     if [[ $want_ironic = 1 ]] ; then
+        if (( $want_ipv6 > 0 )); then
+            # IPv6 don't use broadcast addresses.
+            local ironic_bc=""
+        else
+            local ironic_bc="${net_ironic}${ip_sep}255"
+        fi
         local conmap_complete=`
             python - <<EOPYTHON
 import json
@@ -1147,19 +1184,19 @@ ironic_network={
     'add_bridge': False,
     'add_ovs_bridge': False,
     'bridge_name': 'br-ironic',
-    'subnet': '$net_ironic.0',
+    'subnet': '${net_ironic}${ip_sep}0',
     'netmask': '$ironicnetmask',
-    'broadcast': '$net_ironic.255',
-    'router': '$net_ironic.1',
+    'broadcast': '$ironic_bc',
+    'router': '${net_ironic}${ip_sep}1',
     'router_pref': 50,
     'ranges': {
       'admin': {
-        'start': '$net_ironic.10',
-        'end': '$net_ironic.11'
+        'start': ${net_ironic}${ip_sep}10',
+        'end': '${net_ironic}${ip_sep}11'
       },
       'dhcp': {
-        'start': '$net_ironic.21',
-        'end': '$net_ironic.254'
+        'start': ${net_ironic}${ip_sep}21',
+        'end': ${net_ironic}${ip_sep}254'
       }
     },
     'mtu': 1500
@@ -1843,7 +1880,7 @@ function onadmin_crowbar_register
             set -x
             rm -f /tmp/crowbar_register_done;
             zypper -n in wget screen
-            wget http://$adminip:8091/$image/crowbar_register &&
+            wget http://$(wrap_ip $adminip):8091/$image/crowbar_register &&
             chmod a+x crowbar_register &&
             $hostnamecmd
             zypper -n ref &&
@@ -2829,7 +2866,7 @@ function set_proposalvars
 function set_noproxyvar
 {
     [[ $http_proxy ]] || [[ $https_proxy ]] || return 0
-    [[ $no_proxy =~ "localhost" ]] || no_proxy="127.0.0.1,localhost,$no_proxy"
+    [[ $no_proxy =~ "localhost" ]] || no_proxy="127.0.0.1,localhost,::1,$no_proxy"
     [[ ! $adminip ]] || [[ $no_proxy =~ "$adminip" ]] || no_proxy="$adminip,$no_proxy"
     [[ ! $cloudfqdn ]] || [[ $no_proxy =~ "$cloudfqdn" ]] || no_proxy="$cloudfqdn,$no_proxy"
     export no_proxy="${no_proxy%,}";
@@ -2837,7 +2874,7 @@ function set_noproxyvar
         return 0 # only apply this once
     fi
     local ips
-    printf -v ips '%s,' $net_public.{1..254}
+    printf -v ips '%s,' $net_public${ip_sep}{1..254}
     no_proxy="$ips$no_proxy"
     no_proxy="${no_proxy%,}";
 }
@@ -4811,11 +4848,11 @@ function onadmin_upgrade_ses_to_4
     for node in $ceph_nodes; do
         # Replace SP1 repos with the new ones
         ssh $node "rm /etc/zypp/repos.d/*
-zypper ar -f http://$adminip:8091/suse-12.2/x86_64/install SLES12-SP2-12.2-0
-zypper ar -f http://$adminip:8091/suse-12.2/x86_64/repos/SLES12-SP2-Updates SLES12-SP2-Updates
-zypper ar -f http://$adminip:8091/suse-12.2/x86_64/repos/SLES12-SP2-Pool SLES12-SP2-Pool
-zypper ar -f http://$adminip:8091/suse-12.2/x86_64/repos/SUSE-Enterprise-Storage-4-Pool SUSE-Enterprise-Storage-4-Pool
-zypper ar -f http://$adminip:8091/suse-12.2/x86_64/repos/SUSE-Enterprise-Storage-4-Updates SUSE-Enterprise-Storage-4-Updates
+zypper ar -f http://$(wrap_ip $adminip):8091/suse-12.2/x86_64/install SLES12-SP2-12.2-0
+zypper ar -f http://$(wrap_ip $adminip):8091/suse-12.2/x86_64/repos/SLES12-SP2-Updates SLES12-SP2-Updates
+zypper ar -f http://$(wrap_ip $adminip):8091/suse-12.2/x86_64/repos/SLES12-SP2-Pool SLES12-SP2-Pool
+zypper ar -f http://$(wrap_ip $adminip):8091/suse-12.2/x86_64/repos/SUSE-Enterprise-Storage-4-Pool SUSE-Enterprise-Storage-4-Pool
+zypper ar -f http://$(wrap_ip $adminip):8091/suse-12.2/x86_64/repos/SUSE-Enterprise-Storage-4-Updates SUSE-Enterprise-Storage-4-Updates
 zypper ref
 zypper --non-interactive --gpg-auto-import-keys --no-gpg-checks install ses-upgrade-helper"
 
@@ -5527,7 +5564,7 @@ function onadmin_external_ceph
     local node
     local i=0
     local ip_alloc
-    local ses_repo="http://$adminip:8091/suse-$suseversion/$arch/repos/SUSE-Enterprise-Storage-$sesversion"
+    local ses_repo="http://$(wrap_ip $adminip):8091/suse-$suseversion/$arch/repos/SUSE-Enterprise-Storage-$sesversion"
     for node in ${ceph_cluster[@]}; do
         set_node_alias $node ceph$i
         let "i+=1"
@@ -5544,10 +5581,15 @@ function onadmin_external_ceph
         setcloudnetvars $cloud
     fi
     echo "== Running SES deployment script =="
-    if [[ $want_separate_ceph_network -eq 1 ]]; then
-        safely ${SCRIPTS_DIR}/build_ses.sh ${net_ceph}.0/24 ${net_storage}.0/24 ${ceph_cluster[@]}
+    if [[ ${want_ipv6} == 0 ]]; then
+        net_end=".0/24"
     else
-        safely ${SCRIPTS_DIR}/build_ses.sh ${net_public}.0/24 ${net_storage}.0/24 ${ceph_cluster[@]}
+        net_end=":/64"
+    fi
+    if [[ $want_separate_ceph_network -eq 1 ]]; then
+        safely ${SCRIPTS_DIR}/build_ses.sh ${net_ceph}${net_end} ${net_storage}${net_end} ${ceph_cluster[@]}
+    else
+        safely ${SCRIPTS_DIR}/build_ses.sh ${net_public}${net_end} ${net_storage}${net_end} ${ceph_cluster[@]}
     fi
 }
 


### PR DESCRIPTION
Add a bunch of ipv6 networks:

  fd00:0:0::1:/112
  fd00:0:0::2:/112
  fd00:0:0::3:/112
  fd00:0:0::4:/112
  fd00:0:0::5:/112

Using a 112 as that gives us the full last 16 bits (:XXXX) for hosts.
meaning we can just use existing ipv4 last octet numbers. Ie .100 ==
:100 or .254 == :254.

This is still a WIP and doesn't actually run properly yet. Putting it here for the squad to laugh^Wlook at.
Still got _along_ way to go.