### PR TITLE
qa_crowbarsetup: openvswitch vxlan becoming the default choice

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -257,9 +257,9 @@
       - choice:
           name: networkingmode
           choices:
-            - gre
-            - vlan
             - vxlan
+            - vlan
+            - gre
 
       - string:
           name: want_dvr

--- a/mkcloudruns/mkcloudconfig/SUSECloud.mkcloud
+++ b/mkcloudruns/mkcloudconfig/SUSECloud.mkcloud
@@ -62,7 +62,7 @@ export want_node_aliases='controller=2,network=1,compute=2,nfsshare=1'
 # Set the networking plugin for neutron.
 export networkingplugin=openvswitch
 # Set the networking mode (vlan, vxlan, gre)
-export networkingmode=gre
+export networkingmode=vxlan
 export want_dvr=1
 #export host_mtu= # Set given MTU settings...
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2560,7 +2560,7 @@ function custom_configuration
 
             if [ $networkingplugin = openvswitch ] ; then
                 if [[ $networkingmode = vxlan ]] || iscloudver 6plus; then
-                    proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['gre','vxlan','vlan']"
+                    proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['vxlan','vlan', 'gre']"
                     if [[ $want_dvr = 1 ]]; then
                         proposal_set_value neutron default "['attributes']['neutron']['use_dvr']" "true"
                         # Enable L2 population, because for mkcloud we enable all ml2_type_drivers
@@ -2568,8 +2568,10 @@ function custom_configuration
                         # DVR with GRE or VXLAN requires L2 population
                         proposal_set_value neutron default "['attributes']['neutron']['use_l2pop']" "true"
                     fi
-                else
+                elif [[ $networkingmode = gre ]]; then
                     proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['gre','vlan']"
+                else
+                    proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['vlan']"
                 fi
             elif [ "$networkingplugin" = "linuxbridge" ] ; then
                 if iscloudver 7plus; then


### PR DESCRIPTION
The CI jobs for Cloud7+ are defaulting to vxlan, so we should
transition the jenkins defaults to reflect that. The corresponding
switch of product defaults is done in https://github.com/crowbar/crowbar-openstack/pull/1842