### PR TITLE
openstack-ardana: update staging/maintenance update jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -58,10 +58,10 @@
 - project:
     name: cloud-ardana8-job-std-3cp-devel-staging-updates-x86_64
     ardana_job: '{name}'
-    disabled: true
     ardana_env: cloud-ardana-ci-slot
     cloudsource: develcloud8
-    update: 'cloudsource=stagingcloud8'
+    update_after_deploy: true
+    update_to_cloudsource: stagingcloud8
     branch: stable/pike
     model: std-3cp
     triggers:
@@ -75,7 +75,8 @@
     disabled: true
     ardana_env: cloud-ardana-ci-slot
     cloudsource: GM8+up
-    update: 'test_updates=true'
+    update_after_deploy: true
+    update_to_cloudsource: GM8+testup
     branch: stable/pike
     model: std-3cp
     triggers:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -67,7 +67,8 @@
     disabled: true
     ardana_env: cloud-ardana-ci-slot
     cloudsource: develcloud9
-    update: 'cloudsource=stagingcloud9'
+    update_after_deploy: true
+    update_to_cloudsource: stagingcloud9
     model: std-3cp
     triggers:
      - timed: 'H H * * *'


### PR DESCRIPTION
Update the openstack-ardana jobs automating the cloud update
workflow for the staging media and maintenance updates to use
the recently implemented update automation support.