### PR TITLE
openstack-ardana: fix deployer IP messages for baremetal

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
           env.DEPLOYER_IP = sh (
             returnStdout: true,
             script: '''
-              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+              grep -oP "^${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
                 $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
             '''
           ).trim()

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
           env.DEPLOYER_IP = sh (
             returnStdout: true,
             script: '''
-              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+              grep -oP "^${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
                 $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
             '''
           ).trim()

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
           env.DEPLOYER_IP = sh (
             returnStdout: true,
             script: '''
-              grep -oP "${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+              grep -oP "^${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
                 $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
             '''
           ).trim()


### PR DESCRIPTION
The Jenkins messages displaying the deployer IP associated
with baremetal environments are incorrectly showing two
IP addresses, the "gate" IP and the deployer VM IP
(e.g.: https://ci.suse.de/blue/organizations/jenkins/openstack-ardana/detail/openstack-ardana/1051/pipeline/26).