### PR TITLE
Make obs_scm continue to work with local git path

### DIFF
--- a/scripts/jenkins/ardana/gerrit/build_test_package.py
+++ b/scripts/jenkins/ardana/gerrit/build_test_package.py
@@ -338,7 +338,13 @@ class OBSProject:
                 service_file.truncate()
             # Run the osc service and commit the changes to OBS
             sh.osc('rm', glob.glob('%s*.obscpio' % package.name))
-            sh.osc('service', 'disabledrun')
+            env = os.environ.copy()
+            # TODO use proper api, once available from:
+            # https://github.com/openSUSE/obs-service-tar_scm/issues/258
+            # Workaround to make obs_scm work with a local path.
+            # Otherwise it only works with remote URLs.
+            env['TAR_SCM_TESTMODE'] = '1'
+            sh.osc('service', 'disabledrun', _env=env)
             sh.osc('add', glob.glob('%s*.obscpio' % package.name))
             sh.osc('commit', '-m',
                    'Testing gerrit changes applied to %s'


### PR DESCRIPTION
In 44b3beeaf8663d46467fb3945ddc3d73c65ac452
from https://github.com/openSUSE/obs-service-tar_scm/pull/251
obs_scm was changed to reject anything that is not a remote URL like a
local path. We use a local path to build a test package for git commits
that are not yet merged. Work around this change by setting the
environment variable that is used to bypass this for testing obs_scm.