### PR TITLE
Change neutron defaults to openvswitch vxlan

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -54,16 +54,22 @@
           default: github.com/$repo_owner/automation#$branch
           description: Mandatory, automation repo URL
 
-      - string:
+      - choice:
           name: networkingplugin
-          default: linuxbridge
           description: |
                networking plugin to be used by Neutron. Available options are: openvswitch:gre, vlan, vxlan / linuxbridge:vlan
+          choices:
+            - openvswitch
+            - linuxbridge
 
-      - string:
+      - choice:
           name: networkingmode
-          default: vlan
-          description: networking mode to be used by Neutron. Available options are gre, vlan, vxlan
+          description: |
+               networking mode to be used by Neutron. Available options are gre, vlan, vxlan
+          choices:
+            - vxlan
+            - vlan
+            - gre
 
       - string:
           name: tempest


### PR DESCRIPTION
This is the default choice in product so it would be
good to test it in qa. Scenario 1a is the simplest one
and run most often.
Also changing the parameters to choice to avoid
typos