### PR TITLE
openstack-ardana-gerrit: create periodic gerrit jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -98,11 +98,46 @@
 - project:
     name: cloud-ardana8-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-gerrit-slot
+    ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
-    branch: stable/pike
     develproject: Devel:Cloud:8:Staging
     repository: SLE_12_SP3
-    voting: 0
+    gerrit_change_ids: '4941'
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_gerrit_job}'
+
+- project:
+    name: openstack-ardana-gerrit-cloud8
+    ardana_gerrit_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: stagingcloud8
+    branch:
+    develproject: Devel:Cloud:8:Staging
+    repository: SLE_12_SP3
+    gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}'
+    triggers:
+      - gerrit:
+          server-name: 'gerrit.suse.provo.cloud'
+          trigger-on:
+            - patchset-created-event:
+                exclude-drafts: true
+                exclude-no-code-change: true
+            - draft-published-event
+            - comment-added-contains-event:
+                comment-contains-value: '^suse_recheck$'
+            - comment-added-contains-event:
+                comment-contains-value: '^recheck$'
+          override-votes: true
+          gerrit-build-successful-verified-value: 0
+          skip-vote:
+              notbuilt: true
+          projects:
+            - project-compare-type: 'REG_EXP'
+              project-pattern: !include-raw: gerrit-project-regexp.txt
+              branches:
+                - branch-compare-type: 'PLAIN'
+                  branch-pattern: 'stable/pike'
     jobs:
         - '{ardana_gerrit_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -78,7 +78,41 @@
 - project:
     name: cloud-ardana9-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-gerrit-slot
+    ardana_env: cloud-ardana-ci-slot
     model: demo
+    gerrit_change_ids: '4940'
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_gerrit_job}'
+
+- project:
+    name: openstack-ardana-gerrit-cloud9
+    ardana_gerrit_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    model: demo
+    gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}'
+    triggers:
+      - gerrit:
+          server-name: 'gerrit.suse.provo.cloud'
+          trigger-on:
+            - patchset-created-event:
+                exclude-drafts: true
+                exclude-no-code-change: true
+            - draft-published-event
+            - comment-added-contains-event:
+                comment-contains-value: '^suse_recheck$'
+            - comment-added-contains-event:
+                comment-contains-value: '^recheck$'
+          override-votes: true
+          gerrit-build-successful-verified-value: 1
+          skip-vote:
+              notbuilt: true
+          projects:
+            - project-compare-type: 'REG_EXP'
+              project-pattern: !include-raw: gerrit-project-regexp.txt
+              branches:
+                - branch-compare-type: 'PLAIN'
+                  branch-pattern: 'master'
     jobs:
         - '{ardana_gerrit_job}'

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -18,6 +18,9 @@ pipeline {
   stages {
 
     stage('validate commit message') {
+      when {
+        expression { env.GERRIT_CHANGE_COMMIT_MESSAGE != null }
+      }
       steps {
         script {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${gerrit_change_ids}"

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -5,31 +5,11 @@
     node: cloud-trigger
     disabled: '{obj:disabled|False}'
 
-    triggers:
-      - gerrit:
-          server-name: 'gerrit.suse.provo.cloud'
-          trigger-on:
-            - patchset-created-event:
-                exclude-drafts: true
-                exclude-no-code-change: true
-            - draft-published-event
-            - comment-added-contains-event:
-                comment-contains-value: '^suse_recheck$'
-            - comment-added-contains-event:
-                comment-contains-value: '^recheck$'
-          override-votes: true
-          gerrit-build-successful-verified-value: '{voting|1}'
-          skip-vote:
-              notbuilt: true
-          projects:
-            - project-compare-type: 'REG_EXP'
-              project-pattern: !include-raw: ../gerrit-project-regexp.txt
-              branches:
-                - branch-compare-type: 'PLAIN'
-                  branch-pattern: '{branch|master}'
     logrotate:
       numToKeep: -1
       daysToKeep: 14
+
+    triggers: '{triggers}'
 
     parameters:
 
@@ -64,7 +44,7 @@
 
       - string:
           name: gerrit_change_ids
-          default: '${{GERRIT_CHANGE_NUMBER}}'
+          default: '{gerrit_change_ids}'
           description: >-
             A comma separated list of IDs for changes in gerrit.suse.provo.cloud
             to test.


### PR DESCRIPTION
This commit updates cloud-ardana8-job-gerrit-x86_64 and
cloud-ardana9-job-gerrit-x86_64 to be periodic jobs instead
of jobs triggered by Gerrit change requests. These jobs
will run periodically against a set of test Gerrit reviews [1][2]
to ensure the Gerrit pipelines remain in working order. This
testing is required to monitor the state of the Gerrit pipelines
independently from Gerrit changes.

Two regular Gerrit CI jobs are created to replace the ones
mentioned above: openstack-ardana-gerrit-cloud8 and
openstack-ardana-gerrit-cloud9.

[1] https://gerrit.suse.provo.cloud/4940
[2] https://gerrit.suse.provo.cloud/4941