### PR TITLE
openstack-ardana: fix create os resources tasks on ardana_qe_tests role

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -15,7 +15,7 @@
 #
 ---
 
-ardana_qe_base_dir: "~/ardana-qe"
+ardana_qe_base_dir: "/var/lib/ardana/ardana-qe"
 ardana_qe_test_work_dir: "{{ ardana_qe_base_dir }}/{{ test_name }}"
 ardana_qe_tests_dir: "{{ ardana_qe_base_dir }}/ardana-qa-tests"
 ardana_qe_tests_git_repo: "http://git.suse.provo.cloud"


### PR DESCRIPTION
For creating openstack resources (projects, users, etc) we use ansible
modules which requires the shade library. For that, shade is installed on
the test virtual environment and the ansible python interpreter is set to
use python from the virtual environment.

Using `~` on the virtual enviroment path causes ansible to fail with
`OSError: [Errno 2] No such file or directory`. So this patch replaces
`~` with the full path.