### PR TITLE
openstack-ardana: move cleanWs calls to cleanup stage

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
@@ -92,6 +92,8 @@ pipeline {
           archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
         }
       }
+    }
+    cleanup {
       cleanWs()
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
     }
   }
   post {
-    always {
+    cleanup {
       cleanWs()
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-pcloud.Jenkinsfile
@@ -104,7 +104,6 @@ pipeline {
           archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
         }
       }
-      cleanWs()
     }
     success{
       echo """
@@ -115,6 +114,9 @@ pipeline {
 **
 ******************************************************************************
       """
+    }
+    cleanup {
+      cleanWs()
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-qa-tests.Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
     }
   }
   post {
-    always {
+    cleanup {
       cleanWs()
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tempest.Jenkinsfile
@@ -82,6 +82,8 @@ pipeline {
           junit testResults: ".artifacts/*.xml", allowEmptyResults: true
         }
       }
+    }
+    cleanup {
       cleanWs()
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -117,6 +117,8 @@ pipeline {
     always {
       archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
       junit testResults: ".artifacts/*.xml", allowEmptyResults: true
+    }
+    cleanup {
       cleanWs()
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
@@ -66,6 +66,8 @@ pipeline {
   post {
     always {
       archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+    }
+    cleanup {
       cleanWs()
     }
   }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -143,7 +143,6 @@ pipeline {
           archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
         }
       }
-      cleanWs()
     }
     success{
       echo """
@@ -155,6 +154,9 @@ pipeline {
 ** Please delete the 'openstack-ardana-${ardana_env}' stack manually when you're done.
 ******************************************************************************
       """
+    }
+    cleanup {
+      cleanWs()
     }
   }
 }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -361,7 +361,6 @@ pipeline {
           junit testResults: ".artifacts/*.xml", allowEmptyResults: true
         }
       }
-      cleanWs()
       script{
         if (env.DEPLOYER_IP != null) {
           if (cloud_type == "virtual") {
@@ -450,6 +449,9 @@ pipeline {
           automation-git/scripts/jtsync/jtsync.rb --ci suse --job $JOB_NAME 1
         fi
       '''
+    }
+    cleanup {
+      cleanWs()
     }
   }
 }


### PR DESCRIPTION
The post block supports a 'cleanup' stage that runs after all other
stages. Move calls to the cleanWs function from the 'always' stage
to the 'cleanup' stage so that the workspace will continue to be
available during the 'success' and 'failure' stages.