### PR TITLE
Increase timeout for neutron tests

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
@@ -14,7 +14,8 @@
 # under the License.
 #
 ---
-
+# Adding longer timeout as neutron tests run in sequence.
+ardana_qe_test_timeout: 480
 ardana_qe_test_venv_requires:
   - 'pymysql'
   - 'python-subunit'


### PR DESCRIPTION
Default timeout (2 hours) for the qa job is not enough to run neutron tests as tests run with concurrency=1 due to test design. Setting the timeout to 8 hours till it can be run concurrently.