### PR TITLE
ipv6: Teach net-config about IPv6

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-admin.netv6.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin.netv6.xml
@@ -1,0 +1,8 @@
+<network>
+  <name>cloud-admin</name>
+  <bridge name='cloudbr' stp='off' delay='0' />
+  <mac address='52:54:00:AB:B1:77'/>
+  <ip family='ipv6' address='fd00::1' prefix='112'/>
+  <forward mode='nat'>
+  </forward>
+</network>

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -198,6 +198,9 @@ def net_interfaces_config(args, nicmodel):
 
 
 def net_config(args):
+    template_file = "%s-net.xml" % args.network
+    if args.ipv6:
+        template_file = "%s-net-v6.xml" % args.network
     values = {
         'cloud': args.cloud,
         'bridge': args.bridge,
@@ -208,10 +211,7 @@ def net_config(args):
         'forwardmode': args.forwardmode
     }
 
-    return get_config(
-        values,
-        os.path.join(TEMPLATE_DIR, "%s-net.xml" % args.network)
-    )
+    return get_config(values, os.path.join(TEMPLATE_DIR, template_file))
 
 
 def merge_dicts(d1, d2):

--- a/scripts/lib/libvirt/net-config
+++ b/scripts/lib/libvirt/net-config
@@ -6,6 +6,7 @@ import libvirt_setup
 
 def main():
     parser = argparse.ArgumentParser(description="Create Virtual Network Config")
+    parser.add_argument("--ipv6", help="Use IPv6", action="store_true")
     parser.add_argument("network", help="Name of the network to be configured (admin, ironic)")
     parser.add_argument("cloud", help="Name of the Cloud")
     parser.add_argument("bridge", help="Name of the Virtual bridge to be used for this network")

--- a/scripts/lib/libvirt/templates/admin-net-v6.xml
+++ b/scripts/lib/libvirt/templates/admin-net-v6.xml
@@ -1,0 +1,8 @@
+<network>
+  <name>${cloud}-admin</name>
+  <bridge name='${bridge}' stp='off' delay='0' />
+  <mac address='52:54:00:AB:B1:77'/>
+  <ip family='ipv6' address='${gateway}' prefix='${netmask}'/>
+  <forward mode='${forwardmode}'>
+  </forward>
+</network>

--- a/scripts/lib/libvirt/templates/ironic-net-v6.xml
+++ b/scripts/lib/libvirt/templates/ironic-net-v6.xml
@@ -1,0 +1,8 @@
+<network>
+  <name>${cloud}-ironic</name>
+  <bridge name='${bridge}' stp='off' delay='0' />
+  <mac address='52:54:00:AB:B1:78'/>
+  <ip family='ipv6' address='${gateway}' prefix='${netmask}'/>
+  <forward mode='${forwardmode}'>
+  </forward>
+</network>

--- a/scripts/lib/libvirt/test_libvirt_setup.py
+++ b/scripts/lib/libvirt/test_libvirt_setup.py
@@ -64,19 +64,36 @@ class TestLibvirtHelpers(unittest.TestCase):
 
 class TestLibvirtNetConfig(unittest.TestCase):
 
-    def test_net_config(self):
+    def net_config_common_arguments(self):
         args = Arguments()
         args.network = "admin"
         args.cloud = "cloud"
         args.bridge = "cloudbr"
+        args.cloudfqdn = "unittest.suse.de"
+        args.forwardmode = "nat"
+        return args
+
+    def test_net_config(self):
+        args = self.net_config_common_arguments()
+        args.ipv6 = False
         args.gateway = "192.168.124.1"
         args.netmask = "255.255.248.0"
-        args.cloudfqdn = "unittest.suse.de"
         args.hostip = "192.168.124.10"
-        args.forwardmode = "nat"
 
         should_config = libvirt_setup.readfile(
             "{0}/cloud-admin.net.xml".format(FIXTURE_DIR))
+        is_config = libvirt_setup.net_config(args)
+        self.assertEqual(is_config, should_config)
+
+    def test_ipv6_net_config(self):
+        args = self.net_config_common_arguments()
+        args.ipv6 = True
+        args.gateway = "fd00::1"
+        args.netmask = "112"
+        args.hostip = "fd00::10"
+
+        should_config = libvirt_setup.readfile(
+            "{0}/cloud-admin.netv6.xml".format(FIXTURE_DIR))
         is_config = libvirt_setup.net_config(args)
         self.assertEqual(is_config, should_config)
 


### PR DESCRIPTION
libvirt XML networking templates need to specify different options if we
are going to specify IPv6 networks. Add a new -v6 template, along with a
new option to net-config to support it.