### PR TITLE
SCRD-5293 openstack-ardana-gerrit: enable no-code-change events and fix resource label

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -123,7 +123,7 @@
           trigger-on:
             - patchset-created-event:
                 exclude-drafts: true
-                exclude-no-code-change: true
+                exclude-no-code-change: false
             - draft-published-event
             - comment-added-contains-event:
                 comment-contains-value: '^suse_recheck$'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -98,7 +98,7 @@
           trigger-on:
             - patchset-created-event:
                 exclude-drafts: true
-                exclude-no-code-change: true
+                exclude-no-code-change: false
             - draft-published-event
             - comment-added-contains-event:
                 comment-contains-value: '^suse_recheck$'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -78,7 +78,7 @@
 - project:
     name: cloud-ardana9-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-ci-slot
+    ardana_env: cloud-ardana-gerrit-slot
     model: demo
     gerrit_change_ids: '4940'
     triggers:


### PR DESCRIPTION
When the commit message is edited via the Gerrit UI, a NO_CODE_CHANGE
event is generated by Gerrit. We need to set `exclude-no-code-change`
to false in our gerrit trigger jobs to catch these events.

This PR also fixes the Gerrit Cloud9 job to use the correct Lockable Resources
label (recently broken in #2893).

Tested successfully against https://gerrit.suse.provo.cloud/#/c/4950/