### PR TITLE
openstack-ardana-gerrit: fix resource label

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -78,7 +78,7 @@
 - project:
     name: cloud-ardana9-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-gerrit-slot
+    ardana_env: cloud-ardana-ci-slot
     model: demo
     gerrit_change_ids: '4940'
     triggers:
@@ -89,7 +89,7 @@
 - project:
     name: openstack-ardana-gerrit-cloud9
     ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-ci-slot
+    ardana_env: cloud-ardana-gerrit-slot
     model: demo
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}'
     triggers:


### PR DESCRIPTION
The Jenkins jobs triggered by Gerrit patches must use
a set of Lockable Resources dedicated to Gerrit, labeled
`cloud-ardana-gerrit-slot`, whereas the periodic Gerrit
Jenkins jobs must use the same Lockable Resources as the
other periodic Ardana jobs, the ones `cloud-ardana-ci-slot`.