### PR TITLE
openstack-ardana: disable heat-cloudwatch-api

### DIFF
--- a/scripts/jenkins/ardana/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-cloud.yml
@@ -48,6 +48,7 @@
           loop:
             - manila
             - freezer
+            - heat-cloudwatch-api
 
         - name: Ardana log stream at
           debug:

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -26,6 +26,8 @@ versioned_features:
     enabled: "{{ when_staging }}"
   freezer:
     enabled: "{{ when_cloud8 }}"
+  heat-cloudwatch-api:
+    enabled: "{{ when_cloud8 }}"
   # FIXME: Remove this entry when bsc#1110414 fixed
   fix_ardana_ssh_keyscan:
     enabled: "{{ when_cloud9M3 }}"


### PR DESCRIPTION
Disable the `heat-cloudwatch-api` service when deploying
cloud 8. This service was removed in Queens [1].

[1] https://docs.openstack.org/releasenotes/heat/queens.html