### PR TITLE
ipv6: Catch virsh net-start errors

### DIFF
--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -51,7 +51,7 @@ function libvirt_start_daemon()
 
 function libvirt_net_start()
 {
-    $sudo virsh net-start $cloud-admin
+    $sudo virsh net-start $cloud-admin || exit $?
     $sudo sysctl -e net.ipv4.conf.$cloudbr.forwarding=1
     for dev in $cloudbr-nic $cloudbr ; do
         $sudo ip link set mtu 9000 dev $dev


### PR DESCRIPTION
If virsh net-start fails to start the network, the libvirt_net_start
function in the mkcloud driver continues merrily on, even though the
interface doesn't exist. Exit if it fails.