### PR TITLE
Remove old PTF repo during the upgrade so the new one can be added to zypp

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4889,6 +4889,8 @@ function onadmin_prepare_cloudupgrade_admin_repos
         $zypper rr SLES12-SP2-Pool
         $zypper rr SLES12-SP2-Updates
     fi
+    # remove old PTF repo
+    $zypper rr cloud-ptf
 
     onadmin_setup_local_zypper_repositories
     create_repos_yml


### PR DESCRIPTION

If there's a need to have PTF repo for both original and upgraded cloud,
we have to make sure that the old one is removed when changing the repository
setup.