### PR TITLE
openstack-ardana: get cloud media build number from motd

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/get_cloud_build_version.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/get_cloud_build_version.yml
@@ -15,14 +15,6 @@
 #
 ---
 
-- name: Find cloud build file
-  shell: |
-    find /srv/www/*/x86_64/repos/*Cloud*/ -name build
-  register: cloud_build_file
-  failed_when: false
-
 - name: Get media build version
-  slurp:
-    src: "{{ cloud_build_file.stdout }}"
+  command: "awk '/Media build version/ { print $4 }' /etc/motd"
   register: cloud_media_build_version
-  when: cloud_build_file.rc == 0

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
@@ -27,7 +27,7 @@
   when:
     - rc_action == "finished"
     - rc_task == "deploy"
-    - cloud_media_build_version is not defined or 'content' not in cloud_media_build_version
+    - cloud_media_build_version is not defined or 'stdout' not in cloud_media_build_version
 
 - name: Notify RocketChat
   rocketchat:

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/deploy.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/deploy.yml
@@ -57,7 +57,7 @@ _msg_fields_finished:
     value: "{{ jenkins_build_url_msg }}"
     short: False
   - title: Media version
-    value: "{{ cloud_media_build_version.content | b64decode if cloud_media_build_version is defined else 'NA' }}"
+    value: "{{ cloud_media_build_version['stdout'] | default('Not available', true) }}"
     short: False
   - title: Log
     value: "{{ ansible_log_url_msg if lookup('env', 'BUILD_URL') else 'Not available' }}"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -22,6 +22,7 @@ subunit2sql_venv: "/opt/subunit2sql"
 subunit2sql_bin: "{{ subunit2sql_venv }}/bin/subunit2sql"
 os_health_server: "10.86.0.167"
 os_health_url: "http://{{ os_health_server }}/#/job/{{ os_health_build_name }}"
+os_health_cloud_build: "{{ cloud_media_build_version['stdout'] | default('Not-available', true) }}"
 os_service_name: "{{ test_name.split('_')[0] }}"
 os_health_requires_state: "present"
 os_health_requires:

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/get_cloud_build_version.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/get_cloud_build_version.yml
@@ -15,14 +15,6 @@
 #
 ---
 
-- name: Find cloud build file
-  shell: |
-    find /srv/www/*/x86_64/repos/*OpenStack-*/ -name build | tail -1
-  register: cloud_build_file
-  failed_when: false
-
 - name: Get media build version
-  slurp:
-    src: "{{ cloud_build_file.stdout }}"
+  command: "awk '/Media build version/ { print $4 }' /etc/motd"
   register: cloud_media_build_version
-  when: cloud_build_file.rc == 0

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/main.yml
@@ -27,7 +27,7 @@
   include_vars: "{{ task }}.yml"
 
 - include_tasks: get_cloud_build_version.yml
-  when: cloud_media_build_version is not defined or 'content' not in cloud_media_build_version
+  when: cloud_media_build_version is not defined or 'stdout' not in cloud_media_build_version
 
 - name: Send results to OpenStack-Health
   command: |

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/vars/ardana-qe-tests.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/vars/ardana-qe-tests.yml
@@ -25,4 +25,4 @@ os_health_metadata:
   - "ardana_env:{{ ardana_env }}"
   - "build_name:{{ os_health_build_name }}"
   - "openstack_service:{{ os_service_name.split('-')[0] | lower }}"
-  - "build_version:{{ cloud_media_build_version.content | b64decode }}"
+  - "build_version:{{ os_health_cloud_build }}"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/vars/tempest.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/vars/tempest.yml
@@ -25,4 +25,4 @@ os_health_metadata:
   - "ardana_env:{{ ardana_env }}"
   - "build_name:{{ os_health_build_name }}"
   - "openstack_service:{{ tempest_run_filter }}"
-  - "build_version:{{ cloud_media_build_version.content | b64decode }}"
+  - "build_version:{{ os_health_cloud_build }}"


### PR DESCRIPTION
The cloud media build number is added to the motd by the
`setup_zypper_repos` role. Other roles relies on different methods to
get the cloud media build number, this is very error prone as depending
of the cloudsource there are different methods to get the cloud media
build number and other roles may not have access to cloudsource.

With this change, instead of applying the same logic from `setup_zypper_repos`
to get the media build number, other roles simply read that info from the motd
as it was previously added.