### PR TITLE
Enable rabbit notifications in all_batch scenarios

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
+++ b/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
@@ -11,6 +11,8 @@ proposals:
   attributes:
     trove:
       enabled: true
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud7/cloud7-4nodes-compute-ha.yml
@@ -56,6 +56,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
+++ b/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
@@ -10,6 +10,8 @@ proposals:
   attributes:
     trove:
       enabled: true
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/cloud8-5nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud8/cloud8-5nodes-compute-ha.yml
@@ -54,6 +54,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
@@ -8,6 +8,8 @@ proposals:
       - @@controller@@
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
@@ -54,6 +54,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:


### PR DESCRIPTION
In f55c442 the enable_notifications settings was turned on for mkcloud
proposals, but the proposal step is skipped in some CI jobs and the
batch step is used instead. This patch makes the correction to every
batch file that is used for jobs with mkcloudtarget=all_batch on Cloud
7, 8, and 9, which are currently all broken[1].

[1] https://ci.suse.de/job/cloud-mkcloud9-job-2nodes-x86_64/339/
