### PR TITLE
Rabbit enable notifications qa

### DIFF
--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1a.yaml
@@ -57,6 +57,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-1b.yaml
@@ -61,6 +61,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2a.yaml
@@ -109,6 +109,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2b.yaml
@@ -61,6 +61,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-2c.yaml
@@ -53,6 +53,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-3.yaml
@@ -80,6 +80,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-6a.yaml
@@ -78,6 +78,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8a.yaml
@@ -59,6 +59,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-8b.yaml
@@ -53,6 +53,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud7/qa/no-ssl/qa-scenario-9.yaml
@@ -53,6 +53,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -57,6 +57,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -61,6 +61,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -109,6 +109,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -61,6 +61,8 @@ proposals:
           device: 10.162.26.129:/var/qa2/ha-rabbitmq
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -53,6 +53,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-3.yaml
@@ -81,6 +81,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -78,6 +78,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8a.yaml
@@ -59,6 +59,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud7/qa/ssl-insecure/qa-scenario-8b.yaml
@@ -51,6 +51,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1a.yaml
@@ -43,6 +43,8 @@ proposals:
       - cluster:services
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-1b.yaml
@@ -45,6 +45,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2a.yaml
@@ -100,6 +100,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2b.yaml
@@ -56,6 +56,8 @@ proposals:
         shared:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-2c.yaml
@@ -44,6 +44,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-3.yaml
@@ -69,6 +69,8 @@ proposals:
         shared:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-6a.yaml
@@ -60,6 +60,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8a.yaml
@@ -58,6 +58,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-8b.yaml
@@ -50,6 +50,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud8/qa/no-ssl/qa-scenario-9.yaml
@@ -50,6 +50,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -56,6 +56,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -58,6 +58,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -106,6 +106,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -58,6 +58,8 @@ proposals:
           device: 10.162.26.129:/var/qa2/ha-rabbitmq
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -45,6 +45,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-3.yaml
@@ -78,6 +78,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -75,6 +75,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-8a.yaml
@@ -58,6 +58,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl-insecure/qa-scenario-8b.yaml
@@ -50,6 +50,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud8/qa/ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl/qa-scenario-1a.yaml
@@ -55,6 +55,8 @@ proposals:
       certfile: ##certfile##
       keyfile: ##keyfile##
       client_ca_certs: ##cafile##
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1a.yaml
@@ -43,6 +43,8 @@ proposals:
       - cluster:services
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1b.yaml
@@ -45,6 +45,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2a.yaml
@@ -100,6 +100,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2b.yaml
@@ -56,6 +56,8 @@ proposals:
         shared:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2c.yaml
@@ -44,6 +44,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-3.yaml
@@ -69,6 +69,8 @@ proposals:
         shared:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-6a.yaml
@@ -60,6 +60,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
@@ -58,6 +58,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8b.yaml
@@ -50,6 +50,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-9.yaml
@@ -50,6 +50,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -56,6 +56,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -58,6 +58,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -106,6 +106,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -58,6 +58,8 @@ proposals:
           device: 10.162.26.129:/var/qa2/ha-rabbitmq
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -45,6 +45,8 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-3.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-3.yaml
@@ -78,6 +78,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -75,6 +75,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8a.yaml
@@ -58,6 +58,8 @@ proposals:
           device: ##shared_nfs_for_rabbitmq##
           fstype: nfs
           options: nfsvers=3
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8b.yaml
@@ -50,6 +50,8 @@ proposals:
         mode: drbd
         drbd:
           size: 5
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:

--- a/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
@@ -55,6 +55,8 @@ proposals:
       certfile: ##certfile##
       keyfile: ##keyfile##
       client_ca_certs: ##cafile##
+    client:
+      enable_notifications: true
   deployment:
     elements:
       rabbitmq-server:


### PR DESCRIPTION
In f55c442 the enable_notifications settings was turned on for mkcloud
proposals, but the proposal step is skipped in qa CI jobs and the
batch step is used instead. This patch makes the correction to every
batch file that is used for qa scenario jobs in Clouds
7, 8, and 9.