### PR TITLE
openstack-ardana-gerrit: custom gerrit messages

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -122,10 +122,7 @@
                 comment-contains-value: '^suse_recheck$'
             - comment-added-contains-event:
                 comment-contains-value: '^recheck$'
-          override-votes: true
-          gerrit-build-successful-verified-value: 0
-          skip-vote:
-              notbuilt: true
+          silent: true
           projects:
             - project-compare-type: 'REG_EXP'
               project-pattern: !include-raw: gerrit-project-regexp.txt

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -115,10 +115,7 @@
                 comment-contains-value: '^suse_recheck$'
             - comment-added-contains-event:
                 comment-contains-value: '^recheck$'
-          override-votes: true
-          gerrit-build-successful-verified-value: 1
-          skip-vote:
-              notbuilt: true
+          silent: true
           projects:
             - project-compare-type: 'REG_EXP'
               project-pattern: !include-raw: gerrit-project-regexp.txt

--- a/scripts/jenkins/ardana/gerrit/gerrit_review.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit_review.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import argparse
+
+from pygerrit2 import GerritRestAPI, GerritReview, HTTPDigestAuthFromNetrc
+
+GERRIT_URL = 'https://gerrit.suse.provo.cloud/'
+
+
+def gerrit_review(change_no, patch=None, label=None, vote=1, message=''):
+    auth = HTTPDigestAuthFromNetrc(url=GERRIT_URL)
+    rest = GerritRestAPI(url=GERRIT_URL, auth=auth, verify=False)
+    change = rest.get("/changes/?q={}".format(change_no))[0]
+    print("Posting {}: {} review for change: '{}'".format(label, vote,
+                                                          change['subject']))
+    if not patch:
+        current_rev = rest.get("/changes/?q={}&o=CURRENT_REVISION".format(
+            change['_number']))
+        patch = current_rev[0]['revisions'].values()[0]['_number']
+    rev = GerritReview()
+    rev.set_message(message)
+    if label:
+        rev.add_labels({label: vote})
+
+    rest.review(change['_number'], patch, rev)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Post a Gerrit review')
+    parser.add_argument('change',
+                        help='the Gerrit change number (e.g. 1234)')
+    parser.add_argument('--patch',
+                        default='0',
+                        help='the Gerrit patch number (e.g. 3). If not '
+                             'supplied, the latest patch will be used')
+    parser.add_argument('--label',
+                        default=None,
+                        choices=['Code-Review', 'Verified', 'Workflow'],
+                        help='a label to use for voting')
+    parser.add_argument('--vote',
+                        default='1',
+                        choices=['-2', '-1', '0', '+1', '+2'],
+                        help='the vote value given for the label')
+    parser.add_argument('--message',
+                        default='',
+                        help='string message to be posted with the review')
+    parser.add_argument('--message-file',
+                        default=None,
+                        help='append file contents to the message to be '
+                             'posted with the review')
+
+    args = parser.parse_args()
+
+    message = args.message
+    if args.message_file:
+        with open(args.message_file) as msg_file:
+            message += msg_file.read()
+
+    gerrit_review(int(args.change),
+                  int(args.patch),
+                  args.label,
+                  int(args.vote),
+                  message)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Switches Gerrit Ardana jobs to use the Gerrit REST API for
posting job results instead of relying on the Jenkins
Gerrit Trigger plugin.

A python script was implemented for this, which can be called to post reviews
on Gerrit changes. The script uses pygerrit2 [1] and requires
an HTTP Gerrit username/password to be added to the `.netrc`
ile [2]. Using the script is as simple as running:
    
      ./gerrit_review.py --label 'Code-Review' --vote +1 --message 'LGTM' 1234
    
Examples of the type of message that will reported to Gerrit after this change:
- build started:
```
SUSE Jenkins Gerrit
Patch Set 2: -Verified
Started build (openstack-ardana-gerrit-cloud9): https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/13/

The following links can also be used to track the results:
 - live console output: https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/13/console
 - live pipeline job view: https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/13/display/redirect
```
- build failed:
```
Patch Set 2: Verified-1
Build failed (openstack-ardana-gerrit-cloud9): https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/12/
- validate commit message: PASSED (https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/12//console)
- integration test: FAILED (https://ci.suse.de/job/openstack-ardana/111/display/redirect)
```
- build succeeded:
```
Patch Set 2: Verified+1
Build succeeded (openstack-ardana-gerrit-cloud9): https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/13/
- validate commit message: PASSED (https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/13/console)
- integration test: PASSED (https://ci.suse.de/job/openstack-ardana/111/display/redirect)
```


NOTE: the composed message is just a preview of a more detailed version that will be generated in a following PR using the Pipeline REST API Plugin [3]

[1] https://github.com/dpursehouse/pygerrit2
[2] https://github.com/dpursehouse/pygerrit2#usage
[3] https://github.com/jenkinsci/pipeline-stage-view-plugin/tree/master/rest-api
