### PR TITLE
Run same test as upstream gates

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -238,16 +238,17 @@ h_echo_header "Run tempest"
 if [ -z "${DISABLE_TEMPESTRUN}" ]; then
     sudo -u stack -i <<EOF
 cd /opt/stack/tempest
-tox -e smoke
+tempest run --regex '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))' --concurrency=2 --black-regex=
+testr last --subunit > tempest.subunit
 EOF
 fi
 
 h_echo_header "Store tempest results"
 pip install junitxml
 sudo -u stack -i <<EOF
-cd /opt/stack
-subunit2html devstack.subunit
-subunit2junitxml devstack.subunit > results.xml
+cd /opt/stack/tempest
+subunit2html tempest.subunit /opt/stack/results.html
+subunit2junitxml tempest.subunit > /opt/stack/results.xml
 EOF
 
 exit 0


### PR DESCRIPTION
We were only running tempest smoke tests, we should run the same tests that upstream gates are running.

In addition, we should store the tempest results, it was storing only devstack results.