### PR TITLE
Fix testr subunit failure

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -238,8 +238,7 @@ h_echo_header "Run tempest"
 if [ -z "${DISABLE_TEMPESTRUN}" ]; then
     sudo -u stack -i <<EOF
 cd /opt/stack/tempest
-tempest run --regex '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))' --concurrency=2 --black-regex=
-testr last --subunit > tempest.subunit
+tempest run --regex '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))' --concurrency=2 --subunit > tempest.subunit
 EOF
 fi
 


### PR DESCRIPTION
ci.opensuse.org devstack jobs are failing to store the results with the following error

> 08:53:24 No repository found in /opt/stack/tempest. Create one by running "testr init".

This patch leverage new tempest cli features to store directly the outout