### PR TITLE
Fix subunit2junitxml report

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -247,7 +247,8 @@ pip install junitxml
 sudo -u stack -i <<EOF
 cd /opt/stack/tempest
 subunit2html tempest.subunit /opt/stack/results.html
-subunit2junitxml tempest.subunit > /opt/stack/results.xml
+# subunit2junitxml will fail if test run failed as it forwards subunit stream result code, ignore it
+subunit2junitxml tempest.subunit --output-to /opt/stack/results.xml || true
 EOF
 
 exit 0


### PR DESCRIPTION
subunit2junitxml fails if there are errors causing the job to fail.

Ignore the errors and store the results