### PR TITLE
Fix subunit2junitxml output

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -248,7 +248,7 @@ sudo -u stack -i <<EOF
 cd /opt/stack/tempest
 subunit2html tempest.subunit /opt/stack/results.html
 # subunit2junitxml will fail if test run failed as it forwards subunit stream result code, ignore it
-subunit2junitxml tempest.subunit --output-to /opt/stack/results.xml || true
+subunit2junitxml tempest.subunit --output-to=/opt/stack/results.xml || true
 EOF
 
 exit 0


### PR DESCRIPTION
I started to be embarrassed because of the long list of small fixes that I should have tested previously.
At least the html report is working :) https://ci.opensuse.org/view/OpenStack/job/openstack-devstack-ipv4/36/artifact/results.html
I apologize, but seems that the subunit2junitxml --output-to options needs and `=` 