### PR TITLE
input-model-generator: disable additional LVM volumes

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -29,6 +29,11 @@ designate_backend: bind
 # (i.e. values in service_component_groups)
 disabled_services: ""
 
+# Disable extra volume groups in the generated disk models, since these have no
+# effect anyway as long as `skip_disk_config` is used to skip LVM disk configuration
+# in deployed clouds
+enable_extra_volume_groups: False
+
 cp_prefix: cp1
 max_host_prefix_len: "{{ 33-(cp_prefix|length) }}"
 host_prefix: "{{ ('ardana-' ~ ardana_env)[:max_host_prefix_len|int-1] if ardana_env is defined else 'ardana' }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
@@ -63,7 +63,7 @@
 
         consumer:
            name: os
-{%     for service_component_group in ns.service_component_groups %}
+{%     for service_component_group in ns.service_component_groups if enable_extra_volume_groups %}
 {%       if service_component_group == 'CORE' %}
 
 {%         if scenario['use_cinder_volume_disk'] %}


### PR DESCRIPTION
The virtual Ardana cloud deployments currently disable
all provisioning of LVM volumes by means of the `skip_disk_config`
mechanism. One consequence of this is that services use the
root partition for all their files while the additional
`volume-group` entries in the generated disk model are ignored.

This commit removes this additional `volume-group` entries and
relies only on the root partition the size of which is controlled
only by the ECP openstack flavor associated with the virtual server
instances. The immediate effect is a huge (~50%) reduction in the
storage resources required to instantiate virtual cloud environments
associated with generated input models.