### PR TITLE
openstack-ardana: use dedicated ECP project for CI (SCRD-5739)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana.yaml
@@ -8,5 +8,6 @@
     reserve_env: false
     tempest_run_filter: ''
     cleanup: never
+    os_cloud: ''
     jobs:
         - '{ardana_job}'

--- a/jenkins/ci.suse.de/openstack-ardana-bootstrap-clm.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-bootstrap-clm.yaml
@@ -121,6 +121,13 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
+      - string:
+          name: os_cloud
+          default: ''
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-heat.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-heat.yaml
@@ -74,6 +74,13 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
+      - string:
+          name: os_cloud
+          default: ''
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-qa-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-qa-tests.yaml
@@ -122,6 +122,13 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
+      - string:
+          name: os_cloud
+          default: ''
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
       - choice:
           name: type_of_compute
           choices:

--- a/jenkins/ci.suse.de/openstack-ardana-tempest.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tempest.yaml
@@ -96,6 +96,13 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
+      - string:
+          name: os_cloud
+          default: ''
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -159,6 +159,13 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
+      - string:
+          name: os_cloud
+          default: ''
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -115,6 +115,13 @@
             The Jenkins agent where this job must run. Used by upstream jobs to
             force a job to reuse the same node.
 
+      - string:
+          name: os_cloud
+          default: ''
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
@@ -242,6 +242,13 @@
           description: >-
             Configurable external name for your public endpoints
 
+      - string:
+          name: os_cloud
+          default: ''
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -90,7 +90,8 @@ The following links can also be used to track the results:
               string(name: 'controllers', value: "2"),
               string(name: 'sles_computes', value: "1"),
               string(name: 'cloudsource', value: "$cloudsource"),
-              string(name: 'tempest_run_filter', value: "$tempest_run_filter")
+              string(name: 'tempest_run_filter', value: "$tempest_run_filter"),
+              string(name: 'os_cloud', value: "$os_cloud")
           ], propagate: false, wait: true
           env.jobResult = slaveJob.getResult()
           env.jobUrl = slaveJob.buildVariables.blue_ocean_buildurl

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -66,7 +66,8 @@ pipeline {
             string(name: 'rc_notify', value: "$rc_notify"),
             string(name: 'git_automation_repo', value: "$git_automation_repo"),
             string(name: 'git_automation_branch', value: "$git_automation_branch"),
-            string(name: 'reuse_node', value: "${NODE_NAME}")
+            string(name: 'reuse_node', value: "${NODE_NAME}"),
+            string(name: 'os_cloud', value: "$os_cloud")
           ], propagate: true, wait: true
         }
       }
@@ -88,7 +89,8 @@ pipeline {
                   string(name: 'rc_notify', value: "$rc_notify"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
                   string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                  string(name: 'reuse_node', value: "${NODE_NAME}")
+                  string(name: 'reuse_node', value: "${NODE_NAME}"),
+                  string(name: 'os_cloud', value: "$os_cloud")
                 ], propagate: true, wait: true
               }
             }
@@ -109,7 +111,8 @@ pipeline {
             string(name: 'rc_notify', value: "$rc_notify"),
             string(name: 'git_automation_repo', value: "$git_automation_repo"),
             string(name: 'git_automation_branch', value: "$git_automation_branch"),
-            string(name: 'reuse_node', value: "${NODE_NAME}")
+            string(name: 'reuse_node', value: "${NODE_NAME}"),
+            string(name: 'os_cloud', value: "$os_cloud")
           ], propagate: true, wait: true
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-vcloud.Jenkinsfile
@@ -101,7 +101,8 @@ pipeline {
               string(name: 'heat_action', value: "create"),
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
               string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              string(name: 'reuse_node', value: "${NODE_NAME}")
+              string(name: 'reuse_node', value: "${NODE_NAME}"),
+              string(name: 'os_cloud', value: "$os_cloud")
           ], propagate: false, wait: true
           def jobResult = slaveJob.getResult()
           def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -145,7 +145,8 @@ pipeline {
                   string(name: 'rc_notify', value: "$rc_notify"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
                   string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                  string(name: 'reuse_node', value: "${NODE_NAME}")
+                  string(name: 'reuse_node', value: "${NODE_NAME}"),
+                  string(name: 'os_cloud', value: "$os_cloud")
               ], propagate: false, wait: true
               def jobResult = slaveJob.getResult()
               def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
@@ -211,7 +212,8 @@ pipeline {
               string(name: 'rc_notify', value: "$rc_notify"),
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
               string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              string(name: 'reuse_node', value: "${NODE_NAME}")
+              string(name: 'reuse_node', value: "${NODE_NAME}"),
+              string(name: 'os_cloud', value: "$os_cloud")
           ], propagate: false, wait: true
           def jobResult = slaveJob.getResult()
           def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
@@ -280,7 +282,8 @@ pipeline {
             string(name: 'rc_notify', value: "$rc_notify"),
             string(name: 'git_automation_repo', value: "$git_automation_repo"),
             string(name: 'git_automation_branch', value: "$git_automation_branch"),
-            string(name: 'reuse_node', value: "${NODE_NAME}")
+            string(name: 'reuse_node', value: "${NODE_NAME}"),
+            string(name: 'os_cloud', value: "$os_cloud")
           ], propagate: false, wait: true
           def jobResult = slaveJob.getResult()
           def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
@@ -308,7 +311,8 @@ pipeline {
                   string(name: 'rc_notify', value: "$rc_notify"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
                   string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                  string(name: 'reuse_node', value: "${NODE_NAME}")
+                  string(name: 'reuse_node', value: "${NODE_NAME}"),
+                  string(name: 'os_cloud', value: "$os_cloud")
               ], propagate: false, wait: true
               def jobResult = slaveJob.getResult()
               def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
@@ -337,7 +341,8 @@ pipeline {
               string(name: 'rc_notify', value: "$rc_notify"),
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
               string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              string(name: 'reuse_node', value: "${NODE_NAME}")
+              string(name: 'reuse_node', value: "${NODE_NAME}"),
+              string(name: 'os_cloud', value: "$os_cloud")
           ], propagate: false, wait: true
           def jobResult = slaveJob.getResult()
           def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
@@ -383,7 +388,8 @@ pipeline {
                 string(name: 'ardana_env', value: "$ardana_env"),
                 string(name: 'heat_action', value: "delete"),
                 string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                string(name: 'git_automation_branch', value: "$git_automation_branch")
+                string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                string(name: 'os_cloud', value: "$os_cloud")
               ], propagate: false, wait: false
             } else {
               if (reserve_env == 'true') {

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -69,6 +69,13 @@
             Name of the filter file to use for tempest. Use an empty value to
             skip running tempest.
 
+      - string:
+          name: os_cloud
+          default: '{os_cloud|engcloud-cloud-ci-private}'
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -396,6 +396,13 @@
           description: >-
             Configurable external name for your public endpoints
 
+      - string:
+          name: os_cloud
+          default: '{os_cloud|engcloud-cloud-ci-private}'
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
     pipeline-scm:
       scm:
         - git:

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -9,7 +9,7 @@ parameters:
     type: string
     label: Key Name
     description: Name of key-pair to be used for compute instance
-    default: engcloud-cloud-ci
+    default: {{ os_key_name }}
 {% endif %}
   floating_network:
     type: string

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
@@ -15,7 +15,6 @@
 #
 ---
 
-os_cloud: "engcloud-cloud-ci"
 heat_action: "create"
 api_timeout: "600"
 


### PR DESCRIPTION
Changes all periodic and Gerrit Ardana Jenkins jobs to use a
dedicated `cloud-ci` ECP account, while the shared `cloud`
project is still preserved as a default, to be used for manual 
builds.

This is required to prevent the CI from running into quota limitation
errors that would otherwise occur with an ECP account shared by non-CI
elements (developers, QA, etc.). It also allows us to better monitor
the total CI resource usage by simply looking at the OpenStack project
it's using.

The new `engcloud-cloud-ci-private` OpenStack configuration label
value has the same credentials as the old `engcloud-cloud-ci` value,
with the exception of the project name, which points to the dedicated
`cloud-ci` project instead.