### PR TITLE
openstack-ardana: fix update build URL message

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -23,6 +23,8 @@ pipeline {
     stage('Setup workspace') {
       steps {
         script {
+          // Set this variable to be used by upstream builds
+          env.blue_ocean_buildurl = env.RUN_DISPLAY_URL
           if (ardana_env == '') {
             error("Empty 'ardana_env' parameter value.")
           }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
@@ -23,6 +23,8 @@ pipeline {
     stage('Setup workspace') {
       steps {
         script {
+          // Set this variable to be used by upstream builds
+          env.blue_ocean_buildurl = env.RUN_DISPLAY_URL
           if (ardana_env == '') {
             error("Empty 'ardana_env' parameter value.")
           }


### PR DESCRIPTION
The Blue Ocean URL variable is not passed up to the
main pipeline job from the recently added update downstream
jobs. This commit fixes that.