### PR TITLE
Reorganise and clean tempest run

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -236,19 +236,14 @@ EOF
 h_echo_header "Run tempest"
 
 if [ -z "${DISABLE_TEMPESTRUN}" ]; then
+pip install junitxml
     sudo -u stack -i <<EOF
 cd /opt/stack/tempest
 tempest run --regex '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))' --concurrency=2 --subunit > tempest.subunit
-EOF
-fi
-
-h_echo_header "Store tempest results"
-pip install junitxml
-sudo -u stack -i <<EOF
-cd /opt/stack/tempest
 subunit2html tempest.subunit /opt/stack/results.html
 # subunit2junitxml will fail if test run failed as it forwards subunit stream result code, ignore it
-subunit2junitxml tempest.subunit --output-to=/opt/stack/results.xml || true
+subunit2junitxml tempest.subunit > /opt/stack/results.xml || true
 EOF
+fi
 
 exit 0


### PR DESCRIPTION
The block to store the tempest tests results was out of the if condition to check if we should run tempest.

This patch set run tempest and store the results in the same block, also fixes a problem with the subunit2junitxml converter that was having errors with the `--output-to` option