### PR TITLE
Stop tracking freezer-ui for Rocky

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -138,6 +138,10 @@
               "openstack-horizon-plugin-murano-ui",
               "openstack-gnocchi",
               "openstack-monasca-transform"
+            ].contains(component) ||
+            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Ocata:Staging", "Cloud:OpenStack:Rocky:Staging" ].contains(project) &&
+            [
+              "openstack-horizon-plugin-freezer-ui",
             ].contains(component)
             )
       sequential: true


### PR DESCRIPTION
Freezer didn't have a Rocky release and we're not including it in Cloud
9 so stop worrying about it in trackupstream.