### PR TITLE
Some fixes for mkcloudcloud scripts

### DIFF
--- a/scripts/mkcloudcloud/deploy.sh
+++ b/scripts/mkcloudcloud/deploy.sh
@@ -13,7 +13,7 @@ admin_ip=`cat .admin_ip`
 
 ### PART-2
 ### mkcloud and surrounding setup
-ssh root@$admin_ip
+nc -z -w 60 $admin_ip 22 && ssh root@$admin_ip
 # and execute this
 zypper="zypper --gpg-auto-import-keys -n"
 

--- a/scripts/mkcloudcloud/deploy.sh
+++ b/scripts/mkcloudcloud/deploy.sh
@@ -61,6 +61,9 @@ export want_tempest_proposal=1
 ./mkcloud "\$@"
 EOF
 chmod a+x cloud9
+
+$zypper in nfs-client
+
 ./cloud9 prepareinstcrowbar bootstrapcrowbar instcrowbar
 
 # Rick suggested you could add the remaning nodes as lonelynodes to crowbar

--- a/scripts/mkcloudcloud/deploy.sh
+++ b/scripts/mkcloudcloud/deploy.sh
@@ -62,6 +62,12 @@ export want_tempest_proposal=1
 EOF
 chmod a+x cloud9
 
+if [ ! -f ~/.ssh/id_rsa.pub ]; then
+  ssh-keygen -t rsa -f /root/.ssh/id_rsa -N ""
+  cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+  chmod 600 ~/.ssh/authorized_keys
+fi
+
 $zypper in nfs-client
 
 ./cloud9 prepareinstcrowbar bootstrapcrowbar instcrowbar

--- a/scripts/mkcloudcloud/deploy.sh
+++ b/scripts/mkcloudcloud/deploy.sh
@@ -4,7 +4,11 @@
 ### from local machine to setup infrastructure on engcloud
 export namespace=$USER
 export openstacksshkey=xxx
-./heat-setup.sh
+if ! ./heat-setup.sh; then
+  echo "Error deploying stack"
+  exit 1
+fi
+
 admin_ip=`cat .admin_ip`
 
 ### PART-2


### PR DESCRIPTION
- deploy stack when running deploy.sh
- check for admin to be ready before ssh
- auto-generate ssh key for passwordless login
- install needed nfs-client in admin
- re-deploy stack if it was already creating with deploy.sh
- wait for stack to be ready before proceeding