### PR TITLE
openstack-ardana: add option to enable test updates repos

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -72,11 +72,12 @@
 - project:
     name: cloud-ardana8-job-std-3cp-test-maintenance-updates-x86_64
     ardana_job: '{name}'
-    disabled: true
+    disabled: false
     ardana_env: cloud-ardana-ci-slot
     cloudsource: GM8+up
+    updates_test_enabled: true
     update_after_deploy: true
-    update_to_cloudsource: GM8+testup
+    update_to_cloudsource: GM8+up
     branch: stable/pike
     model: std-3cp
     triggers:

--- a/jenkins/ci.suse.de/openstack-ardana-bootstrap-clm.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-bootstrap-clm.yaml
@@ -72,6 +72,13 @@
                GM<X>+up (official GM plus Cloud-Updates)
                cloud9MX (cloud 9 milestones)
 
+      - bool:
+          name: updates_test_enabled
+          default: false
+          description: >-
+            Enable SLES/Cloud test update repos (the Cloud test update repos will
+            be enabled only when cloudsource is GM based)
+
       - string:
           name: cloud_maint_updates
           default: ''

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -73,6 +73,13 @@
                GM<X>+up (official GM plus Cloud-Updates)
                cloud9MX (cloud 9 milestones)
 
+      - bool:
+          name: updates_test_enabled
+          default: false
+          description: >-
+            Enable SLES/Cloud test update repos (the Cloud test update repos will
+            be enabled only when cloudsource is GM based)
+
       - string:
           name: cloud_maint_updates
           default: ''

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -73,6 +73,13 @@
                GM<X>+up (official GM plus Cloud-Updates)
                cloud9MX (cloud 9 milestones)
 
+      - bool:
+          name: updates_test_enabled
+          default: false
+          description: >-
+            Enable SLES/Cloud test update repos (the Cloud test update repos will
+            be enabled only when cloudsource is GM based)
+
       - string:
           name: cloud_maint_updates
           default: ''

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
           def slaveJob = build job: 'openstack-ardana-update', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
             string(name: 'update_to_cloudsource', value: "$update_to_cloudsource"),
+            string(name: 'updates_test_enabled', value: "$updates_test_enabled"),
             string(name: 'cloud_maint_updates', value: "$cloud_maint_updates"),
             string(name: 'sles_maint_updates', value: "$sles_maint_updates"),
             string(name: 'rc_notify', value: "$rc_notify"),

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -209,6 +209,7 @@ pipeline {
           def slaveJob = build job: 'openstack-ardana-bootstrap-clm', parameters: [
               string(name: 'ardana_env', value: "$ardana_env"),
               string(name: 'cloudsource', value: "$cloudsource"),
+              string(name: 'updates_test_enabled', value: "$updates_test_enabled"),
               string(name: 'cloud_maint_updates', value: "$cloud_maint_updates"),
               string(name: 'sles_maint_updates', value: "$sles_maint_updates"),
               string(name: 'extra_repos', value: "${env.test_repository_url ?: extra_repos}"),
@@ -278,6 +279,7 @@ pipeline {
           def slaveJob = build job: 'openstack-ardana-update', parameters: [
             string(name: 'ardana_env', value: "$ardana_env"),
             string(name: 'update_to_cloudsource', value: "$update_to_cloudsource"),
+            string(name: 'updates_test_enabled', value: "$updates_test_enabled"),
             string(name: 'cloud_maint_updates', value: "$cloud_maint_updates"),
             string(name: 'sles_maint_updates', value: "$sles_maint_updates"),
             string(name: 'rc_notify', value: "$rc_notify"),

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -60,6 +60,13 @@
                cloud9MX (cloud 9 milestones)
 
       - bool:
+          name: updates_test_enabled
+          default: '{updates_test_enabled|false}'
+          description: >-
+            Enable SLES/Cloud test update repos (the Cloud test update repos will
+            be enabled only when cloudsource is GM based)
+
+      - bool:
           name: update_after_deploy
           default: '{update_after_deploy|false}'
           description: >-

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -63,8 +63,8 @@ cloud_test_repos:
 
 cloud_update_repos_enabled: "{{ '+up' in cloudsource }}"
 updates_test_enabled: False
-sles_test_repos_enabled: "{{ updates_test_enabled }}"
-cloud_test_repos_enabled: "{{ updates_test_enabled and 'GM' in cloudsource }}"
+sles_test_repos_enabled: "{{ updates_test_enabled and ((task == 'deploy' and not update_after_deploy) or (task == 'update')) }}"
+cloud_test_repos_enabled: "{{ updates_test_enabled and 'GM' in cloudsource and ((task == 'deploy' and not update_after_deploy) or (task == 'update')) }}"
 
 repos_to_mount: "{{ repos_to_add | select('search', '.*-Pool$') | list }}"
 repos_to_sync: "{{ repos_to_add | difference(repos_to_mount) }}"


### PR DESCRIPTION
Add an option to the jenkins jobs to enable/disable SUSE/Cloud test
updates repositories following the logic in [1].

1. https://github.com/SUSE-Cloud/automation/tree/master/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos#usage