### PR TITLE
Turn on debug logging for cinder in CI (SCRD-5775)

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
+++ b/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
@@ -79,6 +79,8 @@ proposals:
       - @@controller@@
 - barclamp: cinder
   attributes:
+    # NOTE(colleen): REMOVE WHEN SCRD-5775 IS RESOLVED
+    debug: true
     volumes:
     - backend_driver: local
       backend_name: default

--- a/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
+++ b/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
@@ -78,6 +78,8 @@ proposals:
       - @@controller@@
 - barclamp: cinder
   attributes:
+    # NOTE(colleen): REMOVE WHEN SCRD-5775 IS RESOLVED
+    debug: true
     volumes:
     - backend_driver: local
       backend_name: default

--- a/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
@@ -75,7 +75,9 @@ proposals:
       - @@compute-kvm@@
       - @@controller@@
 - barclamp: cinder
+    # NOTE(colleen): REMOVE WHEN SCRD-5775 IS RESOLVED
   attributes:
+    debug: true
     volumes:
     - backend_driver: local
       backend_name: default


### PR DESCRIPTION
Temporarily enable debug logging for cinder while we track down a
heisenbug in cinder-volume.