### PR TITLE
openstack-ardana: add ssh public keys all together

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ssh_keys/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ssh_keys/tasks/main.yml
@@ -16,10 +16,12 @@
 ---
 
 - name: Copy SSH keys
-  authorized_key:
-    user: root
-    state: present
-    key: "{{ item.1 }}"
-  loop: "{{ ssh_pub_keys | subelements('keys') }}"
-  loop_control:
-    label: "{{ item.0.name }}"
+  blockinfile:
+    path: "{{ ansible_env.HOME }}/.ssh/authorized_keys"
+    create: yes
+    block: |
+      {% for dict_item in ssh_pub_keys %}
+      {% for key in dict_item['keys'] %}
+      {{ key }}
+      {% endfor %}
+      {% endfor %}

--- a/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
+++ b/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
@@ -70,20 +70,15 @@
 - name: Ensure public keys on deployer
   hosts: "{{ ardana_env }}"
   remote_user: root
-  gather_facts: false
+  gather_facts: true
   vars:
     task: "deploy"
 
   tasks:
     - block:
         - name: Wait for deployer to be accessible
-          delegate_to: localhost
-          wait_for:
-            host: "{{ ansible_host }}"
-            port: 22
-            search_regex: OpenSSH
-            state: started
-            delay: 10
+          wait_for_connection:
+            sleep: 10
             timeout: 300
 
         - include_role:


### PR DESCRIPTION
Instead of looping through the list of ssh keys and adding one by
one, build a list containing the ssh keys and add them all together in a block.