### PR TITLE
openstack-ardana: fix rados gateway port

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/defaults/main.yml
@@ -17,7 +17,7 @@
 
 
 ses_osd_pool_default_pg_num: 64
-ses_rgw_port: 8080
+ses_rgw_port: "{{ hostvars[ardana_env].ses_rgw_port }}"
 
 ses_openstack_glance_pool:
   name: "glance-{{ ardana_env }}"
@@ -39,7 +39,31 @@ ses_openstack_pools:
   - "{{ ses_openstack_cinder_backup_pool }}"
 
 ses_openstack_keys:
-  - { name: "client.glance-{{ ardana_env }}", key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_glance_pool.name }}", mode: "0600", acls: [] }
-  - { name: "client.cinder-{{ ardana_env }}", key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_pool.name }}, allow rwx pool={{ ses_openstack_nova_pool.name }}, allow rwx pool={{ ses_openstack_glance_pool.name }}", mode: "0600", acls: []  }
-  - { name: "client.cinder_backup-{{ ardana_env }}", key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_backup_pool.name }}", mode: "0600", acls: [] }
-  - { name: "client.rgw.ses-{{ ardana_env }}", key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow rwx", osd_cap: "allow rwx", mgr_cap: "allow r", mode: "0600", acls: [] }
+  - name: "client.glance-{{ ardana_env }}"
+    key: "$(ceph-authtool --gen-print-key)"
+    mon_cap: "allow r"
+    osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_glance_pool.name }}"
+    mgr_cap: "allow r"
+    mode: "0600"
+    acls: []
+  - name: "client.cinder-{{ ardana_env }}"
+    key: "$(ceph-authtool --gen-print-key)"
+    mon_cap: "allow r"
+    osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_pool.name }}, allow rwx pool={{ ses_openstack_nova_pool.name }}, allow rwx pool={{ ses_openstack_glance_pool.name }}"
+    mgr_cap: "allow r"
+    mode: "0600"
+    acls: []
+  - name: "client.cinder_backup-{{ ardana_env }}"
+    key: "$(ceph-authtool --gen-print-key)"
+    mon_cap: "allow r"
+    osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_backup_pool.name }}"
+    mgr_cap: "allow r"
+    mode: "0600"
+    acls: []
+  - name: "client.rgw.ses-{{ ardana_env }}"
+    key: "$(ceph-authtool --gen-print-key)"
+    mon_cap: "allow rwx"
+    osd_cap: "allow rwx"
+    mgr_cap: "allow r"
+    mode: "0600"
+    acls: []

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_rgw.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_rgw.yml
@@ -32,8 +32,6 @@
      [client.rgw.ses-{{ ardana_env }}]
      keyring = /etc/ceph/ceph.client.rgw.ses-{{ ardana_env }}.keyring
      rgw frontends = "civetweb port={{ ses_rgw_port }}"
-     rgw dns name = ses-{{ ardana_env }}
-     rgw enable usage log = true
      rgw keystone url = {{ osrc.results.0.stdout }}
      rgw keystone admin user = admin
      rgw keystone admin password = {{ osrc.results.1.stdout }}

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/create_users.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/create_users.yml
@@ -23,20 +23,23 @@
       --cap mgr "{{ item.mgr_cap|default('') }}"
   args:
     creates: "/etc/ceph/ceph.{{ item.name }}.keyring"
-  with_items: "{{ ses_openstack_keys }}"
-  changed_when: false
+  loop: "{{ ses_openstack_keys }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Check if openstack key(s) already exist(s)
   command: "ceph auth get {{ item.name }}"
   changed_when: false
   failed_when: false
-  with_items: "{{ ses_openstack_keys }}"
+  loop: "{{ ses_openstack_keys }}"
+  loop_control:
+    label: "{{ item.name }}"
   register: openstack_key_exist
 
 - name: Add openstack key(s) to ceph
   command: "ceph auth import -i /etc/ceph/ceph.{{ item.0.name }}.keyring"
   changed_when: false
-  with_together:
-    - "{{ ses_openstack_keys }}"
-    - "{{ openstack_key_exist.results }}"
   when: item.1.rc != 0
+  loop: "{{ ses_openstack_keys | zip(openstack_key_exist.results) | list }}"
+  loop_control:
+    label: "{{ item.0.name }}"

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/main.yml
@@ -26,5 +26,7 @@
 - name: Get ceph keyring file contents
   slurp:
     src: "/etc/ceph/ceph.{{ item.name }}.keyring"
-  loop: "{{ ses_openstack_keys }}"
   register: ceph_files
+  loop: "{{ ses_openstack_keys }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
For each QE environment a new instance of rados gateway listening on a
specific port (defined on the deployer hostvars) should be configured on the
SES cluster, instead of using the same port for all environments.

This change also includes improvements on the output of some SES related
tasks.