### PR TITLE
Copy whole Staging and use a Test project

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -2,12 +2,15 @@
     name: 'openstack-cleanvm'
     project-type: matrix
 
-    triggers:
-      - timed: 'H 4 * * *'
-
     logrotate:
       numToKeep: -1
       daysToKeep: 10
+
+    parameters:
+      - string:
+          name: openstack_project
+          default: None
+          description: name of the main project that should be updated with packages from its staging project
 
     axes:
       - axis:
@@ -19,15 +22,6 @@
             - SLE_12_SP4
             - openSUSE-Leap-42.3
             - openSUSE-Leap-15.0
-      - axis:
-          type: user-defined
-          name: openstack_project
-          values:
-            - Newton
-            - Pike
-            - Queens
-            - Rocky
-            - Master
       - axis:
           type: slave
           name: slave
@@ -94,9 +88,3 @@
 
           exec_jtsync ${main_job_name} ${openstack_project} ${BUILD_NUMBER} $ret
           exit $ret
-      - trigger-builds:
-        - project: openstack-submit
-          condition: SUCCESS
-          current-parameters: true
-          predefined-parameters:
-            openstack_project=${openstack_project}

--- a/jenkins/ci.opensuse.org/openstack-prepare-staging.py
+++ b/jenkins/ci.opensuse.org/openstack-prepare-staging.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python2
+import osc.commandline
+import osc.core
+import sys
+import os
+
+try:
+    from xml.etree import cElementTree as ET
+except ImportError:
+    import cElementTree as ET
+
+# copied from newer osc/core.py
+def get_package_results(apiurl, project, package=None, wait=False, *args, **kwargs):
+    """generator that returns a the package results as an xml structure"""
+    xml = ''
+    waiting_states = ('blocked', 'scheduled', 'dispatching', 'building',
+                      'signing', 'finished')
+    while True:
+        waiting = False
+        try:
+            xml = ''.join(show_results_meta(apiurl, project, package, *args, **kwargs))
+        except HTTPError as e:
+            # check for simple timeout error and fetch again
+            if e.code == 502 or e.code == 504:
+                # re-try result request
+                continue
+            root = ET.fromstring(e.read())
+            if e.code == 400 and kwargs.get('multibuild') and re.search('multibuild', getattr(root.find('summary'), 'text', '')):
+                kwargs['multibuild'] = None
+                kwargs['locallink'] = None
+                continue
+            raise
+        root = ET.fromstring(xml)
+        kwargs['oldstate'] = root.get('state')
+        for result in root.findall('result'):
+            if result.get('dirty') is not None:
+                waiting = True
+                break
+            elif result.get('code') in waiting_states:
+                waiting = True
+                break
+            else:
+                packages = result.find('status')
+                for p in packages:
+                    if p.get('code') in waiting_states:
+                        waiting = True
+                        break
+                if waiting:
+                    break
+
+        if not wait or not waiting:
+            break
+        else:
+            yield xml
+    yield xml
+
+# copied from newer osc/core.py
+def is_package_results_success(xmlstring):
+    ok = ('succeeded', 'disabled', 'excluded', 'published', 'unpublished')
+
+    root = ET.fromstring(xmlstring)
+    for result in root.findall('result'):
+        if result.get('dirty') is not None:
+            return False
+        if result.get('code') not in ok:
+            return False
+        if result.get('state') not in ok:
+            return False
+        packages = result.find('status')
+        for p in packages:
+            if p.get('code') not in ok:
+                return False
+    return True
+
+class _OscModifiedPrjresults(osc.commandline.Osc):
+    # reduced from newer osc/commandline.py
+    @osc.cmdln.option('-w', '--watch', action='store_true',
+                  help='watch the results until all finished building')
+    @osc.cmdln.option('', '--xml', action='store_true', default=False,
+                  help='generate output in XML')
+    def do_prjresults(self, subcmd, opts, *args):
+        project = args[0]
+        apiurl = self.get_api_url()
+        kwargs = {}
+        kwargs['wait'] = True
+        last = None
+        for results in get_package_results(apiurl, project, package=None, **kwargs):
+            last = results
+            print(results)
+        if last and is_package_results_success(last):
+            return
+        return 3
+
+def run_osc(*args):
+    cli = _OscModifiedPrjresults()
+    argv = ['osc', '-A', 'https://api.opensuse.org']
+    argv.extend(args)
+    exit = cli.main(argv=argv)
+    return exit
+
+def run_osc_prjstatus(project):
+    # TODO replace _OscModifiedPrjresults once the osc here is new enough to have
+    # https://github.com/openSUSE/osc/pull/461 and
+    # https://github.com/openSUSE/osc/pull/465
+    return run_osc('prjresults', '--watch', '--xml', project)
+
+def run_osc_release(project):
+    # TODO replace this once the osc here is new enough to have
+    # https://github.com/openSUSE/osc/commit/fb80026651c47d262dbff33136ae5306ff83aff3
+    return run_osc('api', '-m', 'POST', '/source/%s?cmd=release&nodelay=1' % project)
+
+def main():
+    branch = os.environ['openstack_project']
+    if 'Rocky' == branch:
+        project = 'Cloud:OpenStack:' + branch
+        project_staging = project + ':Staging'
+        project_totest = project + ':ToTest'
+        run_osc_release(project_staging)
+        exit = run_osc_prjstatus(project_totest)
+        if exit != None:
+            print(project_totest + " failed.")
+            sys.exit(exit)
+    else:
+        print("%s not supported for argument openstack_project." % branch)
+        # don't fail so the previous staging implementation
+        # still works for older releases
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/jenkins/ci.opensuse.org/openstack-prepare-staging.yaml
+++ b/jenkins/ci.opensuse.org/openstack-prepare-staging.yaml
@@ -1,0 +1,16 @@
+- job:
+    name: 'openstack-prepare-staging'
+    node: cloud-trackupstream
+
+    parameters:
+      - string:
+          name: openstack_project
+          default: None
+          description: name of the main project that should be updated with packages from its staging project
+
+    builders:
+      - shell: !include-raw: openstack-prepare-staging.py
+
+    wrappers:
+      - build-name:
+          name: '#${BUILD_NUMBER} / C:O:${ENV,var="openstack_project"}'

--- a/jenkins/ci.opensuse.org/openstack-staging.yaml
+++ b/jenkins/ci.opensuse.org/openstack-staging.yaml
@@ -1,0 +1,44 @@
+- job:
+    name: 'openstack-staging'
+    project-type: matrix
+
+    triggers:
+      - timed: 'H 4 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 10
+
+    axes:
+      - axis:
+          type: user-defined
+          name: openstack_project
+          values:
+            - Newton
+            - Pike
+            - Queens
+            - Rocky
+            - Master
+      - axis:
+          type: slave
+          name: slave
+          values:
+            - cloud-cleanvm
+    execution-strategy:
+      sequential: true
+    builders:
+      - trigger-builds:
+        - project: openstack-prepare-staging
+          block: true
+          predefined-parameters:
+            openstack_project=${openstack_project}
+      - trigger-builds:
+        - project: openstack-cleanvm
+          block: true
+          predefined-parameters:
+            openstack_project=${openstack_project}
+      - trigger-builds:
+        - project: openstack-submit
+          condition: SUCCESS
+          predefined-parameters:
+            openstack_project=${openstack_project}

--- a/jenkins/ci.opensuse.org/openstack-submit.yaml
+++ b/jenkins/ci.opensuse.org/openstack-submit.yaml
@@ -21,6 +21,7 @@
           OSC="osc -A https://api.opensuse.org"
           COS="Cloud:OpenStack:$openstack_project"
           COSS="$COS:Staging"
+          COST="$COS:ToTest"
           export BS_CHECKOUT=/home/jenkins/OBS_CHECKOUT/$COSS
           submitcmd="$OSC copypac -K -e"
           OSCBUILDDIST=SLE_11_SP3
@@ -45,6 +46,13 @@
               exit 1
             ;;
           esac
+
+          if [ "Cloud:OpenStack:Rocky" = "$COS" ]; then
+              # TODO replace this once the osc here is new enough to have
+              # https://github.com/openSUSE/osc/commit/fb80026651c47d262dbff33136ae5306ff83aff3
+              $OSC api -m POST "/source/${COST}?cmd=release&nodelay=1"
+              exit 0
+          fi
 
           # first ls, then loop in order to catch failing 'osc ls' calls
           components=`$OSC ls $COSS 2>/dev/null`

--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -131,7 +131,11 @@ case "$cloudsource" in
         osrelease=${osrelease^}
         $zypper ar -G -f $cloudopenstackmirror/$osrelease/$REPO/ cloud
         if test -n "$OSHEAD" ; then
-            $zypper ar -G -f $cloudopenstackmirror/$osrelease:/Staging/$REPO/ cloudhead
+            if [ "Rocky" = "$osrelease" ]; then
+                $zypper ar -G -f $cloudopenstackmirror/$osrelease:/ToTest/$REPO/ cloudhead
+            else
+                $zypper ar -G -f $cloudopenstackmirror/$osrelease:/Staging/$REPO/ cloudhead
+            fi
         fi
     ;;
     *)


### PR DESCRIPTION
Currently Staging may receive changes during testing and when its
finished changes that weren't tested may be submited instead of only
those that were tested. This fixes both by first making a copy of
Cloud:OpenStack:Rocky:Staging in Cloud:OpenStack:Rocky:ToTest and after
successful testing copy that to Cloud:OpenStack:Rocky.

This only makes the change for Rocky, it can be extended to the rest
later if that is useful.

This implements part of the alternative mentioned in
SUSE/cloud-specs#178 .

For all release branches fix that if there are multiple base
distributions to test on, only submit Staging after all of them
succeeded instead of after one of them. To accomplish that testing
multiple bases is done in a subjob.

To avoid a race where new source and old binaries are tested and
released building in Rocky:ToTest needs to be enabled. In Rocky
building can be disabled once the following is done.

To allow all packages to receive this testing Rocky:Staging needs the
packages it currently inherits from Rocky. This can be done by the
script following inside this commit message. Afterwards Rocky can be
removed from the repository inheritance hierachy of Rocky:Staging.

```
!#/usr/bin/python2
import sh
rocky_staging_packages = set(sh.osc('ls', 'Cloud:OpenStack:Rocky:Staging').split('\n'))
rocky_packages = set(sh.osc('ls', 'Cloud:OpenStack:Rocky').split('\n'))
packages_to_copy = rocky_packages - rocky_staging_packages
for p in packages_to_copy:
    sh.osc('branch', '--nodevelproject', 'Cloud:OpenStack:Rocky', p, 'Cloud:OpenStack:Rocky:Staging')
```