### PR TITLE
Start tracking python-ardana-configurationprocesor from git.

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -55,6 +55,7 @@
             - ardana-swift
             - ardana-tempest
             - ardana-tls
+            - python-ardana-configurationprocessor
             - python-ardana-opsconsole-server
             - python-cinderlm
       - axis:


### PR DESCRIPTION
Doing releases from pypi doesn't work because in general people
forget about doing that, or are unable to push the release due
to restrictions.