### PR TITLE
Revert "Turn on debug logging for cinder in CI (SCRD-5775)"

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
+++ b/scripts/scenarios/cloud7/cloud7-2nodes-default.yml
@@ -79,8 +79,6 @@ proposals:
       - @@controller@@
 - barclamp: cinder
   attributes:
-    # NOTE(colleen): REMOVE WHEN SCRD-5775 IS RESOLVED
-    debug: true
     volumes:
     - backend_driver: local
       backend_name: default

--- a/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
+++ b/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
@@ -78,8 +78,6 @@ proposals:
       - @@controller@@
 - barclamp: cinder
   attributes:
-    # NOTE(colleen): REMOVE WHEN SCRD-5775 IS RESOLVED
-    debug: true
     volumes:
     - backend_driver: local
       backend_name: default

--- a/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
@@ -75,9 +75,7 @@ proposals:
       - @@compute-kvm@@
       - @@controller@@
 - barclamp: cinder
-    # NOTE(colleen): REMOVE WHEN SCRD-5775 IS RESOLVED
   attributes:
-    debug: true
     volumes:
     - backend_driver: local
       backend_name: default


### PR DESCRIPTION
Reverts SUSE-Cloud/automation#2940

The issue was fixed with a change in the systemd unit file:

https://build.opensuse.org/package/rdiff/Cloud:OpenStack:Rocky:Staging/openstack-cinder?linkrev=base&rev=40