### PR TITLE
Fix freezer-ui exclusion in trackupstream

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -128,7 +128,6 @@
             ].contains(component) ||
             [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Ocata:Staging" ].contains(project) &&
             [
-              "openstack-horizon-plugin-freezer-ui",
               "openstack-horizon-plugin-neutron-fwaas-ui",
               "openstack-horizon-plugin-neutron-vpnaas-ui",
               "openstack-neutron-vsphere",


### PR DESCRIPTION
In b242d67 we tried to add the Rocky project to the list of exclusions
for the freezer-ui package but neglected to remove freezer-ui from its
original exclusion list. This fixes that.