### PR TITLE
Stop tracking openstack-utils for Queens and Rocky

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -78,7 +78,6 @@
             - openstack-swift
             - openstack-trove
             - openstack-tempest
-            - openstack-utils
             - openstack-zaqar
             - python-heat-cfntools
             - python-monasca-common


### PR DESCRIPTION
openstack-utils is a RedHat utility that hasn't been updated in two
years. We don't use it directly nor do we reference it in our
documentation. Let's stop being concerned about it.