### PR TITLE
openstack-ardana-gerrit: enable ardana-configuration-processor

### DIFF
--- a/scripts/jenkins/ardana/gerrit/project-map.json
+++ b/scripts/jenkins/ardana/gerrit/project-map.json
@@ -1,6 +1,7 @@
 {
   "ardana-ansible": "ardana-ansible",
   "ardana-input-model": "ardana-input-model",
+  "ardana-configuration-processor": "python-ardana-configurationprocessor",
   "ardana-extensions-dcn": "ardana-extensions-dcn",
   "ardana-extensions-nsx": "ardana-extensions-nsx",
   "ardana-extensions-ses": "ardana-ses",


### PR DESCRIPTION
Add ardana-configuration-processor to the list of repositories
which are source-tracked by IBS packages and are processed by
Gerrit related Jenkins jobs (Gerrit CI, trackupstream-trigger).

Depends on #2944