### PR TITLE
openstack-ardana9: re-enable monasca services

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -17,7 +17,6 @@
     clm_model: standalone
     controllers: '3'
     sles_computes: '1'
-    disabled_services: 'monasca|logging|ceilometer|octavia|cassandra|kafka|spark|storm'
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -32,7 +31,6 @@
     clm_model: integrated
     controllers: '3'
     sles_computes: '1'
-    disabled_services: 'monasca|logging|ceilometer|octavia|cassandra|kafka|spark|storm'
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -47,7 +45,6 @@
     clm_model: standalone
     controllers: '2'
     sles_computes: '1'
-    disabled_services: 'monasca|logging|ceilometer|octavia|cassandra|kafka|spark|storm'
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -74,7 +71,6 @@
     lmm_nodes: '1'
     dbmq_nodes: '1'
     sles_computes: '1'
-    disabled_services: 'monasca|logging|ceilometer|octavia|cassandra|kafka|spark|storm'
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -92,7 +88,6 @@
     clm_model: standalone
     controllers: '3'
     sles_computes: '1'
-    disabled_services: 'monasca|logging|ceilometer|octavia|cassandra|kafka|spark|storm'
     triggers:
      - timed: 'H H * * *'
     jobs:


### PR DESCRIPTION
Re-enable monasca services and services depending on monasca in
the generated input models used by Cloud 9 periodic and Gerrit jobs.

NOTE: already tested with https://ci.suse.de/blue/organizations/jenkins/cloud-ardana9-job-std-min-x86_64/detail/cloud-ardana9-job-std-min-x86_64/103/pipeline that these services are again functional in Cloud9.