### PR TITLE
input-model-generator: fix external network support

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
@@ -211,8 +211,8 @@ Specifying this macro adds the internal load-balancer to the network group.
 account and object servers. This macro expands into the swift component endpoints.
 * _NEUTRON-EXT_: configures the network group as a Neutron flat external network that will be used to provide external access 
 to VMs (via floating IP Addresses). When this macro is specified as a component endpoint, the generated network group
-will be tagged with `neutron.l3_agent.external_network_bridge` and a `neutron_external_networks` entry is generated and
-added to the Neutron configuration data corresponding to this network.
+will be tagged with `neutron.networks.flat` and a `neutron_external_networks` entry is generated and added to the Neutron
+configuration data corresponding to this network.
 * _NEUTRON-VLAN_: configures the network group as a Neutron VLAN provider network. When this macro is specified as a
 component endpoint, the generated network group will be tagged with `neutron.networks.vlan` and a VLAN `neutron_provider_networks`
 entry is generated and added to the Neutron configuration data corresponding to this network. A route is also configured

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
@@ -19,7 +19,7 @@
 
   network-groups:
 
-{% set ns = namespace(physnet_id=0, routes=[]) %}
+{% set ns = namespace(physnet_id=0, extnet_id=0, routes=[]) %}
 {% for network_group in scenario['network_groups'] %}
 
     - name: {{ network_group.name|upper }}
@@ -196,7 +196,9 @@
         # This is the network group that will be used to provide
         # external access to VMs (via floating IP Addresses)
         #
-        - neutron.l3_agent.external_network_bridge
+        - neutron.networks.flat:
+            provider-physical-network: external{{ ns.extnet_id | ternary(ns.extnet_id, '') }}
+{%       set ns.extnet_id = ns.extnet_id+1 %}
 {%     endif %}
 {%     if 'NEUTRON-VLAN' in network_group['component_endpoints'] %}
 {%       set ns.physnet_id = ns.physnet_id+1 %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -59,12 +59,13 @@
 {%   endif %}
 {% endfor %}
         neutron_external_networks:
-{% for network_group in scenario.network_groups %}
-{%   if 'NEUTRON-EXT' in network_group.component_endpoints %}
-          - name: NEUTRON-{{ network_group.name|upper }}-EXT-NET
+{% for network_group in scenario.network_groups if 'NEUTRON-EXT' in network_group.component_endpoints %}
+          - name: ext-net{{ loop.index0 | ternary(loop.index0, '') }}
             cidr: 172.{{ ns.net_id }}.0.0/16
             gateway: 172.{{ ns.net_id }}.0.1
-{%     set ns.net_id = ns.net_id+1 %}
-{%   endif %}
+            provider:
+            - network_type: flat
+              physical_network: external{{ loop.index0 | ternary(loop.index0, '') }}
+{%   set ns.net_id = ns.net_id+1 %}
 {% endfor %}
 {% endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm.yml
@@ -32,5 +32,5 @@ scenario:
 
   service_template: standard
   network_template: compact
-  interface_template: compact-bond
+  interface_template: compact
   disk_template: compact

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/compact-bond.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/compact-bond.yml
@@ -34,9 +34,14 @@ interface_models:
           num_interfaces: 2
         network_groups:
           - EXTERNAL-API
-          - EXTERNAL-VM
           - GUEST
           - MANAGEMENT
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
+          - EXTERNAL-VM
+          - TENANT-VLAN
 
   - name: COMPUTE
     service_groups:
@@ -47,6 +52,11 @@ interface_models:
           mode: "active-backup"
           num_interfaces: 2
         network_groups:
-          - EXTERNAL-VM
           - GUEST
           - MANAGEMENT
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
+          - EXTERNAL-VM
+          - TENANT-VLAN

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/compact.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/compact.yml
@@ -13,7 +13,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-
 ---
 
 interface_models:
@@ -23,29 +22,15 @@ interface_models:
     network_interfaces:
       - network_groups:
           - MANAGEMENT
-      - network_groups:
-          - ARDANA
-      - forced_network_groups:
+        forced_network_groups:
           - EXTERNAL-API
 
-  - name: CORE
+  - name: CONTROLLER
     service_groups:
-      - core
+      - controller
     network_interfaces:
-      - network_groups:
-          - ARDANA
       - network_groups:
           - EXTERNAL-API
-          - INTERNAL-API
-          - MANAGEMENT
-
-  - name: NEUTRON
-    service_groups:
-      - neutron
-    network_interfaces:
-      - network_groups:
-          - ARDANA
-      - network_groups:
           - GUEST
           - MANAGEMENT
       - network_groups:
@@ -58,48 +43,8 @@ interface_models:
       - rhel-compute
     network_interfaces:
       - network_groups:
-          - ARDANA
-      - network_groups:
           - GUEST
           - MANAGEMENT
       - network_groups:
           - EXTERNAL-VM
           - TENANT-VLAN
-
-  - name: SWOBJ
-    service_groups:
-      - swobj
-    network_interfaces:
-      - network_groups:
-          - ARDANA
-      - network_groups:
-          - MANAGEMENT
-          - SWIFT
-
-  - name: SWPAC
-    service_groups:
-      - swpac
-    network_interfaces:
-      - network_groups:
-          - ARDANA
-      - network_groups:
-          - MANAGEMENT
-          - SWIFT
-
-  - name: DBMQ
-    service_groups:
-      - dbmq
-    network_interfaces:
-      - network_groups:
-          - ARDANA
-      - network_groups:
-          - MANAGEMENT
-
-  - name: LMM
-    service_groups:
-      - lmm
-    network_interfaces:
-      - network_groups:
-          - ARDANA
-      - network_groups:
-          - MANAGEMENT

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/full-spread-bond.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/full-spread-bond.yml
@@ -34,7 +34,10 @@ interface_models:
     network_interfaces:
       - network_groups:
           - ARDANA
-      - network_groups:
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
           - EXTERNAL-API
           - INTERNAL-API
           - MANAGEMENT
@@ -45,10 +48,12 @@ interface_models:
     network_interfaces:
       - network_groups:
           - ARDANA
-      - network_groups:
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
           - GUEST
           - MANAGEMENT
-      - network_groups:
           - EXTERNAL-VM
           - TENANT-VLAN
 
@@ -59,10 +64,12 @@ interface_models:
     network_interfaces:
       - network_groups:
           - ARDANA
-      - network_groups:
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
           - GUEST
           - MANAGEMENT
-      - network_groups:
           - EXTERNAL-VM
           - TENANT-VLAN
 
@@ -72,7 +79,10 @@ interface_models:
     network_interfaces:
       - network_groups:
           - ARDANA
-      - network_groups:
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
           - MANAGEMENT
           - SWIFT
 
@@ -82,7 +92,10 @@ interface_models:
     network_interfaces:
       - network_groups:
           - ARDANA
-      - network_groups:
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
           - MANAGEMENT
           - SWIFT
 
@@ -92,7 +105,10 @@ interface_models:
     network_interfaces:
       - network_groups:
           - ARDANA
-      - network_groups:
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
           - MANAGEMENT
 
   - name: LMM
@@ -101,5 +117,8 @@ interface_models:
     network_interfaces:
       - network_groups:
           - ARDANA
-      - network_groups:
+      - bond:
+          mode: "active-backup"
+          num_interfaces: 2
+        network_groups:
           - MANAGEMENT

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
@@ -30,13 +30,18 @@ network_groups:
     component_endpoints:
       - MANAGEMENT
       - INTERNAL-API
-      - NEUTRON-VLAN
 
   - name: EXTERNAL-VM
     hostname_suffix: extvm
     tagged_vlan: true
     component_endpoints:
       - NEUTRON-EXT
+
+  - name: TENANT-VLAN
+    hostname_suffix: tvlan
+    tagged_vlan: false
+    component_endpoints:
+      - NEUTRON-VLAN
 
   - name: GUEST
     hostname_suffix: guest

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/full-spread.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/full-spread.yml
@@ -27,7 +27,6 @@ network_groups:
     tagged_vlan: false
     component_endpoints:
       - MANAGEMENT
-      - NEUTRON-VLAN
     routes:
       - default
       - INTERNAL-API
@@ -49,6 +48,12 @@ network_groups:
     tagged_vlan: true
     component_endpoints:
       - NEUTRON-EXT
+
+  - name: TENANT-VLAN
+    hostname_suffix: tvlan
+    tagged_vlan: false
+    component_endpoints:
+      - NEUTRON-VLAN
 
   - name: GUEST
     hostname_suffix: guest


### PR DESCRIPTION
Using the `neutron.l3_agent.external_network_bridge` tag to
indicate the provider network used as a backend by the neutron
external network has been broken since cloud8 [1]. Using this
tag will effectively supply no provider network attributes to
the external neutron network, which in turn causes neutron
to automatically select one of the tenant networks to act as
a backend for the external network.

This commit fixes the generated external neutron network
configuration to provide explicit provider attribute values
and to model the external network as a flat provider network.

The commit also changes the generated names used for the external neutron
networks to match the name used by the `ardana-input-model` input models
(e.g. `ext-net`, `ext-net1` and so on), because the implementation of many
of the QA test automation scripts is still based on this assumption.

An issue occurs intermittently when the management network is
co-attached with one of the neutron networks on the same interface
[2]. To avoid that, the input model generator scenarios are updated
such that the MANAGEMENT network is no longer attached to the same
interface as the neutron external network (EXTERNAL-VM) or the neutron
VLAN tenant network (TENANT-VLAN).

To preserve the current association with bare-metal hardware interfaces,
the bond interfaces in the `compact-bond` and `full-spread` interface
templates also had to be split, to accommodate the increase in required
number of interfaces. New templates were created for this, while the
"bond" ones are preserved.

This change depends on https://gitlab.suse.de/cloud-qe/ardana-bm-info/merge_requests/6

[1] https://bugzilla.suse.com/show_bug.cgi?id=1100583
[2] https://bugzilla.suse.com/show_bug.cgi?id=1067482