### PR TITLE
openstack-ardana: switch to LVM root partition images

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-bootstrap-clm.Jenkinsfile
@@ -59,6 +59,7 @@ pipeline {
               git clone $git_automation_repo --branch $git_automation_branch automation-git
               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
               ansible_playbook load-job-params.yml
+              ansible_playbook setup-ssh-access.yml -e @input.yml
             ''')
           }
           env.DEPLOYER_IP = sh (

--- a/scripts/jenkins/ardana/ansible/bootstrap-clm.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-clm.yml
@@ -26,10 +26,8 @@
 
   pre_tasks:
     - block:
-        - name: Grow 1st partition filesystem
-          shell: |
-            /usr/sbin/growpart /dev/vda 1 && /sbin/resize2fs /dev/vda1
-          failed_when: False
+        - include_role:
+            name: setup_root_partition
           when: not is_physical_deploy
 
         - include_role:

--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -78,7 +78,7 @@
 - name: Bootstrap other virtual nodes for ardana
   hosts: ardana_virt_hosts
   remote_user: root
-  gather_facts: False
+  gather_facts: True
   vars:
     task: "deploy"
     ansible_ssh_common_args: >
@@ -97,12 +97,8 @@
             delay: 10
             timeout: 300
 
-        - name: Grow 1st partition filesystem
-          shell: |
-            /usr/sbin/growpart /dev/vda 1 && /sbin/resize2fs /dev/vda1
-          failed_when: False
-          register: growpart
-          changed_when: growpart.rc == 0
+        - include_role:
+            name: setup_root_partition
 
         - name: Create ardana group
           group:

--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -61,6 +61,7 @@
             - state: touch
               path: "/etc/openstack/skip_disk_config"
           become: yes
+          when: not want_lvm
       rescue:
         - include_role:
             name: rocketchat_notify
@@ -152,6 +153,7 @@
               path: "/etc/openstack"
             - state: touch
               path: "/etc/openstack/skip_disk_config"
+          when: not want_lvm
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -24,6 +24,15 @@ want_caasp: False
 virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
 virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 
+want_lvm: True
+# use different flavors and images when LVM support is enabled:
+#  - LVM enabled images have the root partition set up as an LVM volume
+#  - LVM enabled flavors have a smaller disk size for generated input models,
+#  because the generated input models will also include additional volumes for
+#  each service group
+vcloud_image_name_prefix: "{{ 'cleanvm-jeos-lvm' if want_lvm else 'cleanvm-jeos' }}"
+vcloud_flavor_name_prefix: "{{ 'cloud-ardana-job-lvm' if want_lvm else 'cloud-ardana-job' }}"
+
 cli_stack_queries:
   - "admin-floating-ip"
   - "admin-mgmt-ip"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -42,6 +42,10 @@ ardana_qe_tests_requires:
 sles_sdk_repos:
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
+  # As a temporary solution to the problem of python-devel/python-base package mismatch
+  # between the SLES12SP4 base image and the released SLES12SP4-SDK ISO, the
+  # SP3 SDK-Updates repo is also included
+  - "SLE{{ ansible_distribution_major_version }}-SP3-SDK-Updates"
 
 ardana_qe_test_run_filters: "{{ role_path }}/files/run_filters/{{ test_name }}"
 

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/defaults/main.yml
@@ -20,21 +20,21 @@ virt_artifacts:
   cloud8:
     sles_distro_id: sles12sp3-x86_64
     rhel_distro_id: rhel73-x86_64
-    sles_image: cleanvm-jeos-SLE12SP3
+    sles_image: "{{ vcloud_image_name_prefix }}-SLE12SP3"
     rhel_image: centos73
     clm_flavor: cloud-ardana-job-compute
     controller_flavor: cloud-ardana-job-controller
     compute_flavor: cloud-ardana-job-compute
-    disk_size: 30
+    disk_size: 20
   cloud9:
     sles_distro_id: sles12sp4-x86_64
     rhel_distro_id: rhel73-x86_64
-    sles_image: cleanvm-jeos-SLE12SP4
+    sles_image: "{{ vcloud_image_name_prefix }}-SLE12SP4"
     rhel_image: centos73
     clm_flavor: cloud-ardana-job-compute
     controller_flavor: cloud-ardana-job-controller
     compute_flavor: cloud-ardana-job-compute
-    disk_size: 30
+    disk_size: 20
 
 # Exhaustive list of service components required by the CLM node.
 # When service components that are not in this list are hosted

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/vars/caasp.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/vars/caasp.yml
@@ -17,4 +17,4 @@
 # compute node.
 ---
 
-compute_flavor: cloud-ardana-job-controller
+compute_flavor: "{{ vcloud_flavor_name_prefix }}-controller"

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/vars/standard.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/vars/standard.yml
@@ -34,9 +34,9 @@ clm_service_components:
   - barbican-client
   - ntp-client
 
-clm_flavor: cloud-ardana-job-compute
-controller_flavor: cloud-ardana-job-controller
-compute_flavor: cloud-ardana-job-compute
+clm_flavor: "{{ vcloud_flavor_name_prefix }}-compute"
+controller_flavor: "{{ vcloud_flavor_name_prefix }}-controller"
+compute_flavor: "{{ vcloud_flavor_name_prefix }}-compute"
 sles_images:
   cloud8: cleanvm-jeos-SLE12SP3
   cloud9: cleanvm-jeos-SLE12SP4

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -29,10 +29,11 @@ designate_backend: bind
 # (i.e. values in service_component_groups)
 disabled_services: ""
 
-# Disable extra volume groups in the generated disk models, since these have no
-# effect anyway as long as `skip_disk_config` is used to skip LVM disk configuration
+# Disable extra volume groups in the generated disk models when LVM is
+# disabled in the base image, since these have no effect anyway as long as
+# `skip_disk_config` is also used to skip LVM disk configuration
 # in deployed clouds
-enable_extra_volume_groups: False
+enable_extra_volume_groups: "{{ want_lvm }}"
 
 cp_prefix: cp1
 max_host_prefix_len: "{{ 33-(cp_prefix|length) }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/full-spread.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/full-spread.yml
@@ -38,14 +38,14 @@ service_groups:
   - name: clm
     type: cluster
     prefix: clm
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ (clm_model == "standalone") | ternary(1, 0) }}'
     service_components:
       - CLM
   - name: core
     type: cluster
     prefix: core
-    heat_flavor_id: cloud-ardana-job-controller
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-controller"
     member_count: '{{ core_nodes|default(2) }}'
     service_components:
       - '{{ (clm_model == "integrated") | ternary("CLM", '') }}'
@@ -53,35 +53,35 @@ service_groups:
   - name: lmm
     type: cluster
     prefix: lmm
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ lmm_nodes|default(3) }}'
     service_components:
       - LMM
   - name: dbmq
     type: cluster
     prefix: dbmq
-    heat_flavor_id: cloud-ardana-job-minimal
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-minimal"
     member_count: '{{ dbmq_nodes|default(3) }}'
     service_components:
       - DBMQ
   - name: swpac
     type: cluster
     prefix: swpac
-    heat_flavor_id: cloud-ardana-job-minimal
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-minimal"
     member_count: '{{ swpac_nodes|default(3) }}'
     service_components:
       - SWPAC
   - name: neutron
     type: cluster
     prefix: neutron
-    heat_flavor_id: cloud-ardana-job-minimal
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-minimal"
     member_count: '{{ neutron_nodes|default(3) }}'
     service_components:
       - NEUTRON
   - name: sles-compute
     type: resource
     prefix: sles-comp
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ sles_computes|default(1) }}'
     min_count: 0
     service_components:
@@ -91,7 +91,7 @@ service_groups:
     prefix: rhel-comp
     distro_id: rhel73-x86_64
     heat_image_id: centos73
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ rhel_computes|default(1) }}'
     min_count: 0
     service_components:
@@ -99,7 +99,7 @@ service_groups:
   - name: swobj
     type: resource
     prefix: swobj
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ swobj_nodes|default(3) }}'
     min_count: '{{ [ swobj_nodes|default(3)|int, 3 ] | min }}'
     service_components:

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/split.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/split.yml
@@ -33,14 +33,14 @@ service_groups:
   - name: clm
     type: cluster
     prefix: clm
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ (clm_model == "standalone") | ternary(1, 0) }}'
     service_components:
       - CLM
   - name: core
     type: cluster
     prefix: core
-    heat_flavor_id: cloud-ardana-job-controller
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-controller"
     member_count: '{{ core_nodes|default(2) }}'
     service_components:
       - '{{ (clm_model == "integrated") | ternary("CLM", '') }}'
@@ -50,14 +50,14 @@ service_groups:
   - name: lmm
     type: cluster
     prefix: lmm
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ lmm_nodes|default(3) }}'
     service_components:
       - LMM
   - name: dbmq
     type: cluster
     prefix: dbmq
-    heat_flavor_id: cloud-ardana-job-minimal
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-minimal"
     member_count: '{{ dbmq_nodes|default(3) }}'
     service_components:
       - DBMQ
@@ -65,7 +65,7 @@ service_groups:
   - name: sles-compute
     type: resource
     prefix: sles-comp
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ sles_computes|default(1) }}'
     min_count: 0
     service_components:
@@ -74,7 +74,7 @@ service_groups:
     type: resource
     prefix: rhel-comp
     distro_id: rhel73-x86_64
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ rhel_computes|default(1) }}'
     min_count: 0
     service_components:

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/standard.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/standard.yml
@@ -28,14 +28,14 @@ service_groups:
   - name: clm
     type: cluster
     prefix: c0
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ (clm_model == "standalone") | ternary(1, 0) }}'
     service_components:
       - CLM
   - name: controller
     type: cluster
     prefix: c1
-    heat_flavor_id: cloud-ardana-job-controller
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-controller"
     member_count: '{{ controllers|default(3) }}'
     service_components:
       - '{{ (clm_model == "integrated") | ternary("CLM", '') }}'
@@ -48,7 +48,7 @@ service_groups:
   - name: sles-compute
     type: resource
     prefix: sles-comp
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ sles_computes|default(1) }}'
     min_count: 0
     service_components:
@@ -57,7 +57,7 @@ service_groups:
     type: resource
     prefix: rhel-comp
     distro_id: rhel73-x86_64
-    heat_flavor_id: cloud-ardana-job-compute
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ rhel_computes|default(1) }}'
     min_count: 0
     service_components:

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -33,3 +33,7 @@ os_health_requires:
 sles_sdk_repos:
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
+  # As a temporary solution to the problem of python-devel/python-base package mismatch
+  # between the SLES12SP4 base image and the released SLES12SP4-SDK ISO, the
+  # SP3 SDK-Updates repo is also included
+  - "SLE{{ ansible_distribution_major_version }}-SP3-SDK-Updates"

--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
@@ -1,0 +1,35 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+# List of tools required for partition resizing
+part_resize_tools:
+  basic:
+    - fdisk
+    - parted
+    - growpart
+  lvm:
+    - lvdisplay
+    - lvs
+    - vgs
+
+# if / is not on bootable partition, updated dynamically otherwise
+sles_vm_fdisk_start_field: 2
+
+# the size (in GB) to which the LVM root partition is resized
+# this needs to be less than 95% of the total available size, otherwise
+# the Ardana osconfig play will fail
+min_deployer_root_part_size: 24

--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
@@ -1,0 +1,224 @@
+#
+# (c) Copyright 2015-2017 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Expand the partition backing the root file system of the VM to fill the
+# disk and grow the root filesystem to an appropriate size to support the
+# initial phases of an Ardana deployment before osconfig-run.yml applies
+# the file system layout settings defined in the input model.
+---
+
+- name: Get root fs mount details
+  set_fact:
+    root_mount: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | first }}"
+
+- name: Set list of required tools
+  set_fact:
+    _required_tools: >
+      {%- set _req_tools = part_resize_tools.basic -%}
+      {%- if root_mount.device.startswith('/dev/mapper') -%}
+      {%-   set _ = _req_tools.extend(part_resize_tools.lvm) -%}
+      {%- endif -%}
+      {{- _req_tools -}}
+
+- name: Check for required tools
+  shell: >
+    command -v {{ item }}
+  register: _which_result
+  changed_when: False
+  failed_when:
+    - _which_result.rc > 1
+  with_items: "{{ _required_tools }}"
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+
+- name: Fail if required tools not found
+  fail:
+    # NOTE: blank line at start of msg text is intentional
+    msg: |
+
+      Required tools are missing from the SLES VM image:
+      {% for r in _which_result.results %}
+      {%   if r.rc %}
+          {{ r.item }}
+      {%   endif %}
+      {% endfor %}
+  when:
+    - _which_result.results | selectattr("rc") | list | length > 0
+
+- name: Setup root fs settings for non-LVM
+  set_fact:
+    root_fs_dev_path: "{{ root_mount.device }}"
+    root_fs_dev_name: "{{ root_mount.device | basename }}"
+  when:
+    - not root_mount.device.startswith('/dev/mapper')
+
+- name: Determine VG & LV for root device
+  command: >
+    lvs
+      -o vg_name,lv_name
+      --noheadings
+      --nameprefixes
+      --unquoted
+      {{ root_mount.device }}
+  register: _lvs_root_device_result
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+
+- name: Extract VG & LV for root filesystem
+  set_fact:
+    root_vg: "{{ _lvs_root_device_result.stdout.strip().split(' ')[0].split('=')[1] }}"
+    root_lv: "{{ _lvs_root_device_result.stdout.strip().split(' ')[1].split('=')[1] }}"
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+
+- name: Determine PV backing root device
+  command: >
+    vgs
+      -o pv_name
+      --noheadings
+      --nameprefixes
+      --unquoted
+      {{ root_vg }}
+  register: _vgs_root_vg_result
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+
+- name: Extract PV backing root filesystem
+  set_fact:
+    root_pv: "{{ _vgs_root_vg_result.stdout.strip().split(' ')[0].split('=')[1] }}"
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+
+- name: Setup root fs settings for LVM
+  set_fact:
+    root_fs_dev_path: "{{ root_pv }}"
+    root_fs_dev_name: "{{ root_pv | basename }}"
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+
+- name: Determine root fs base device
+  # NOTE: using shell rather than command here because we want to expand
+  # the given path using shell file globbing to find the desired entry
+  # under /sys/block.
+  shell: >
+    readlink -e /sys/block/*/{{ root_fs_dev_name | quote }}
+  register: _root_dev_sys_block_result
+
+- name: Extract root fs base device
+  set_fact:
+    root_fs_base_dev: "/dev/{{ _root_dev_sys_block_result.stdout | dirname | basename }}"
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+
+- name: Determine root fs device partition
+  command: >
+    cat /sys/block/{{ root_fs_base_dev | basename | quote }}/{{
+                      root_fs_dev_name | quote }}/partition
+  register: _read_sys_block_partition_result
+
+- name: Extract root fs device partition
+  set_fact:
+    root_fs_partition: "{{ _read_sys_block_partition_result.stdout | int }}"
+
+- name: Print starting partition size
+  command: parted --script {{ root_fs_base_dev }} print
+  register: sles_vm_partitions
+
+- debug:
+    var: sles_vm_partitions
+
+- name: Print starting filesystem size
+  command: df -h /
+  register: sles_vm_filesystems
+  changed_when: False
+
+- debug:
+    var: sles_vm_filesystems
+
+- name: Change fdisk start field number for single partition layout
+  set_fact:
+    sles_vm_fdisk_start_field: 3
+  when:
+    - root_fs_partition | int == 1
+
+- name: Check if disk is much larger than root partition
+  shell: fdisk -l {{ root_fs_base_dev }} | awk -v DEV={{ root_fs_dev_path }}
+      '$1 == "Disk" && $NF == "sectors" { total = $(NF-1) }
+       $1 == DEV { used = $({{ sles_vm_fdisk_start_field | int }}+1) }
+       END { print int(total/used) }'
+  register: sles_vm_disk_size
+  changed_when: False
+
+- name: Get the start sector of the root partition
+  shell: fdisk -l {{ root_fs_base_dev }} | awk -v DEV={{ root_fs_dev_path }}
+      '$1 == DEV { print ${{ sles_vm_fdisk_start_field | int }}; }'
+  register: sles_vm_partition_start
+  when:
+    - sles_vm_disk_size.stdout != "inf"
+    - (sles_vm_disk_size.stdout | int) > 1
+  failed_when: (sles_vm_partition_start.stdout | int) == 0
+
+- name: Grow root partition filesystem
+  shell: |
+    /usr/sbin/growpart {{ root_fs_base_dev }} {{ root_fs_partition }}
+  register: sles_vm_resize_partition
+  when:
+    - sles_vm_partition_start.changed
+    - (sles_vm_disk_size.stdout | int) > 1
+
+- name: Check root vol size
+  shell: >
+    lvdisplay {{ root_vg }}/{{ root_lv }} | grep "LV Size" | awk '{print $3}'
+  register: sles_lvm_root_size
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+  changed_when: False
+
+- name: Resize pv if necessary
+  command: pvresize {{ root_pv }}
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+    - (sles_lvm_root_size.stdout | int) < (min_deployer_root_part_size | int)
+
+- name: Resize lv if necessary
+  command: lvresize -L {{ min_deployer_root_part_size }}G /dev/{{ root_vg }}/{{ root_lv }}
+  register: _lvresize_output
+  failed_when: ( _lvresize_output.rc != 0 ) and ( "matches existing size" not in _lvresize_output.stderr )
+  when:
+    - root_mount.device.startswith('/dev/mapper')
+    - (sles_lvm_root_size.stdout | int) < (min_deployer_root_part_size | int)
+
+- name: Resize the filesystem
+  command: resize2fs "{{ root_mount.device }}"
+  register: sles_vm_resize_filesystem
+  when:
+    - sles_vm_resize_partition is not skipped
+
+- name: Print finishing partition size
+  command: parted {{ root_fs_base_dev }} print
+  register: sles_vm_partitions
+  when:
+    - sles_vm_resize_partition is not skipped
+
+- debug: var=sles_vm_partitions
+
+- name: Print finishing filesystem size
+  command: df -h /
+  register: sles_vm_filesystems
+  when:
+    - sles_vm_resize_filesystem is not skipped
+
+- debug: var=sles_vm_filesystems


### PR DESCRIPTION
This PR enables LVM disk configuration in Ardana deployment:
 - use a different SLES image set (cleanvm-jeos-lvm-SLE12SP3/SP4),
     which use an LVM root partition
 - reduce the size of the volume groups in the generated heat stacks
     from 30 GB to 20 GB, to be aligned with those used by `ardana-dev-tools`
 - remove the ansible tasks that were previously disabling the Ardana
     disk configuration in `osconfig-ansible`

It also adds a `setup_root_partition` ansible role inspired largely from
`ardana-dev-tools` [1], which automates expanding the root partition,
LVM volume and file system of the cloud nodes.

The PR also adds the `SLES12SP3-SDK-Updates` repository to the
list of repositories required to install `python-devel`, to correct the problem of
strict version dependency between `python-base`, which comes from the base
SLES12SP4 image (which contains latest, unreleased packages) and 
`python-devel`, which comes from the SP4-SDK/Update repositories (which
are behind the base image, and contain only the latest released packages).

[1] https://github.com/ArdanaCLM/ardana-dev-tools/blob/master/ansible/roles/vagrant-vm/tasks/setup-root-partition.yml
