### PR TITLE
openstack-ardana: cleanup and better job parameter tips

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -13,7 +13,6 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
-    branch: stable/pike
     model: std-3cp
     triggers:
      - timed: 'H H * * *'
@@ -25,7 +24,6 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
-    branch: stable/pike
     model: dac-3cp
     triggers:
      - timed: 'H H * * *'
@@ -37,7 +35,6 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
-    branch: stable/pike
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -48,7 +45,6 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
-    branch: stable/pike
     model: std-split
     triggers:
      - timed: 'H H * * *'
@@ -62,7 +58,6 @@
     cloudsource: develcloud8
     update_after_deploy: true
     update_to_cloudsource: stagingcloud8
-    branch: stable/pike
     model: std-3cp
     triggers:
      - timed: 'H H * * *'
@@ -78,7 +73,6 @@
     updates_test_enabled: true
     update_after_deploy: true
     update_to_cloudsource: GM8+up
-    branch: stable/pike
     model: std-3cp
     triggers:
      - timed: 'H H * * *'
@@ -90,7 +84,6 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: GM8+up
-    branch: stable/pike
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -114,7 +107,6 @@
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
     cloudsource: stagingcloud8
-    branch:
     develproject: Devel:Cloud:8:Staging
     repository: SLE_12_SP3
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -12,7 +12,6 @@
     name: cloud-ardana9-job-std-3cp-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
-    model: std-3cp-gen
     scenario_name: standard
     clm_model: standalone
     controllers: '3'
@@ -26,7 +25,6 @@
     name: cloud-ardana9-job-dac-3cp-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
-    model: dac-3cp-gen
     scenario_name: standard
     clm_model: integrated
     controllers: '3'
@@ -40,7 +38,6 @@
     name: cloud-ardana9-job-std-min-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
-    model: std-min-gen
     scenario_name: standard
     clm_model: standalone
     controllers: '2'
@@ -64,7 +61,6 @@
     name: cloud-ardana9-job-std-split-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
-    model: std-split-gen
     scenario_name: std-split
     clm_model: standalone
     core_nodes: '1'
@@ -83,7 +79,6 @@
     cloudsource: develcloud9
     update_after_deploy: true
     update_to_cloudsource: stagingcloud9
-    model: std-3cp-gen
     scenario_name: standard
     clm_model: standalone
     controllers: '3'
@@ -97,7 +92,6 @@
     name: cloud-ardana9-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
-    model: std-min-gen
     gerrit_change_ids: '4940'
     triggers:
      - timed: 'H H * * *'
@@ -108,7 +102,6 @@
     name: openstack-ardana-gerrit-cloud9
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
-    model: std-min-gen
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}'
     triggers:
       - gerrit:

--- a/jenkins/ci.suse.de/openstack-ardana-pcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-pcloud.yaml
@@ -51,13 +51,15 @@
       - choice:
           name: scenario_name
           choices:
-            - entry-scale-kvm
-            - entry-scale-swift
             - standard
+            - entry-scale-kvm
             - std-split
             - mid-scale
           description: >-
-            The scenario used to generate the input model
+            The name of one of the available scenarios that can be used to generate input models.
+            If this parameter is set, the following parameters may also be set to different values, to control
+            various aspects of the generated input model: clm_model, controllers, core_nodes, lmm_nodes, dbmq_nodes,
+            neutron_nodes, swpac_nodes, swobj_nodes, sles_computes, rhel_computes and disabled_services.
 
       - choice:
           name: clm_model
@@ -65,58 +67,93 @@
             - standalone
             - integrated
           description: |
-            standalone - one node dedicated for CLM
-            integrated - the first controller node will also be used as a CLM node
+            The type of deployer node deployment to use for the generated input model. Can take one of the following values:
+
+              standalone - one node dedicated for CLM
+              integrated - the first controller node will also be used as a CLM node
+
+            Input model generator scenarios using this parameter : all
 
       - string:
           name: controllers
           default: '3'
-          description: Number of nodes used as controller
+          description: |
+            The number of controller nodes in the generated input model.
+
+            Input model generator scenarios using this parameter is available: standard, entry-scale-kvm.
 
       - string:
           name: core_nodes
           default: '2'
-          description: Number of OpenStack core service nodes
+          description: |
+            The number of OpenStack core services nodes in the generated input model.
+
+            Input model generator scenarios using this parameter is available: mid-scale, std-split.
 
       - string:
           name: lmm_nodes
           default: '1'
-          description: Number of LMM nodes
+          description: |
+            The number of LMM services nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale, std-split.
 
       - string:
           name: dbmq_nodes
           default: '3'
-          description: Number of database & rabbitmq nodes
+          description: |
+            The number of database & rabbitmq service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: std-split, mid-scale.
 
       - string:
           name: neutron_nodes
           default: '1'
-          description: Number of neutron network nodes
+          description: |
+            The number of neutron network nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale.
 
       - string:
           name: swpac_nodes
           default: '1'
-          description: Number of swift proxy/account/container service nodes
+          description: |
+            The number of swift proxy/account/container service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale.
 
       - string:
           name: swobj_nodes
           default: '1'
-          description: Number of swift object service nodes
+          description: |
+            The number of swift object service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: std-split, mid-scale.
 
       - string:
           name: sles_computes
           default: '2'
-          description: Number of SLES compute nodes
+          description: |
+            The number of SLES compute nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: all
 
       - string:
           name: rhel_computes
           default: '0'
-          description: Number of RHEL compute nodes
+          description: |
+            The number of RHEL (CentOS) compute nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: all
 
       - string:
           name: disabled_services
           default: ''
-          description: Regex matching service components and component groups to disable in the generated input model
+          description:
+          description: |
+            Regex matching service components and component groups to exclude from the generated input model.
+
+            Input model generator scenarios using this parameter: all
 
       - bool:
           name: rc_notify

--- a/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
@@ -50,36 +50,32 @@
             The cloud release value used to select the correct OpenStack images and flavors for the virtual environment.
 
       - string:
-          name: git_input_model_branch
+          name: model
           default: ''
           description: >-
-            The git repository branch to use for input models. If empty the branch is set based
-            on the cloud release version (cloud8: stable/pike, cloud9: master)
+            The name of the one of the available 'ardana-ci' input models to use from the ardana-input-model git repository.
 
-      - string:
-          name: git_input_model_path
-          default: 2.0/ardana-ci
-          description: >-
-            Relative path in the input model git repository where the input models are located
 
-      - string:
-          name: model
-          default: std-min
-          description: >-
-            The Input Model to use from the input model git repository / branch / path, or the name of the generated
-            input model.
+            NOTE: use this parameter only if you want to use an existing input model. To generate an input model instead,
+            leave this field empty and use the 'scenario_name' parameter instead.
 
       - choice:
           name: scenario_name
           choices:
             -
             - entry-scale-kvm
-            - entry-scale-swift
             - standard
             - std-split
             - mid-scale
           description: >-
-            The scenario used to generate the input model
+            The name of one of the available scenarios that can be used to generate input models.
+            If this parameter is set, the following parameters may also be set to different values, to control
+            various aspects of the generated input model: clm_model, controllers, core_nodes, lmm_nodes, dbmq_nodes,
+            neutron_nodes, swpac_nodes, swobj_nodes, sles_computes, rhel_computes and disabled_services.
+
+
+            NOTE: use this parameter only if you want to use a generated input model. To use an existing input model instead,
+            leave this field empty and use the 'model' parameter instead.
 
       - choice:
           name: clm_model
@@ -87,58 +83,126 @@
             - standalone
             - integrated
           description: |
-            standalone - one node dedicated for CLM
-            integrated - the first controller node will also be used as a CLM node
+            The type of deployer node deployment to use for the generated input model. Can take one of the following values:
+
+              standalone - one node dedicated for CLM
+              integrated - the first controller node will also be used as a CLM node
+
+            Input model generator scenarios using this parameter : all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: controllers
           default: '3'
-          description: Number of nodes used as controller
+          description: |
+            The number of controller nodes in the generated input model.
+
+            Input model generator scenarios using this parameter is available: standard, entry-scale-kvm.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: core_nodes
           default: '2'
-          description: Number of OpenStack core service nodes
+          description: |
+            The number of OpenStack core services nodes in the generated input model.
+
+            Input model generator scenarios using this parameter is available: mid-scale, std-split.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: lmm_nodes
           default: '1'
-          description: Number of LMM nodes
+          description: |
+            The number of LMM services nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale, std-split.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: dbmq_nodes
           default: '3'
-          description: Number of database & rabbitmq nodes
+          description: |
+            The number of database & rabbitmq service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: std-split, mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: neutron_nodes
           default: '1'
-          description: Number of neutron network nodes
+          description: |
+            The number of neutron network nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: swpac_nodes
           default: '1'
-          description: Number of swift proxy/account/container service nodes
+          description: |
+            The number of swift proxy/account/container service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: swobj_nodes
           default: '1'
-          description: Number of swift object service nodes
+          description: |
+            The number of swift object service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: std-split, mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: sles_computes
           default: '2'
-          description: Number of SLES compute nodes
+          description: |
+            The number of SLES compute nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: rhel_computes
           default: '0'
-          description: Number of RHEL compute nodes
+          description: |
+            The number of RHEL (CentOS) compute nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: disabled_services
           default: ''
-          description: Regex matching service components and component groups to disable in the generated input model
+          description:
+          description: |
+            Regex matching service components and component groups to exclude from the generated input model.
+
+            Input model generator scenarios using this parameter: all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: virt_config_name

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -51,8 +51,6 @@ pipeline {
               string(name: 'gerrit_change_ids', value: "$gerrit_change_ids"),
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
               string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              string(name: 'git_input_model_branch', value: "$GERRIT_BRANCH"),
-              string(name: 'model', value: "$model"),
               string(name: 'scenario_name', value: "standard"),
               string(name: 'clm_model', value: "standalone"),
               string(name: 'controllers', value: "2"),

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -129,8 +129,6 @@ pipeline {
             script {
               def slaveJob = build job: 'openstack-ardana-vcloud', parameters: [
                   string(name: 'ardana_env', value: "$ardana_env"),
-                  string(name: 'git_input_model_branch', value: "$git_input_model_branch"),
-                  string(name: 'git_input_model_path', value: "$git_input_model_path"),
                   string(name: 'model', value: "$model"),
                   string(name: 'scenario_name', value: "$scenario_name"),
                   string(name: 'clm_model', value: "$clm_model"),

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -50,12 +50,6 @@
             to test.
 
       - string:
-          name: model
-          default: '{model|std-min}'
-          description: >-
-            The Input Model to use from the input model git repository / branch / path.
-
-      - string:
           name: cloudsource
           default: '{cloudsource|stagingcloud9}'
           description: >-

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -108,37 +108,47 @@
           default: ''
           description: List of SLES maintenance update IDs separated by comma (eg. 7434,7435)
 
-      - string:
-          name: git_input_model_branch
-          default: '{branch|}'
-          description: >-
-            The git repository branch to use for input models. If empty the branch is set based
-            on the cloud release version (cloud8: stable/pike, cloud9: master)
-
-      - string:
-          name: git_input_model_path
-          default: 2.0/ardana-ci
-          description: >-
-            Relative path in the input model git repository where the input models are located
-
-      - string:
+      - choice:
           name: model
-          default: '{model|std-min}'
+          choices:
+            - '{model|}'
+            - dac-3cp
+            - dac-min
+            - demo
+            - deployerincloud
+            - deployerincloud-lite
+            - entry-scale-swift
+            - mid-size
+            - minimal
+            - standard
+            - std-3cm
+            - std-3cp
+            - std-min
+            - std-split
           description: >-
-            The Input Model to use from the input model git repository / branch / path, or the name of the generated
-            input model.
+            The name of the one of the available 'ardana-ci' input models to use from the ardana-input-model git repository.
+
+
+            NOTE: use this parameter only if you want to use an existing input model. To generate an input model instead,
+            leave this field empty and use the 'scenario_name' parameter instead.
 
       - choice:
           name: scenario_name
           choices:
             - '{scenario_name|}'
             - entry-scale-kvm
-            - entry-scale-swift
             - standard
             - std-split
             - mid-scale
           description: >-
-            The scenario used to generate the input model
+            The name of one of the available scenarios that can be used to generate input models.
+            If this parameter is set, the following parameters may also be set to different values, to control
+            various aspects of the generated input model: clm_model, controllers, core_nodes, lmm_nodes, dbmq_nodes,
+            neutron_nodes, swpac_nodes, swobj_nodes, sles_computes, rhel_computes and disabled_services.
+
+
+            NOTE: use this parameter only if you want to use a generated input model. To use an existing input model instead,
+            leave this field empty and use the 'model' parameter instead.
 
       - choice:
           name: clm_model
@@ -147,58 +157,126 @@
             - standalone
             - integrated
           description: |
-            standalone - one node dedicated for CLM
-            integrated - the first controller node will also be used as a CLM node
+            The type of deployer node deployment to use for the generated input model. Can take one of the following values:
+
+              standalone - one node dedicated for CLM
+              integrated - the first controller node will also be used as a CLM node
+
+            Input model generator scenarios using this parameter : all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: controllers
           default: '{controllers|3}'
-          description: Number of nodes used as controller
+          description: |
+            The number of controller nodes in the generated input model.
+
+            Input model generator scenarios using this parameter is available: standard, entry-scale-kvm.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: core_nodes
           default: '{core_nodes|2}'
-          description: Number of OpenStack core service nodes
+          description: |
+            The number of OpenStack core services nodes in the generated input model.
+
+            Input model generator scenarios using this parameter is available: mid-scale, std-split.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: lmm_nodes
           default: '{lmm_nodes|1}'
-          description: Number of LMM nodes
+          description: |
+            The number of LMM services nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale, std-split.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: dbmq_nodes
           default: '{dbmq_nodes|3}'
-          description: Number of database & rabbitmq nodes
+          description: |
+            The number of database & rabbitmq service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: std-split, mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: neutron_nodes
           default: '1'
-          description: Number of neutron network nodes
+          description: |
+            The number of neutron network nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: swpac_nodes
           default: '1'
-          description: Number of swift proxy/account/container service nodes
+          description: |
+            The number of swift proxy/account/container service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: swobj_nodes
           default: '1'
-          description: Number of swift object service nodes
+          description: |
+            The number of swift object service nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: std-split, mid-scale.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: sles_computes
           default: '{sles_computes|2}'
-          description: Number of SLES compute nodes
+          description: |
+            The number of SLES compute nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: rhel_computes
           default: '0'
-          description: Number of RHEL compute nodes
+          description: |
+            The number of RHEL (CentOS) compute nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - string:
           name: disabled_services
           default: '{disabled_services|}'
-          description: Regex matching service components and component groups to disable in the generated input model
+          description:
+          description: |
+            Regex matching service components and component groups to exclude from the generated input model.
+
+            Input model generator scenarios using this parameter: all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
 
       - bool:
           name: ses_enabled


### PR DESCRIPTION
This commit improves the description of the 'model' and 'scenario_name'
Ardana Jenkins job parameters, as well as removes some parameters
that haven't been used in a long time.

Starting with this commit, the user must select either a 'model'
or a 'scenario_name' when triggering a job manually.