### PR TITLE
openstack-ansible: entry-scale-kvm periodic jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -73,6 +73,41 @@
         - '{ardana_job}'
 
 - project:
+    name: cloud-ardana9-job-entry-scale-kvm-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: stagingcloud9
+    scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    rhel_computes: '0'
+    tempest_run_filter: 'ci'
+    qa_test_list: 'iverify,cinder,heat,magnum,neutron,nova-attach,nova_volume,nova_server,nova_services,nova_flavor,nova_image,tempest_cleanup'
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana9-job-entry-scale-kvm-qe102-x86_64
+    ardana_job: '{name}'
+    concurrent: False
+    ardana_env: qe102
+    reserve_env: false
+    scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    rhel_computes: '0'
+    tempest_run_filter: 'ci'
+    qa_test_list: 'iverify,cinder,heat,magnum,neutron,nova-attach,nova_volume,nova_server,nova_services,nova_flavor,nova_image,tempest_cleanup'
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
     name: cloud-ardana9-job-std-3cp-devel-staging-updates-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -317,7 +317,7 @@
           type: multi-select
           visible-items: 10
           multi-select-delimiter: ','
-          default-value: ''
+          default-value: '{qa_test_list|}'
           value: >-
             iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,
             heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,


### PR DESCRIPTION
Adds two periodic jobs targeting the `entry-scale-kvm`
input model generator scenario in Cloud9 Ardana and also
running a set of QA test cases in addition to the `ci`
tempest test filter:

 - `cloud-ardana9-job-entry-scale-kvm-x86_64`: uses a virtual
 cloud deployment, same as all the other jobs
 - cloud-ardana9-job-entry-scale-kvm-qe102-x86_64: uses the
 `qe102` bare-metal setup to deploy a physical cloud