### PR TITLE
Enable ipv6 mix-mode virtual deployment.

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-pcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-pcloud.yaml
@@ -196,6 +196,12 @@
           description: >-
             Configurable external name for your public endpoints
 
+      - bool:
+          name: ipv6
+          default: false
+          description: >-
+            Use ipv6 networks in the cloud input model.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
@@ -257,6 +257,12 @@
             The OpenStack API credentials used to manage virtual clouds (leave
             empty to use the default shared 'cloud' ECP account).
 
+      - bool:
+          name: ipv6
+          default: false
+          description: >-
+            Use ipv6 networks in the cloud input model.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -400,6 +400,12 @@
           description: >-
             The OpenStack API credentials used to manage virtual clouds (leave
             empty to use the default shared 'cloud' ECP account).
+      
+      - bool:
+          name: ipv6
+          default: false
+          description: >-
+            Use ipv6 networks in the cloud input model.
 
     pipeline-scm:
       scm:

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -21,7 +21,11 @@ parameters:
     type: string
     label: Default CIDR
     description: Default CIDR value to use for networks which don't have CIDR specified
+{%   if ipv6 == true %}
+    default: "2001::/64"
+{%    else   %}
     default: "1.1.1.0/24"
+{%    endif  %}
 
 resources:
 
@@ -44,7 +48,11 @@ resources:
     properties:
       network_id: { get_resource: default_network }
       cidr: { get_param: default_subnet_cidr }
+{%   if ipv6 == true %}
+      ip_version: 6
+{%    else   %}
       ip_version: 4
+{%    endif  %}
       enable_dhcp: False
 
   # networks and subnets
@@ -75,12 +83,21 @@ resources:
         - start: "{{ pool[0] }}"
           end: "{{ pool[1] }}"
 {%     endfor %}
-{%   endif %}
+{%     endif  %}
+{%   if ipv6 == true %}
+{%   if network.is_mgmt %}
       ip_version: 4
+{%   else   %}
+      ip_version: 6
+{%   endif  %}
+{%   else   %}
+      ip_version: 4
+{%   endif  %}
+      enable_dhcp: {{ network.is_mgmt }}
 {%   if network.gateway is defined %}
       gateway_ip: "{{ network.gateway }}"
-{%   endif %}
-      enable_dhcp: {{ network.is_mgmt }}
+{%   endif   %}
+
 
 {%   if network.external %}
   router_ext_{{ name }}_interface:

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/firewall_rules.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/firewall_rules.yml
@@ -29,13 +29,14 @@
 #
 
   firewall-rules:
-    - name: SSH
+
+{% if ipv6 == true %}
+    - name: SSH_CLM
       network-groups:
 {% for network_group in scenario['network_groups']
   if 'CLM' in network_group['component_endpoints'] or
-     'MANAGEMENT' in network_group['component_endpoints'] or
-     'EXTERNAL-API' in network_group['component_endpoints'] %}
-        - {{ network_group.name|upper }}
+     'MANAGEMENT' in network_group['component_endpoints'] %}
+         - {{ network_group.name|upper }}
 {% endfor  %}
       rules:
       - type: allow
@@ -43,15 +44,43 @@
         port-range-min: 22
         port-range-max: 22
         protocol: tcp
+{% endif   %}
 
-    - name: PING
+    - name: SSH
       network-groups:
+{% if ipv6 == true %}
+{% for network_group in scenario['network_groups']
+  if 'MANAGEMENT' in network_group['component_endpoints'] or
+     'EXTERNAL-API' in network_group['component_endpoints'] %}
+        - {{ network_group.name|upper }}
+{% endfor  %}
+{% else %}
 {% for network_group in scenario['network_groups']
   if 'CLM' in network_group['component_endpoints'] or
      'MANAGEMENT' in network_group['component_endpoints'] or
      'EXTERNAL-API' in network_group['component_endpoints'] %}
         - {{ network_group.name|upper }}
 {% endfor  %}
+{% endif %}
+      rules:
+      - type: allow
+{% if ipv6 == true %}
+        remote-ip-prefix:  ::/128
+{% else %}
+        remote-ip-prefix:  0.0.0.0/0
+{% endif %}
+        port-range-min: 22
+        port-range-max: 22
+        protocol: tcp
+
+{% if ipv6 == true %}
+    - name: PING_CLM
+      network-groups:
+{% for network_group in scenario['network_groups']
+  if 'CLM' in network_group['component_endpoints'] or
+     'MANAGEMENT' in network_group['component_endpoints']%}
+        - {{ network_group.name|upper }}
+{% endfor %}
       rules:
       # open ICMP echo request (ping)
       - type: allow
@@ -61,6 +90,52 @@
         # icmp code
         port-range-max: 0
         protocol: icmp
+{% endif %}
+
+    - name: PING
+      network-groups:
+{% if ipv6 == true %}
+{% for network_group in scenario['network_groups']
+  if 'MANAGEMENT' in network_group['component_endpoints'] or
+     'EXTERNAL-API' in network_group['component_endpoints'] %}
+        - {{ network_group.name|upper }}
+{% endfor  %}
+{% else %}
+{% for network_group in scenario['network_groups']
+  if 'CLM' in network_group['component_endpoints'] or
+     'MANAGEMENT' in network_group['component_endpoints'] or
+     'EXTERNAL-API' in network_group['component_endpoints'] %}
+        - {{ network_group.name|upper }}
+{% endfor  %}
+{% endif %}
+      rules:
+      # open ICMP echo request (ping)
+      - type: allow
+{% if ipv6 == true %}
+        remote-ip-prefix:  ::/128
+{% else %}
+        remote-ip-prefix:  0.0.0.0/0
+{% endif %}
+        # icmp type
+        port-range-min: 8
+        # icmp code
+        port-range-max: 0
+        protocol: icmp
+
+{% if ipv6 == true %}
+    - name: NETCAT_IPv6
+      network-groups:
+{% for network_group in scenario['network_groups']
+  if 'MANAGEMENT' in network_group['component_endpoints'] %}
+        - {{ network_group.name|upper }}
+{% endfor  %}
+      rules:
+      - type: allow
+        remote-ip-prefix:  ::128
+        port-range-min: 11382
+        port-range-max: 11382
+        protocol: tcp
+{% endif %}
 
     - name: NETCAT
       network-groups:
@@ -75,16 +150,45 @@
         port-range-max: 11382
         protocol: tcp
 
-    - name: FRONTAIL
+{% if ipv6 == true %}
+    - name: FRONTAIL_CLM
       network-groups:
 {% for network_group in scenario['network_groups']
   if 'CLM' in network_group['component_endpoints'] or
-     'EXTERNAL-API' in network_group['component_endpoints'] %}
+     'MANAGEMENT' in network_group['component_endpoints'] %}
         - {{ network_group.name|upper }}
-{% endfor  %}
+{% endfor %}
       rules:
       - type: allow
         remote-ip-prefix:  0.0.0.0/0
+        port-range-min: 9091
+        port-range-max: 9091
+        protocol: tcp
+{% endif %}
+
+    - name: FRONTAIL
+      network-groups:
+{% if ipv6 == true %}
+{% for network_group in scenario['network_groups']
+  if 'MANAGEMENT' in network_group['component_endpoints'] or
+     'EXTERNAL-API' in network_group['component_endpoints'] %}
+        - {{ network_group.name|upper }}
+{% endfor  %}
+{% else %}
+{% for network_group in scenario['network_groups']
+  if 'CLM' in network_group['component_endpoints'] or
+     'MANAGEMENT' in network_group['component_endpoints'] or
+     'EXTERNAL-API' in network_group['component_endpoints'] %}
+        - {{ network_group.name|upper }}
+{% endfor  %}
+{% endif %}
+      rules:
+      - type: allow
+{% if ipv6 == true %}
+        remote-ip-prefix:  ::/128
+{% else    %}
+        remote-ip-prefix:  0.0.0.0/0
+{% endif %}
         port-range-min: 9091
         port-range-max: 9091
         protocol: tcp

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
@@ -36,10 +36,20 @@
 {%   if network_group['tagged_vlan']|default(True) %}
       vlanid: {{ ns.net_id }}
 {%   endif %}
-      tagged-vlan: {{ network_group['tagged_vlan']|default('True')|lower }}
+      tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
+{%   if ipv6 == true %}
+{%   if ns.net_id != 100 %}
+      cidr: fc00:0:0:{{ ns.net_id }}::/64
+      gateway-ip: fc00:0:0:{{ ns.net_id }}::1
+{%   else %}
       cidr: 192.168.{{ ns.net_id }}.0/24
       gateway-ip: 192.168.{{ ns.net_id }}.1
-{%  endif %}
+{%   endif %}
+{%   else  %}
+      cidr: 192.168.{{ ns.net_id }}.0/24
+      gateway-ip: 192.168.{{ ns.net_id }}.1
+{%   endif %}
+{%   endif %}
       network-group: {{ network_group.name|upper }}
 
 {%   set ns.net_id = ns.net_id+1 %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -45,29 +45,47 @@
 {% for network_group in scenario.network_groups %}
 {%   if 'NEUTRON-VLAN' in network_group.component_endpoints %}
 {%     set ns.physnet_id = ns.physnet_id+1 %}
+
           - name: NEUTRON-{{ network_group.name|upper }}-VLAN-NET
             provider:
               - network_type: vlan
                 physical_network: physnet{{ ns.physnet_id }}
                 segmentation_id: {{ ns.vlan_id }}
-            cidr: 172.{{ ns.net_id }}.1.0/24
             no_gateway:  True
             enable_dhcp: True
+{% if ipv6 == true %}
+            cidr: fc00:0:0:{{ ns.net_id }}::/64
+            allocation_pools:
+              - start: fc00:0:0:{{ ns.net_id }}::10
+                end: fc00:0:0:{{ ns.net_id }}::250
+            host_routes:
+              # route to management network
+              - destination: fc00:0:0:{{ ns.mgmt_net_id }}::/64
+                nexthop:  fc00:0:0:{{ ns.net_id }}::1
+{%     set ns.net_id = ns.net_id+1 %}
+{%     set ns.vlan_id = ns.vlan_id+1 %}
+{% else %}
+            cidr: 172.{{ ns.net_id }}.1.0/24
             allocation_pools:
               - start: 172.{{ ns.net_id }}.1.10
                 end: 172.{{ ns.net_id }}.1.250
             host_routes:
-              # route to management network
+            # route to management network
               - destination: 192.168.{{ ns.mgmt_net_id }}.0/24
                 nexthop:  172.{{ ns.net_id }}.1.1
-
 {%     set ns.net_id = ns.net_id+1 %}
 {%     set ns.vlan_id = ns.vlan_id+1 %}
+{%   endif %}
 {%   endif %}
 {% endfor %}
         neutron_external_networks:
 {% for network_group in scenario.network_groups if 'NEUTRON-EXT' in network_group.component_endpoints %}
           - name: ext-net{{ loop.index0 | ternary(loop.index0, '') }}
+{% if ipv6 == true %}
+            cidr: fc00:0:0:{{ ns.net_id }}::/64
+            gateway-ip: fc00:0:0:{{ ns.net_id }}::1
+{%     set ns.net_id = ns.net_id+1 %}
+{% else %}
             cidr: 172.{{ ns.net_id }}.0.0/16
             gateway: 172.{{ ns.net_id }}.0.1
 {%   if not enable_external_network_bridge %}
@@ -76,5 +94,6 @@
               physical_network: external{{ loop.index0 | ternary(loop.index0, '') }}
 {%   endif %}
 {%   set ns.net_id = ns.net_id+1 %}
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/compact.yml
@@ -16,6 +16,13 @@
 ---
 
 network_groups:
+  - name: MANAGEMENT
+    hostname_suffix: mgmt
+    tagged_vlan: false
+    component_endpoints:
+      - MANAGEMENT
+      - INTERNAL-API
+
   - name: EXTERNAL-API
     hostname_suffix: extapi
     tagged_vlan: true
@@ -23,13 +30,6 @@ network_groups:
       - EXTERNAL-API
     routes:
       - default
-
-  - name: MANAGEMENT
-    hostname_suffix: mgmt
-    tagged_vlan: false
-    component_endpoints:
-      - MANAGEMENT
-      - INTERNAL-API
 
   - name: EXTERNAL-VM
     hostname_suffix: extvm


### PR DESCRIPTION
- This PR enables user to create IPv6 mix-mode virtual deployment. Mix-mode deployment is using ipv4 network for the deployment/management purpose as accessing ECP over ipv6 is not yet possible. Other reasons are accessing internal repo, dns & ntp services over IPv6.  All other cloud  deployment networks (EXTERNAL-API, GUEST, STORAGE, etc) are being configured  to use ipv6.  

- Tested locally by generating input model and heat template for different scenarios (entry-scale-kvm, mid-scale, std-split, standard)
