### PR TITLE
openstack-ardana-gerrit: use dedicated workspace

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
   agent {
     node {
       label 'cloud-pipeline'
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
 


### PR DESCRIPTION
The openstack-ardana-gerrit job is currently reusing the
Jenkins workspace for all its builds, which causes conflicts
when multiple jobs are running in parallel.