### PR TITLE
openstack-ardana: fix std-min cloud8 jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -35,6 +35,7 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
+    model: std-min
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -84,6 +85,7 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: GM8+up
+    model: std-min
     triggers:
      - timed: 'H H * * *'
     jobs:


### PR DESCRIPTION
Adds missing `std-min` model parameter value.