### PR TITLE
Fix domain shut off test

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -466,7 +466,7 @@ function setupadmin
 
 function wait_for_node_shutdown
 {
-    wait_for 150 1 "LC_ALL=C virsh domstate $1 | grep shut.off" "$1 node to shut down"
+    wait_for 150 1 "LC_ALL=C virsh domstate $1 | grep 'shut off'" "$1 node to shut down"
 }
 
 function remove_snapshot_volume


### PR DESCRIPTION
This patch fixes a test for when a virsh domain is shut down.
The old text was "shut.off", but virsh has since changed to "shut off".
This also fixes doing a snapshot, which first shuts the domain down.
Without this fix, snapshotting will fail after it asks the domain to shut
down.