### PR TITLE
openstack-ardana-gerrit: use develcloud cloudsource

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -95,7 +95,7 @@
     name: cloud-ardana8-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
-    cloudsource: stagingcloud8
+    cloudsource: develcloud8
     gerrit_change_ids: '4941'
     triggers:
      - timed: 'H H * * *'
@@ -106,7 +106,7 @@
     name: openstack-ardana-gerrit-cloud8
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
-    cloudsource: stagingcloud8
+    cloudsource: develcloud8
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
     triggers:
       - gerrit:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -128,6 +128,7 @@
     name: cloud-ardana9-job-gerrit-x86_64
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
+    cloudsource: develcloud9
     gerrit_change_ids: '4940'
     triggers:
      - timed: 'H H * * *'
@@ -138,6 +139,7 @@
     name: openstack-ardana-gerrit-cloud9
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: develcloud9
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
     triggers:
       - gerrit:

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
@@ -44,4 +44,4 @@
           predefined-parameters: |
             project=Devel:Cloud:{version}
             subproject=Staging
-            package_blacklist=ardana
+            package_blacklist=ardana venv

--- a/scripts/jenkins/ardana/gerrit/README.md
+++ b/scripts/jenkins/ardana/gerrit/README.md
@@ -102,11 +102,8 @@ package corresponds to the _stable/pike_ branch of the [keystone-ansible](http:/
 * every time a change is merged in Gerrit in one of these projects, the [ardana-trigger-trackupstream](https://ci.suse.de/job/ardana-trigger-trackupstream/)
 Jenkins job is triggered to rebuild the associated IBS package to reflect the latest sources in the Gerrit repository
 and the tracked git branch.
-* consequently, the automated testing validating open Gerrit changes always use the packages in the staging project
-as a baseline, to ensure the sources being tested correspond to the most recent Gerrit repository state available
-at the time the testing process starts. Even so, there is always a slight chance that some last minute
-Gerrit changes will not be included, but most of the time this will not negatively impact the CI process
-because it automatically takes care of Gerrit change dependencies.
+* consequently, the automated testing validating open Gerrit changes always builds packages corresponding to the most
+recent Gerrit repository state available at the time the testing process starts.
 
 ## Building test IBS packages
 
@@ -130,9 +127,13 @@ The process of building test RPM packages can be summarized as follows:
   * Gerrit changes that are not mapped to a corresponding IBS package according to
   [gerrit-settings.json](gerrit-settings.json) are skipped
   * all other changes are merged on top of the `test-branch` branch
-* finally, corresponding OBS packages are built, starting as copies of their existing IBS counterparts
-taken from the Cloud staging project (also taken from [gerrit-settings.json](gerrit-settings.json) unless
-otherwise specified), and updated to package the sources in the local git clones and the populated `test-branch` branch
+* finally, OBS packages corresponding to collected Gerrit changes are built, starting as copies of their existing IBS
+counterparts taken from the Cloud non-staging project (also configured in [gerrit-settings.json](gerrit-settings.json) unless
+otherwise specified), and updated to package the sources in the local git clones and the populated `test-branch` branch.
+Furthermore, remaining packages in the [gerrit-settings.json](gerrit-settings.json) list, that do not have corresponding
+Gerrit changes in the list of changes collected at the first step, are also updated to include the latest merged sources
+in Gerrit, where this is needed. 
+
 
 ## Posting Gerrit comments and/or labels
 

--- a/scripts/jenkins/ardana/gerrit/gerrit-settings.json
+++ b/scripts/jenkins/ardana/gerrit/gerrit-settings.json
@@ -45,11 +45,11 @@
   },
   "obs-project": {
     "master": {
-      "develproject": "Devel:Cloud:9:Staging",
+      "develproject": "Devel:Cloud:9",
       "repository": "SLE_12_SP4"
     },
     "stable/pike": {
-      "develproject": "Devel:Cloud:8:Staging",
+      "develproject": "Devel:Cloud:8",
       "repository": "SLE_12_SP3"
     }
   }


### PR DESCRIPTION
Use the develcloudX cloudsource for Gerrit jobs instead of
stagingcloudX. This will effectively isolate the Gerrit CI
from OpenStack package updates landing in IBS in the staging
project (*), while at the same time continuing to include the latest
Ardana ansible sources.

This PR comes as a continuation of #2903 . The final result of these two
PRs modifies Ardana Jenkins Gerrit jobs to use the following classes of packages, layered on top of eachother:
 - cloud baseline: Devel:Cloud:X packages, which are already validated by the Ardana IBS gating jobs
 - Ardana baseline: Ardana ansible packages rebuilt to correspond to the latest merged Gerrit repository sources, which are already validated individually by the Gerrit CI against the Devel:Cloud:X contents before they are merged
 - Gerrit changes being tested: Ardana ansible packages rebuilt to include the target open Gerrit change and all its dependencies

Given this new setup, if a Jenkins Gerrit integration job fails, the failure can only be caused by one of the Gerrit changes being tested, while the defects affecting the staging media will accumulate in the Devel:Cloud:X:Staging project until the Jenkins IBS gating job passes, without affecting the Gerrit CI (*). When a Gerrit change is made to address a breaking package update landed in the staging project, it must pass both the Gerrit CI and the Ardana IBS gating job, which means that it must be validated against both the staging and non-staging projects, which is an added advantage, because it forces developers to account for backwards-compatibility.   

(*) non-VENV OpenStack package updates landing in IBS in the non-staging project may still break the Gerrit CI, as they are not validated against Ardana, only against Crowbar