### PR TITLE
mkcloud-gating: exclude Ardana venv packages

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-gating-template.yaml
@@ -44,4 +44,4 @@
           predefined-parameters: |
             project=Devel:Cloud:{version}
             subproject=Staging
-            package_blacklist=ardana
+            package_blacklist=ardana venv


### PR DESCRIPTION
The Crowbar IBS gating job has been mistakingly submitting
Ardana venv packages to the non-staging IBS project, which
overlaps with the Ardana IBS gating job.