### PR TITLE
openstack-ardana-gerrit: fix dependency URL

### DIFF
--- a/scripts/jenkins/ardana/gerrit/gerrit.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit.py
@@ -147,7 +147,8 @@ class GerritChange(GerritApiCaller):
                                  for r in revision_obj['commit']['parents']]
         self.mergeable = self._change_object.get('mergeable', False)
         self.submittable = self._change_object.get('submittable', False)
-        self.gerrit_url = "{}/{}/{}".format(GERRIT_URL, self.id, self.patchset)
+        self.gerrit_url = "{}/#/c/{}/{}".format(GERRIT_URL, self.id,
+                                                self.patchset)
 
     def _find_dependency_headers(self):
         if self._dependency_headers is not None:


### PR DESCRIPTION
The message posted by Jenkins when a dependency change is updated
was using an incorrect URL, e.g.:

SUSE Jenkins Gerrit
Patch Set 1: -Verified
Needs recheck. New patchset 2 was published for direct dependency: https://gerrit.suse.provo.cloud/5259/2

This commit fixes the URL.