### PR TITLE
openstack-ardana-gerrit: fix cloudsource check

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -74,7 +74,7 @@ The following links can also be used to track the results:
 
     stage('integration test') {
       when {
-        expression { cloudsource == 'stagingcloud9' }
+        expression { cloudsource == 'develcloud9' }
       }
       steps {
         script {
@@ -115,7 +115,7 @@ The following links can also be used to track the results:
           # Post reviews only for jobs triggered by Gerrit
           if [ -n "$GERRIT_CHANGE_NUMBER" ] ; then
             if [[ $BUILD_RESULT == SUCCESS ]]; then
-              if [[ $cloudsource == stagingcloud9 ]]; then
+              if [[ $cloudsource == develcloud9 ]]; then
                 vote=+2
               else
                 vote=0
@@ -125,7 +125,7 @@ Build succeeded (${JOB_NAME}): ${BUILD_URL}
 
 "
             else
-              if [[ $cloudsource == stagingcloud9 ]]; then
+              if [[ $cloudsource == develcloud9 ]]; then
                 vote=-2
               else
                 vote=-1

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -53,7 +53,7 @@
 
       - string:
           name: cloudsource
-          default: '{cloudsource|stagingcloud9}'
+          default: '{cloudsource|develcloud9}'
           description: >-
             The cloud repository (from provo-clouddata) to be used for testing.
             This value can take the following form:


### PR DESCRIPTION
Fix the cloudsource check which decides for which branch the
integration tests are run and how the Gerrit job votes on
Gerrit changes (broken with the recent commit that switched
the Gerrit CI from `stagingcloudX` to `develcloudX`)