### PR TITLE
openstack-ardana: disable LVM for GM8

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -24,7 +24,7 @@ want_caasp: False
 virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
 virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 
-want_lvm: True
+want_lvm: "{{ when_staging_or_devel or not when_cloud8 }}"
 # use different flavors and images when LVM support is enabled:
 #  - LVM enabled images have the root partition set up as an LVM volume
 #  - LVM enabled flavors have a smaller disk size for generated input models,


### PR DESCRIPTION
Until the root LV name patch [1] is released as a maintenance
update, the GM8 media cannot be tested with the LVM root
partition feature enabled.

[1] https://gerrit.suse.provo.cloud/5143