### PR TITLE
openstack-ardana: exclude SLES12-SP3-SDK on bare-metal

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -31,3 +31,11 @@ versioned_features:
   # FIXME: Remove this entry when bsc#1110414 fixed
   fix_ardana_ssh_keyscan:
     enabled: "{{ when_cloud9M3 }}"
+  # As a temporary solution to the problem of python-devel/python-base package mismatch
+  # between the SLES12SP4 base image and the released SLES12SP4-SDK ISO, the
+  # SP3 SDK-Updates repo is also included alongside SLES12SP4-SDK repos when the SP4 LVM
+  # image is used
+  # FIXME: Remove this entry when python-devel isn't required by QA/tempest test cases anymore
+  add_sdk_sp3_repo:
+    enabled: "{{ when_cloud9 and not is_physical_deploy }}"
+

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -42,10 +42,6 @@ ardana_qe_tests_requires:
 sles_sdk_repos:
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
-  # As a temporary solution to the problem of python-devel/python-base package mismatch
-  # between the SLES12SP4 base image and the released SLES12SP4-SDK ISO, the
-  # SP3 SDK-Updates repo is also included
-  - "SLE{{ ansible_distribution_major_version }}-SP3-SDK-Updates"
 
 ardana_qe_test_run_filters: "{{ role_path }}/files/run_filters/{{ test_name }}"
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/qe_test_requires.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/qe_test_requires.yml
@@ -15,6 +15,10 @@
 #
 
 ---
+- name: Include SLES12-SP3-SDK-Update repo
+  set_fact:
+    sles_sdk_repos: "{{ sles_sdk_repos+['SLE12-SP3-SDK-Updates'] }}"
+  when: versioned_features.add_sdk_sp3_repo
 
 - name: Ensure SLES-SDK repos {{ ardana_qe_tests_requires_state }}
   zypper_repository:

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -33,7 +33,3 @@ os_health_requires:
 sles_sdk_repos:
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
-  # As a temporary solution to the problem of python-devel/python-base package mismatch
-  # between the SLES12SP4 base image and the released SLES12SP4-SDK ISO, the
-  # SP3 SDK-Updates repo is also included
-  - "SLE{{ ansible_distribution_major_version }}-SP3-SDK-Updates"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
@@ -15,6 +15,10 @@
 #
 
 ---
+- name: Include SLES12-SP3-SDK-Update repo
+  set_fact:
+    sles_sdk_repos: "{{ sles_sdk_repos+['SLE12-SP3-SDK-Updates'] }}"
+  when: versioned_features.add_sdk_sp3_repo
 
 - name: Ensure SLES-SDK repos {{ os_health_requires_state }}
   zypper_repository:


### PR DESCRIPTION
As a temporary solution to the problem of python-devel/python-base
package mismatch between the SLES12SP4 base image and the released
SLES12SP4-SDK ISO, the SP3 SDK-Updates repo is also included alongside
SLES12SP4-SDK repos. This must only be used with the cloud9 virtual
cloud deployments, however.