### PR TITLE
openstack-ardana: disable LVM for GM8 cloudsources 

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -24,7 +24,7 @@ want_caasp: False
 virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
 virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 
-want_lvm: True
+want_lvm: "{{ versioned_features.want_lvm.enabled }}"
 # use different flavors and images when LVM support is enabled:
 #  - LVM enabled images have the root partition set up as an LVM volume
 #  - LVM enabled flavors have a smaller disk size for generated input models,

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -15,11 +15,11 @@
 #
 ---
 
-when_staging: "{{ cloud_source | default(cloudsource) is match('.*staging.*') }}"
-when_staging_or_devel: "{{ cloud_source | default(cloudsource) is match('.*(staging|devel).*') }}"
-when_cloud8: "{{ cloud_source | default(cloudsource) is match('.*8.*') }}"
-when_cloud9: "{{ cloud_source | default(cloudsource) is match('.*9.*') }}"
-when_cloud9M3: "{{ cloud_source | default(cloudsource) is match('cloud9M3') }}"
+when_staging: "{{ cloudsource is match('.*staging.*') }}"
+when_staging_or_devel: "{{ cloudsource is match('.*(staging|devel).*') }}"
+when_cloud8: "{{ cloudsource is match('.*8.*') }}"
+when_cloud9: "{{ cloudsource is match('.*9.*') }}"
+when_cloud9M3: "{{ cloudsource is match('cloud9M3') }}"
 
 versioned_features:
   manila:

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -31,3 +31,7 @@ versioned_features:
   # FIXME: Remove this entry when bsc#1110414 fixed
   fix_ardana_ssh_keyscan:
     enabled: "{{ when_cloud9M3 }}"
+  # Disable LVM on virtual deployments with GM8* cloudsources
+  # until https://gerrit.suse.provo.cloud/#/c/5143/ gets released
+  want_lvm:
+    enabled: "{{ when_staging_or_devel or not when_cloud8 }}"

--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
@@ -16,15 +16,16 @@
 ---
 
 # List of tools required for partition resizing
-part_resize_tools:
-  basic:
-    - fdisk
-    - parted
-    - growpart
-  lvm:
-    - lvdisplay
-    - lvs
-    - vgs
+resize_tools: "{{ root_mount.device.startswith('/dev/mapper') | ternary (basic_resize_tools + lvm_resize_tools, basic_resize_tools) }}"
+basic_resize_tools:
+  - fdisk
+  - parted
+  - growpart
+
+lvm_resize_tools:
+  - lvdisplay
+  - lvs
+  - vgs
 
 # if / is not on bootable partition, updated dynamically otherwise
 sles_vm_fdisk_start_field: 2

--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
@@ -24,15 +24,6 @@
   set_fact:
     root_mount: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | first }}"
 
-- name: Set list of required tools
-  set_fact:
-    _required_tools: >
-      {%- set _req_tools = part_resize_tools.basic -%}
-      {%- if root_mount.device.startswith('/dev/mapper') -%}
-      {%-   set _ = _req_tools.extend(part_resize_tools.lvm) -%}
-      {%- endif -%}
-      {{- _req_tools -}}
-
 - name: Check for required tools
   shell: >
     command -v {{ item }}
@@ -40,9 +31,7 @@
   changed_when: False
   failed_when:
     - _which_result.rc > 1
-  with_items: "{{ _required_tools }}"
-  when:
-    - root_mount.device.startswith('/dev/mapper')
+  loop: "{{ resize_tools }}"
 
 - name: Fail if required tools not found
   fail:
@@ -120,8 +109,6 @@
 - name: Extract root fs base device
   set_fact:
     root_fs_base_dev: "/dev/{{ _root_dev_sys_block_result.stdout | dirname | basename }}"
-  when:
-    - root_mount.device.startswith('/dev/mapper')
 
 - name: Determine root fs device partition
   command: >


### PR DESCRIPTION
Disable LVM on virtual deployments with GM8* cloudsources until https://gerrit.suse.provo.cloud/#/c/5143 gets released.

This PR also includes a fix for `setup_root_partition` role and a cleanup on the versioned conditional variables.