### PR TITLE
openstack-ardana: move root_mount to role defaults

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
@@ -15,6 +15,8 @@
 #
 ---
 
+root_mount: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | first }}"
+
 # List of tools required for partition resizing
 resize_tools: "{{ root_mount.device.startswith('/dev/mapper') | ternary (basic_resize_tools + lvm_resize_tools, basic_resize_tools) }}"
 basic_resize_tools:

--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
@@ -20,10 +20,6 @@
 # the file system layout settings defined in the input model.
 ---
 
-- name: Get root fs mount details
-  set_fact:
-    root_mount: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | first }}"
-
 - name: Check for required tools
   shell: >
     command -v {{ item }}


### PR DESCRIPTION
Following @rtamalin suggestion, this change moves `root_mount` variable to
`defaults.yml` as it makes more sense when this variable is used to define
`resize_tools` which is also in `defaults.yml`