### PR TITLE
openstack-ardana: automate SLES image update (SCRD-5116)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -259,3 +259,13 @@
                   branch-pattern: 'stable/pike'
     jobs:
         - '{ardana_gerrit_job}'
+
+- project:
+    name: cloud-ardana8-job-image-update
+    ardana_image_update_job: '{name}'
+    triggers:
+    openstack_ardana_job: cloud-ardana8-job-std-min-x86_64
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images_SLE_12_SP3/ardana-jeos-SLE12SP3.x86_64.qcow2.xz
+    sles_image: cleanvm-jeos-lvm-SLE12SP3
+    jobs:
+        - '{ardana_image_update_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -239,3 +239,13 @@
                   branch-pattern: 'master'
     jobs:
         - '{ardana_gerrit_job}'
+
+- project:
+    name: cloud-ardana9-job-image-update
+    ardana_image_update_job: '{name}'
+    triggers:
+    openstack_ardana_job: cloud-ardana9-job-std-min-x86_64
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images_SLE_12_SP4/ardana-jeos-SLE12SP4.x86_64.qcow2.xz
+    sles_image: cleanvm-jeos-lvm-SLE12SP4
+    jobs:
+        - '{ardana_image_update_job}'

--- a/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-vcloud.yaml
@@ -263,6 +263,13 @@
           description: >-
             Use ipv6 networks in the cloud input model.
 
+      - string:
+          name: sles_image
+          default: ''
+          description: >-
+            Use this parameter to override the default SLES OpenStack image used for SLES
+            virtual cloud nodes.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
@@ -1,0 +1,89 @@
+/**
+ * The openstack-ardana-image-update Jenkins Pipeline
+ * This job automates updating the base SLES image used by virtual cloud nodes.
+ */
+
+pipeline {
+  // skip the default checkout, because we want to use a custom path
+  options {
+    skipDefaultCheckout()
+    timestamps()
+  }
+
+  agent {
+    node {
+      label 'cloud-ardana-ci'
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
+    }
+  }
+
+  stages {
+
+    stage('Setup workspace') {
+      steps {
+        script {
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${sles_image}"
+        }
+      }
+    }
+
+    stage('upload new image version') {
+      steps {
+        sh '''
+          wget -qO- ${download_image_url} | xz -d > ${sles_image}.qcow2
+
+          # The cloud-ci user cannot create public images or change their
+          # membership; until that is resolved by updating its privileges,
+          # resort to doing everything twice, once for the 'cloud-ci'
+          # project and a second time for the 'cloud' project
+          for os_cloud in engcloud-cloud-ci-private engcloud-cloud-ci; do
+              openstack --os-cloud $os_cloud image show ${sles_image}-update && \
+                  openstack --os-cloud $os_cloud image delete ${sles_image}-update
+
+              openstack --os-cloud $os_cloud image create \
+                  --file ${sles_image}.qcow2 \
+                  --disk-format qcow2 \
+                  --container-format bare \
+                  --private \
+                  ${sles_image}-update
+          done
+        '''
+      }
+    }
+
+    stage('integration test') {
+      steps {
+        script {
+          def slaveJob = build job: openstack_ardana_job, parameters: [
+              string(name: 'sles_image', value: "${sles_image}-update"),
+              string(name: 'git_automation_repo', value: "$git_automation_repo"),
+              string(name: 'git_automation_branch', value: "$git_automation_branch")
+          ], propagate: true, wait: true
+        }
+      }
+    }
+  }
+  post {
+    success {
+      sh '''
+          # The cloud-ci user cannot create public images or change their
+          # membership; until that is resolved by updating its privileges,
+          # resort to doing everything twice, once for the 'cloud-ci'
+          # project and a second time for the 'cloud' project
+          for os_cloud in engcloud-cloud-ci-private engcloud-cloud-ci; do
+              openstack --os-cloud $os_cloud image set \
+                  --name ${sles_image}-$(date +%Y%m%d) \
+                  --deactivate \
+                  ${sles_image}
+
+              openstack --os-cloud $os_cloud image set \
+                  --name ${sles_image} \
+                  ${sles_image}-update
+          done
+      '''
+    }
+    cleanup {
+      cleanWs()
+    }
+  }
+}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-image-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-image-update-template.yaml
@@ -1,0 +1,53 @@
+- job-template:
+    name: '{ardana_image_update_job}'
+    project-type: pipeline
+    disabled: '{obj:disabled|False}'
+    concurrent: '{concurrent|False}'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 30
+
+    triggers: '{triggers}'
+
+    parameters:
+      - string:
+          name: sles_image
+          default: '{sles_image|}'
+          description: >-
+            The name of the cloud image that needs to be updated and tested
+
+      - string:
+          name: download_image_url
+          default: '{download_image_url|}'
+          description: >-
+            The URL pointing to the updated image file
+
+      - string:
+          name: openstack_ardana_job
+          default: '{openstack_ardana_job|openstack-ardana}'
+          description: >-
+            The Ardana job to use to validate the updated image
+
+      - string:
+          name: git_automation_repo
+          default: '{git_automation_repo|https://github.com/SUSE-Cloud/automation.git}'
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: '{git_automation_branch|master}'
+          description: >-
+            The git automation branch
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${{git_automation_repo}}
+            branches:
+              - ${{git_automation_branch}}
+            browser: auto
+            wipe-workspace: false
+      script-path: jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+      lightweight-checkout: false

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -440,6 +440,13 @@
           description: >-
             Use ipv6 networks in the cloud input model.
 
+      - string:
+          name: sles_image
+          default: ''
+          description: >-
+            Use this parameter to override the default SLES OpenStack image used for SLES
+            virtual cloud nodes.
+
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
Create a `cloud-ardana8-job-image-update` and a
`cloud-ardana9-job-image-update` Jenkins job that takes
in a SLES image built in IBS [1] and updates the OpenStack
image configured in the ECP and used as a base SLES image
by the CI, after running a batch of integration test cases
on it.
 
Implements: SCRD-5116

[1] initially at https://build.suse.de/project/show/home:fmccarthy:ardana-images, then officially moved to https://build.suse.de/project/show/Devel:Cloud:Images