### PR TITLE
openstack-ardana: retry repository rsync when rc = 24

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
@@ -33,6 +33,10 @@
       - "--delete-delay"
   delegate_to: "{{ inventory_hostname }}"
   loop: "{{ cloud_maint_updates_list }}"
+  register: cloud_sync_result
+  retries: 5
+  until: cloud_sync_result.rc != 24
+  delay: 300
 
 - name: Rsync SLES MU repo(s)
   synchronize:
@@ -46,6 +50,10 @@
       - "--delete-delay"
   delegate_to: "{{ inventory_hostname }}"
   loop: "{{ sles_maint_updates_list }}"
+  register: sles_sync_result
+  retries: 5
+  until: sles_sync_result.rc != 24
+  delay: 300
 
 - name: Add cloud MU zypper repo(s)
   zypper_repository:

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_sles_cloud_repos.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_sles_cloud_repos.yml
@@ -46,6 +46,10 @@
       - "--delete-delay"
   delegate_to: "{{ inventory_hostname }}"
   loop: "{{ repos_to_sync }}"
+  register: sync_result
+  retries: 5
+  until: sync_result.rc != 24
+  delay: 300
 
 - name: Mount repos that are not frequently updated
   mount:


### PR DESCRIPTION
This change adds retries to rsync tasks on setup_zypper_repos role to prevent error: `rsync warning: some files vanished before they could be transferred (code 24) at main.c(1652) [generator=3.1.0]` which is recurring on CI.