### PR TITLE
qa_crowbarsetup.sh: check for broken marker also on Crowbar test updates

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -274,8 +274,10 @@ function addcloudmaintupdates
 
 function addcloudtestupdates
 {
-    add_mount "repos/$arch/SUSE-OpenStack-Cloud-$cloudrepover-Updates-test/" \
-        "$tftpboot_repos_dir/SUSE-OpenStack-Cloud-$cloudrepover-Updates-test/" "cloudtup"
+    if isrepoworking SUSE-OpenStack-Cloud-$cloudrepover-Updates-test ; then
+        add_mount "repos/$arch/SUSE-OpenStack-Cloud-$cloudrepover-Updates-test/" \
+            "$tftpboot_repos_dir/SUSE-OpenStack-Cloud-$cloudrepover-Updates-test/" "cloudtup"
+    fi
 }
 
 function addcloudpool


### PR DESCRIPTION
For about a month there is a broken test update in the SOC8 Updates
Test repository that breaks everything, and its not getting removed.
Allow to blacklist the -test update channel as well.