### PR TITLE
openstack-ardana: remove SDK SP3 repo hack

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -42,10 +42,6 @@ ardana_qe_tests_requires:
 sles_sdk_repos:
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
-  # As a temporary solution to the problem of python-devel/python-base package mismatch
-  # between the SLES12SP4 base image and the released SLES12SP4-SDK ISO, the
-  # SP3 SDK-Updates repo is also included
-  - "SLE{{ ansible_distribution_major_version }}-SP3-SDK-Updates"
 
 ardana_qe_test_run_filters: "{{ role_path }}/files/run_filters/{{ test_name }}"
 

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -33,7 +33,3 @@ os_health_requires:
 sles_sdk_repos:
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
   - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
-  # As a temporary solution to the problem of python-devel/python-base package mismatch
-  # between the SLES12SP4 base image and the released SLES12SP4-SDK ISO, the
-  # SP3 SDK-Updates repo is also included
-  - "SLE{{ ansible_distribution_major_version }}-SP3-SDK-Updates"


### PR DESCRIPTION
As a temporary solution to the problem of python-devel/python-base
package version mismatch between the SLES12-SP4 base image and the
released SLES12-SP4-SDK GM, the SP3 SDK-Updates repo was also included
before installing python-devel.

The root cause of the problem was identified as an incorrectly
built SLES12-SP4 image and was corrected by including the
`snapshot-SP4` repositories from SLE-12 update projects instead
of the `standard` ones [1], hence this hack is no longer required.

[1] https://build.suse.de/project/meta/home:fmccarthy:ardana-images