### PR TITLE
input-model-generator: re-enable external_network_bridge

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -35,3 +35,8 @@ versioned_features:
   # until https://gerrit.suse.provo.cloud/#/c/5143/ gets released
   want_lvm:
     enabled: "{{ when_staging_or_devel or not when_cloud8 }}"
+  # Keep using the deprecated external_network_bridge option with GM8*
+  # cloudsources until the http://bugzilla.suse.com/show_bug.cgi?id=1117198
+  # fix gets released
+  external_network_bridge:
+    enabled: "{{ when_cloud8 and not when_staging_or_devel }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
@@ -211,8 +211,8 @@ Specifying this macro adds the internal load-balancer to the network group.
 account and object servers. This macro expands into the swift component endpoints.
 * _NEUTRON-EXT_: configures the network group as a Neutron flat external network that will be used to provide external access 
 to VMs (via floating IP Addresses). When this macro is specified as a component endpoint, the generated network group
-will be tagged with `neutron.networks.flat` and a `neutron_external_networks` entry is generated and added to the Neutron
-configuration data corresponding to this network.
+will be tagged with `neutron.l3_agent.external_network_bridge` or `neutron.networks.flat`, depending on the `enable_external_network_bridge`
+global parameter value, and a `neutron_external_networks` entry is generated and added to the Neutron configuration data corresponding to this network.
 * _NEUTRON-VLAN_: configures the network group as a Neutron VLAN provider network. When this macro is specified as a
 component endpoint, the generated network group will be tagged with `neutron.networks.vlan` and a VLAN `neutron_provider_networks`
 entry is generated and added to the Neutron configuration data corresponding to this network. A route is also configured
@@ -318,7 +318,9 @@ either `bind` (default) or `powerdns`.
 * `disabled_services` : can be used to selectively exclude service components or entire service component
 groups from the generated input model. Accepts a regular expression as value (e.g. `freezer.*|logging.*`),
 which is used to filter out matching service components and service component groups.
-
+* `enable_external_network_bridge`: can be used to switch between using the deprecated `external_network_bridge`
+input model option to configure an external network and configuring a flat provider network to represent
+the external network.
 
 # Limitations
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -35,6 +35,8 @@ disabled_services: ""
 # in deployed clouds
 enable_extra_volume_groups: "{{ want_lvm }}"
 
+enable_external_network_bridge: "{{ versioned_features.external_network_bridge.enabled }}"
+
 cp_prefix: cp1
 max_host_prefix_len: "{{ 33-(cp_prefix|length) }}"
 host_prefix: "{{ ('ardana-' ~ ardana_env)[:max_host_prefix_len|int-1] if ardana_env is defined else 'ardana' }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/network_groups.yml
@@ -196,9 +196,13 @@
         # This is the network group that will be used to provide
         # external access to VMs (via floating IP Addresses)
         #
+{%       if enable_external_network_bridge %}
+        - neutron.l3_agent.external_network_bridge
+{%       else %}
         - neutron.networks.flat:
             provider-physical-network: external{{ ns.extnet_id | ternary(ns.extnet_id, '') }}
-{%       set ns.extnet_id = ns.extnet_id+1 %}
+{%         set ns.extnet_id = ns.extnet_id+1 %}
+{%       endif %}
 {%     endif %}
 {%     if 'NEUTRON-VLAN' in network_group['component_endpoints'] %}
 {%       set ns.physnet_id = ns.physnet_id+1 %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -24,9 +24,16 @@
       data:
 {% if bm_info is defined %}
         neutron_provider_networks:
-{{ bm_info.neutron.provider_networks | to_nice_yaml(indent=2) | indent(10, True) }}
+{{   bm_info.neutron.provider_networks | to_nice_yaml(indent=2) | indent(10, True) }}
         neutron_external_networks:
-{{ bm_info.neutron.external_networks | to_nice_yaml(indent=2) | indent(10, True) }}
+{%   for external_network in bm_info.neutron.external_networks %}
+          - {{ external_network | to_nice_yaml(indent=2) | indent(12, False) }}
+{%     if not enable_external_network_bridge and 'provider' not in external_network %}
+            provider:
+            - network_type: flat
+              physical_network: external{{ loop.index0 | ternary(loop.index0, '') }}
+{%     endif %}
+{%   endfor %}
 {% else %}
         neutron_provider_networks:
 {% set ns = namespace(mgmt_net_id=0, physnet_id=0, net_id=30, vlan_id=100+scenario.network_groups|length) %}
@@ -63,9 +70,11 @@
           - name: ext-net{{ loop.index0 | ternary(loop.index0, '') }}
             cidr: 172.{{ ns.net_id }}.0.0/16
             gateway: 172.{{ ns.net_id }}.0.1
+{%   if not enable_external_network_bridge %}
             provider:
             - network_type: flat
               physical_network: external{{ loop.index0 | ternary(loop.index0, '') }}
+{%   endif %}
 {%   set ns.net_id = ns.net_id+1 %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Keep using the `external_network_bridge` deprecated input
model option for GM8+up deployments until the bsc#1117198 fix
is released.

Also requires reverting https://gitlab.suse.de/cloud-qe/ardana-bm-info/merge_requests/7