### PR TITLE
qa_crowbarsetup: Rewrite Trove error message

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3016,7 +3016,7 @@ function deploy_single_proposal
             ;;
         trove)
             if iscloudver 9plus; then
-                echo "Trove is SOC 8- only. Skipping"
+                echo "Trove is only for SOC 8 and below. Skipping"
                 return
             fi
             ;;


### PR DESCRIPTION
The warning for attempting to deploy trove for Cloud 9+ read a little
strangely. Reword it.