### PR TITLE
heat-generator: fix default value for tagged-vlan

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -587,7 +587,7 @@ def generate_heat_model(input_model, virt_config):
     # Next, add global networks
     for network in input_model['networks'].itervalues():
         cidr = None
-        vlan = network['vlanid'] if network.get('tagged-vlan') else None
+        vlan = network['vlanid'] if network.get('tagged-vlan', True) else None
         gateway = IPAddress(
             network['gateway-ip']) if network.get('gateway-ip') else None
         if network.get('cidr'):

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
@@ -25,10 +25,10 @@
 {%  if bm_info is defined %}
 {{ bm_info.networks[network_group.name|replace('-', '_')|lower] | to_nice_yaml(indent=2) | indent(6, True) }}
 {%-  else -%}
-{%   if network_group['tagged_vlan']|default(False) %}
+{%   if network_group['tagged_vlan']|default(True) %}
       vlanid: {{ ns.net_id }}
 {%   endif %}
-      tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
+      tagged-vlan: {{ network_group['tagged_vlan']|default('True')|lower }}
       cidr: 192.168.{{ ns.net_id }}.0/24
       gateway-ip: 192.168.{{ ns.net_id }}.1
 {%  endif %}


### PR DESCRIPTION
The False default `tagged-vlan` value used by the heat generator did
not correspond to the default `tagged-vlan` value used in the
input models (True). This is causing external network connectivity
issues when the std-min input model is used.