### PR TITLE
Provide feedback for unmergeable changes

### DIFF
--- a/scripts/jenkins/ardana/gerrit/gerrit_merge.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit_merge.py
@@ -58,6 +58,10 @@ def gerrit_merge(change, dry_run=False):
         return 1
 
     if not check_all_dependencies_satisfied(change):
+        msg = "Unable to merge: Commit dependencies are not satisifed."
+        print(msg)
+        if not dry_run:
+            change.review(message=msg)
         return 1
 
     if not dry_run:


### PR DESCRIPTION
When a change is unable to be merged because of its dependencies not
being met we should provide feedback to the user. Other unmet
requirements (such as required labels etc) are already obvious in the
gerrit UI.

Fixes: SCRD-5890