### PR TITLE
to_ip: Fallback to resolving IPv6

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -27,7 +27,7 @@ function get_getent_hosts
 
 function to_ip6
 {
-    get_getent_hosts $1 ip6
+    echo "[$(get_getent_hosts $1 ip6)]"
 }
 
 function to_ip4
@@ -41,7 +41,7 @@ function to_ip
     if [ -z $ip ]; then
         ip=$(to_ip6 $1)
     fi
-    echo $ip
+    echo "$ip"
 }
 
 function to_fqdn

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -37,7 +37,11 @@ function to_ip4
 
 function to_ip
 {
-    to_ip4 $1
+    ip=$(to_ip4 $1)
+    if [ -z $ip ]; then
+        ip=$(to_ip6 $1)
+    fi
+    echo $ip
 }
 
 function to_fqdn


### PR DESCRIPTION
Currently to_ip only calls to_ip4 to resolve addresses using the
ahostsv4 database of getent's resolver. The code already supports
resolving IPv6 addresses using the ahostsv6 database, so fallback to
using that if IPv4 address is returned.