### PR TITLE
openstack-ardana: add more QA tests to entry-scale-kvm-qe102 job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -83,7 +83,9 @@
     sles_computes: '2'
     rhel_computes: '0'
     tempest_filter_list: 'ci'
-    qa_test_list: 'iverify,cinder,heat,magnum,neutron,nova-attach,nova_volume,nova_server,nova_services,nova_flavor,nova_image,tempest_cleanup'
+    qa_test_list: >-
+      iverify,cinder,heat,magnum,neutron,nova-attach,nova_volume,nova_server,
+      nova_services,nova_flavor,nova_image,tempest_cleanup
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -100,8 +102,16 @@
     controllers: '3'
     sles_computes: '2'
     rhel_computes: '0'
-    tempest_filter_list: 'ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,magnum,manila,monasca,network,neutron-api,swift'
-    qa_test_list: 'iverify,cinder,heat,magnum,neutron,nova-attach,nova_volume,nova_server,nova_services,nova_flavor,nova_image,tempest_cleanup'
+    tempest_filter_list: >-
+      ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,
+      magnum,manila,monasca,network,neutron-api,swift
+    qa_test_list: >-
+      iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,
+      heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,
+      nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,
+      barbican-functional,horizon,horizon_integration-tests,keystone-api,keystone-ldap,
+      keystone-k2k-config,keystone-websso-config,keystone-x509-config,
+      service-ansible-playbooks,enable_tls,tempest_cleanup
     rc_notify: 'true'
     triggers:
      - timed: 'H H * * *'


### PR DESCRIPTION
This change adds more QA tests to be run on the
`cloud-ardana9-job-entry-scale-kvm-qe102-x86_64` periodic job