### PR TITLE
openstack-ardana: flatten pipeline jobs

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -2,6 +2,8 @@
  * The openstack-ardana Jenkins Pipeline
  */
 
+def ardana_lib = null
+
 pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
@@ -53,28 +55,52 @@ pipeline {
             returnStdout: true,
             script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
           ).trim()
+          sh('''
+            rm -rf "$SHARED_WORKSPACE"
+            mkdir -p "$SHARED_WORKSPACE"
+
+            # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
+            ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
+
+            cd $SHARED_WORKSPACE
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            cd automation-git
+
+            if [ -n "$github_pr" ] ; then
+              scripts/jenkins/ardana/pr-update.sh
+            fi
+
+            source scripts/jenkins/ardana/jenkins-helper.sh
+            ansible_playbook load-job-params.yml \
+              -e jjb_file=$SHARED_WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml \
+              -e jjb_type=job-template
+            ansible_playbook notify-rc-pcloud.yml -e @input.yml
+          ''')
+          ardana_lib = load "$SHARED_WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
         }
-        sh('''
-          rm -rf "$SHARED_WORKSPACE"
-          mkdir -p "$SHARED_WORKSPACE"
+      }
+    }
 
-          # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
-          ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
+    stage('Prepare input model') {
+      steps {
+        script {
+          if (scenario_name != '') {
+            ardana_lib.ansible_playbook('generate-input-model')
+          } else {
+            ardana_lib.ansible_playbook('clone-input-model')
+          }
+        }
+      }
+    }
 
-          cd $SHARED_WORKSPACE
-          git clone $git_automation_repo --branch $git_automation_branch automation-git
-          cd automation-git
-
-          if [ -n "$github_pr" ] ; then
-            scripts/jenkins/ardana/pr-update.sh
-          fi
-
-          source scripts/jenkins/ardana/jenkins-helper.sh
-          ansible_playbook load-job-params.yml \
-            -e jjb_file=$SHARED_WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml \
-            -e jjb_type=job-template
-          ansible_playbook notify-rc-pcloud.yml -e @input.yml
-        ''')
+    stage('Generate heat template') {
+      when {
+        expression { cloud_type == 'virtual' }
+      }
+      steps {
+        script {
+          ardana_lib.ansible_playbook('generate-heat-template')
+        }
       }
     }
 
@@ -82,98 +108,29 @@ pipeline {
       // abort all stages if one of them fails
       failFast true
       parallel {
-        stage('Prepare BM cloud') {
+
+        stage('Start bare-metal deployer VM') {
           when {
             expression { cloud_type == 'physical' }
           }
           steps {
             script {
-              def slaveJob = build job: 'openstack-ardana-pcloud', parameters: [
-                  string(name: 'ardana_env', value: "$ardana_env"),
-                  string(name: 'scenario_name', value: "$scenario_name"),
-                  string(name: 'clm_model', value: "$clm_model"),
-                  string(name: 'controllers', value: "$controllers"),
-                  string(name: 'core_nodes', value: "$core_nodes"),
-                  string(name: 'lmm_nodes', value: "$lmm_nodes"),
-                  string(name: 'dbmq_nodes', value: "$dbmq_nodes"),
-                  string(name: 'neutron_nodes', value: "$neutron_nodes"),
-                  string(name: 'swift_nodes', value: "$swift_nodes"),
-                  string(name: 'sles_computes', value: "$sles_computes"),
-                  string(name: 'rhel_computes', value: "$rhel_computes"),
-                  string(name: 'disabled_services', value: "$disabled_services"),
-                  string(name: 'rc_notify', value: "$rc_notify"),
-                  string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                  string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                  string(name: 'reuse_node', value: "${NODE_NAME}")
-              ], propagate: false, wait: true
-              def jobResult = slaveJob.getResult()
-              def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
-              def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
-              echo jobMsg
-              if (jobResult != 'SUCCESS') {
-                 error(jobMsg)
-              }
-
-              // Load the environment variables set by the downstream job
-              env.DEPLOYER_IP = slaveJob.buildVariables.DEPLOYER_IP
-              currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
-              echo """
-******************************************************************************
-** The deployer for the '${ardana_env}' physical environment is reachable at:
-**
-**        ssh root@${DEPLOYER_IP}
-**
-******************************************************************************
-              """
+              ardana_lib.ansible_playbook('start-deployer-vm')
             }
           }
         }
 
-        stage('Prepare virtual cloud') {
-          when {
-            expression { cloud_type == 'virtual' }
-          }
+        stage('Create heat stack') {
           steps {
             script {
-              def slaveJob = build job: 'openstack-ardana-vcloud', parameters: [
-                  string(name: 'ardana_env', value: "$ardana_env"),
-                  string(name: 'model', value: "$model"),
-                  string(name: 'scenario_name', value: "$scenario_name"),
-                  string(name: 'clm_model', value: "$clm_model"),
-                  string(name: 'controllers', value: "$controllers"),
-                  string(name: 'core_nodes', value: "$core_nodes"),
-                  string(name: 'lmm_nodes', value: "$lmm_nodes"),
-                  string(name: 'dbmq_nodes', value: "$dbmq_nodes"),
-                  string(name: 'neutron_nodes', value: "$neutron_nodes"),
-                  string(name: 'swift_nodes', value: "$swift_nodes"),
-                  string(name: 'sles_computes', value: "$sles_computes"),
-                  string(name: 'rhel_computes', value: "$rhel_computes"),
-                  string(name: 'disabled_services', value: "$disabled_services"),
-                  string(name: 'rc_notify', value: "$rc_notify"),
-                  string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                  string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                  string(name: 'reuse_node', value: "${NODE_NAME}"),
-                  string(name: 'os_cloud', value: "$os_cloud")
-              ], propagate: false, wait: true
-              def jobResult = slaveJob.getResult()
-              def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
-              def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
-              echo jobMsg
-              if (jobResult != 'SUCCESS') {
-                 error(jobMsg)
-              }
-
-              // Load the environment variables set by the downstream job
-              env.DEPLOYER_IP = slaveJob.buildVariables.DEPLOYER_IP
-              currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
-              echo """
-******************************************************************************
-** The deployer for the '${ardana_env}' virtual environment is reachable at:
-**
-**        ssh root@${DEPLOYER_IP}
-**
-******************************************************************************
-              """
+              ardana_lib.trigger_build('openstack-ardana-heat', [
+                string(name: 'ardana_env', value: "$ardana_env"),
+                string(name: 'heat_action', value: "create"),
+                string(name: 'git_automation_repo', value: "$git_automation_repo"),
+                string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                string(name: 'reuse_node', value: "${NODE_NAME}"),
+                string(name: 'os_cloud', value: "$os_cloud")
+              ], false)
             }
           }
         }
@@ -184,80 +141,48 @@ pipeline {
           }
           steps {
             script {
-              def slaveJob = build job: 'openstack-ardana-testbuild-gerrit', parameters: [
-                  string(name: 'gerrit_change_ids', value: "$gerrit_change_ids"),
-                  string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                  string(name: 'git_automation_branch', value: "$git_automation_branch")
-              ], propagate: false, wait: true
-
-              def jobResult = slaveJob.getResult()
-              def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
-              def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
-              echo jobMsg
-              if (jobResult != 'SUCCESS') {
-                 error(jobMsg)
+              def slaveJob = ardana_lib.trigger_build('openstack-ardana-testbuild-gerrit', [
+                string(name: 'gerrit_change_ids', value: "$gerrit_change_ids"),
+                string(name: 'git_automation_repo', value: "$git_automation_repo"),
+                string(name: 'git_automation_branch', value: "$git_automation_branch")
+              ], false)
+              env.test_repository_url = "http://download.suse.de/ibs/Devel:/Cloud:/Testbuild:/ardana-ci-${slaveJob.getNumber()}/standard/Devel:Cloud:Testbuild:ardana-ci-${slaveJob.getNumber()}.repo"
+              if (extra_repos == '') {
+                env.extra_repos = test_repository_url
+              } else {
+                env.extra_repos = "${test_repository_url},${extra_repos}"
               }
-
-              // Load the environment variables set by the downstream job
-              env.test_repository_url = slaveJob.buildVariables.test_repository_url
             }
           }
         }
+
       } // parallel
-    } // stage('parallel stage')
+    } // stage('Prepare infra and build package(s)')
+
+    stage('Setup SSH access') {
+      steps {
+        script {
+          ardana_lib.ansible_playbook('setup-ssh-access')
+          ardana_lib.get_deployer_ip()
+        }
+      }
+    }
 
     stage('Bootstrap CLM') {
       steps {
         script {
-          def slaveJob = build job: 'openstack-ardana-bootstrap-clm', parameters: [
-              string(name: 'ardana_env', value: "$ardana_env"),
-              string(name: 'cloudsource', value: "$cloudsource"),
-              string(name: 'updates_test_enabled', value: "$updates_test_enabled"),
-              string(name: 'maint_updates', value: "$maint_updates"),
-              string(name: 'extra_repos', value: "${env.test_repository_url ?: extra_repos}"),
-              string(name: 'rc_notify', value: "$rc_notify"),
-              string(name: 'git_automation_repo', value: "$git_automation_repo"),
-              string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              string(name: 'reuse_node', value: "${NODE_NAME}"),
-              string(name: 'os_cloud', value: "$os_cloud")
-          ], propagate: false, wait: true
-          def jobResult = slaveJob.getResult()
-          def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
-          def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
-          echo jobMsg
-          if (jobResult != 'SUCCESS') {
-             error(jobMsg)
-          }
+          ardana_lib.ansible_playbook('bootstrap-clm', "-e extra_repos='$extra_repos'")
         }
       }
     }
 
     stage('Bootstrap nodes') {
-      failFast true
-      parallel {
-        stage('Bootstrap BM nodes') {
-          when {
-            expression { cloud_type == 'physical' }
-          }
-          steps{
-            sh('''
-              cd $SHARED_WORKSPACE
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook bootstrap-pcloud-nodes.yml -e @input.yml
-            ''')
-          }
-        }
-
-        stage('Bootstrap virtual nodes') {
-          when {
-            expression { cloud_type == 'virtual' }
-          }
-          steps{
-            sh('''
-              cd $SHARED_WORKSPACE
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook bootstrap-vcloud-nodes.yml -e @input.yml
-            ''')
+      steps{
+        script {
+          if (cloud_type == 'virtual') {
+            ardana_lib.ansible_playbook('bootstrap-vcloud-nodes')
+          } else {
+            ardana_lib.ansible_playbook('bootstrap-pcloud-nodes')
           }
         }
       }
@@ -265,11 +190,9 @@ pipeline {
 
     stage('Deploy cloud') {
       steps {
-        sh('''
-          cd $SHARED_WORKSPACE
-          source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-          ansible_playbook deploy-cloud.yml -e @input.yml
-        ''')
+        script {
+          ardana_lib.ansible_playbook('deploy-cloud')
+        }
       }
     }
 
@@ -279,67 +202,31 @@ pipeline {
       }
       steps {
         script {
-          def slaveJob = build job: 'openstack-ardana-update', parameters: [
-            string(name: 'ardana_env', value: "$ardana_env"),
-            string(name: 'update_to_cloudsource', value: "$update_to_cloudsource"),
-            string(name: 'updates_test_enabled', value: "$updates_test_enabled"),
-            string(name: 'maint_updates', value: "$maint_updates"),
-            string(name: 'rc_notify', value: "$rc_notify"),
-            string(name: 'git_automation_repo', value: "$git_automation_repo"),
-            string(name: 'git_automation_branch', value: "$git_automation_branch"),
-            string(name: 'reuse_node', value: "${NODE_NAME}"),
-            string(name: 'os_cloud', value: "$os_cloud")
-          ], propagate: false, wait: true
-          def jobResult = slaveJob.getResult()
-          def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
-          def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
-          echo jobMsg
-          if (jobResult != 'SUCCESS') {
-             error(jobMsg)
-          }
+          ardana_lib.ansible_playbook('ardana-update', "-e cloudsource=$update_to_cloudsource")
         }
       }
     }
 
-    stage ('Run Tempest/QA tests') {
+    stage ('Prepare tests') {
       when {
-        expression { tempest_filter_list != '' || qa_test_list != '' }
+        expression { tempest_filter_list != '' || qa_test_list != '' || want_caasp == 'true' }
       }
       steps {
         script {
-          def slaveJob = build job: 'openstack-ardana-tests', parameters: [
-              string(name: 'ardana_env', value: "$ardana_env"),
-              string(name: 'tempest_filter_list', value: "$tempest_filter_list"),
-              string(name: 'qa_test_list', value: "$qa_test_list"),
-              string(name: 'rc_notify', value: "$rc_notify"),
-              string(name: 'git_automation_repo', value: "$git_automation_repo"),
-              string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              string(name: 'reuse_node', value: "${NODE_NAME}"),
-              string(name: 'os_cloud', value: "$os_cloud")
-          ], propagate: false, wait: true
-          def jobResult = slaveJob.getResult()
-          def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
-          def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
-          echo jobMsg
-          if (jobResult != 'SUCCESS') {
-             error(jobMsg)
+          // Generate stages for Tempest tests
+          ardana_lib.generate_tempest_stages(env.tempest_filter_list)
+          // Generate stages for QA tests
+          ardana_lib.generate_qa_tests_stages(env.qa_test_list)
+          // Generate stage for CaaSP deployment
+          if (want_caasp == 'true') {
+            stage('Deploy CaaSP') {
+              ardana_lib.ansible_playbook('deploy-caasp')
+            }
           }
         }
       }
     }
 
-    stage('Deploy CaaSP') {
-      when {
-        expression { want_caasp == 'true' }
-      }
-      steps {
-        sh('''
-          cd $SHARED_WORKSPACE
-          source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-          ansible_playbook deploy-caasp.yml -e @input.yml
-        ''')
-      }
-    }
   }
 
   post {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
@@ -1,0 +1,70 @@
+/**
+ * The openstack-ardana Jenkins pipeline library
+ */
+
+def ansible_playbook(playbook, params='') {
+  sh("""
+    cd $SHARED_WORKSPACE
+    source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+    ansible_playbook """+playbook+""".yml -e @input.yml """+params
+  )
+}
+
+def trigger_build(job_name, parameters, propagate=true, wait=true) {
+  def slaveJob = build job: job_name, parameters: parameters, propagate: propagate, wait: wait
+  if (wait && !propagate) {
+    def jobResult = slaveJob.getResult()
+    def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
+    def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
+    echo jobMsg
+    if (jobResult != 'SUCCESS') {
+      error(jobMsg)
+    }
+  }
+  return slaveJob
+}
+
+def get_deployer_ip() {
+  env.DEPLOYER_IP = sh (
+    returnStdout: true,
+    script: '''
+      grep -oP "^${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
+        $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+    '''
+  ).trim()
+  currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"
+  echo """
+******************************************************************************
+** The deployer for the '${ardana_env}' environment is reachable at:
+**
+**        ssh root@${DEPLOYER_IP}
+**
+******************************************************************************
+  """
+}
+
+def generate_tempest_stages(tempest_filter_list) {
+  for (filter in tempest_filter_list.split(',')) {
+    catchError {
+      stage("Tempest: "+filter) {
+        ansible_playbook('run-tempest', "-e tempest_run_filter=$filter")
+      }
+    }
+    archiveArtifacts artifacts: ".artifacts/**/ansible.log, .artifacts/**/*${filter}*", allowEmptyArchive: true
+    junit testResults: ".artifacts/testr_results_region1_${filter}.xml", allowEmptyResults: true
+  }
+}
+
+def generate_qa_tests_stages(qa_test_list) {
+  for (test in qa_test_list.split(',')) {
+    catchError {
+      stage("QA test: "+test) {
+        ansible_playbook('run-ardana-qe-tests', "-e test_name=$test")
+      }
+    }
+    archiveArtifacts artifacts: ".artifacts/**/${test}*", allowEmptyArchive: true
+    junit testResults: ".artifacts/${test}.xml", allowEmptyResults: true
+  }
+}
+
+return this

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
@@ -28,3 +28,8 @@ ardana_qe_test_venv_requires:
   - 'stestr'
 
 ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"
+
+dpdk: false
+dpdk_br: br-dpdk0
+octavia: false
+esx: false

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/remove_compute_node.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/remove_compute_node.yml
@@ -13,3 +13,4 @@ ardana_qe_test_venv_requires:
  #passed: "cat {{ ardana_qe_test_log }} | grep 'PASS' | wc -l"
 ardana_qe_test_get_failed_cmd: "grep -A 6 'FAIL' {{ ardana_qe_test_log }} || echo 'None'"
 
+type_of_compute: SLES-COMPUTE


### PR DESCRIPTION
This commit changes the way pipeline jobs are organized,
such that it minimizes the number of downstream jobs
being triggered. This is done by "merging" copies of the
`openstack-ardana-vcloud`, `openstack-ardana-pcloud`,
`openstack-ardana-tests`, `openstack-ardana-bootstrap-clm` 
and `openstack-ardana-update` jobs into their parent pipeline
jobs (`openstack-ardana` and `openstack-ardana-update-and-test`).

To reduce the duplication that comes from flattening
the pipeline jobs, a small groovy library was added,
containing a few functions reused by various pipeline
stages.

Advantages gained by this change in strategy:
 - jobs are easier to navigate and debug (everything is in
 view of a single job, the user isn't required to navigate
 the pipeline hierarchy to gather needed information anymore)
 - reduced number of workers required by a single pipeline job
 build
 - using a shared workspace is no longer a necessity, which also
 allows jobs to run on any number of agent nodes
 - introducing changes in the CI has a lower impact on existing
 running jobs, because the risk of triggering updated downstream
 jobs with incorrect parameters is much reduced
 - as a direct consequence of the above, testing CI changes before
 merge also gets easier
 - the possibility of generating and reporting stage-based results
 back to Gerrit is also simplified
 - simplifying pipelines is a first step towards generating Jenkinsfiles
 - jobs that were previously triggered downstream may now evolve separately
 from their parent jobs (i.e. have different parameters)

Downsides:
 - longer pipelines, especially when many tempest and QA test cases
 are executed
 - higher level of pipeline stage duplication (mitigated somewhat by
 using a shared groovy library)