### PR TITLE
Enable caasp-openstack-heat-templates tracking for Cloud 7

### DIFF
--- a/jenkins/ci.suse.de/cloud-trackupstream.yaml
+++ b/jenkins/ci.suse.de/cloud-trackupstream.yaml
@@ -79,8 +79,7 @@
             ].contains(project) &&
             [
               "openstack-dashboard-theme-HPE",
-              "documentation-suse-openstack-cloud",
-              "caasp-openstack-heat-templates"
+              "documentation-suse-openstack-cloud"
             ].contains(component)
           )
           ||


### PR DESCRIPTION
We now also ship caasp-openstack-heat-templates on Cloud 7 and therefore
have to track the package as well.