### PR TITLE
mkcloud: avoid malformatted ssh key injection

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -439,11 +439,11 @@ function setupadmin
     echo "Injecting public key into admin node..."
     local x keyfile
     for keyfile in ~/.ssh/*.pub ; do
-        local pubkey=`cat $keyfile`
+        local pubkey=$(< $keyfile)
         ssh_password root@$adminip "
             mkdir -p ~/.ssh;
             grep -q '$pubkey' ~/.ssh/authorized_keys 2>/dev/null ||
-                echo '$pubkey injected-from-host' >> ~/.ssh/authorized_keys
+                echo '$pubkey' >> ~/.ssh/authorized_keys
         "
     done
     if [[ $user_keyfile ]]; then


### PR DESCRIPTION
So far it appended a suffix which was never used for anything,
and with https://github.com/crowbar/crowbar-core/pull/1696 merged
it became more strict in what it accepted.