### PR TITLE
openstack-ardana: fix flattened pipeline stages

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -121,6 +121,9 @@ pipeline {
         }
 
         stage('Create heat stack') {
+          when {
+            expression { cloud_type == 'virtual' }
+          }
           steps {
             script {
               ardana_lib.trigger_build('openstack-ardana-heat', [

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
@@ -44,26 +44,30 @@ def get_deployer_ip() {
 }
 
 def generate_tempest_stages(tempest_filter_list) {
-  for (filter in tempest_filter_list.split(',')) {
-    catchError {
-      stage("Tempest: "+filter) {
-        ansible_playbook('run-tempest', "-e tempest_run_filter=$filter")
+  if (tempest_filter_list != '') {
+    for (filter in tempest_filter_list.split(',')) {
+      catchError {
+        stage("Tempest: "+filter) {
+          ansible_playbook('run-tempest', "-e tempest_run_filter=$filter")
+        }
       }
+      archiveArtifacts artifacts: ".artifacts/**/ansible.log, .artifacts/**/*${filter}*", allowEmptyArchive: true
+      junit testResults: ".artifacts/testr_results_region1_${filter}.xml", allowEmptyResults: true
     }
-    archiveArtifacts artifacts: ".artifacts/**/ansible.log, .artifacts/**/*${filter}*", allowEmptyArchive: true
-    junit testResults: ".artifacts/testr_results_region1_${filter}.xml", allowEmptyResults: true
   }
 }
 
 def generate_qa_tests_stages(qa_test_list) {
-  for (test in qa_test_list.split(',')) {
-    catchError {
-      stage("QA test: "+test) {
-        ansible_playbook('run-ardana-qe-tests', "-e test_name=$test")
+  if (qa_test_list != '') {
+    for (test in qa_test_list.split(',')) {
+      catchError {
+        stage("QA test: "+test) {
+          ansible_playbook('run-ardana-qe-tests', "-e test_name=$test")
+        }
       }
+      archiveArtifacts artifacts: ".artifacts/**/${test}*", allowEmptyArchive: true
+      junit testResults: ".artifacts/${test}.xml", allowEmptyResults: true
     }
-    archiveArtifacts artifacts: ".artifacts/**/${test}*", allowEmptyArchive: true
-    junit testResults: ".artifacts/${test}.xml", allowEmptyResults: true
   }
 }
 


### PR DESCRIPTION
Corrects two recently introduced issues with flattened pipeline stages:
- not addressing empty `tempest_filter_list` or `qa_test_list` values
- missing condition for 'Create heat stack' stage