### PR TITLE
openstack-ardana: generate pipeline build report follow-up

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -111,10 +111,9 @@ The following links can also be used to track the results:
         env.BUILD_RESULT = currentBuild.currentResult
         sh('''
           automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
-            -j $JOB_NAME -b $BUILD_NUMBER --recursive \
+            --recursive \
             --filter 'Declarative: Post Actions' \
-            --filter 'Setup workspace' \
-            pipeline-report.txt || :
+            --filter 'Setup workspace' > pipeline-report.txt || :
 
           # Post reviews only for jobs triggered by Gerrit
           if [ -n "$GERRIT_CHANGE_NUMBER" ] ; then

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -237,10 +237,9 @@ pipeline {
       script{
         sh('''
           automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
-            -j $JOB_NAME -b $BUILD_NUMBER --recursive \
+            --recursive \
             --filter 'Declarative: Post Actions' \
-            --filter 'Setup workspace' \
-            .artifacts/pipeline-report.txt || :
+            --filter 'Setup workspace' > .artifacts/pipeline-report.txt || :
         ''')
         archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
         if ( env.tempest_filter_list != null && tempest_filter_list != '' ) {


### PR DESCRIPTION
Following up on the commit that introduced the
`jenkins-job-pipeline-report.py` script, which generates
a summary report for a pipeline Jenkins job build:
 - addressed post-review feedback [1]
   - use stdout instead of dumping to file
   - other
 - improved the command line parameter handling
   - joined -j and -b into a single positional parameter
   - fall-back to using the JOB_NAME and BUILD_NUMBER
   environment variables if not explicitly provided
   - make the build number optional and use the latest
   build when not supplied

[1] https://github.com/SUSE-Cloud/automation/pull/3019#pullrequestreview-183576280