### PR TITLE
openstack-ardana: collect jUnit results just once

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -94,7 +94,6 @@ pipeline {
   post {
     always {
       archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
-      junit testResults: ".artifacts/*.xml", allowEmptyResults: true
     }
     cleanup {
       cleanWs()

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -242,9 +242,6 @@ pipeline {
             --filter 'Setup workspace' > .artifacts/pipeline-report.txt || :
         ''')
         archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
-        if ( env.tempest_filter_list != null && tempest_filter_list != '' ) {
-          junit testResults: ".artifacts/*.xml", allowEmptyResults: true
-        }
       }
       script{
         if (env.DEPLOYER_IP != null) {


### PR DESCRIPTION
The recent work done to 'flatten' the Ardana pipeline
job hierarchy created a situation which causes some jobs
to collect jUnit test case results twice.

This commit corrects that condition.