### PR TITLE
openstack-ardana: add Jenkins BUILD_URL to motd

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
@@ -1,4 +1,7 @@
 Built from: {{ built_from }}
+{% if lookup('env', 'BUILD_URL') %}
+Built by: {{ lookup('env', 'BUILD_URL') }}
+{% endif %}
 Media build version: {{ media_build_version }}
 Configured repositories:
 {% for repo in repos_to_add | sort %}


### PR DESCRIPTION
Adds the Jenkins job build URL to the motd generated
on the deployer node.