### PR TITLE
openstack-ardana-gerrit: enable integration for cloud8

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -61,9 +61,6 @@ The following links can also be used to track the results:
     }
 
     stage('integration test') {
-      when {
-        expression { cloudsource == 'develcloud9' }
-      }
       steps {
         script {
           // reserve a resource here for the openstack-ardana job, to avoid


### PR DESCRIPTION
Enables running integration testing for cloud8 Gerrit.