### PR TITLE
openstack-ardana: use ci.nue.suse.com URLs

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -31,8 +31,6 @@ input_model_path: "{{ workspace_path }}/input_model"
 is_physical_deploy: "{{ ardana_env in groups['qe_all'] }}"
 rc_notify: False
 
-jjb_file: "../../../../jenkins/ci.suse.de/{{ lookup('env', 'JOB_NAME') }}.yaml"
-
 suse_release: "suse-{{ ansible_distribution_version }}"
 local_repos_base_dir: "/srv/www/{{ suse_release }}/{{ ansible_architecture }}/repos"
 

--- a/scripts/jenkins/ardana/ansible/group_vars/all/jenkins.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/jenkins.yml
@@ -1,0 +1,6 @@
+jenkins_build_url: "{{ lookup('env', 'BUILD_URL') | replace('ci.suse.de', 'ci.nue.suse.com') }}"
+jenkins_artifacts_url: "{{ jenkins_build_url + 'artifact/.artifacts/' if jenkins_build_url else 'NA' }}"
+
+jenkins_artifacts_dir: "{{ lookup('env', 'WORKSPACE') }}/.artifacts"
+
+jjb_file: "../../../../jenkins/ci.suse.de/{{ lookup('env', 'JOB_NAME') }}.yaml"

--- a/scripts/jenkins/ardana/ansible/roles/jenkins_artifacts/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/jenkins_artifacts/defaults/main.yml
@@ -15,7 +15,5 @@
 #
 ---
 
-jenkins_artifacts_dir: "{{ lookup('env', 'WORKSPACE') }}/.artifacts"
-
 jenkins_artifacts_to_collect:
   - src: "~/.ansible/ansible.log"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
@@ -46,11 +46,10 @@ os_health_server: "10.86.0.167"
 os_health_url: "http://{{ os_health_server }}/#/job/{{ os_health_build_name }}"
 os_health_url_msg: "[{{ os_health_url }}]({{ os_health_url }})"
 
-ansible_log_url: "{{ lookup('env', 'BUILD_URL') }}artifact/.artifacts/ansible.log"
+ansible_log_url: "{{ jenkins_build_url }}artifact/.artifacts/ansible.log"
 ansible_log_url_msg: "[{{ ansible_log_url }}]({{ ansible_log_url }})"
 ansible_log_stream: "http://{{ hostvars[ardana_env].ansible_host if ardana_env in groups['all'] else 'NA' }}:9091/"
 ansible_log_stream_msg: "[{{ ansible_log_stream }}]({{ ansible_log_stream }})"
-jenkins_build_url: "{{ lookup('env', 'BUILD_URL') }}"
 jenkins_build_url_msg: "{{ (jenkins_build_url != '') | ternary('[' ~ jenkins_build_url ~ '](' ~ jenkins_build_url ~ ')', lookup('env', 'USER')) }}"
 
 rc_im_name: "{{ scenario_name | default(model) }}"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/main.yml
@@ -42,7 +42,7 @@
     attachments:
       - color: "{{ rc_msg_color }}"
         title: "{{ rc_msg_title }}"
-        title_link: "{{ lookup('env', 'BUILD_URL') }}console"
+        title_link: "{{ jenkins_build_url }}console"
         text:
         collapsed: "{{ rc_att_colapsed | default(False) }}"
         fields: "{{ rc_msg_fields_started if rc_action == 'started' else rc_msg_fields_finished }}"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/ardana-qe-tests.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/ardana-qe-tests.yml
@@ -16,7 +16,7 @@
 ---
 
 os_health_build_name: "{{ ardana_env }}_qa_{{ test_name }}"
-ardana_qe_test_log_url: "{{ lookup('env', 'BUILD_URL') }}artifact/.artifacts/{{ test_name }}.log"
+ardana_qe_test_log_url: "{{ jenkins_build_url }}artifact/.artifacts/{{ test_name }}.log"
 ardana_qe_test_log_url_msg: "[{{ ardana_qe_test_log_url }}]({{ ardana_qe_test_log_url }})"
 
 rc_att_colapsed: True
@@ -45,7 +45,7 @@ _rc_msg_fields_finished:
     value: "{{ ardana_qe_failed_tests.stdout if ardana_qe_failed_tests is defined else 'Timeout' if test_output is defined and test_output.rc == 124 else 'Not available' }}"
     short: False
   - title: Log
-    value: "{{ ardana_qe_test_log_url_msg if lookup('env', 'BUILD_URL') else 'Not available' }}"
+    value: "{{ ardana_qe_test_log_url_msg if jenkins_build_url else 'Not available' }}"
     short: False
   - title: Deployer
     value: "{{ hostvars[ardana_env].ansible_host }}"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/deploy.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/deploy.yml
@@ -59,7 +59,7 @@ _msg_fields_finished:
     value: "{{ cloud_media_build_version['stdout'] | default('Not available', true) }}"
     short: False
   - title: Log
-    value: "{{ ansible_log_url_msg if lookup('env', 'BUILD_URL') else 'Not available' }}"
+    value: "{{ ansible_log_url_msg if jenkins_build_url else 'Not available' }}"
     short: False
   - title: Deployer
     value: "{{ hostvars[ardana_env].ansible_host if ardana_env in groups['all'] else 'NA' }}"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/tempest.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/tempest.yml
@@ -16,7 +16,7 @@
 ---
 
 os_health_build_name: "{{ ardana_env }}_tempest_{{ tempest_run_filter }}"
-tempest_log_url: "{{ lookup('env', 'BUILD_URL') }}artifact/.artifacts/testr_results_region1_{{ tempest_run_filter }}.log"
+tempest_log_url: "{{ jenkins_build_url }}artifact/.artifacts/testr_results_region1_{{ tempest_run_filter }}.log"
 tempest_log_url_msg: "[{{ tempest_log_url }}]({{ tempest_log_url }})"
 
 rc_att_colapsed: True
@@ -48,7 +48,7 @@ rc_msg_fields_finished_temp:
     value: "{{ tempest_failed_tests.stdout if tempest_failed_tests is defined else 'Not available' }}"
     short: False
   - title: Tempest log
-    value: "{{ tempest_log_url_msg if lookup('env', 'BUILD_URL') else 'Not available' }}"
+    value: "{{ tempest_log_url_msg if jenkins_build_url else 'Not available' }}"
     short: False
   - title: Deployer
     value: "{{ hostvars[ardana_env].ansible_host }}"

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/update.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/update.yml
@@ -47,7 +47,7 @@ _msg_fields_finished:
     value: "{{ jenkins_build_url_msg }}"
     short: False
   - title: Log
-    value: "{{ ansible_log_url_msg if lookup('env', 'BUILD_URL') else 'Not available' }}"
+    value: "{{ ansible_log_url_msg if jenkins_build_url else 'Not available' }}"
     short: False
   - title: Deployer
     value: "{{ hostvars[ardana_env].ansible_host }}"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -15,7 +15,6 @@
 #
 ---
 
-jenkins_artifacts_url: "{{ lookup('env', 'BUILD_URL') + 'artifact/.artifacts/' if lookup('env', 'BUILD_URL') else 'NA' }}"
 clouddata_server: "provo-clouddata.cloud.suse.de"
 cloud_media_build_version: {}
 

--- a/scripts/jenkins/jenkins-job-pipeline-report.py
+++ b/scripts/jenkins/jenkins-job-pipeline-report.py
@@ -150,6 +150,7 @@ def generate_summary(server, job_name, build_number,
                         filter_stages, recursive, depth+1)
                     stage_url = server.get_pipeline_url(d_job_name,
                                                         d_build_number)
+        stage_url = stage_url.replace('ci.suse.de', 'ci.nue.suse.com')
         summary += '{}  - {}: {}{}\n'.format(
             ' '*depth*4, stage['name'], stage['status'],
             ' ({})'.format(stage_url) if stage_url else ''


### PR DESCRIPTION
Use ci.nue.suse.com intead of ci.suse.de, because the latter
doesn't work for all VPN users.