### PR TITLE
Ensure we default ipv6 fact access to false

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -21,7 +21,7 @@ parameters:
     type: string
     label: Default CIDR
     description: Default CIDR value to use for networks which don't have CIDR specified
-{%   if ipv6 == true %}
+{%   if (ipv6 | default(false)) == true %}
     default: "2001::/64"
 {%    else   %}
     default: "1.1.1.0/24"
@@ -48,7 +48,7 @@ resources:
     properties:
       network_id: { get_resource: default_network }
       cidr: { get_param: default_subnet_cidr }
-{%   if ipv6 == true %}
+{%   if (ipv6 | default(false)) == true %}
       ip_version: 6
 {%    else   %}
       ip_version: 4
@@ -84,7 +84,7 @@ resources:
           end: "{{ pool[1] }}"
 {%     endfor %}
 {%     endif  %}
-{%   if ipv6 == true %}
+{%   if (ipv6 | default(false)) == true %}
 {%   if network.is_mgmt %}
       ip_version: 4
 {%   else   %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/firewall_rules.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/firewall_rules.yml
@@ -30,7 +30,7 @@
 
   firewall-rules:
 
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
     - name: SSH_CLM
       network-groups:
 {% for network_group in scenario['network_groups']
@@ -48,7 +48,7 @@
 
     - name: SSH
       network-groups:
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
 {% for network_group in scenario['network_groups']
   if 'MANAGEMENT' in network_group['component_endpoints'] or
      'EXTERNAL-API' in network_group['component_endpoints'] %}
@@ -64,7 +64,7 @@
 {% endif %}
       rules:
       - type: allow
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
         remote-ip-prefix:  ::/128
 {% else %}
         remote-ip-prefix:  0.0.0.0/0
@@ -73,7 +73,7 @@
         port-range-max: 22
         protocol: tcp
 
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
     - name: PING_CLM
       network-groups:
 {% for network_group in scenario['network_groups']
@@ -94,7 +94,7 @@
 
     - name: PING
       network-groups:
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
 {% for network_group in scenario['network_groups']
   if 'MANAGEMENT' in network_group['component_endpoints'] or
      'EXTERNAL-API' in network_group['component_endpoints'] %}
@@ -111,7 +111,7 @@
       rules:
       # open ICMP echo request (ping)
       - type: allow
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
         remote-ip-prefix:  ::/128
 {% else %}
         remote-ip-prefix:  0.0.0.0/0
@@ -122,7 +122,7 @@
         port-range-max: 0
         protocol: icmp
 
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
     - name: NETCAT_IPv6
       network-groups:
 {% for network_group in scenario['network_groups']
@@ -150,7 +150,7 @@
         port-range-max: 11382
         protocol: tcp
 
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
     - name: FRONTAIL_CLM
       network-groups:
 {% for network_group in scenario['network_groups']
@@ -168,7 +168,7 @@
 
     - name: FRONTAIL
       network-groups:
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
 {% for network_group in scenario['network_groups']
   if 'MANAGEMENT' in network_group['component_endpoints'] or
      'EXTERNAL-API' in network_group['component_endpoints'] %}
@@ -184,7 +184,7 @@
 {% endif %}
       rules:
       - type: allow
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
         remote-ip-prefix:  ::/128
 {% else    %}
         remote-ip-prefix:  0.0.0.0/0

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
@@ -37,7 +37,7 @@
       vlanid: {{ ns.net_id }}
 {%   endif %}
       tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
-{%   if ipv6 == true %}
+{%   if (ipv6 | default(false)) == true %}
 {%   if ns.net_id != 100 %}
       cidr: fc00:0:0:{{ ns.net_id }}::/64
       gateway-ip: fc00:0:0:{{ ns.net_id }}::1

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -53,7 +53,7 @@
                 segmentation_id: {{ ns.vlan_id }}
             no_gateway:  True
             enable_dhcp: True
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
             cidr: fc00:0:0:{{ ns.net_id }}::/64
             allocation_pools:
               - start: fc00:0:0:{{ ns.net_id }}::10
@@ -81,7 +81,7 @@
         neutron_external_networks:
 {% for network_group in scenario.network_groups if 'NEUTRON-EXT' in network_group.component_endpoints %}
           - name: ext-net{{ loop.index0 | ternary(loop.index0, '') }}
-{% if ipv6 == true %}
+{% if (ipv6 | default(false)) == true %}
             cidr: fc00:0:0:{{ ns.net_id }}::/64
             gateway-ip: fc00:0:0:{{ ns.net_id }}::1
 {%     set ns.net_id = ns.net_id+1 %}


### PR DESCRIPTION
For some reason the ipv6 fact is not getting defined with a default
of false in recent Ardana CI runs causing breakages.

To help avoid the issue, ensure any use of the ipv6 fact explicitly
defaults to false.