### PR TITLE
openstack-ardana: fix pipeline job report

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -236,6 +236,7 @@ pipeline {
     always {
       script{
         sh('''
+          cd $SHARED_WORKSPACE
           automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
             --recursive \
             --filter 'Declarative: Post Actions' \


### PR DESCRIPTION
Fix the pipeline job execution report generated at the end
of the openstack-ardana pipeline job by using the shared workspace.