### PR TITLE
openstack-ardana: gather facts after nodes are up

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -78,7 +78,8 @@
 - name: Bootstrap other virtual nodes for ardana
   hosts: ardana_virt_hosts
   remote_user: root
-  gather_facts: True
+  # NOTE: don't gather facts before nodes become accessible
+  gather_facts: false
   vars:
     task: "deploy"
     ansible_ssh_common_args: >
@@ -88,14 +89,12 @@
   tasks:
     - block:
         - name: Wait for cloud nodes to be accessible
-          delegate_to: localhost
-          wait_for:
-            host: "{{ ansible_ssh_host }}"
-            port: 22
-            search_regex: OpenSSH
-            state: started
-            delay: 10
+          wait_for_connection:
+            sleep: 10
             timeout: 300
+
+        - name: Gather facts
+          setup:
 
         - include_role:
             name: setup_root_partition

--- a/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
+++ b/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
@@ -70,7 +70,8 @@
 - name: Ensure public keys on deployer
   hosts: "{{ ardana_env }}"
   remote_user: root
-  gather_facts: true
+  # NOTE: don't gather facts before deployer becomes accessible
+  gather_facts: false
   vars:
     task: "deploy"
 
@@ -80,6 +81,9 @@
           wait_for_connection:
             sleep: 10
             timeout: 300
+
+        - name: Gather facts
+          setup:
 
         - include_role:
             name: ssh_keys


### PR DESCRIPTION
The target ansible hosts need to be up, otherwise gathering
facts will fail. We already check for that, but we also need
to postpone gathering facts until after the `wait_for_connection`
check.