### PR TITLE
openstack-ardana: fix ansible connection through bastion host

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -85,6 +85,7 @@
     ansible_ssh_common_args: >
       -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o
       StrictHostKeyChecking=no -W %h:%p -q root@{{ hostvars[ardana_env].ansible_host }}'
+      -o ControlPath='~/.ansible/cp/{{ ardana_env }}-%r@%h:%p'
 
   tasks:
     - block:


### PR DESCRIPTION
By default ansible saves ssh’s ControlPath sockets on `~/.ansible/cp`
[1] and when running multiple playbooks in parallel that access hosts with
the same IP addrests through distincts bastion hosts, the sockets
are created/reused with the same name. This results in ansible accessing
hosts targeted in one playbook from another.

This change ovewrites the ssh control path when the hosts are accessed
thorugh the bastion. The ssh control path is set based on the ardana_env
value together with the login, host and port.

1. https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-ssh-control-path