### PR TITLE
openstack-ardana: remove unused Gerrit jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -92,17 +92,6 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana8-job-gerrit-x86_64
-    ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-ci-slot
-    cloudsource: develcloud8
-    gerrit_change_ids: '4941'
-    triggers:
-     - timed: 'H H * * *'
-    jobs:
-        - '{ardana_gerrit_job}'
-
-- project:
     name: openstack-ardana-gerrit-cloud8
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -135,17 +135,6 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana9-job-gerrit-x86_64
-    ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-ci-slot
-    cloudsource: develcloud9
-    gerrit_change_ids: '4940'
-    triggers:
-     - timed: 'H H * * *'
-    jobs:
-        - '{ardana_gerrit_job}'
-
-- project:
     name: openstack-ardana-gerrit-cloud9
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot


### PR DESCRIPTION
The `cloud-ardana[8|9]-job-gerrit-x86_64` jobs were introduced
a while ago to monitor the status of the Gerrit CI. However, they
have never actually served their purpose, because
 1. they need to target actual open Gerrit changes
 2. those gerrit changes need constant maintenance, otherwise they
 get abandoned
 3. they need resources to run, which are scarce