### PR TITLE
Update local ipv6 address to use fd::/64.

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
@@ -39,8 +39,8 @@
       tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
 {%   if (ipv6 | default(false)) == true %}
 {%   if ns.net_id != 100 %}
-      cidr: fc00:0:0:{{ ns.net_id }}::/64
-      gateway-ip: fc00:0:0:{{ ns.net_id }}::1
+      cidr: fd00:0:0:{{ ns.net_id }}::/64
+      gateway-ip: fd00:0:0:{{ ns.net_id }}::1
 {%   else %}
       cidr: 192.168.{{ ns.net_id }}.0/24
       gateway-ip: 192.168.{{ ns.net_id }}.1

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -54,14 +54,14 @@
             no_gateway:  True
             enable_dhcp: True
 {% if (ipv6 | default(false)) == true %}
-            cidr: fc00:0:0:{{ ns.net_id }}::/64
+            cidr: fd00:0:0:{{ ns.net_id }}::/64
             allocation_pools:
-              - start: fc00:0:0:{{ ns.net_id }}::10
-                end: fc00:0:0:{{ ns.net_id }}::250
+              - start: fd00:0:0:{{ ns.net_id }}::10
+                end: fd00:0:0:{{ ns.net_id }}::250
             host_routes:
               # route to management network
-              - destination: fc00:0:0:{{ ns.mgmt_net_id }}::/64
-                nexthop:  fc00:0:0:{{ ns.net_id }}::1
+              - destination: fd00:0:0:{{ ns.mgmt_net_id }}::/64
+                nexthop:  fd00:0:0:{{ ns.net_id }}::1
 {%     set ns.net_id = ns.net_id+1 %}
 {%     set ns.vlan_id = ns.vlan_id+1 %}
 {% else %}
@@ -82,8 +82,8 @@
 {% for network_group in scenario.network_groups if 'NEUTRON-EXT' in network_group.component_endpoints %}
           - name: ext-net{{ loop.index0 | ternary(loop.index0, '') }}
 {% if (ipv6 | default(false)) == true %}
-            cidr: fc00:0:0:{{ ns.net_id }}::/64
-            gateway-ip: fc00:0:0:{{ ns.net_id }}::1
+            cidr: fd00:0:0:{{ ns.net_id }}::/64
+            gateway-ip: fd00:0:0:{{ ns.net_id }}::1
 {%     set ns.net_id = ns.net_id+1 %}
 {% else %}
             cidr: 172.{{ ns.net_id }}.0.0/16


### PR DESCRIPTION
Updating unique local ipv6 address to use fd::/64 instead of fc::/64 according to https://en.wikipedia.org/wiki/Unique_local_address.