### PR TITLE
generate-radvd-conf: Increase AdvRDNSSLifetime

### DIFF
--- a/scripts/mkcloudhost/generate-radvd-conf
+++ b/scripts/mkcloudhost/generate-radvd-conf
@@ -23,7 +23,7 @@ interface v${host_letter}<NUM>br
   };
   RDNSS <PREFIX>::1
   {
-    AdvRDNSSLifetime 60;
+    AdvRDNSSLifetime 100;
   };
 };
 


### PR DESCRIPTION
Due to misreading the error message during the testing, AdvRDNSSLifetime
must be at least *Max*RtrAdvInternal, not the minimum. Bump to the
maxiumum value.