### PR TITLE
openstack-ardana: use lockable resource for qe102 job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -96,7 +96,7 @@
     ardana_job: '{name}'
     concurrent: False
     ardana_env: qe102
-    reserve_env: false
+    reserve_env: true
     scenario_name: entry-scale-kvm
     clm_model: standalone
     controllers: '3'


### PR DESCRIPTION
This enable QA members to pause the daily job rebuild if necessary by
manually reserving the qe102 lockable resource at ci.suse.de