### PR TITLE
switch to unified github context string: suse/cloud

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr.yaml
@@ -84,23 +84,24 @@
         github_pr_sha=${github_opts[1]}
         github_pr_branch=${github_opts[2]}
         ghpr_paras="--org ${crowbar_org} --repo ${crowbar_repo} --sha ${github_pr_sha}"
+        gh_context="suse/cloud"
 
         function crowbargating_trap()
         {
-            $ghpr --action set-status $ghpr_paras --status "failure" --targeturl ${BUILD_URL} --context "suse/mkcloud/testbuild" --message "testbuild job failed" --debugratelimit
+            $ghpr --action set-status $ghpr_paras --status "failure" --targeturl ${BUILD_URL} --context "${gh_context}/testbuild" --message "testbuild job failed" --debugratelimit
         }
 
         # using a trap to catch all errors of the following commands
         trap "crowbargating_trap" ERR
 
         # report that the job has started (status "pending")
-        $ghpr --action set-status $ghpr_paras --status "pending" --targeturl ${BUILD_URL} --context "suse/mkcloud/testbuild" --message "Started testbuild job"
+        $ghpr --action set-status $ghpr_paras --status "pending" --targeturl ${BUILD_URL} --context "${gh_context}/testbuild" --message "Started testbuild job"
 
         # do the build
         ${automationrepo}/scripts/crowbar-testbuild.rb --org $crowbar_org --repo $crowbar_repo --pr $crowbar_github_pr --trigger-gating
 
         # update the status
-        $ghpr --action set-status $ghpr_paras --status "pending" --targeturl ${BUILD_URL} --context "suse/mkcloud" --message "Queued testbuild PR gating"
-        $ghpr --action set-status $ghpr_paras --status "success" --targeturl ${BUILD_URL} --context "suse/mkcloud/testbuild" --message "testbuild job succeeded" --debugratelimit
+        $ghpr --action set-status $ghpr_paras --status "pending" --targeturl ${BUILD_URL} --context "${gh_context}" --message "Queued testbuild PR gating"
+        $ghpr --action set-status $ghpr_paras --status "success" --targeturl ${BUILD_URL} --context "${gh_context}/testbuild" --message "testbuild job succeeded" --debugratelimit
 
         trap "-" ERR

--- a/jenkins/ci.suse.de/openstack-mkcloud-log-parser-test.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud-log-parser-test.yaml
@@ -41,9 +41,9 @@
           default: SUSE-Cloud/automation:PR_ID:SHA1:master
           description: >-
             String is a ':' separated list of these values:
-            $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context
+            $ORG/$repo:$PR_ID:$SHA1:$BRANCH:$context_suffix
 
-            Note: SHA1 must be latest commit in PR, $context is optional
+            Note: SHA1 must be latest commit in PR, $context_suffix is optional
             (only use if multiple gating runs needed per PR)
 
     wrappers:
@@ -90,10 +90,10 @@
               github_pr_repo=${github_opts[0]}
               github_pr_id=${github_opts[1]}
               github_pr_sha=${github_opts[2]}
-              github_pr_context=${github_opts[4]}
-              ghs_context=suse/mkcloud
-              if [[ $github_pr_context ]] ; then
-                ghs_context=$ghs_context/$github_pr_context
+              github_pr_context_suffix=${github_opts[4]}
+              ghs_context=suse/cloud
+              if [[ $github_pr_context_suffix ]] ; then
+                ghs_context=$ghs_context/$github_pr_context_suffix
               fi
 
               echo "testing PR: https://github.com/$github_pr_repo/pull/$github_pr_id"

--- a/scripts/github_pr/github_pr_cloud.yaml
+++ b/scripts/github_pr/github_pr_cloud.yaml
@@ -101,11 +101,11 @@ pr_processing:
       organization: SUSE-Cloud
       repositories:
         - automation
-      context: suse/mkcloud
+      context: suse/cloud
     filter: *suse_automation
   - config:
       organization: SUSE-Cloud
       repositories:
         - cct
-      context: suse/mkcloud
+      context: suse/cloud
     filter: *suse_cct

--- a/scripts/github_pr/github_pr_crowbar.yaml
+++ b/scripts/github_pr/github_pr_crowbar.yaml
@@ -89,7 +89,7 @@ pr_processing:
         - crowbar-hyperv
         - crowbar-init
         - crowbar-openstack
-      context: suse/mkcloud/testbuild
+      context: suse/cloud/testbuild
     filter: *suse_crowbar
   - config:
       organization: sap-oc
@@ -100,5 +100,5 @@ pr_processing:
         - crowbar-ha
         - crowbar-openstack
         - crowbar-monitoring
-      context: suse/mkcloud/testbuild
+      context: suse/cloud/testbuild
     filter: *sap-oc_crowbar

--- a/scripts/jenkins/github-pr/parse.rc
+++ b/scripts/jenkins/github-pr/parse.rc
@@ -8,6 +8,6 @@ github_opts=(${github_pr//:/ })
 github_pr_repo=${github_opts[0]}
 github_pr_id=${github_opts[1]}
 github_pr_sha=${github_opts[2]}
-github_pr_context=${github_opts[4]:-}
+github_pr_context_suffix=${github_opts[4]:-}
 github_org=${github_pr_repo%/*}
 github_repo=${github_pr_repo##*/}

--- a/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
+++ b/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
@@ -119,9 +119,9 @@ if [[ $github_pr ]] ; then
     # split $github_pr into multiple variables
     source ${automationrepo}/scripts/jenkins/github-pr/parse.rc
 
-    github_context=suse/mkcloud
-    if [[ $github_pr_context ]] ; then
-      github_context=$github_context/$github_pr_context
+    github_context=suse/cloud
+    if [[ $github_pr_context_suffix ]] ; then
+      github_context=$github_context/$github_pr_context_suffix
     fi
     ghpr_paras="--org ${github_org} --repo ${github_repo} --sha $github_pr_sha --context $github_context"
 


### PR DESCRIPTION
The previous context string "suse/mkcloud" was specific
to mkcloud. So it would be misleading to let jobs testing
other deployment tools report a status using this context
string.

On the other hand adding new context strings and requiring
them as mandatory for a merge would mean that on most PRs
some checks will never be run, because not all PRs run with
all deployment tools.

So this new context string
- must have a success status which is mandatory for a merge
- will be used for the status of the default test (PR build)
  of this PR.
  Hint: this is the "standard" job, that is defined in the
  github-pr yaml in:
  https://github.com/SUSE-Cloud/automation/blob/master/scripts/github_pr/github_pr_cloud.yaml#L5
  The "standard" is not added as suffix to the context, while
  all other build names (keys on the same level in the yaml) are
  appended as suffix to the base context.
- is the base string for all additional (optional and mandatory)
  contexts that are required (this is already the case).
  e.g.
    old: suse/mkcloud/stable
    new: suse/cloud/stable