### PR TITLE
Disable cinder backup if swift is not enabled

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -130,6 +130,7 @@ function h_setup_devstack {
     (cd $DEVSTACK_DIR && ./tools/create-stack-user.sh)
 
     SWIFT_SERVICES="
+enable_service c-bak
 enable_service s-proxy
 enable_service s-object
 enable_service s-container
@@ -165,7 +166,6 @@ enable_service placement-api
 enable_service n-cpu
 enable_service c-vol
 enable_service n-obj
-enable_service c-bak
 enable_service q-agt
 disable_service horizon
 enable_service cinder


### PR DESCRIPTION
All tempest tests in tempest.api.volume.test_volumes_backup and
tempest.api.volume.admin.test_volumes_backup are failing because
cinder-backup is trying to use swift as a backend.
However, because of we are using Python3, swift can not be enabled.

This patch disables cinder backup in case that swift is not enabled per
 https://review.openstack.org/#/c/75073/

Signed-off-by: aojeagarcia <aojeagarcia@suse.com>