### PR TITLE
Make update_automation truly atomic updating

### DIFF
--- a/jenkins/ci.opensuse.org/macros.yaml
+++ b/jenkins/ci.opensuse.org/macros.yaml
@@ -3,7 +3,14 @@
     builders:
       - shell: |
           #!/bin/bash -x
-          [ -e ~/bin/update_automation ] || mkdir -p ~/bin && wget -O ~/bin/update_automation https://raw.github.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation && chmod a+x ~/bin/update_automation
+          if [ ! -e ~/bin/update_automation ]; then
+              mkdir -p ~/bin
+              tmpf=$(mktemp ~/bin/update_automation.XXXXXX)
+              wget -O $tmpf https://raw.github.com/SUSE-Cloud/automation/master/scripts/jenkins/update_automation
+              chmod a+x $tmpf
+              mv -vu $tmpf ~/bin/update_automation
+              rm -f $tmpf
+          fi
           # fetch the latest automation updates
           ~/bin/update_automation
 


### PR DESCRIPTION
Using wget -O is dangerous on parallel runs, as it might
cause two jobs running at the same time to update the update_automation
script, which causes this error:

 /root/bin/update_automation: /bin/bash: bad interpreter: Text file busy
 Build step 'Execute shell' marked build as failure

This is a security measurement by the kernel to avoid races with
somebody replacing the content of a shell script while it is being
executed.