### PR TITLE
openstack-ardana: lower timeout for stack creation

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
@@ -18,5 +18,6 @@
 heat_action: "create"
 api_timeout: "600"
 
+heat_stack_create_timeout: 480
 heat_stack_name: "openstack-ardana-{{ ardana_env }}"
 monitor_stack_after_delete: True

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/create.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/create.yml
@@ -21,5 +21,6 @@
     name: "{{ heat_stack_name }}"
     state: present
     template: "{{ heat_template_file }}"
+    timeout: "{{ heat_stack_create_timeout }}"
     api_timeout: "{{ api_timeout }}"
   register: heat_stack_create


### PR DESCRIPTION
Sometimes (eg. due to some issue on ECP) the stack gets stuck on CREATING
state until it times out which by default is 1 hour. However creating a heat stack
takes in average 3 minutes and if it takes much longer it will probably
not be crated successfully.

This change sets the heat stack creation timeout to 8 minutes (should be
more than enough to create the stack) so we can throw the error and try
again faster.