### PR TITLE
jenkins-report: avoid raising an exception

### DIFF
--- a/scripts/jenkins/jenkins-job-pipeline-report.py
+++ b/scripts/jenkins/jenkins-job-pipeline-report.py
@@ -150,7 +150,8 @@ def generate_summary(server, job_name, build_number,
                         filter_stages, recursive, depth+1)
                     stage_url = server.get_pipeline_url(d_job_name,
                                                         d_build_number)
-        stage_url = stage_url.replace('ci.suse.de', 'ci.nue.suse.com')
+        if stage_url is not None:
+            stage_url = stage_url.replace('ci.suse.de', 'ci.nue.suse.com')
         summary += '{}  - {}: {}{}\n'.format(
             ' '*depth*4, stage['name'], stage['status'],
             ' ({})'.format(stage_url) if stage_url else ''


### PR DESCRIPTION
When calling jenkins-job-pipeline-report.py after an ABORTED job,
stage_url will be None and calling .replace() on a NoneType object
will raise an Exception.

Only call stage_url.replace() when stage_url is not None.

```
[openstack-ardana-2358] Running shell script
+ cd /home/jenkins/shared/cloud-ardana-ci-slot6
+ automation-git/scripts/jenkins/jenkins-job-pipeline-report.py --recursive --filter 'Declarative: Post Actions' --filter 'Setup workspace'
Traceback (most recent call last):
  File "automation-git/scripts/jenkins/jenkins-job-pipeline-report.py", line 247, in <module>
    main()
  File "automation-git/scripts/jenkins/jenkins-job-pipeline-report.py", line 243, in main
    args.filter, args.recursive)
  File "automation-git/scripts/jenkins/jenkins-job-pipeline-report.py", line 187, in print_pipeline_report
    filter_stages, recursive)
  File "automation-git/scripts/jenkins/jenkins-job-pipeline-report.py", line 150, in generate_summary
    filter_stages, recursive, depth+1)
  File "automation-git/scripts/jenkins/jenkins-job-pipeline-report.py", line 153, in generate_summary
    stage_url = stage_url.replace('ci.suse.de', 'ci.nue.suse.com')
AttributeError: 'NoneType' object has no attribute 'replace'
```