### PR TITLE
openstack-ardana: remove workaround for bsc#1110414

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -28,9 +28,6 @@ versioned_features:
     enabled: "{{ when_cloud8 }}"
   heat-api-cloudwatch:
     enabled: "{{ when_cloud8 }}"
-  # FIXME: Remove this entry when bsc#1110414 fixed
-  fix_ardana_ssh_keyscan:
-    enabled: "{{ when_cloud9M3 }}"
   # Disable LVM on virtual deployments with GM8* cloudsources
   # until https://gerrit.suse.provo.cloud/#/c/5143/ gets released
   want_lvm:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
@@ -34,14 +34,6 @@
   register: vrrp
   when: is_physical_deploy
 
-# FIXME: Remove task when bsc#1110414 fixed
-- name: Workaround for bug bsc#1110414
-  replace:
-    path: "~/openstack/ardana/ansible/roles/ardana-ssh-keyscan/tasks/main.yml"
-    regexp: '"\$'
-    replace: '"'
-  when: versioned_features.fix_ardana_ssh_keyscan.enabled
-
 - name: Commit changes
   shell: |
     git add -A


### PR DESCRIPTION
As `bsc#1110414` is already fixed, we do not need a workaround for it
anymore.