### PR TITLE
ipv6: Add network details to routed.cloud

### DIFF
--- a/scripts/mkcloudhost/routed.cloud
+++ b/scripts/mkcloudhost/routed.cloud
@@ -9,13 +9,27 @@ if [ "$n" -lt 1 -o "$n" -gt 32 ] ; then
   exit 1
 fi
 
+function random_ipv6_prefix {
+    perl -e 'printf "fd%02x:%04x:%04x:%04x", rand(2**8), rand(2**16), rand(2**16), rand(2**16)'
+}
+
 : ${reposerver:=clouddata.cloud.suse.de}
 : ${nfsserver:=clouddata.cloud.suse.de}
 export reposerver nfsserver
-export net_admin=$(cloudadminnet $n)
-export net_ironic=$(cloudironicnet $n)
-export net_public=$(routedcloudpublicnet $n)
-export adminnetmask=255.255.255.0
+if (( $want_ipv6 > 0 )); then
+    export net_admin=$(ipv6prefix $n)
+    export net_public=$(ipv6prefix $((0x80|n)))
+    export net_ironic=$(random_ipv6_prefix)
+    export adminnetmask=64
+    reposerver=clouddata6.cloud.suse.de
+    nfsserver=clouddata6.cloud.suse.de
+    export http_proxy=http://[${net_admin}::1]:3128/
+else
+    export net_admin=$(cloudadminnet $n)
+    export net_ironic=$(cloudironicnet $n)
+    export net_public=$(routedcloudpublicnet $n)
+    export adminnetmask=255.255.255.0
+fi
 export virtualcloud=$vcloudname$n
 export cloud=$virtualcloud
 export NOSETUPPORTFORWARDING=1


### PR DESCRIPTION
If want_ipv6 is set to > 0, set the routed cloud on the mkch* hosts to
use the prefix from 99c199e928c7 for the admin network. Based on the
admin network prefix, set the public network prefix so that they
overlap. Create a random IPv6 prefix for the ironic network.