### PR TITLE
openstack-ardana: add a jenkins job for cloud8 maintenace gating

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -15,6 +15,14 @@
         - '{ardana_gating_job}'
 
 - project:
+    name: cloud-ardana8-maintenance-gating
+    ardana_maintenance_gating_job: '{name}'
+    ardana_env: cloud-ardana-maintenance-slot
+    version: 8
+    jobs:
+      - '{ardana_maintenance_gating_job}'
+
+- project:
     name: cloud-ardana8-job-std-3cp-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
@@ -83,6 +91,19 @@
     model: std-3cp
     triggers:
      - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
+    ardana_job: '{name}'
+    disabled: false
+    reserve_env: false
+    cloudsource: GM8+up
+    scenario_name: entry-scale-kvm
+    tempest_filter_list: "smoke,full"
+    qa_test_list: "iverify"
+    triggers: []
     jobs:
         - '{ardana_job}'
 

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-maintenance-gating.Jenkinsfile
@@ -1,0 +1,121 @@
+/**
+ * The openstack-ardana-maintenance-gating Jenkins Pipeline
+ */
+
+def ardana_lib = null
+
+pipeline {
+  // skip the default checkout, because we want to use a custom path
+  options {
+    skipDefaultCheckout()
+    timestamps()
+  }
+
+  agent {
+    node {
+      label 'cloud-trigger'
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
+    }
+  }
+
+  stages {
+    stage('Setup workspace') {
+      steps {
+        script {
+          if (ardana_env == '') {
+            error("Empty 'ardana_env' parameter value.")
+          }
+          if (maint_updates == '') {
+            error("Empty 'maint_updates' parameter value.")
+          }
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${maint_updates}"
+
+          sh('''
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+          ''')
+
+          ardana_lib = load "automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+        }
+      }
+    }
+
+    stage('Trigger jobs') {
+      // Do not abort all stages if one of them fails
+      failFast false
+      parallel {
+        stage('Run cloud deploy job') {
+          when {
+            expression { deploy == 'true' }
+          }
+          steps {
+            script {
+              // reserve a resource here for the openstack-ardana job, to avoid
+              // keeping a cloud-ardana-ci worker busy while waiting for a
+              // resource to become available.
+              // if not instructed to reserve a resource, use a dummy resource and a zero quantity
+              // to fool Jenkins into thinking it reserved a resourcewhen in fact it didn't
+              lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
+                variable: 'reserved_env', quantity: reserve_env == 'true' ? 1:0 ) {
+                  def ardana_env = "${ardana_env}-deploy"
+                  if (env.reserved_env && reserved_env != null) {
+                    ardana_env = reserved_env
+                  }
+                  def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
+                    string(name: 'ardana_env', value: "$ardana_env"),
+                    string(name: 'reserve_env', value: "false"),
+                    string(name: 'cloudsource', value: "$cloudsource"),
+                    string(name: 'maint_updates', value: "$maint_updates"),
+                    string(name: 'update_after_deploy', value: "false"),
+                    string(name: 'rc_notify', value: "true"),
+                    string(name: 'cleanup', value: "on success"),
+                    string(name: 'git_automation_repo', value: "$git_automation_repo"),
+                    string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                    string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
+                  ], false)
+              }
+            }
+          }
+        }
+
+        stage('Run cloud update job') {
+          when {
+            expression { deploy_and_update == 'true' }
+          }
+          steps {
+            script {
+              // reserve a resource here for the openstack-ardana job, to avoid
+              // keeping a cloud-ardana-ci worker busy while waiting for a
+              // resource to become available.
+              // if not instructed to reserve a resource, use a dummy resource and a zero quantity
+              // to fool Jenkins into thinking it reserved a resourcewhen in fact it didn't
+              lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
+                variable: 'reserved_env', quantity: reserve_env == 'true' ? 1:0 ) {
+                  def ardana_env = "${ardana_env}-update"
+                  if (env.reserved_env && reserved_env != null) {
+                    ardana_env = reserved_env
+                  }
+                  def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
+                    string(name: 'ardana_env', value: "$ardana_env"),
+                    string(name: 'reserve_env', value: "false"),
+                    string(name: 'cloudsource', value: "$cloudsource"),
+                    string(name: 'maint_updates', value: "$maint_updates"),
+                    string(name: 'update_after_deploy', value: "true"),
+                    string(name: 'rc_notify', value: "true"),
+                    string(name: 'cleanup', value: "on success"),
+                    string(name: 'git_automation_repo', value: "$git_automation_repo"),
+                    string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                    string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
+                  ], false)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  post{
+    cleanup {
+      cleanWs()
+    }
+  }
+}

--- a/jenkins/ci.suse.de/templates/cloud-ardana-maintenance-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-maintenance-gating-template.yaml
@@ -1,0 +1,103 @@
+- job-template:
+    name: '{ardana_maintenance_gating_job}'
+    project-type: pipeline
+    disabled: '{obj:disabled|False}'
+    concurrent: '{concurrent|True}'
+    wrappers:
+      - timestamps
+
+    logrotate:
+      numToKeep: 500
+      daysToKeep: 90
+
+    properties:
+      - authorization:
+          cloud:
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-delete
+            - job-discover
+            - job-read
+            - job-workspace
+            - run-delete
+            - run-update
+            - scm-tag
+          anonymous:
+            - job-read
+
+    parameters:
+      - validating-string:
+          name: ardana_env
+          default: '{ardana_env|cloud-ardana-maintenance-slot}'
+          regex: '[A-Za-z0-9-_]+'
+          msg: >-
+            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+          description: >-
+            The virtual or hardware environment identifier. This field should either
+            be set to one of the values associated with the known hardware environments
+            (e.g. qe101), or to a value that will identify the created virtual environment.
+
+            WARNING: if a virtual environment associated with the supplied ardana_env already
+            exists, it will be replaced.
+
+      - bool:
+          name: reserve_env
+          default: '{reserv_env|true}'
+          description: >-
+            Reserve the 'ardana_env' lockable resource throughout the execution of this job
+
+      - choice:
+          name: cloudsource
+          choices:
+            - 'GM{version|8}+up'
+            - GM8+up
+            - hosGM8+up
+          description: >-
+            The cloud repository (from provo-clouddata) to be used for testing.
+            This value can take the following form:
+
+               GM<X>+up (official GM plus Cloud-Updates)
+               hosGM8+up (official HOS GM plus Cloud-Updates)
+
+      - validating-string:
+          name: maint_updates
+          default: ''
+          regex: '([0-9]+(,[0-9]+)*)*'
+          msg: The entered value failed validation
+          description: List of maintenance update IDs separated by comma (eg. 7396,7487)
+
+      - bool:
+          name: deploy
+          default: true
+          description: >-
+            Start a job to deploy ardana with MU(s)
+
+      - bool:
+          name: deploy_and_update
+          default: true
+          description: >-
+            Start a job to deploy ardana then update with MU(s)
+
+      - string:
+          name: git_automation_repo
+          default: https://github.com/SUSE-Cloud/automation.git
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: master
+          description: >-
+            The git automation branch
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${{git_automation_repo}}
+            branches:
+              - ${{git_automation_branch}}
+            browser: auto
+            wipe-workspace: false
+      script-path: jenkins/ci.suse.de/pipelines/openstack-ardana-maintenance-gating.Jenkinsfile
+      lightweight-checkout: false

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -65,3 +65,5 @@ rc_channels:
   qe202: "cloud-qe-hlm202"
   qe2023: "cloud-qe-hlm2023par"
   scale: "cloud-qe-scale"
+  cloud-ardana-ci-slot16: "cloud-maintenance"
+  cloud-ardana-ci-slot17: "cloud-maintenance"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
@@ -26,6 +26,12 @@
 - include_tasks: post_defcore.yml
   when: tempest_run_filter == 'defcore'
 
+- name: Fail if something went wrong during tempest execution
+  fail:
+    msg: "Something went wrong with tempest."
+  when: tempest_results_processed.results.0.stdout == ''
+  register: tempest_status
+
 - name: Fail if any tempest test has failed
   fail:
     msg: "{{ tempest_results_processed.results.3.stdout }} tests failed."

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/defaults/main.yml
@@ -27,7 +27,7 @@ rc_bot:
 rc_auth_info_git_url: "https://gitlab.suse.de/cloud-qe/ardana-bm-info.git"
 rc_auth_info_dir: "{{ workspace_path }}/ardana-bm-info"
 
-rc_channel: "{{ is_physical_deploy | ternary(rc_channels[ardana_env], '@' ~ ardana_env.split('-')[0]) }}"
+rc_channel: "{{ rc_channels[ardana_env] | default('@' ~ ardana_env.split('-')[0]) }}"
 
 rc_channel_id_query: "json.channels[?name=='{{ rc_channels[ardana_env] }}']._id"
 

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
@@ -10,13 +10,15 @@ Configured repositories:
 {% if is_milestone %}
   - {{ media[cloud_release].name }}
 {% endif %}
-{% for id in maint_updates_list %}
-{%   for product in maintenance_updates_path %}
-{%     if maintenance_updates_path[product] in mu_url.results | selectattr('item', 'equalto', id) | map(attribute='content') | join(' ') %}
+{% if cloud_repo_path is defined %}
+{%   for id in maint_updates_list %}
+{%     for product in maintenance_updates_path %}
+{%       if maintenance_updates_path[product] in mu_url.results | selectattr('item', 'equalto', id) | map(attribute='content') | join(' ') %}
   - {{ product }}-Maint-Update-{{ id }}
-{%     endif %}
+{%       endif %}
+{%     endfor %}
 {%   endfor %}
-{% endfor %}
+{% endif %}
 {% for repo in extra_repos_list %}
   - {{ repo }}
 {% endfor %}

--- a/scripts/jenkins/ardana/ansible/run-tempest.yml
+++ b/scripts/jenkins/ardana/ansible/run-tempest.yml
@@ -62,6 +62,8 @@
 
         - include_role:
             name: send_to_os_health
+          when: "'failed' not in tempest_status"
+
 
   post_tasks:
       - include_role:


### PR DESCRIPTION
This change adds a new jenkins job for testing maintenance updates, this
job starts two instances of the openstack-ardana job:

1. Deploy: Will deploy ardana including the MU(s) and run tests
2. Update: Will deploy aradana, update to MU(s) after, and run tests