### PR TITLE
openstack-ardana: trigger pcloud001 job based on updates test repo

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -10,6 +10,18 @@
         - '{ardana_url_trigger_job}'
 
 - project:
+    name: cloud-ardana8-updates-test-trigger
+    ardana_url_trigger_job: '{name}'
+    version: '8'
+    url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-Updates-test/SUSE:Maintenance:Test:OpenStack-Cloud:{version}:x86_64.repo'
+    check_date: true
+    projects:
+      - project: 'cloud-ardana{version}-job-entry-scale-kvm-pcloud001-x86_64'
+        block: false
+    jobs:
+        - '{ardana_url_trigger_job}'
+
+- project:
     name: cloud-ardana8-gating
     ardana_gating_job: '{name}'
     concurrent: False
@@ -107,7 +119,8 @@
     concurrent: false
     ardana_env: pcloud001
     reserve_env: true
-    cloudsource: stagingcloud8
+    cloudsource: GM8+up
+    updates_test_enabled: true
     scenario_name: entry-scale-kvm
     clm_model: standalone
     controllers: '3'
@@ -125,8 +138,7 @@
       keystone-k2k-config,keystone-websso-config,keystone-x509-config,\
       service-ansible-playbooks,enable_tls,tempest_cleanup"
     rc_notify: 'true'
-    triggers:
-     - timed: 'H H * * *'
+    triggers: []
     jobs:
         - '{ardana_job}'
 

--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -1,9 +1,13 @@
 - project:
     name: cloud-ardana8-gating-trigger
-    ardana_gating_trigger_job: '{name}'
+    ardana_url_trigger_job: '{name}'
     version: '8'
+    url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-devel-staging/media.1/build'
+    projects:
+      - project: 'cloud-ardana{version}-gating'
+        block: false
     jobs:
-        - '{ardana_gating_trigger_job}'
+        - '{ardana_url_trigger_job}'
 
 - project:
     name: cloud-ardana8-gating

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -1,9 +1,13 @@
 - project:
     name: cloud-ardana9-gating-trigger
-    ardana_gating_trigger_job: '{name}'
+    ardana_url_trigger_job: '{name}'
     version: '9'
+    url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-devel-staging/media.1/build'
+    projects:
+      - project: 'cloud-ardana{version}-gating'
+        block: false
     jobs:
-        - '{ardana_gating_trigger_job}'
+        - '{ardana_url_trigger_job}'
 
 - project:
     name: cloud-ardana9-gating

--- a/jenkins/ci.suse.de/templates/cloud-ardana-url-trigger-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-url-trigger-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{ardana_gating_trigger_job}'
+    name: '{ardana_url_trigger_job}'
     project-type: multijob
     node: cloud-trigger
 
@@ -8,7 +8,8 @@
           cron: 'H/5 * * * *'
           polling-node: cloud-trigger
           urls:
-            - url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-devel-staging/media.1/build'
+            - url: '{url}'
+              check-date: '{check_date|false}'
               check-content:
                 - simple: true
 
@@ -17,6 +18,4 @@
       daysToKeep: 14
 
     builders:
-      - trigger-builds:
-         - project: cloud-ardana{version}-gating
-           block: false
+      - trigger-builds: '{projects}'


### PR DESCRIPTION
The ardana job for testing cloud8 on pcloud001 QE environment should be
triggered when there is a change on the Updates-test repository.

This change also updates the cloud-ardana-gating-trigger-template to
get the url and a list of projects from the job definition, making
possible reusing it to create other url trigger jobs with different
urls.