### PR TITLE
openstack-ardana: enable SES on cloud9 qe102 periodic job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -139,6 +139,7 @@
     controllers: '3'
     sles_computes: '2'
     rhel_computes: '0'
+    ses_enabled: true
     tempest_filter_list: "\
       ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,\
       magnum,manila,monasca,network,neutron-api,swift"


### PR DESCRIPTION
Enable SES on periodic job qe102 used by QE.