### PR TITLE
Update path for amphora image rpm file.

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
@@ -38,4 +38,4 @@ defcore_results: "~/refstack_results.subunit"
 subunit_html_results: "~/testr_results_region1.html"
 subunit_xml_results: "~/testr_results_region1.xml"
 
-octavia_amphora_image_rpm: "find /srv/www/*/x86_64/repos/*OpenStack*/noarch/ -name '*octavia-amphora-image*' | tail -n1"
+octavia_amphora_image_rpm: "find /srv/www/*/x86_64/repos/*OpenStack*/ -name '*octavia-amphora-image*' | tail -n1"


### PR DESCRIPTION
Update path to look for amphora image to work with cloud8 & cloud9.

Cloud9:
 find /srv/www/*/x86_64/repos/*OpenStack*/ -name '*octavia-amphora-image*' | tail -n1
/srv/www/suse-12.4/x86_64/repos/SUSE-OpenStack-Cloud-9-Pool/suse/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-2.187.noarch.rpm

Cloud8:
 find /srv/www/*/x86_64/repos/*OpenStack*/ -name '*octavia-amphora-image*' | tail -n1
/srv/www/suse-12.3/x86_64/repos/SUSE-OpenStack-Cloud-8-Pool/noarch/openstack-octavia-amphora-image-x86_64-0.1.0-1.21.noarch.rpm