### PR TITLE
Remove vnc_keymap from all cloud 9 qa scenarios

### DIFF
--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1a.yaml
@@ -122,7 +122,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-1b.yaml
@@ -127,7 +127,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2a.yaml
@@ -184,7 +184,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2b.yaml
@@ -133,7 +133,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     vcenter:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-2c.yaml
@@ -106,7 +106,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-6a.yaml
@@ -118,7 +118,6 @@ proposals:
 - barclamp: nova
   attributes:
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
@@ -141,7 +141,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8b.yaml
@@ -132,7 +132,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-9.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-9.yaml
@@ -130,7 +130,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
   deployment:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1a.yaml
@@ -160,7 +160,6 @@ proposals:
     itxt_instance: ''
     use_shared_instance_storage: true
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     ssl:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1b.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-1b.yaml
@@ -165,7 +165,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     ssl:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2a.yaml
@@ -214,7 +214,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     ssl:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2b.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2b.yaml
@@ -174,7 +174,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     ssl:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2c.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-2c.yaml
@@ -122,7 +122,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     ssl:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-6a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-6a.yaml
@@ -154,7 +154,6 @@ proposals:
 - barclamp: nova
   attributes:
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8a.yaml
@@ -158,7 +158,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8b.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl-insecure/qa-scenario-8b.yaml
@@ -152,7 +152,6 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:

--- a/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
@@ -162,7 +162,6 @@ proposals:
     itxt_instance: ''
     use_shared_instance_storage: true
     use_migration: true
-    vnc_keymap: de
     kvm:
       ksm_enabled: true
     ssl:


### PR DESCRIPTION
After this change https://github.com/crowbar/crowbar-openstack/pull/1893
vnc_keymap is not passing schema validation