### PR TITLE
openstack-staging: node openstack-rpm-packaging

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-staging.yaml
+++ b/jenkins/ci.opensuse.org/openstack-staging.yaml
@@ -23,7 +23,7 @@
           type: slave
           name: slave
           values:
-            - cloud-cleanvm
+            - openstack
     execution-strategy:
       sequential: true
     builders:


### PR DESCRIPTION
usually has an executor free, use that instead. The job
openstack-staging only calls other jobs but still needs one slot.
cloud-cleanvm only has one executor slot.