### PR TITLE
openstack-ardana: enable SES for all cloud8 jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -36,6 +36,8 @@
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
     model: std-3cp
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -47,6 +49,8 @@
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
     model: dac-3cp
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -58,6 +62,8 @@
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
     model: std-min
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -69,6 +75,8 @@
     ardana_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
     model: std-split
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -82,6 +90,8 @@
     update_after_deploy: true
     update_to_cloudsource: stagingcloud8
     model: std-3cp
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -97,6 +107,8 @@
     update_after_deploy: true
     update_to_cloudsource: GM8+up
     model: std-3cp
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -108,6 +120,8 @@
     ardana_env: cloud-ardana-ci-slot
     cloudsource: GM8+up
     model: std-min
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -147,6 +161,8 @@
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
     cloudsource: develcloud8
+    ses_enabled: true
+    ses_rgw_enabled: false
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
     triggers:
       - gerrit:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -181,6 +181,8 @@
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
     cloudsource: develcloud9
+    ses_enabled: false
+    ses_rgw_enabled: false
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
     triggers:
       - gerrit:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -87,6 +87,8 @@ The following links can also be used to track the results:
               string(name: 'controllers', value: "2"),
               string(name: 'sles_computes', value: "1"),
               string(name: 'cloudsource', value: "$cloudsource"),
+              string(name: 'ses_enabled', value: "$ses_enabled"),
+              string(name: 'ses_rgw_enabled', value: "$ses_rgw_enabled"),
               string(name: 'tempest_filter_list', value: "$tempest_filter_list"),
               string(name: 'os_cloud', value: "$os_cloud")
             ], propagate: false, wait: true

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -67,6 +67,18 @@
                develcloud<X> (Devel:Cloud:X)
                GM<X> (official GM)
 
+      - bool:
+          name: ses_enabled
+          default: '{ses_enabled|false}'
+          description: Configure SES backend for glance, cinder, cinder-backup and nova
+
+      - bool:
+          name: ses_rgw_enabled
+          default: '{ses_rgw_enabled|false}'
+          description: |
+            Configure object-store service with RADOS Gateway. This only takes effect
+            if ses_enabled is set to true.
+
       - string:
           name: tempest_filter_list
           default: '{tempest_filter_list|ci}'


### PR DESCRIPTION
This change enable SES for all ardana-cloud8 jobs. In that way, besides
deploying ardana, those jobs will also deploy a SES cluster and
configure glance, nova, cinder and cinder-backup with SES backend.

As those jobs relies on tempest for testing and tempest does not support
object-store service configured with RADOS gateway, the object-store
service will not be configured with RADOS gateway (`ses_rgw_enabled =
false`).