### PR TITLE
openstack-ardana: deploy SES only for virtual deployments

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -182,9 +182,9 @@ pipeline {
             }
           }
         }
-        stage('Deploy SES') {
+        stage('Deploy SES for vcloud') {
           when {
-            expression { ses_enabled == 'true' }
+            expression { ses_enabled == 'true' && cloud_type == 'virtual' }
           }
           steps {
             script {


### PR DESCRIPTION
For bare-metal deployments we do not need to deploy SES as it uses an
existing SES cluster.