### PR TITLE
SCRD-6075 Add versioning support for designate services

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -37,3 +37,6 @@ versioned_features:
   # fix gets released
   external_network_bridge:
     enabled: "{{ when_cloud8 and not when_staging_or_devel }}"
+  # designate zone/pool (Cloud8) or worker/producer (Cloud9)
+  designate_worker_producer:
+    enabled: "{{ when_cloud9 }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -38,6 +38,8 @@ enable_extra_volume_groups: "{{ want_lvm }}"
 
 enable_external_network_bridge: "{{ versioned_features.external_network_bridge.enabled }}"
 
+enable_designate_worker_producer: "{{ versioned_features.designate_worker_producer.enabled }}"
+
 cp_prefix: cp1
 max_host_prefix_len: "{{ 33-(cp_prefix|length) }}"
 host_prefix: "{{ ('ardana-' ~ ardana_env)[:max_host_prefix_len|int-1] if ardana_env is defined else 'ardana' }}"
@@ -82,8 +84,8 @@ service_component_groups:
     - cinder-backup
     - designate-api
     - designate-central
-    - designate-pool-manager
-    - designate-zone-manager
+    - "{{ enable_designate_worker_producer | ternary('desigate-worker', 'designate-pool-manager') }}"
+    - "{{ enable_designate_worker_producer | ternary('desigate-producer', 'designate-zone-manager') }}"
     - designate-mdns
     - glance-api
     #- glance-api:


### PR DESCRIPTION
For Cloud9 we want to switch to using the designate worker/producer
services than the deprecated zone/pool managers. To support this we
define a new versioned feature, designate_worker_producer, which is
true for Cloud9 deployments.

This new versioned feature setting is checked when defining the CORE
service components list, and we generate either worker or pool and
producer or zone entries accordingly in the list.

NOTE: This change should not be landed until the corresponding patch
to the ardana/designate-ansible.git repo that fixes worker/producer
deployment for designate in Cloud9, with Gerrit ChangeID
I647ff48154d4af3e1c400b6ff8bc973a56ab81bd.