### PR TITLE
openstack-ardana: use dedicated slots for gating jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -25,8 +25,8 @@
     name: cloud-ardana8-gating
     ardana_gating_job: '{name}'
     concurrent: False
-    ardana_env: cloud-ardana-ci-slot
     version: '8'
+    ardana_env: 'cloud-ardana-gate{version}-slot'
     jobs:
         - '{ardana_gating_job}'
 

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -13,8 +13,8 @@
     name: cloud-ardana9-gating
     ardana_gating_job: '{name}'
     concurrent: False
-    ardana_env: cloud-ardana-ci-slot
     version: '9'
+    ardana_env: 'cloud-ardana-gate{version}-slot'
     jobs:
         - '{ardana_gating_job}'
 


### PR DESCRIPTION
Change the lockable resources allocation strategy to use
dedicated slots for Ardana IBS gating jobs. This approach
guarantees that the cloud environments that are left running
after a gating job failure are not not destroyed by other CI
jobs of less importance and are therefore available for debugging.

This should significantly shorten the amount of time needed to
identify and fix the issues affecting the gating jobs.