### PR TITLE
Add heat template for devstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ This project has several scripts for different automated tasks. Some of them are
 # Documentation
 
 ## Crowbar deployments
-Find out more about configuration and usage in [`/docs/mkcloud.md`](docs/mkcloud.md)
 
-## Ardana deployment
-Find out more about configuration and usage in [`/docs/ardana/testing.md`](docs/ardana/testing.md)
+Find out more in [`/docs/mkcloud.md`](docs/mkcloud.md)
+
+## Ardana deployments
+
+Find out more in [`/docs/ardana/`](docs/ardana/)
+
+## devstack deployments
+
+Find out more in [`/docs/devstack/`](docs/devstack/)
 
 # License
 

--- a/docs/devstack/README.md
+++ b/docs/devstack/README.md
@@ -1,0 +1,63 @@
+# Launching `devstack` on OpenStack via Heat
+
+This repository provides [a heat
+template](../../scripts/heat/devstack-heat-template.yaml) for
+launching
+[`devstack`](https://docs.openstack.org/devstack/latest/index.html) in
+a single VM inside an OpenStack cloud.  It uses
+[`qa_devstack.sh`](../../scripts/jenkins/qa_devstack.sh) in order to
+prepare the VM for `devstack` and then run it.
+
+## Example usage
+
+The below examples use [OpenStack's Heat CLI
+client](https://docs.openstack.org/python-heatclient/latest/cli/stack.html#stack-create);
+however it is also possible to [launch a stack via the Horizon web
+dashboard](https://docs.openstack.org/heat-dashboard/latest/user/stacks.html#launch-a-stack).
+
+Firstly, [set up your environment with the right
+credentials](https://docs.openstack.org/python-openstackclient/rocky/cli/man/openstack.html#authentication-methods),
+e.g.
+
+    source openrc
+
+or
+
+    # assuming ~/.config/openstack/my-cloud.yaml exists
+    export OS_CLOUD=my-cloud
+
+and ensure you have the Python OpenStack client and the `heatclient`
+extension both installed.
+
+Then, to boot `devstack` on Leap 15.0:
+
+    openstack stack create \
+        -t scripts/heat/devstack-heat-template.yaml \
+        --parameter key_name=$USER \
+        --parameter image_name=openSUSE-Leap-15.0 \
+        $USER-devstack-leap
+
+To boot `devstack` on SLES 12 SP3:
+
+    openstack stack create \
+        -t scripts/heat/devstack-heat-template.yaml \
+        --parameter key_name=$USER \
+        --parameter image_name=SLES12-SP3-JeOS.x86_64 \
+        $USER-devstack-sles12-sp3
+
+To boot `devstack` on SLES 12 SP3 using modified versions of
+`qa_devstack.sh` and `devstack` from forked branches in GitHub:
+
+    openstack stack create \
+        -t scripts/heat/devstack-heat-template.yaml \
+        --parameter key_name=$USER \
+        --parameter image_name=SLES12-SP3-JeOS.x86_64 \
+        --parameter qa_devstack_fork=$USER
+        --parameter qa_devstack_branch=devstack-sle
+        --parameter devstack_fork=$USER
+        --parameter devstack_branch=sles-support \
+        $USER-devstack-sles12-sp3
+
+There are more parameters available; details are available inside [the
+heat template](../../scripts/heat/devstack-heat-template.yaml) itself,
+near the top.

--- a/scripts/heat/devstack-heat-template.yaml
+++ b/scripts/heat/devstack-heat-template.yaml
@@ -1,0 +1,202 @@
+# See docs/devstack/ for documentation on how to use this.
+
+heat_template_version: 2016-10-14
+
+description: Single-node devstack
+
+parameters:
+  key_name:
+    type: string
+    label: SSH public key name
+    description: Name of the SSH public key to be used for access to the compute instance
+
+  floating_network_name:
+    type: string
+    label: Floating network name
+    default: floating
+
+  flavor_name:
+    type: string
+    label: Flavor
+    description: Flavor of the server
+    default: m1.large
+
+  image_name:
+    type: string
+    label: Image
+    description: Image to boot the server with
+    default: openSUSE-Leap-15.0
+    # This would be better, but DNS is broken:
+    # default: openSUSE-Leap-15.0-JeOS.x86_64
+
+  run_tempest:
+    type: boolean
+    label: Run Tempest
+    description: Set to 'True' to run Tempest tests.  Defaults to 'False'.
+    default: False
+
+  qa_devstack_fork:
+    type: string
+    label: qa_devstack.sh fork
+    description: GitHub user/organization from which to fetch qa_devstack.sh
+    default: SUSE-Cloud
+
+  qa_devstack_branch:
+    type: string
+    label: qa_devstack.sh branch
+    description: GitHub branch from which to fetch qa_devstack.sh
+    default: master
+
+  devstack_fork:
+    type: string
+    label: devstack fork
+    description: GitHub user/organization from which to fetch devstack
+    default: openstack-dev
+
+  devstack_branch:
+    type: string
+    label: devstack branch
+    description: GitHub branch from which to fetch devstack
+    default: master
+
+conditions:
+  skip_tempest_res:
+    equals:
+      - {get_param: run_tempest}
+      - False
+
+resources:
+  ping_ssh_secgroup:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: ping_ssh_secgroup
+      description: Ping and SSH
+      rules:
+      - protocol: icmp
+      - protocol: tcp
+        port_range_min: 22
+        port_range_max: 22
+
+  network:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: True
+
+  subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network }
+      cidr: 10.1.1.0/24
+      ip_version: 4
+      enable_dhcp: True
+      allocation_pools:
+        - start: 10.1.1.50
+          end:   10.1.1.99
+      gateway_ip: 10.1.1.1
+
+  router_ext:
+    type: OS::Neutron::Router
+    properties:
+      external_gateway_info:
+        network: { get_param: floating_network_name }
+
+  router_ext_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router_ext }
+      subnet_id: { get_resource: subnet }
+
+  port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_resource: network }
+      fixed_ips:
+        - subnet_id: { get_resource: subnet }
+      security_groups:
+        - default
+        - { get_resource: ping_ssh_secgroup }
+
+  floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: floating
+
+  floating_ip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: floating_ip }
+      port_id: { get_resource: port }
+
+  server:
+    type: OS::Nova::Server
+    properties:
+      key_name: { get_param: key_name }
+      image: { get_param: image_name }
+      flavor: { get_param: flavor_name }
+      networks:
+        - port: { get_resource: port }
+      user_data_format: SOFTWARE_CONFIG
+      user_data:
+        get_resource: cloud_init
+
+  cloud_init:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        disable_root: false
+
+        groups:
+          - stack
+
+        users:
+          - name: stack
+            lock_passwd: False
+            sudo: ["ALL=(ALL) NOPASSWD:ALL\nDefaults:stack !requiretty"]
+            shell: /bin/bash
+            primary_group: stack
+            # Not supported on openSUSE yet; causes this message:
+            #   Skipping modules 'ssh-import-id' because they are not verified on distro 'opensuse'.  To run anyway, add them to 'unverified_modules' in config.
+            #ssh_import_id: { get_param: key_name }
+
+        runcmd:
+          # Work around https://bugs.launchpad.net/cloud-init/+bug/1486113
+          - mkdir /home/stack/.ssh
+          - cp -p /root/.ssh/authorized_keys /home/stack/.ssh
+
+          # Use wget to retrieve qa_devstack.sh server-side rather than relying
+          # on heat's write_files client-side magic.  This works around
+          # https://bugs.launchpad.net/cloud-init/+bug/1486113 which would write
+          # the file before the stack user/group exist, but more importantly, it
+          # allows us to dynamically determine the URL from the parameters.
+          - str_replace:
+              template: |
+                curl -o /home/stack/qa_devstack.sh \
+                  https://raw.githubusercontent.com/$fork/automation/$branch/scripts/jenkins/qa_devstack.sh
+              params:
+                $fork:
+                  get_param: qa_devstack_fork
+                $branch:
+                  get_param: qa_devstack_branch
+          - chmod 755 /home/stack/qa_devstack.sh
+
+          - chown -R stack:stack /home/stack
+          - str_replace:
+              template: |
+                HOME=/root \
+                DISABLE_TEMPESTRUN=$tempest \
+                DEVSTACK_FORK=$fork \
+                DEVSTACK_BRANCH=$branch \
+                /home/stack/qa_devstack.sh # ipv6
+              params:
+                $fork:
+                  get_param: devstack_fork
+                $branch:
+                  get_param: devstack_branch
+                $tempest:
+                  if: ["skip_tempest_res", "yes", ""]
+
+outputs:
+  # floating IP address of the admin node
+  floating-ip:
+    description: Floating IP address of the admin node
+    value: { get_attr: [floating_ip, floating_ip_address] }


### PR DESCRIPTION
Hopefully this will help put an end to the many manual hacks we have floating around the place, e.g.

- https://en.opensuse.org/SDB:DevStack
- https://confluence.suse.de/display/SOC/Devstack+in+libvirt+VM
- https://confluence.suse.de/display/SOC/Run+devstack+in+the+ENG+cloud
- https://confluence.suse.de/display/SOC/Devstack+on+OpenSUSE
- https://confluence.suse.de/display/HSLP/Install+Devstack

This works (on ECP at least) and so should instantly be useful, but I'm not sure whether the PR is complete as is, or whether I need to add something else, e.g.

### docs

It's pretty self-explanatory but I could update one of the above pages and make the others redirect to it.

### CI

Maybe adjust the existing devstack Jenkins job to use this instead of cleanvm?