### PR TITLE
ardana: deprecate service nova-consoleauth

### DIFF
--- a/scripts/jenkins/ardana/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-cloud.yml
@@ -49,6 +49,7 @@
             - manila
             - freezer
             - heat-api-cloudwatch
+            - nova-console-auth
 
         - name: Ardana log stream at
           debug:

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -28,6 +28,8 @@ versioned_features:
     enabled: "{{ when_cloud8 }}"
   heat-api-cloudwatch:
     enabled: "{{ when_cloud8 }}"
+  nova-console-auth:
+    enabled: "{{ when_cloud8 }}"
   # Disable LVM on virtual deployments with GM8* cloudsources
   # until https://gerrit.suse.provo.cloud/#/c/5143/ gets released
   want_lvm:


### PR DESCRIPTION
Service nova-consoleauth has been deprecated in Rocky[1]. We need this change to fix CI error for the cleanup of such service on ardana-input-model repo.
[1] https://docs.openstack.org/releasenotes/
    nova/rocky.html#relnotes-18-0-0-stable-rocky
[2] https://jira.suse.de/browse/SCRD-6808