### PR TITLE
SCRD-6812 Enable manila for Cloud9 deployments

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -23,7 +23,7 @@ when_cloud9M3: "{{ cloudsource is match('cloud9M3') }}"
 
 versioned_features:
   manila:
-    enabled: "{{ when_staging }}"
+    enabled: "{{ when_staging or when_cloud9 }}"
   freezer:
     enabled: "{{ when_cloud8 }}"
   heat-api-cloudwatch:


### PR DESCRIPTION
Now that we are enabling manila in the ardana-ansible verb action lists
(in the .list files under roles/deployer-setup/files) we can enabled
manila for Cloud9 deployments in general.

Note however that until SCRD-6814 is addressed manila will be deployed
without any real configuration defined and therefore won't be usable
for actual testing in the CI.