### PR TITLE
openstack-ardana: disable RGW on QE 102 job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -144,6 +144,7 @@
     sles_computes: '2'
     rhel_computes: '0'
     ses_enabled: true
+    ses_rgw_enabled: false
     tempest_filter_list: "\
       ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,\
       magnum,manila,monasca,network,neutron-api,swift"


### PR DESCRIPTION
Disabling RADOS Gateway from QE102 job as tempest does not support it
and it is causing tempest object-store tests to fail.