### PR TITLE
Use a fixed refstack client to upload defcore results

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3495,17 +3495,26 @@ function oncontroller_upload_defcore
     pushd /var/lib/openstack-tempest-test
     # get the test list
     wget "https://refstack.openstack.org/api/v1/guidelines/2018.02/tests" -O defcore-with-id.txt
+
     # remove the id in [] or tempest will complain on incorrect regex
     sed -e 's/\[[^][]*\]//g' defcore-with-id.txt > defcore.txt
+
     # run only the specified tests
     tempest run --whitelist-file defcore.txt
-    source /root/.openrc
+
+    # get a subunit-2to1 filter directly
     wget https://raw.githubusercontent.com/testing-cabal/subunit/master/filters/subunit-2to1
 
+    # save the latest tempest run results
     local testdriver=testr
     [ -f ".stestr.conf" ] && testdriver=stestr
     $testdriver last --subunit | python subunit-2to1 > tempest.subunit_1.log
-    test -d refstack-client || safely git clone https://github.com/openstack/refstack-client
+
+    # clone a refstack client
+    test -d refstack-client || safely git clone https://github.com/kbaikov/refstack-client
+
+    # upload to refstack server
+    source /root/.openrc
     yes | refstack-client/refstack-client upload-subunit --keystone-endpoint $OS_AUTH_URL --url https://10.86.0.98 --insecure tempest.subunit_1.log
     popd
 }


### PR DESCRIPTION
Refstack client throws a python exception when run if
tempest config was not generated by the said client
This is fixed in my local fork until the upstream fixes it