### PR TITLE
openstack-ardana: fix bootstrap vcloud for CentOS

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -156,7 +156,7 @@
             name: CentOS-Base
             description: "CentOS Base Repository"
             gpgcheck: no
-            baseurl: "http://{{ hostvars['localhost'].admin_mgmt_ip }}:79/ardana/rhel7/yum/OS"
+            baseurl: "http://{{ hostvars['localhost'].admin_conf_ip }}:79/ardana/rhel7/yum/OS"
           when: ansible_os_family == 'RedHat'
       rescue:
         - include_role:


### PR DESCRIPTION
The variable holding the deployer IP is admin_conf_ip not admin_mgmt_ip