### PR TITLE
openstack-ardana: enable SES for all cloud9 jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -216,8 +216,6 @@
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
     cloudsource: develcloud8
-    ses_enabled: true
-    ses_rgw_enabled: false
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
     triggers:
       - gerrit:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -26,6 +26,8 @@
     clm_model: standalone
     controllers: '3'
     sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -39,6 +41,8 @@
     clm_model: integrated
     controllers: '3'
     sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -52,6 +56,8 @@
     clm_model: standalone
     controllers: '2'
     sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -66,6 +72,8 @@
     controllers: '1'
     sles_computes: '1'
     disabled_services: 'monasca|logging|ceilometer|cassandra|kafka|spark|storm|octavia'
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -81,6 +89,8 @@
     lmm_nodes: '1'
     dbmq_nodes: '1'
     sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -97,6 +107,8 @@
     sles_computes: '2'
     rhel_computes: '0'
     tempest_filter_list: 'ci'
+    ses_enabled: true
+    ses_rgw_enabled: false
     qa_test_list: "\
       iverify,cinder,heat,magnum,neutron,nova-attach,nova_volume,nova_server,\
       nova_services,nova_flavor,nova_image,tempest_cleanup"
@@ -120,6 +132,8 @@
     swift_nodes: '3'
     sles_computes: '2'
     rhel_computes: '0'
+    ses_enabled: true
+    ses_rgw_enabled: false
     tempest_filter_list: "\
       ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,\
       magnum,manila,monasca,network,neutron-api,swift"
@@ -176,6 +190,8 @@
     clm_model: standalone
     controllers: '3'
     sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -196,14 +212,11 @@
     jobs:
         - '{ardana_job}'
 
-
 - project:
     name: openstack-ardana-gerrit-cloud9
     ardana_gerrit_job: '{name}'
     ardana_env: cloud-ardana-gerrit-slot
     cloudsource: develcloud9
-    ses_enabled: false
-    ses_rgw_enabled: false
     gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
     triggers:
       - gerrit:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -87,8 +87,8 @@ The following links can also be used to track the results:
               string(name: 'controllers', value: "2"),
               string(name: 'sles_computes', value: "1"),
               string(name: 'cloudsource', value: "$cloudsource"),
-              string(name: 'ses_enabled', value: "$ses_enabled"),
-              string(name: 'ses_rgw_enabled', value: "$ses_rgw_enabled"),
+              string(name: 'ses_enabled', value: "true"),
+              string(name: 'ses_rgw_enabled', value: "false"),
               string(name: 'tempest_filter_list', value: "$tempest_filter_list"),
               string(name: 'os_cloud', value: "$os_cloud")
             ], propagate: false, wait: true


### PR DESCRIPTION
This change enable SES for all ardana cloud9 jobs.
In that way, besides deploying ardana, those jobs
will also deploy a SES cluster and configure glance,
nova, cinder and cinder-backup with SES backend.

As those jobs rely on tempest for testing and
tempest does not support object-store service
configured with RADOS gateway, the object-store
service will not be configured with RADOS gateway
(ses_rgw_enabled = false).

This change also removes the SES parameters from
Gerrit jobs, because they are similar for cloud8/9.