### PR TITLE
openstack-ardana-gerrit: voting job for cloud8

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
@@ -19,6 +19,7 @@
               project-pattern: !include-raw: gerrit-project-regexp.txt
               branches:
                 - branch-pattern: master
+                - branch-pattern: stable/pike
     wrappers:
       - workspace-cleanup
 

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -117,21 +117,13 @@ The following links can also be used to track the results:
           # Post reviews only for jobs triggered by Gerrit
           if [ -n "$GERRIT_CHANGE_NUMBER" ] ; then
             if [[ $BUILD_RESULT == SUCCESS ]]; then
-              if [[ $cloudsource == develcloud9 ]]; then
-                vote=+2
-              else
-                vote=0
-              fi
+              vote=+2
               message="
 Build succeeded (${JOB_NAME}): ${BUILD_URL}
 
 "
             else
-              if [[ $cloudsource == develcloud9 ]]; then
-                vote=-2
-              else
-                vote=-1
-              fi
+              vote=-2
               message="
 Build failed (${JOB_NAME}): ${BUILD_URL}
 


### PR DESCRIPTION
Make the Ardana Gerrit Jenkins jobs vote Verify -2/+2, merge Gerrit
changes and handle Gerrit events, the same way it is currently done
for cloud9.