### PR TITLE
openstack-ardana: disable cinder LVM backend with SES

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -25,6 +25,7 @@ clouddata_server: "provo-clouddata.cloud.suse.de"
 rhel_enabled: "{{ rhel_computes is defined and rhel_computes | int > 0 }}"
 ses_enabled: False
 ses_rgw_enabled: False
+cinder_lvm_enabled: '{{ not ses_enabled }}'
 
 workspace_path: "{{ lookup('env', 'WORKSPACE') | default('.', true) }}"
 input_model_path: "{{ workspace_path }}/input_model"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
@@ -79,7 +79,6 @@ scenario:
     Standard scenario with all services enabled, {{ clm_model }} CLM node, {{ controllers }} controller nodes,
     {{ sles_computes }} SLES compute nodes and {{ rhel_computes }} RHEL compute nodes.
   audit_enabled: False
-  ses_enabled: False
   use_cinder_volume_disk: False
   use_glance_cache_disk: False
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/baremetal/disks.yml.j2
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/baremetal/disks.yml.j2
@@ -100,12 +100,13 @@
                 - account
                 - container
                 - object-0
+{%     if cinder_lvm_enabled | bool %}
         - name: cinder-volume
           devices:
             - name: /dev/sdc
           consumer:
             name: cinder
-
+{%     endif %}
 {%   elif 'compute' in service_group.name %}
         - name: ardana-vg
           consumer:
@@ -160,11 +161,14 @@
               mkfs-opts: -O large_file
 
       device-groups:
+
+{%     if cinder_lvm_enabled | bool %}
         - name: cinder-volume
           devices:
             - name: /dev/sdc
           consumer:
             name: cinder
+{%     endif %}
 
 {%   elif 'neutron' in service_group.name %}
         - name: ardana-vg

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
@@ -238,13 +238,15 @@
             rings:
               - object-0
 {%         elif service_component_group == 'CORE' %}
-{%           set ns.drive_idx = ns.drive_idx+1 %}
+{%           if cinder_lvm_enabled | bool %}
+{%             set ns.drive_idx = ns.drive_idx+1 %}
 
       - name: cinder-volume
         devices:
           - name: /dev/sd{{ drive_letters[ns.drive_idx] }}
         consumer:
           name: cinder
+{%           endif %}
 {%         endif %}
 {%       endfor %}
 {%     endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm.yml
@@ -26,7 +26,6 @@ scenario:
     Multi-cluster scenario with all services enabled, {{ clm_model }} CLM node,
     {{ sles_computes }} SLES compute nodes and {{ rhel_computes }} RHEL compute nodes.
   audit_enabled: True
-  ses_enabled: "{{ ses_enabled | default(False) }}"
   use_cinder_volume_disk: True
   use_glance_cache_disk: False
   availability_zones: "{{ availability_zones }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/mid-scale-kvm.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/mid-scale-kvm.yml
@@ -33,7 +33,6 @@ scenario:
     agent nodes, {{ swift_nodes }} swift nodes, {{ lmm_nodes }} LMM nodes and with {{ sles_computes }} SLES compute nodes
     and {{ rhel_computes }} RHEL compute nodes.
   audit_enabled: False
-  ses_enabled: False
   use_cinder_volume_disk: True
   use_glance_cache_disk: False
   availability_zones: "{{ availability_zones }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/standard.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/standard.yml
@@ -28,7 +28,6 @@ scenario:
     Standard scenario with all services enabled, {{ clm_model }} CLM node, {{ controllers }} controller nodes,
     {{ sles_computes }} SLES compute nodes and {{ rhel_computes }} RHEL compute nodes.
   audit_enabled: False
-  ses_enabled: False
   use_cinder_volume_disk: False
   use_glance_cache_disk: False
   availability_zones: "{{ availability_zones }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/std-split.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/std-split.yml
@@ -31,7 +31,6 @@ scenario:
     {{ dbmq_nodes }} database nodes, {{ lmm_nodes }} LMM nodes, {{ sles_computes }} SLES compute nodes and
     {{ rhel_computes }} RHEL compute nodes.
   audit_enabled: False
-  ses_enabled: False
   use_cinder_volume_disk: False
   use_glance_cache_disk: False
   availability_zones: "{{ availability_zones }}"


### PR DESCRIPTION
Disable the cinder LVM backend by default if SES is enabled.

To avoid confusion, this PR also removes the unused `ses_enabled` variables
from the input model generator templates. Only the global variable
has effect.