### PR TITLE
cleanvm: Import keys before patch

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -155,15 +155,15 @@ if [ -z "$skip_reposetup" ]; then
     $addrepofunc
 fi
 
-# install maintenance updates
-# run twice, first installs zypper update, then the rest
-$zypper -n patch --skip-interactive || $zypper -n patch --skip-interactive
-
 # grizzly or master does not want dlp
 $zypper rr dlp || true
 
 $zypper rr Virtualization_Cloud # repo was dropped but is still in some images for cloud-init
 $zypper --gpg-auto-import-keys -n ref
+
+# install maintenance updates
+# run twice, first installs zypper update, then the rest
+$zypper -n patch --skip-interactive || $zypper -n patch --skip-interactive
 
 # wickedd needs to be configured properly to avoid overriding
 # the hostname (see <https://bugzilla.opensuse.org/show_bug.cgi?id=974661>).


### PR DESCRIPTION
If the repository list is not refreshed before the first patch, keys for
the default oss repos will not be imported yet and the patch will fail,
which can cause other installation errors down the line[1].

[1] https://ci.opensuse.org/job/openstack-cleanvm/image=openSUSE-Leap-15.0,slave=cloud-cleanvm/3507/console