### PR TITLE
Run only smoke tests on devstack jobs

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -239,7 +239,7 @@ if [ -z "${DISABLE_TEMPESTRUN}" ]; then
 pip install junitxml
     sudo -u stack -i <<EOF
 cd /opt/stack/tempest
-tempest run --regex '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))' --concurrency=2 --subunit > tempest.subunit
+tempest run --smoke --subunit | tee tempest.subunit | subunit-trace -f -n
 subunit2html tempest.subunit /opt/stack/results.html
 # subunit2junitxml will fail if test run failed as it forwards subunit stream result code, ignore it
 subunit2junitxml tempest.subunit > /opt/stack/results.xml || true


### PR DESCRIPTION
It turns out that running the same regex for tempest in our devstack
jobs we never were able to have a green job.

Having jobs without tests passing is useless, so until we will able to
have it green it's better to switch back to the previous state where we
only ran the smoke tempest tests.

In addition, we improve the logging of the job leveraging the
subunit-trace command to show the logs in the console

Signed-off-by: aojeagarcia <aojeagarcia@suse.com>