### PR TITLE
openstack-ardana: fix get milestone version from cloudsource

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/vars/milestone.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/vars/milestone.yml
@@ -15,7 +15,7 @@
 #
 ---
 
-milestone: "{{ cloudsource[-1] }}"
+milestone: "{{ cloudsource | regex_search('\\d+$') }}"
 built_from: "{{ media[cloud_release].url }}/{{ media[cloud_release].iso }}"
 media_build_version: "{{ media_url.content | regex_search('SUSE-OPENSTACK-CLOUD-\\d-x86_64-Build\\d{4}') }}"
 


### PR DESCRIPTION
Get the milestone version from cloudsource using a regex instead of
getting the last digit which does not work for versions with 2 or more digits.