### PR TITLE
openstack-ardana: fix core disks model

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/baremetal/disks.yml.j2
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/baremetal/disks.yml.j2
@@ -160,9 +160,8 @@
               fstype: ext4
               mkfs-opts: -O large_file
 
-      device-groups:
-
 {%     if cinder_lvm_enabled | bool %}
+      device-groups:
         - name: cinder-volume
           devices:
             - name: /dev/sdc


### PR DESCRIPTION
On disk input model 'device_groups' cannot be empty.