### PR TITLE
openstack-ardana: make cloud deployment optional

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -214,6 +214,9 @@ pipeline {
     }
 
     stage('Deploy cloud') {
+      when {
+        expression { deploy_cloud == 'true' }
+      }
       steps {
         script {
           ardana_lib.ansible_playbook('deploy-cloud')
@@ -223,7 +226,7 @@ pipeline {
 
     stage('Update cloud') {
       when {
-        expression { update_after_deploy == 'true' }
+        expression { deploy_cloud == 'true' && update_after_deploy == 'true' }
       }
       steps {
         script {

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -63,6 +63,14 @@
                cloud9MX (cloud 9 milestones)
 
       - bool:
+          name: deploy_cloud
+          default: '{deploy|true}'
+          description: >-
+            If left unchecked, the cloud deployment steps will be skipped. This option can be
+            used if you only need to set up the infrastructure and configure the cloud media and
+            repositories, but skip the actual cloud deployment, e.g. for testing purposes.
+
+      - bool:
           name: updates_test_enabled
           default: '{updates_test_enabled|false}'
           description: >-

--- a/scripts/jenkins/ardana/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-cloud.yml
@@ -38,19 +38,6 @@
 
   tasks:
     - block:
-        - name: Remove versioned features from input model when not enabled
-          replace:
-            path: "{{ input_model_path }}/data/control_plane.yml"
-            regexp: '(.*{{ item }}.*)'
-            replace: '#\1'
-          when: not versioned_features[item].enabled
-          delegate_to: localhost
-          loop:
-            - manila
-            - freezer
-            - heat-api-cloudwatch
-            - nova-console-auth
-
         - name: Ardana log stream at
           debug:
             msg: "http://{{ ansible_host }}:9091/"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_clone/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_clone/tasks/main.yml
@@ -27,3 +27,15 @@
   synchronize:
     src: "{{ git_input_model_dest }}/{{ git_input_model_path }}/{{ model }}/"
     dest: "{{ input_model_path }}/"
+
+- name: Remove versioned features from input model when not enabled
+  replace:
+    path: "{{ input_model_path }}/data/control_plane.yml"
+    regexp: '(.*{{ item }}.*)'
+    replace: '#\1'
+  when: not versioned_features[item].enabled
+  loop:
+    - manila
+    - freezer
+    - heat-api-cloudwatch
+    - nova-console-auth

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
@@ -58,3 +58,15 @@
     - not is_physical_deploy
     - virt_config_file != ''
     - not want_caasp
+
+- name: Remove versioned features from input model when not enabled
+  replace:
+    path: "{{ input_model_path }}/data/control_plane.yml"
+    regexp: '(.*{{ item }}.*)'
+    replace: '#\1'
+  when: not versioned_features[item].enabled
+  loop:
+    - manila
+    - freezer
+    - heat-api-cloudwatch
+    - nova-console-auth


### PR DESCRIPTION
Add an option to skip running the steps that deploy the Ardana
cloud. This option can be used if one only needs to set up the
infrastructure and configure the cloud media and repositories,
but skip the actual cloud deployment, e.g. for testing purposes.