### PR TITLE
openstack-ardana: remove ceilometer-api from SOC9 (SCRD-6079)

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -40,3 +40,10 @@ versioned_features:
   # designate zone/pool (Cloud8) or worker/producer (Cloud9)
   designate_worker_producer:
     enabled: "{{ when_cloud9 }}"
+
+input_model_versioned_features:
+  - manila
+  - freezer
+  - heat-api-cloudwatch
+  - nova-console-auth
+  - ceilometer-api

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -30,6 +30,8 @@ versioned_features:
     enabled: "{{ when_cloud8 }}"
   nova-console-auth:
     enabled: "{{ when_cloud8 }}"
+  ceilometer-api:
+    enabled: "{{ when_cloud8 }}"
   # Keep using the deprecated external_network_bridge option with GM8*
   # cloudsources until the http://bugzilla.suse.com/show_bug.cgi?id=1117198
   # fix gets released

--- a/scripts/jenkins/ardana/ansible/roles/input_model_clone/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_clone/tasks/main.yml
@@ -39,3 +39,4 @@
     - freezer
     - heat-api-cloudwatch
     - nova-console-auth
+    - ceilometer-api

--- a/scripts/jenkins/ardana/ansible/roles/input_model_clone/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_clone/tasks/main.yml
@@ -34,9 +34,5 @@
     regexp: '(.*{{ item }}.*)'
     replace: '#\1'
   when: not versioned_features[item].enabled
-  loop:
-    - manila
-    - freezer
-    - heat-api-cloudwatch
-    - nova-console-auth
-    - ceilometer-api
+  loop: "{{ input_model_versioned_features }}"
+

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
@@ -65,9 +65,4 @@
     regexp: '(.*{{ item }}.*)'
     replace: '#\1'
   when: not versioned_features[item].enabled
-  loop:
-    - manila
-    - freezer
-    - heat-api-cloudwatch
-    - nova-console-auth
-    - ceilometer-api
+  loop: "{{ input_model_versioned_features }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
@@ -70,3 +70,4 @@
     - freezer
     - heat-api-cloudwatch
     - nova-console-auth
+    - ceilometer-api


### PR DESCRIPTION
The `ceilometer-api` service has been removed from Rocky. This
change removes it from all generated input models used for Cloud9
jobs.