### PR TITLE
openstack-ardana: re-enable LVM disk models

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -24,7 +24,7 @@ want_caasp: False
 virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
 virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 
-want_lvm: False
+want_lvm: True
 # use different flavors and images when LVM support is enabled:
 #  - LVM enabled images have the root partition set up as an LVM volume
 #  - LVM enabled flavors have a smaller disk size for generated input models,

--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -30,10 +30,6 @@ versioned_features:
     enabled: "{{ when_cloud8 }}"
   nova-console-auth:
     enabled: "{{ when_cloud8 }}"
-  # Disable LVM on virtual deployments with GM8* cloudsources
-  # until https://gerrit.suse.provo.cloud/#/c/5143/ gets released
-  want_lvm:
-    enabled: "{{ when_staging_or_devel or not when_cloud8 }}"
   # Keep using the deprecated external_network_bridge option with GM8*
   # cloudsources until the http://bugzilla.suse.com/show_bug.cgi?id=1117198
   # fix gets released


### PR DESCRIPTION
The LVM based disk input model configuration has been disabled
during the Pike ECP upgrade [1][2] to reduce resources usage and impact.
The ECP has been stable for a long time, so it's time to re-enable
it in all jobs.

[1] https://gerrit.suse.provo.cloud/#/c/5143/
[2] #2998