### PR TITLE
openstack-ardana: add option to use salt API to create SES resources

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -227,7 +227,7 @@
     controllers: '2'
     sles_computes: '0'
     rhel_computes: '2'
-    ses_enabled: false
+    ses_enabled: true
     ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -206,7 +206,7 @@
     controllers: '2'
     sles_computes: '0'
     rhel_computes: '2'
-    ses_enabled: false
+    ses_enabled: true
     ses_rgw_enabled: false
     triggers:
      - timed: 'H H * * *'

--- a/scripts/jenkins/ardana/ansible/ardana-ses-rgw.yml
+++ b/scripts/jenkins/ardana/ansible/ardana-ses-rgw.yml
@@ -50,7 +50,7 @@
 
   tasks:
     - block:
-        - name: Add RGW endpoint on SES config
+        - name: Add RADOS GW entry on SES config
           lineinfile:
             path: "/tmp/ses_config/ses_config.yml"
             regex: "^radosgw_urls"

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -25,6 +25,7 @@ clouddata_server: "provo-clouddata.cloud.suse.de"
 rhel_enabled: "{{ rhel_computes is defined and rhel_computes | int > 0 }}"
 ses_enabled: False
 ses_rgw_enabled: False
+ardana_ses_integration_version: 2
 cinder_lvm_enabled: '{{ not ses_enabled }}'
 
 workspace_path: "{{ lookup('env', 'WORKSPACE') | default('.', true) }}"

--- a/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/defaults/main.yml
@@ -25,6 +25,7 @@ ardana_scratch_playbooks:
   - "ardana-reconfigure.yml"
   - "ardana-cloud-configure.yml"
 
+ses_salt_api_secret: "salt-api-secret"
 ses_ardana_config_path: "/tmp/ses_config"
-ses_cluster_id: "qe1"
+ses_cluster_id: "qe"
 ses_rgw_port: 8080

--- a/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/tasks/main.yml
@@ -20,17 +20,4 @@
     path: "{{ ses_ardana_config_path }}"
     state: directory
 
-- name: Copy ceph keyring files
-  copy:
-    dest: "{{ ses_ardana_config_path }}/ceph.{{ item.item.name }}.keyring"
-    content: "{{ item.content | b64decode }}"
-    mode: 0644
-  when: "item.item.name != 'client.rgw.ses-' ~ ardana_env"
-  loop: "{{ hostvars['ses-' + ses_cluster_id].ceph_files.results }}"
-  loop_control:
-    label: "{{ item.item.name }}"
-
-- name: Generate ses-config.yml
-  template:
-    src: ses-config.yml.j2
-    dest: "{{ ses_ardana_config_path }}/ses_config.yml"
+- include_tasks: ses_configure_v{{ ardana_ses_integration_version }}.yml

--- a/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/tasks/ses_configure_v1.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/tasks/ses_configure_v1.yml
@@ -15,7 +15,17 @@
 #
 ---
 
-- include_tasks: delete_pools.yml
+- name: Copy ceph keyring files
+  copy:
+    dest: "{{ ses_ardana_config_path }}/ceph.{{ item.item.name }}.keyring"
+    content: "{{ item.content | b64decode }}"
+    mode: 0644
+  when: "item.item.name != 'client.rgw.ses-' ~ ardana_env"
+  loop: "{{ hostvars['ses-' + ses_cluster_id].ceph_files.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
 
-- include_tasks: configure_ses.yml
-  when: ardana_ses_integration_version == 1
+- name: Generate ses-config.yml
+  template:
+    src: ses-config.yml.j2
+    dest: "{{ ses_ardana_config_path }}/ses_config.yml"

--- a/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/tasks/ses_configure_v2.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_ardana_integration/tasks/ses_configure_v2.yml
@@ -1,0 +1,54 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Get salt-api token
+  uri:
+    url: "http://{{ hostvars['ses-' ~ ses_cluster_id].ansible_host }}:8000/login"
+    method: POST
+    body:
+      username: "admin"
+      sharedsecret: "{{ ses_salt_api_secret }}"
+      eauth: "sharedsecret"
+    body_format: "json"
+  register: _salt_token
+
+- name: Run openstack.integrate
+  uri:
+    url: "http://{{ hostvars['ses-' ~ ses_cluster_id].ansible_host }}:8000/"
+    method: POST
+    headers:
+      X-Auth-Token: "{{ _salt_token.json.return.0.token }}"
+    body:
+      client: "runner"
+      fun: "openstack.integrate"
+      prefix: "{{ ardana_env }}"
+    body_format: "json"
+  register: _ses_conf
+
+- name: Generate ses-config.yml
+  copy:
+    content: "{{ _ses_conf.json.return.0 | to_nice_yaml }}"
+    dest: "{{ ses_ardana_config_path }}/ses_config.yml"
+
+- name: Remove RADOS GW config entries (will be configured after ardana deployment)
+  lineinfile:
+    path: "{{ ses_ardana_config_path }}/ses_config.yml"
+    regexp: "{{ item }}"
+    state: absent
+  loop:
+    - "^radosgw_url.*"
+    - "^-.*swift.*v1$"

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/defaults/main.yml
@@ -20,16 +20,16 @@ ses_osd_pool_default_pg_num: 64
 ses_rgw_port: "{{ hostvars[ardana_env].ses_rgw_port }}"
 
 ses_openstack_glance_pool:
-  name: "glance-{{ ardana_env }}"
+  name: "{{ ardana_env }}-cloud-images"
   pg_num: "{{ ses_osd_pool_default_pg_num }}"
 ses_openstack_cinder_pool:
-  name: "cinder-{{ ardana_env }}"
+  name: "{{ ardana_env }}-cloud-volumes"
   pg_num: "{{ ses_osd_pool_default_pg_num }}"
 ses_openstack_nova_pool:
-  name: "nova-{{ ardana_env }}"
+  name: "{{ ardana_env }}-cloud-vms"
   pg_num: "{{ ses_osd_pool_default_pg_num }}"
 ses_openstack_cinder_backup_pool:
-  name: "backups-{{ ardana_env }}"
+  name: "{{ ardana_env }}-cloud-backups"
   pg_num: "{{ ses_osd_pool_default_pg_num }}"
 
 ses_openstack_pools:
@@ -39,31 +39,33 @@ ses_openstack_pools:
   - "{{ ses_openstack_cinder_backup_pool }}"
 
 ses_openstack_keys:
-  - name: "client.glance-{{ ardana_env }}"
+  - name: "client.{{ ardana_env }}-glance"
     key: "$(ceph-authtool --gen-print-key)"
     mon_cap: "allow r"
     osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_glance_pool.name }}"
     mgr_cap: "allow r"
     mode: "0600"
     acls: []
-  - name: "client.cinder-{{ ardana_env }}"
+  - name: "client.{{ ardana_env }}-cinder"
     key: "$(ceph-authtool --gen-print-key)"
     mon_cap: "allow r"
     osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_pool.name }}, allow rwx pool={{ ses_openstack_nova_pool.name }}, allow rwx pool={{ ses_openstack_glance_pool.name }}"
     mgr_cap: "allow r"
     mode: "0600"
     acls: []
-  - name: "client.cinder_backup-{{ ardana_env }}"
+  - name: "client.{{ ardana_env }}-cinder-backup"
     key: "$(ceph-authtool --gen-print-key)"
     mon_cap: "allow r"
     osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool={{ ses_openstack_cinder_backup_pool.name }}"
     mgr_cap: "allow r"
     mode: "0600"
     acls: []
-  - name: "client.rgw.ses-{{ ardana_env }}"
-    key: "$(ceph-authtool --gen-print-key)"
-    mon_cap: "allow rwx"
-    osd_cap: "allow rwx"
-    mgr_cap: "allow r"
-    mode: "0600"
-    acls: []
+
+ses_rgw_key:
+  name: "client.rgw.ses-{{ ardana_env }}"
+  key: "$(ceph-authtool --gen-print-key)"
+  mon_cap: "allow rwx"
+  osd_cap: "allow rwx"
+  mgr_cap: "allow r"
+  mode: "0600"
+  acls: []

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_rgw.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_rgw.yml
@@ -15,6 +15,28 @@
 #
 ---
 
+- name: Create RADOS GW key
+  shell: |
+    ceph-authtool -C /etc/ceph/ceph.{{ ses_rgw_key.name }}.keyring \
+      --name {{ ses_rgw_key.name }} --add-key {{ ses_rgw_key.key }} \
+      --cap mon "{{ ses_rgw_key.mon_cap|default('') }}" --cap osd \
+      "{{ ses_rgw_key.osd_cap|default('') }}" --cap mds \
+      "{{ ses_rgw_key.mds_cap|default('') }}" \ --cap mgr \
+      "{{ ses_rgw_key.mgr_cap|default('') }}"
+  args:
+    creates: "/etc/ceph/ceph.{{ ses_rgw_key.name }}.keyring"
+
+- name: Check if RADOS GW key already exist
+  command: "ceph auth get {{ ses_rgw_key.name }}"
+  changed_when: false
+  failed_when: false
+  register: rgw_key_exist
+
+- name: Add RADOS GW key to ceph
+  command: "ceph auth import -i /etc/ceph/ceph.{{ ses_rgw_key.name }}.keyring"
+  changed_when: false
+  when: rgw_key_exist.rc != 0
+
 - name: Get required info from Cloud
   shell: awk -n -F '=' {{ item }} ~/keystone.osrc
   delegate_to: "{{ ardana_env }}"

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_rgw.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_rgw.yml
@@ -60,7 +60,7 @@
      rgw keystone admin project = admin
      rgw keystone admin domain = Default
      rgw keystone api version = 3
-     rgw keystone accepted roles = admin,Member,_member_
+     rgw keystone accepted roles = admin,Member,_member_,member
      rgw keystone accepted admin roles = admin
      rgw keystone verify ssl = false
   notify: Restart radosgw

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_ses.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_ses.yml
@@ -15,7 +15,8 @@
 #
 ---
 
-- include_tasks: delete_pools.yml
+- include_tasks: create_pools.yml
 
-- include_tasks: configure_ses.yml
-  when: ardana_ses_integration_version == 1
+- include_tasks: create_users.yml
+
+- include_tasks: get_ses_conf.yml

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/create_pools.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/create_pools.yml
@@ -15,11 +15,6 @@
 #
 ---
 
-- name: Ensure openstack pool(s) deleted
-  command: "ceph osd pool delete {{ item.name }} {{ item.name }} --yes-i-really-really-mean-it"
-  with_items: "{{ ses_openstack_pools | unique }}"
-  changed_when: false
-
 - name: Create openstack pool(s)
   command: "ceph osd pool create {{ item.name }} {{ item.pg_num }}"
   with_items: "{{ ses_openstack_pools | unique }}"

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/delete_pools.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/delete_pools.yml
@@ -15,7 +15,7 @@
 #
 ---
 
-- include_tasks: delete_pools.yml
-
-- include_tasks: configure_ses.yml
-  when: ardana_ses_integration_version == 1
+- name: Ensure openstack pool(s) deleted
+  command: "ceph osd pool delete {{ item.name }} {{ item.name }} --yes-i-really-really-mean-it"
+  with_items: "{{ ses_openstack_pools | unique }}"
+  changed_when: false

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/get_ses_conf.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/get_ses_conf.yml
@@ -15,7 +15,14 @@
 #
 ---
 
-- include_tasks: delete_pools.yml
+- name: Get ses conf options
+  shell: grep 'fsid\|mon_host\|mon_initial\|network' /etc/ceph/ceph.conf | awk '{ print $3 }'
+  register: conf_options
 
-- include_tasks: configure_ses.yml
-  when: ardana_ses_integration_version == 1
+- name: Get ceph keyring file contents
+  slurp:
+    src: "/etc/ceph/ceph.{{ item.name }}.keyring"
+  register: ceph_files
+  loop: "{{ ses_openstack_keys }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/scripts/jenkins/ses/ansible/roles/ses/defaults/main.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/defaults/main.yml
@@ -18,6 +18,7 @@ ses_version: 5
 ses_deepsea_minions: "*"
 ses_zap_disks: False
 ses_add_zypper_repos: True
+ses_salt_api_secret: "salt-api-secret"
 ses_repo_server: "http://provo-clouddata.cloud.suse.de"
 
 ses_osd_pool_default_pg_num: 64

--- a/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
@@ -112,8 +112,14 @@
     var: stage4.stdout_lines
     verbosity: 1
 
-- name: run iscsi workaround
-  command: salt-run state.orch ceph.stage.iscsi
+- name: Run iscsi workaround
+  command: "salt-run state.orch ceph.stage.iscsi"
   when:
     - stage4.stdout.find('lrbd has been enabled, and is dead') != -1  # Implement workaround of the cosmetic issue https://www.suse.com/support/kb/doc/?id=7018668
+    
+# For some reason sometimes the radosgw package is not installed
+- name: Ensure RADOS GW installed
+  package:
+    name: ceph-radosgw
+    state: present
 

--- a/scripts/jenkins/ses/ansible/roles/ses/tasks/salt_setup.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/tasks/salt_setup.yml
@@ -32,6 +32,13 @@
   notify:
     - Restart and enable salt-minion
 
+- name: Drop salt api secret conf
+  template:
+    src: "sharedsecret.conf.j2"
+    dest: "/etc/salt/master.d/sharedsecret.conf"
+  notify:
+    - Restart and enable salt-master
+
 - meta: flush_handlers
 
 - name: "Wait for salt-minion to initialize"

--- a/scripts/jenkins/ses/ansible/roles/ses/templates/sharedsecret.conf.j2
+++ b/scripts/jenkins/ses/ansible/roles/ses/templates/sharedsecret.conf.j2
@@ -1,0 +1,1 @@
+sharedsecret: {{ ses_salt_api_secret }}


### PR DESCRIPTION
Add support for ardana SES integration v2, which uses the salt-api to
configure ceph for openstack.

It is possible to configure which version of ardana SES integration to
use by setting `ardana_ses_integration_version` which defaults to 2.