### PR TITLE
openstack-ardana: Fix MU gating job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -34,7 +34,7 @@
     name: cloud-ardana8-maintenance-gating
     ardana_maintenance_gating_job: '{name}'
     ardana_env: cloud-ardana-maintenance-slot
-    version: 8
+    version: '8'
     jobs:
       - '{ardana_maintenance_gating_job}'
 

--- a/jenkins/ci.suse.de/templates/cloud-ardana-maintenance-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-maintenance-gating-template.yaml
@@ -51,14 +51,13 @@
           name: cloudsource
           choices:
             - 'GM{version|8}+up'
-            - GM8+up
-            - hosGM8+up
+            - 'hosGM{version|8}+up'
           description: >-
             The cloud repository (from provo-clouddata) to be used for testing.
             This value can take the following form:
 
                GM<X>+up (official GM plus Cloud-Updates)
-               hosGM8+up (official HOS GM plus Cloud-Updates)
+               hosGM<X>+up (official HOS GM plus Cloud-Updates)
 
       - validating-string:
           name: maint_updates
@@ -90,6 +89,13 @@
           default: master
           description: >-
             The git automation branch
+
+      - hidden:
+          name: version
+          default: '{version}'
+          description: >-
+            Cloud version number (8, 9 etc.)
+
 
     pipeline-scm:
       scm:


### PR DESCRIPTION
The `version` parameter was missing from the job. This change
adds that parameter as a hidden parameter type.