### PR TITLE
openstack-ardana-gating: make update optional

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -15,6 +15,7 @@
     concurrent: False
     version: '9'
     ardana_env: 'cloud-ardana-gate{version}-slot'
+    deploy_and_update: false
     jobs:
         - '{ardana_gating_job}'
 

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -49,6 +49,9 @@ pipeline {
       parallel {
 
         stage('Run cloud deploy job') {
+          when {
+            expression { deploy == 'true' }
+          }
           steps {
             script {
               // reserve a resource here for the openstack-ardana job, to avoid
@@ -71,7 +74,7 @@ pipeline {
 
         stage('Run cloud update job') {
           when {
-            expression { version != '9' }
+            expression { deploy_and_update == 'true' }
           }
           steps {
             script {

--- a/jenkins/ci.suse.de/templates/cloud-ardana-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-gating-template.yaml
@@ -21,14 +21,17 @@
           description: >-
             The Lockable Resource label representing the resource pool to used by this job.
 
-      - validating-string:
-          name: version
-          default: '{version}'
-          regex: '[0-9]+'
-          msg: >-
-            Cloud version value not valid.
+      - bool:
+          name: deploy
+          default: '{deploy|true}'
           description: >-
-            Cloud version number (8, 9 etc.)
+            Run Ardana deploy validation step
+
+      - bool:
+          name: deploy_and_update
+          default: '{deploy_and_update|true}'
+          description: >-
+            Run Ardana deploy and update validation step
 
       - string:
           name: git_automation_repo
@@ -41,6 +44,12 @@
           default: '{git_automation_branch|master}'
           description: >-
             The git automation branch
+
+      - hidden:
+          name: version
+          default: '{version}'
+          description: >-
+            Cloud version number (8, 9 etc.)
 
     logrotate:
       numToKeep: -1


### PR DESCRIPTION
The Ardana IBS gating job runs two validation tests in parallel:
one that deploys an Ardana cloud based on the staging cloud
media (DC8S, DC9S), the other that deploys an Ardana cloud based on the
non-staging media (DC8) and then updates the cloud installation to
the staging media.

In some circumstances, both staging and non-staging builds are
broken (e.g. by a submitrequest breaking a package in the non-staging
project) and are subsequently fixed by patches that land in the
staging area. In these cases, the deploy-and-update job will not
pass and needs to be manually circumvented to unblock the CI/CD
pipeline.

This change allows the gating job to be (re)started with the update
validation step disabled.