### PR TITLE
openstack-ardana-gating: disable failfast

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -44,8 +44,8 @@ pipeline {
     }
 
     stage('Trigger validation jobs') {
-      // abort all stages if one of them fails
-      failFast true
+      // Do not abort all stages if one of them fails
+      failFast false
       parallel {
 
         stage('Run cloud deploy job') {


### PR DESCRIPTION
The fail-fast feature was enabled for the IBS gating job, which
basically means that if one of the parallel validation steps
failed, the other one was immediately aborted.

This change disables fail-fast for two main reasons:
  - allowing both jobs to run to completion usually gives more
  information about the state of both staging and non-staging cloud
  media
  - the fail-fast feature gives awful results in terms of UI
  usability (e.g. the job state is gray - meaning aborted - instead
  of red, when one validation job fails and the other is aborted)