### PR TITLE
openstack-ardana: add python-PySocks to CentOS 7.5

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/files/enable-centos-rpms-on-rhel/roles/deployer-rhel-repo/vars/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/files/enable-centos-rpms-on-rhel/roles/deployer-rhel-repo/vars/main.yml
@@ -197,3 +197,4 @@ rhel_repo_rpms_list:
   - python-deprecation
   - python-munch
   - libsodium23
+  - python-PySocks


### PR DESCRIPTION
Add the missing python-PySocks package to the plays that provision
CentOS 7.5 repositories for RHEL compute nodes.