### PR TITLE
Set default for `want_ipv6`

### DIFF
--- a/scripts/mkcloudhost/routed.cloud
+++ b/scripts/mkcloudhost/routed.cloud
@@ -15,6 +15,7 @@ function random_ipv6_prefix {
 
 : ${reposerver:=clouddata.cloud.suse.de}
 : ${nfsserver:=clouddata.cloud.suse.de}
+: ${want_ipv6:=0}
 export reposerver nfsserver
 if (( $want_ipv6 > 0 )); then
     export net_admin=$(ipv6prefix $n)


### PR DESCRIPTION
If the `want_ipv6` variable is not set on entry to `routed.cloud`, the
arithmetic evaluation will fail. This change introduces a default.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>