### PR TITLE
SCRD-6889 Remove horizon_integration-tests filter

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -209,7 +209,7 @@
       iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
       heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,\
       nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,\
-      barbican-functional,horizon,horizon_integration-tests,keystone-api,keystone-ldap,\
+      barbican-functional,horizon,keystone-api,keystone-ldap,\
       keystone-k2k-config,keystone-websso-config,keystone-x509-config,\
       service-ansible-playbooks,enable_tls,tempest_cleanup,nova_guest_image"
     rc_notify: 'true'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -142,7 +142,7 @@
       iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
       heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,\
       nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,\
-      barbican-functional,horizon,horizon_integration-tests,keystone-api,keystone-ldap,\
+      barbican-functional,horizon,keystone-api,keystone-ldap,\
       keystone-k2k-config,keystone-websso-config,keystone-x509-config,\
       service-ansible-playbooks,enable_tls,tempest_cleanup,nova_guest_image"
     rc_notify: 'true'
@@ -171,7 +171,7 @@
       iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
       heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,\
       nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,\
-      barbican-functional,horizon,horizon_integration-tests,keystone-api,keystone-ldap,\
+      barbican-functional,horizon,keystone-api,keystone-ldap,\
       keystone-k2k-config,keystone-websso-config,keystone-x509-config,\
       service-ansible-playbooks,enable_tls,tempest_cleanup,nova_guest_image"
     rc_notify: 'true'

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -71,7 +71,7 @@
             iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,
             heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,
             nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,
-            barbican-functional,horizon,horizon_integration-tests,freezer,
+            barbican-functional,horizon,freezer,
             keystone-api,keystone-ldap,keystone-k2k-config,keystone-websso-config,keystone-x509-config,
             remove_compute_node,add_compute_node,tempest_cleanup,service-ansible-playbooks,enable_tls,
             change_credentials,nova_guest_image

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -116,7 +116,7 @@
             iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,
             heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,
             nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,
-            barbican-functional,horizon,horizon_integration-tests,freezer,keystone-soapui,
+            barbican-functional,horizon,freezer,keystone-soapui,
             remove_compute_node,add_compute_node,tempest_cleanup,service-ansible-playbooks,
             change_credentials,nova_guest_image
           description: >-

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -346,7 +346,7 @@
             iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,
             heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,
             nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,
-            barbican-functional,horizon,horizon_integration-tests,freezer,
+            barbican-functional,horizon,freezer,
             keystone-api,keystone-ldap,keystone-k2k-config,keystone-websso-config,keystone-x509-config,
             remove_compute_node,add_compute_node,tempest_cleanup,service-ansible-playbooks,enable_tls,
             change_credentials,nova_guest_images


### PR DESCRIPTION
The right filter for Horizon Selenium tests in ardana is "horizon". I am not sure how "horizon_integration-tests" got created. No tests were run using this filter. This fix is to remove all references of "horizon_integration-tests ".