### PR TITLE
openstack-ardana: add Provo and public NTP servers

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -58,7 +58,11 @@ ntp_servers:
   - ntp.suse.de
   - ntp0.suse.de
   - ntp1.suse.de
+  - ntp2.suse.de
   - ntp3.suse.de
+  - kirk.provo.novell.com
+  - 1.us.pool.ntp.org
+  - 2.us.pool.ntp.org
 
 dns_servers:
   - 147.2.2.2 # nsnwb.microfocus.com


### PR DESCRIPTION
To avoid issues with NUE-PRV network connectivity, extend the
list of NTP servers to include Provo as well as public servers.