### PR TITLE
openstack-ardana: add support CentOS computes with SES backend

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
@@ -29,3 +29,30 @@ ardana_scratch_playbooks:
     when: "{{ is_physical_deploy }}"
   - play: "site.yml"
   - play: "ardana-cloud-configure.yml"
+
+ardana_third_party_playbooks:
+  - "third-party-deploy.yml"
+  - "third-party-import.yml"
+
+ardana_ceph_third_party_dir: "~/third-party/ceph/pkgs/rhel/"
+ardana_rhel_ceph_client_pkg_repo: "https://download.ceph.com/rpm-{{ ardana_ceph_release_name[_ceph_version.stdout.split('.')[0]] }}/el7/x86_64"
+ardana_centos_pkg_repo: "http://centos.mirror.lstn.net/7/storage/x86_64/ceph-{{ ardana_ceph_release_name[_ceph_version.stdout.split('.')[0]] }}"
+ardana_ceph_release_name:
+  "12": "luminous"
+ardana_rhel_ceph_client_pkg_list:
+  - ceph-common
+  - libcephfs2
+  - librados2
+  - libradosstriper1
+  - librbd1
+  - librgw2
+  - python-cephfs
+  - python-rados
+  - python-rbd
+  - python-rgw
+
+ardana_rhel_ceph_client_pkg_requires:
+  - "lttng-ust-2.10.0-1.el7.x86_64.rpm"
+  - "leveldb-1.12.0-5.el7.1.x86_64.rpm"
+  - "libbabeltrace-1.2.4-3.1.el7.x86_64.rpm"
+  - "userspace-rcu-0.10.0-3.el7.x86_64.rpm"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
@@ -56,6 +56,11 @@
 - include_tasks: setup_rhel_repo.yml
   when: rhel_enabled
 
+- include_tasks: setup_rhel_ceph_client_repo.yml
+  when:
+    - rhel_enabled
+    - ses_enabled
+
 - include_tasks: reimage_nodes.yml
   when: is_physical_deploy
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/setup_rhel_ceph_client_repo.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/setup_rhel_ceph_client_repo.yml
@@ -1,0 +1,47 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Ensure third-party ceph packages dir
+  file:
+    path: "{{ ardana_ceph_third_party_dir }}"
+    state: directory
+
+- name: Get ceph version from SES cluster
+  shell: "ceph version | awk '{ print $3 }' | cut -d'-' -f1"
+  register: _ceph_version
+  delegate_to: "{{ 'ses-' ~ ses_cluster_id }}"
+  remote_user: root
+
+- name: Download RHEL ceph client requires
+  get_url:
+    url: "{{ ardana_centos_pkg_repo }}/{{ item }}"
+    dest: "{{ ardana_ceph_third_party_dir }}"
+  loop: "{{ ardana_rhel_ceph_client_pkg_requires }}"
+
+- name: Download RHEL ceph client packages
+  get_url:
+    url: "{{ ardana_rhel_ceph_client_pkg_repo }}/{{ item }}-{{ _ceph_version.stdout }}-0.el7.x86_64.rpm"
+    dest: "{{ ardana_ceph_third_party_dir }}"
+  loop: "{{ ardana_rhel_ceph_client_pkg_list }}"
+
+- name: Run playbooks to deploy third-party yum repo
+  command: "ansible-playbook -i hosts/localhost {{ item }}"
+  args:
+    chdir: "{{ ardana_openstack_path }}"
+  loop: "{{ ardana_third_party_playbooks }}"
+  register: ansible_third_party_plays
+  when: not (ansible_third_party_plays | default({})) is failed


### PR DESCRIPTION
This change adds support for deploying ardana using CentOS computes and
SES backend.

The ceph client packages are downloaded from the official ceph repos [1]
and some required libraries are downloaded from the official CentOS repos [2].

1. https://download.ceph.com/rpm-luminous/el7/x86_64/
2. http://centos.mirror.lstn.net/7/storage/x86_64/ceph-luminous/