### PR TITLE
openstack-ardana: disable deploy start messages for maintenance jobs

### DIFF
--- a/scripts/jenkins/ardana/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-cloud.yml
@@ -34,6 +34,7 @@
         rc_state: "Started"
       when:
         - rc_notify
+        - rc_notify_start
         - not is_physical_deploy
 
   tasks:

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -32,6 +32,7 @@ input_model_path: "{{ workspace_path }}/input_model"
 
 is_physical_deploy: "{{ ardana_env in groups['qe_all'] }}"
 rc_notify: False
+rc_notify_start: True
 
 suse_release: "suse-{{ ansible_distribution_version }}"
 local_repos_base_dir: "/srv/www/{{ suse_release }}/{{ ansible_architecture }}/repos"

--- a/scripts/jenkins/ardana/ansible/host_vars/cloud-ardana-ci-slot16.yml
+++ b/scripts/jenkins/ardana/ansible/host_vars/cloud-ardana-ci-slot16.yml
@@ -1,0 +1,18 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+rc_notify_start: False

--- a/scripts/jenkins/ardana/ansible/host_vars/cloud-ardana-ci-slot17.yml
+++ b/scripts/jenkins/ardana/ansible/host_vars/cloud-ardana-ci-slot17.yml
@@ -1,0 +1,1 @@
+cloud-ardana-ci-slot16.yml


### PR DESCRIPTION
Only deploy finished and test results messages will be sent to the
`cloud-maintenance` channel.