### PR TITLE
Lower CPU model for Intel

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
@@ -15,7 +15,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>

--- a/scripts/lib/libvirt/fixtures/cloud-admin.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin.xml
@@ -15,7 +15,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
@@ -14,7 +14,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -14,7 +14,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -14,7 +14,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -14,7 +14,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>

--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -14,7 +14,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>

--- a/scripts/lib/libvirt/templates/cpu-intel.xml
+++ b/scripts/lib/libvirt/templates/cpu-intel.xml
@@ -4,7 +4,7 @@
     <pae/>
   </features>
   <cpu mode='custom' match='exact'>
-    <model fallback='allow'>Haswell-noTSX</model>
+    <model fallback='allow'>SandyBridge-IBRS</model>
     <feature policy='require' name='vmx'/>
     <feature policy='disable' name='monitor'/>
   </cpu>


### PR DESCRIPTION
Running `mkcloud` in a VM on the ECP is currently only possible if the
hypervisor is at least Haswell based. A large fraction of our hardware
is older than that and `libvirt` fails with

   libvirt.libvirtError: the CPU is incompatible with host CPU: Host CPU does not provide required features: fma, movbe, fsgsbase, bmi1, avx2, smep, bmi2, erms, invpcid

on those hypervisors. This change lowers the default CPU model to
SandyBridge.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>