### PR TITLE
qa_crowbarsetup: write temp net route to another file

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -996,9 +996,9 @@ EOF
     fi
     ifdown br0
     rm -f /etc/sysconfig/network/ifcfg-br0
-    routes_file=/etc/sysconfig/network/routes
+    routes_file=/etc/sysconfig/network/ifroute-eth0
     if ! [ -e $routes_file ] || ! grep -q "^default" $routes_file; then
-        echo "default $net${ip_sep}1 - -" > $routes_file
+        echo "default $net${ip_sep}1" > $routes_file
     fi
     echo "${crowbar_name}.$cloudfqdn" > /etc/HOSTNAME
     hostname `cat /etc/HOSTNAME`


### PR DESCRIPTION
Write crowbar's temporary static net route to another file
because for some reason in ECP, wicked gets confused
when it gets our routes file and a ifroute-eth0 from chef