### PR TITLE
SCRD-5899 run wipe_disks.yml for virtual deployments too (bsc#1110061)

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
@@ -23,10 +23,7 @@ ardana_openstack_playbooks:
   - "ready-deployment.yml"
 
 ardana_scratch_playbooks:
-  - play: "ardana-ssh-keyscan.yml"
-    when: "{{ is_physical_deploy and when_cloud9 }}"
   - play: "wipe_disks.yml -e automate=true"
-    when: "{{ is_physical_deploy }}"
   - play: "site.yml"
   - play: "ardana-cloud-configure.yml"
 


### PR DESCRIPTION
Issues: SCRD-5899

To ensure that we exercise the problem scenario identified in
bsc#1110061, i.e. wipe_disks.yml failed if run before site.yml,
in standard CI runs we want to enable it for both virtual and
physical deployments.

Additionally with bsc#1110061 fixed we no longer need to explicitly
run ardana-ssh-keyscan.yml before running wipe_disks.yml.