### PR TITLE
cloud-ardana-gating: always keep envs after build

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
                 ardana_lib.trigger_build("cloud-ardana${version}-job-std-min-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),
+                  string(name: 'cleanup', value: "never"),
                   string(name: 'rc_notify', value: "true"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
                   string(name: 'git_automation_branch', value: "$git_automation_branch")
@@ -87,6 +88,7 @@ pipeline {
                 ardana_lib.trigger_build("cloud-ardana${version}-job-std-3cp-devel-staging-updates-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),
+                  string(name: 'cleanup', value: "never"),
                   string(name: 'rc_notify', value: "true"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
                   string(name: 'git_automation_branch', value: "$git_automation_branch")


### PR DESCRIPTION
Change the IBS gating jobs for Ardana to always keep environments
after the job run, even if they succed. This can help with manually
investigating the status of the gate post-build, or running additional
test cases on it through Jenkins.