### PR TITLE
rpm-packaging-results: avoid using --watch with --csv

### DIFF
--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-sles12.yaml
@@ -52,7 +52,7 @@
                   unset failed
                   unset kickscheduler
                   unset succeeded
-                  res=`osc results --csv -w -r standard`
+                  res=`osc results --csv -r standard`
                   if [ $? -ne 0 ]; then
                       sleep 5
                       continue


### PR DESCRIPTION
newer versions of osc no longer ignore "-w" when used with
--csv but instead print an error message:

  Please implement support for osc prjresults --watch without --xml.

We can however just ignore the wait, as we wait afterwards anyway.