### PR TITLE
openstack-ardana-heat: remove shared workspace

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-heat.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-heat.yaml
@@ -55,8 +55,14 @@
               - create: create a new heat stack
               - delete: delete a heat stack
 
-            If the create action is selected, a heat template file is required, which can only
-            be supplied by running this job as a downstream job.
+            If the create action is selected, a heat template needs to be supplied through the
+            'heat_template' parameter.
+
+      - text:
+          name: heat_template
+          default: ''
+          description: >-
+            The heat orchestration template describing the heat stack to be instantiated.
 
       - string:
           name: git_automation_repo
@@ -69,13 +75,6 @@
           default: master
           description: >-
             The git automation branch
-
-      - string:
-          name: reuse_node
-          default: ''
-          description: >-
-            The Jenkins agent where this job must run. Used by upstream jobs to
-            force a job to reuse the same node.
 
       - string:
           name: os_cloud

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -16,11 +16,7 @@ pipeline {
 
   agent {
     node {
-      label reuse_node ? reuse_node : "cloud-ardana-ci"
-      // This job may also run asynchronously from its upstream job and may outlive it.
-      // When that happens, the shared 'ardana_env' workspace may no longer be valid,
-      // which is why this job needs a backup dedicated workspace (until a better mechanism
-      // is used to manage a shared automation repository clone)
+      label "cloud-ardana-ci"
       customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
@@ -38,26 +34,14 @@ pipeline {
             error("Empty 'heat_action' parameter value.")
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${heat_action} ${ardana_env}"
-          // Use a shared workspace folder for all jobs running on the same
-          // target 'ardana_env' cloud environment
-          env.SHARED_WORKSPACE = sh (
-            returnStdout: true,
-            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
-          ).trim()
-          if (reuse_node == '') {
-            if (heat_action == 'create') {
-              error("This job needs to be called by an upstream job to create a heat stack.")
-            }
-            // Resort to the backup dedicated workspace if this job is running asynchronously
-            // from its upstream job
-            env.SHARED_WORKSPACE = "$WORKSPACE"
-            sh('''
-              git clone $git_automation_repo --branch $git_automation_branch automation-git
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook load-job-params.yml
-            ''')
-          }
-          ardana_lib = load "$SHARED_WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          // The ardana_lib.ansible_playbook scripts still rely on this variable
+          env.SHARED_WORKSPACE = "$WORKSPACE"
+          sh('''
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+            ansible_playbook load-job-params.yml
+          ''')
+          ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
         }
       }
     }
@@ -84,10 +68,13 @@ pipeline {
       }
       steps {
         script {
+          // Dump the heat_template multi-string parameter value into a file
+          writeFile file: "$WORKSPACE/heat_template.yml", text: params.heat_template
+
           retry(1) {
             lock(resource: 'cloud-ECP-API') {
               timeout(time: 10, unit: 'MINUTES') {
-                ardana_lib.ansible_playbook('heat-stack')
+                ardana_lib.ansible_playbook('heat-stack', "-e heat_template_file=$WORKSPACE/heat_template.yml")
               }
             }
           }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -126,12 +126,19 @@ pipeline {
           }
           steps {
             script {
+
+              // Needed to pass the generated heat template file contents as a text parameter value
+              def heat_template = sh (
+                returnStdout: true,
+                script: 'cat "$SHARED_WORKSPACE/heat-stack-${scenario_name}${model}.yml"'
+              )
+
               ardana_lib.trigger_build('openstack-ardana-heat', [
                 string(name: 'ardana_env', value: "$ardana_env"),
                 string(name: 'heat_action', value: "create"),
+                text(name: 'heat_template', value: heat_template),
                 string(name: 'git_automation_repo', value: "$git_automation_repo"),
                 string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                string(name: 'reuse_node', value: "${NODE_NAME}"),
                 string(name: 'os_cloud', value: "$os_cloud")
               ], false)
             }

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -20,7 +20,7 @@ parameters:
   default_subnet_cidr:
     type: string
     label: Default CIDR
-    description: Default CIDR value to use for networks which don't have CIDR specified
+    description: Default CIDR value to use for networks which do not have CIDR specified
 {%   if (ipv6 | default(false)) == true %}
     default: "2001::/64"
 {%    else   %}
@@ -37,7 +37,7 @@ resources:
       external_gateway_info:
         network: { get_param: floating_network }
 
-  # a dummy network/subnet to which to connect ports which aren't associated with
+  # a dummy network/subnet to which to connect ports which are not associated with
   # a network
   default_network:
     type: OS::Neutron::Net


### PR DESCRIPTION
The `openstack-ardana-heat` Jenkins job is the only job still
actively using the concept of a "shared workspace" - sharing
a file location on the Jenkins agent between two job runs.
The requirement comes from the fact that the generated heat
template file describing the Ardana cloud environment needs to
be passed from the `openstack-ardana` down to the `openstack-ardana-heat`
job that will use it to instantiate the cloud environment.

Using a text (multi-line string) job parameter achieves the same
result, while at the same time removing the need to share a file
location between upstream and downstream jobs. This is the first
step towards removing the concept of a shared workspace and also
making the `openstack-ardana-heat` job a more generic
job that handles heat stack creation/deletion, which could be
reused by other projects as well (e.g. to create the SES cluster).

Another advantage is the fact that a user may now also trigger the
job manually to create a heat stack, by simply dumping the heat
template contents into the text input.

NOTE: this PR is part of a larger effort to remove the shared workspace
concept from all Ardana jobs and reuse the Crowbar CI approach of sharing
global automation repository git clones stored on the Jenkins agent nodes
(see #3152).
