### PR TITLE
openstack-ardana: remove shared workspace

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -57,13 +57,6 @@
           default: master
           description: The git automation branch
 
-      - string:
-          name: reuse_node
-          default: ''
-          description: >-
-            The Jenkins agent where this job must run. Used by upstream jobs to
-            force a job to reuse the same node.
-
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -146,13 +146,6 @@
             The git automation branch
 
       - string:
-          name: reuse_node
-          default: ''
-          description: >-
-            The Jenkins agent where this job must run. Used by upstream jobs to
-            force a job to reuse the same node.
-
-      - string:
           name: os_cloud
           default: ''
           description: >-

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -141,13 +141,6 @@
             The git automation branch
 
       - string:
-          name: reuse_node
-          default: ''
-          description: >-
-            The Jenkins agent where this job must run. Used by upstream jobs to
-            force a job to reuse the same node.
-
-      - string:
           name: os_cloud
           default: ''
           description: >-

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -109,13 +109,6 @@
             The git automation branch
 
       - string:
-          name: reuse_node
-          default: ''
-          description: >-
-            The Jenkins agent where this job must run. Used by upstream jobs to
-            force a job to reuse the same node.
-
-      - string:
           name: os_cloud
           default: ''
           description: >-

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -34,8 +34,6 @@ pipeline {
             error("Empty 'heat_action' parameter value.")
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${heat_action} ${ardana_env}"
-          // The ardana_lib.ansible_playbook scripts still rely on this variable
-          env.SHARED_WORKSPACE = "$WORKSPACE"
           sh('''
             git clone $git_automation_repo --branch $git_automation_branch automation-git
             source automation-git/scripts/jenkins/ardana/jenkins-helper.sh

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
 
   agent {
     node {
-      label reuse_node ? reuse_node : "cloud-ardana-ci"
+      label "cloud-ardana-ci"
       customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
@@ -41,28 +41,13 @@ pipeline {
             error("Empty 'tempest_run_filter' and 'qa_test_list' parameter values.")
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
-          // Use a shared workspace folder for all jobs running on the same
-          // target 'ardana_env' cloud environment
-          env.SHARED_WORKSPACE = sh (
-            returnStdout: true,
-            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
-          ).trim()
-          if (reuse_node == '') {
-            // Resort to the backup dedicated workspace if this job is running as
-            // a standalone job allowing users to run several tests in parallel
-            // targeting the same environment.
-            env.SHARED_WORKSPACE = "$WORKSPACE"
-            sh('''
-               git clone $git_automation_repo --branch $git_automation_branch automation-git
-               source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-               ansible_playbook load-job-params.yml
-               ansible_playbook setup-ssh-access.yml -e @input.yml
-            ''')
-          } else {
-            // archiveArtifacts and junit don't support absolute paths, so we have to to this instead
-            sh "ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}"
-          }
-          ardana_lib = load "$SHARED_WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          sh('''
+             git clone $git_automation_repo --branch $git_automation_branch automation-git
+             source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+             ansible_playbook load-job-params.yml
+             ansible_playbook setup-ssh-access.yml -e @input.yml
+          ''')
+          ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.get_deployer_ip()
 
           // Generate stages for Tempest tests

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
 
   agent {
     node {
-      label reuse_node ? reuse_node : "cloud-ardana-ci"
+      label "cloud-ardana-ci"
       customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
@@ -40,28 +40,13 @@ pipeline {
             env.qa_test_list = ''
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
-          // Use a shared workspace folder for all jobs running on the same
-          // target 'ardana_env' cloud environment
-          env.SHARED_WORKSPACE = sh (
-            returnStdout: true,
-            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
-          ).trim()
-          if (reuse_node == '') {
-            sh('''
-              rm -rf $SHARED_WORKSPACE
-              mkdir -p $SHARED_WORKSPACE
-
-              # archiveArtifacts and junit don't support absolute paths, so we have to to this instead
-              ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}
-
-              cd $SHARED_WORKSPACE
-              git clone $git_automation_repo --branch $git_automation_branch automation-git
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook load-job-params.yml
-              ansible_playbook setup-ssh-access.yml -e @input.yml
-            ''')
-          }
-          ardana_lib = load "$SHARED_WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          sh('''
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+            ansible_playbook load-job-params.yml
+            ansible_playbook setup-ssh-access.yml -e @input.yml
+          ''')
+          ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.get_deployer_ip()
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
 
   agent {
     node {
-      label reuse_node ? reuse_node : "cloud-ardana-ci"
+      label "cloud-ardana-ci"
       customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }
@@ -31,28 +31,14 @@ pipeline {
             error("Empty 'ardana_env' parameter value.")
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
-          // Use a shared workspace folder for all jobs running on the same
-          // target 'ardana_env' cloud environment
-          env.SHARED_WORKSPACE = sh (
-            returnStdout: true,
-            script: 'echo "$(dirname $WORKSPACE)/shared/${ardana_env}"'
-          ).trim()
-          if (reuse_node == '') {
-            sh('''
-              rm -rf $SHARED_WORKSPACE
-              mkdir -p $SHARED_WORKSPACE
+          sh('''
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
+            ansible_playbook load-job-params.yml
+            ansible_playbook setup-ssh-access.yml -e @input.yml
+          ''')
 
-              cd $SHARED_WORKSPACE
-              git clone $git_automation_repo --branch $git_automation_branch automation-git
-              source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-              ansible_playbook load-job-params.yml
-              ansible_playbook setup-ssh-access.yml -e @input.yml
-            ''')
-          }
-          // archiveArtifacts and junit don't support absolute paths, so we have to to this instead
-          sh "ln -s ${SHARED_WORKSPACE}/.artifacts ${WORKSPACE}"
-
-          ardana_lib = load "$SHARED_WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.get_deployer_ip()
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
@@ -4,7 +4,7 @@
 
 def ansible_playbook(playbook, params='') {
   sh("""
-    cd $SHARED_WORKSPACE
+    cd $WORKSPACE
     source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
     ansible_playbook """+playbook+""".yml -e @input.yml """+params
   )
@@ -29,7 +29,7 @@ def get_deployer_ip() {
     returnStdout: true,
     script: '''
       grep -oP "^${ardana_env}\\s+ansible_host=\\K[0-9\\.]+" \\
-        $SHARED_WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
+        $WORKSPACE/automation-git/scripts/jenkins/ardana/ansible/inventory
     '''
   ).trim()
   currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env} (${DEPLOYER_IP})"

--- a/scripts/jenkins/ardana/README.md
+++ b/scripts/jenkins/ardana/README.md
@@ -47,7 +47,7 @@ high-level work items need to be completed to enable generating the Jenkinsfile 
   downstream job and using the `.buildVariables` build job object attribute in the upstream job
   (NOTE: this is only possible if the downstream job is also a pipeline job)
 * passing information from one stage to the next:
-  * use the shared workspace
+  * use the workspace
   * use ansible variables (host/group vars, extra vars) as much as possible
   * use build environment variables (which can only be set by using `env.<variable-name>` in a pipeline script block)
 * use the lockable resources mechanism to throttle parallel builds and
@@ -103,7 +103,7 @@ be executed with a regular bash script. The following exceptions have been ident
   * the build name can only be set by using the `currentBuild.displayName` variable in a script block
   * build environment variables can only be set by using `env.<variable-name>` in a pipeline script block.
   Exporting environment variables from shell scripts has no effect. Build environment variables are needed
-  to pass information from one stage to the next. __NOTE__: this can be avoided by using the shared workspace
+  to pass information from one stage to the next. __NOTE__: this can be avoided by using the workspace
   (e.g. creating host/group ansible var files or persisting ansible facts) instead of setting environment
   variables.
   * downstream builds can be triggered using the `build job` directive and the returned object can be used

--- a/scripts/jenkins/ardana/jenkins-helper.sh
+++ b/scripts/jenkins/ardana/jenkins-helper.sh
@@ -14,14 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-SHARED_WORKSPACE=${SHARED_WORKSPACE:-"$PWD"}
 ANSIBLE_VENV=${ANSIBLE_VENV:-"/opt/ansible"}
-AUTOMATION_DIR=${AUTOMATION_DIR:-"$SHARED_WORKSPACE/automation-git"}
+AUTOMATION_DIR=${AUTOMATION_DIR:-"$WORKSPACE/automation-git"}
 
 
 function ansible_playbook {
   set +x
-  export WORKSPACE=$SHARED_WORKSPACE
   export ANSIBLE_FORCE_COLOR=true
   source $ANSIBLE_VENV/bin/activate
   if [[ "$PWD" != *scripts/jenkins/ardana/ansible ]]; then


### PR DESCRIPTION
Remove the deprecated logic that implements the shared workspace
concept - sharing a file location on the Jenkins agent between
several job runs.

This concept isn't required anymore, since every Ardana job now has
the ability to run independently from other jobs.

NOTE: this PR depends on #3151 and is part of a larger effort to remove the
shared workspace concept from all Ardana jobs and reuse the Crowbar CI
approach of sharing global automation repository git clones stored on the
Jenkins agent nodes.