### PR TITLE
WIP openstack-ardana: use automation_update

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
@@ -52,7 +52,9 @@
       - shell: |
           set -x
 
-          git clone $git_automation_repo --branch $git_automation_branch automation-git
+          IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+          export git_automation_repo="${repo_arr[3]}"
+          curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
 
           if [[ -n $GERRIT_EVENT_TYPE ]]; then
               if [[ $GERRIT_EVENT_TYPE == 'change-merged' ]]; then

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -30,7 +30,9 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${staging_build}"
 
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
 
           env.starttime = sh (

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -26,7 +26,9 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${gerrit_change_ids}"
 
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
 
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -35,7 +35,11 @@ pipeline {
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${heat_action} ${ardana_env}"
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            # Need a local git clone copy to run from
+            export use_global_clone=false
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.load_extra_params_as_vars(extra_params)

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
@@ -32,7 +32,11 @@ pipeline {
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${gerrit_change_ids}"
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            # Need a local git clone copy to run from
+            export use_global_clone=false
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
           ardana_lib = load "automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.load_extra_params_as_vars(extra_params)

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
@@ -42,7 +42,11 @@ pipeline {
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
           sh('''
-             git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            # Need a local git clone copy to run from
+            export use_global_clone=false
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.load_extra_params_as_vars(extra_params)

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -41,7 +41,11 @@ pipeline {
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            # Need a local git clone copy to run from
+            export use_global_clone=false
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.load_extra_params_as_vars(extra_params)

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
@@ -32,7 +32,11 @@ pipeline {
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            # Need a local git clone copy to run from
+            export use_global_clone=false
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.load_extra_params_as_vars(extra_params)

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -55,9 +55,13 @@ pipeline {
             env.qa_test_list = ''
           }
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
-            cd automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            # Need a local git clone copy to run from
+            export use_global_clone=false
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
 
+            cd $WORKSPACE/automation-git
             if [ -n "$github_pr" ] ; then
               scripts/jenkins/ardana/pr-update.sh
             fi

--- a/jenkins/ci.suse.de/pipelines/openstack-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-maintenance-gating.Jenkinsfile
@@ -31,7 +31,9 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${maint_updates}"
 
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
           ''')
 
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"

--- a/jenkins/ci.suse.de/pipelines/openstack-ses.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ses.Jenkinsfile
@@ -25,9 +25,14 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ses_id}"
 
           sh('''
-            git clone $git_automation_repo --branch $git_automation_branch automation-git
-
             set +x
+
+            IFS='/' read -r -a repo_arr <<< "$git_automation_repo"
+            export git_automation_repo="${repo_arr[3]}"
+            # Need a local git clone copy to run from
+            export use_global_clone=false
+            curl https://raw.githubusercontent.com/$git_automation_repo/automation/$git_automation_branch/scripts/jenkins/ardana/openstack-ardana.prep.sh | bash
+
             export ANSIBLE_FORCE_COLOR=true
             cd $WORKSPACE/automation-git/scripts/jenkins/ses/ansible
             source /opt/ansible/bin/activate

--- a/scripts/jenkins/ardana/openstack-ardana.prep.sh
+++ b/scripts/jenkins/ardana/openstack-ardana.prep.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -x
+shopt -s extglob
+
+# emptying the workspace
+cd $WORKSPACE
+rm -rf ./* ./.[a-zA-Z]*
+
+git_automation_repo=${git_automation_repo:-"SUSE-Cloud"}
+git_automation_branch=${git_automation_branch:-"master"}
+use_global_clone=${use_global_clone:-true}
+
+export github_pr=${github_pr:-}
+export automationrepo=~/github.com/${git_automation_repo}/automation
+export AUTOMATION_REPO="github.com/${git_automation_repo}/automation#${git_automation_branch}"
+
+# automation bootstrapping
+if ! [ -e ${automationrepo}/scripts/jenkins/update_automation ] ; then
+  rm -rf ${automationrepo}
+  curl https://raw.githubusercontent.com/${git_automation_repo}/automation/${git_automation_branch}/scripts/jenkins/update_automation | bash
+fi
+
+# fetch the latest automation updates
+${automationrepo}/scripts/jenkins/update_automation
+
+automationrepo_orig=$automationrepo
+automationrepo=${WORKSPACE}/automation-git
+
+if $use_global_clone && [ -z "$github_pr" ]; then
+  ln -s $automationrepo_orig $automationrepo
+else
+  mkdir -p $automationrepo
+  rsync -a ${automationrepo_orig%/}/ $automationrepo/
+fi
+pushd $automationrepo
+ghremote=origin
+
+if [ -n "$github_pr" ]; then
+    # split $github_pr into multiple variables
+    source ${automationrepo}/scripts/jenkins/github-pr/parse.rc
+
+    # Support for automation self-gating
+    if [ -n "$github_pr_id" ]; then
+        git config --get-all remote.${ghremote}.fetch | grep -q pull || \
+            git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
+        git fetch $ghremote 2>&1 | grep -v '\[new ref\]' || :
+        git checkout -t $ghremote/pr/$github_pr_id
+        git config user.email cloud-devel+jenkins@suse.de
+        git config user.name "Jenkins User"
+        echo "we merge to always test what will end up in master"
+        git merge master -m temp-merge-commit
+        # Show latest commit in log to see what's really tested.
+        # Include a unique indent so that the log parser plugin
+        # can ignore the output and avoid false positives.
+        git --no-pager show | sed 's/^/|@| /'
+    fi
+fi
+popd


### PR DESCRIPTION
With the shared workspace mechanism out of the way,
the Ardana pipeline jobs can be modified to use the
Crowbar CI approach of managing a shared
SUSE-Cloud/automation repository git clone on every
Jenkins agent, instead of creating a new git clone
every time a job runs.

This is accomplished by calling the same script
that is used by the Crowbar CI - `update_automation`,
which basically creates or updates the shared git
clone - but with two important differences, which are
described below.

The Ardana CI jobs make use of a `git_automation_repo`
and `git_automation_branch` pair of parameters, by default
pointing to the SUSE-Cloud/automation repository and master
branch, which can be modified to point to a custom fork,
branch and/or commit number instead.

The need for these parameters comes from the way that Jenkins
pipeline jobs work: the Jenkins job configuration needs a git
repository location from which to load the job pipeline definition
(i.e. the Jenkinsfile). For most cases, this is the
SUSE-Cloud/automation master branch, but we need to support
these additional use-cases:

1. an Ardana CI contributor wants to test some changes available
in a custom git fork, branch or commit, without publishing them as
a GitHub pull request. For this to be possible, the Jenkins jobs
need to be triggered manually and pointed to the custom git fork,
branch or commit.

2. an Ardana CI contributor wants to run custom tests on an
automation repository GitHub pull request. This should be as
easy ad triggering Jenkins jobs and pointing them to a PR number.

3. ultimately, the "CI for CI" - the CI that validates automation
repository GitHub pull request - needs to run automated testing
against an open pull request

The second thing that needs to be done differently from the Crowbar
CI is the way the shared git clone is actually used. The Ardana CI
implementation is based on the idea that the back-end scripts (e.g.
ansible, python) can be run independently from Jenkins and directly
from a local copy of the automation git repository. To preserve this
assumption and allow these scripts to run and modify the contents of
the automation repository freely, as if executed from a local copy,
most of the Ardana Jenkins jobs cannot simply share the automation
repository git clone, they need to create a copy of it in their
workspace, which can be modified independently of the master git clone.

Implements: https://jira.suse.de/browse/SCRD-4983
Partially implements: https://jira.suse.de/browse/SCRD-4307