### PR TITLE
mkcloud: add date/timestamp to PS4

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -26,7 +26,7 @@ exec 2> >(exec tee -ia $log_file >&2)
 
 if [[ $debug_mkcloud = 1 ]] ; then
     set -x
-    PS4='+(${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+    PS4='+\D{%Y/%m/%d %T} (${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 fi
 
 cache_dir_default=/var/cache/mkcloud/$cloud


### PR DESCRIPTION
Timing data is often crucial for effective debugging, so include it in the bash `PS4` tracing lines.