### PR TITLE
Jenkins pipeline job and input model generator scenario for Crowbar

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar.yaml
@@ -1,0 +1,12 @@
+# Multi-purpose, customizable, manually triggered Crowbar job
+- project:
+    name: openstack-crowbar
+    crowbar_job: '{name}'
+    concurrent: True
+    triggers:
+    ardana_env: ''
+    reserve_env: false
+    cleanup: never
+    os_cloud: ''
+    jobs:
+        - '{crowbar_job}'

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -1,0 +1,295 @@
+/**
+ * The openstack-crowbar Jenkins Pipeline
+ */
+
+def ardana_lib = null
+
+pipeline {
+  options {
+    // skip the default checkout, because we want to use a custom path
+    skipDefaultCheckout()
+    timestamps()
+    // reserve a resource if instructed to do so, otherwise use a dummy resource
+    // and a zero quantity to fool Jenkins into thinking it reserved a resource when in fact it didn't
+    lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
+         variable: 'reserved_env',
+         quantity: reserve_env == 'true' ? 1:0 )
+  }
+
+  agent {
+    node {
+      label 'cloud-ardana-ci'
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
+    }
+  }
+
+  stages {
+    stage('Setup workspace') {
+      steps {
+        script {
+          // Set this variable to be used by upstream builds
+          env.blue_ocean_buildurl = env.RUN_DISPLAY_URL
+          env.cloud_type = "virtual"
+          if (ardana_env == '') {
+            error("Empty 'ardana_env' parameter value.")
+          }
+          if (env.reserved_env && reserved_env != null) {
+            env.ardana_env = reserved_env
+          }
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
+          if ( ardana_env.startsWith("qe") || ardana_env.startsWith("pcloud") ) {
+              env.cloud_type = "physical"
+          }
+          sh('''
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+            cd automation-git
+
+            if [ -n "$github_pr" ] ; then
+              scripts/jenkins/ardana/pr-update.sh
+            fi
+
+            source scripts/jenkins/ardana/jenkins-helper.sh
+            ansible_playbook load-job-params.yml \
+              -e jjb_file=$WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml \
+              -e jjb_type=job-template
+            ansible_playbook notify-rc-pcloud.yml -e @input.yml
+          ''')
+          ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+        }
+      }
+    }
+
+    stage('Prepare input model') {
+      steps {
+        script {
+          if (scenario_name != '') {
+            ardana_lib.ansible_playbook('generate-input-model')
+          } else {
+            ardana_lib.ansible_playbook('clone-input-model')
+          }
+        }
+      }
+    }
+
+    stage('Generate heat template') {
+      when {
+        expression { cloud_type == 'virtual' }
+      }
+      steps {
+        script {
+          ardana_lib.ansible_playbook('generate-heat-template')
+        }
+      }
+    }
+
+    stage('Create heat stack') {
+      when {
+        expression { cloud_type == 'virtual' }
+      }
+      steps {
+        script {
+
+          // Needed to pass the generated heat template file contents as a text parameter value
+          def heat_template = sh (
+            returnStdout: true,
+            script: 'cat "$WORKSPACE/heat-stack-${scenario_name}${model}.yml"'
+          )
+
+          ardana_lib.trigger_build('openstack-ardana-heat', [
+            string(name: 'ardana_env', value: "$ardana_env"),
+            string(name: 'heat_action', value: "create"),
+            text(name: 'heat_template', value: heat_template),
+            string(name: 'git_automation_repo', value: "$git_automation_repo"),
+            string(name: 'git_automation_branch', value: "$git_automation_branch"),
+            string(name: 'os_cloud', value: "$os_cloud")
+          ], false)
+        }
+      }
+    }
+
+    stage('Setup SSH access') {
+      steps {
+        script {
+          ardana_lib.ansible_playbook('setup-ssh-access')
+          ardana_lib.get_deployer_ip()
+        }
+      }
+    }
+
+    stage('Bootstrap admin node') {
+      steps {
+        script {
+          sh('''
+             # This step does the following on the admin node:
+             #  - waits for it to complete boot
+             #  - resizes the root partition
+             #  - sets up Crowbar network/DNS and repos
+             #  - installs crowbar packages
+             #
+             # qa_crowbarsetup.sh onadmin_runlist prepareinstallcrowbar
+          ''')
+        }
+      }
+    }
+
+    stage('Bootstrap nodes') {
+      steps {
+        script {
+          sh('''
+             # This step does the following on the non-admin nodes:
+             #  - waits for them to complete boot
+             #  - resizes the root partition
+             #  - sets up accounts, passwordless SSH and sudo
+          ''')
+        }
+      }
+    }
+
+    stage('Install crowbar') {
+      when {
+        expression { deploy_cloud == 'true' }
+      }
+      steps {
+        script {
+          sh('''
+             # This step does the following on the admin node:
+             #  - installs crowbar
+             #
+             # qa_crowbarsetup.sh onadmin_runlist bootstrapcrowbar installcrowbar
+          ''')
+        }
+      }
+    }
+
+    stage('Register nodes') {
+      when {
+        expression { deploy_cloud == 'true' }
+      }
+      steps {
+        script {
+          sh('''
+             # This step does the following
+             #  - registers the Crowbar cloud nodes
+          ''')
+        }
+      }
+    }
+
+    stage('Deploy cloud') {
+      when {
+        expression { deploy_cloud == 'true' }
+      }
+      steps {
+        script {
+          sh('''
+             # This step does the following:
+             #  - deploys the crowbar proposal
+          ''')
+        }
+      }
+    }
+
+    stage('Test') {
+      when {
+        expression { deploy_cloud == 'true' }
+      }
+      steps {
+        script {
+          sh('''
+             # This step does the following:
+             #  - runs tests on the deployed cloud
+             #
+             # qa_crowbarsetup.sh onadmin_runlist onadmin_testsetup
+          ''')
+        }
+      }
+    }
+
+  }
+
+  post {
+    always {
+      script{
+        sh('''
+          automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
+            --recursive \
+            --filter 'Declarative: Post Actions' \
+            --filter 'Setup workspace' > .artifacts/pipeline-report.txt || :
+        ''')
+        archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+      }
+      script{
+        if (env.DEPLOYER_IP != null) {
+          if (cloud_type == "virtual") {
+            if (cleanup == "always" ||
+                cleanup == "on success" && currentBuild.currentResult == "SUCCESS" ||
+                cleanup == "on failure" && currentBuild.currentResult != "SUCCESS") {
+
+              build job: 'openstack-ardana-heat', parameters: [
+                string(name: 'ardana_env', value: "$ardana_env"),
+                string(name: 'heat_action', value: "delete"),
+                string(name: 'git_automation_repo', value: "$git_automation_repo"),
+                string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                string(name: 'os_cloud', value: "$os_cloud")
+              ], propagate: false, wait: false
+            } else {
+              if (reserve_env == 'true') {
+                echo """
+******************************************************************************
+** The admin node for the '${ardana_env}' virtual environment is reachable at:
+**
+**        ssh root@${DEPLOYER_IP}
+**
+** IMPORTANT: the '${ardana_env}' virtual environment may be (may have
+** already been) deleted by any of the future periodic job runs. To prevent
+** that, you should use the Lockable Resource page at
+** https://ci.nue.suse.com/lockable-resources and reserve the '${ardana_env}'
+** resource.
+**
+** Please remember to release the '${ardana_env}' Lockable Resource when
+** you're done with the environment.
+**
+** You don't have to manually delete the heat stack if you don't want to.
+**
+******************************************************************************
+                """
+              } else {
+                echo """
+******************************************************************************
+** The admin node for the '${ardana_env}' virtual environment is reachable at:
+**
+**        ssh root@${DEPLOYER_IP}
+**
+** Please delete the 'openstack-ardana-${ardana_env}' stack when you're done,
+** by using one of the following methods:
+**
+**  1. log into the ECP at https://engcloud.prv.suse.net/project/stacks/
+**  and delete the stack manually, or
+**
+**  2. (preferred) trigger a manual build for the openstack-ardana-heat job at
+**  https://ci.nue.suse.com/job/openstack-ardana-heat/build and use the
+**  same '${ardana_env}' ardana_env value and the 'delete' action for the
+**  parameters
+**
+******************************************************************************
+                """
+              }
+            }
+          } else {
+            echo """
+******************************************************************************
+** The admin node for the '${ardana_env}' physical environment is reachable at:
+**
+**        ssh root@${DEPLOYER_IP}
+**
+******************************************************************************
+            """
+          }
+        }
+      }
+    }
+    cleanup {
+      cleanWs()
+    }
+  }
+}

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -1,0 +1,185 @@
+- job-template:
+    name: '{crowbar_job}'
+    project-type: pipeline
+    disabled: '{obj:disabled|False}'
+    concurrent: '{concurrent|False}'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 30
+
+    triggers: '{triggers}'
+
+    parameters:
+      - validating-string:
+          name: ardana_env
+          default: '{ardana_env|}'
+          regex: '[A-Za-z0-9-_]+'
+          msg: >-
+            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+          description: >-
+            The virtual or hardware environment identifier. This field should either
+            be set to one of the values associated with the known hardware environments
+            (e.g. qe101), or to a value that will identify the created virtual environment.
+
+            WARNING: if a virtual environment associated with the supplied ardana_env already
+            exists, it will be replaced.
+
+      - bool:
+          name: reserve_env
+          default: '{reserve_env|true}'
+          description: >-
+            Reserve the 'ardana_env' lockable resource throughout the execution of this job
+
+      - choice:
+          name: cloudsource
+          choices:
+            - '{cloudsource|stagingcloud9}'
+            - stagingcloud8
+            - develcloud8
+            - GM8
+            - GM8+up
+            - hosdevelcloud8
+            - hosGM8
+            - hosGM8+up
+            - stagingcloud9
+            - develcloud9
+            - cloud9M3
+            - cloud9M4
+            - cloud9M5
+            - cloud9M6
+            - cloud9M7
+            - cloud9M8
+            - cloud9M9
+            - cloud9M10
+          description: >-
+            The cloud repository (from provo-clouddata) to be used for testing.
+            This value can take the following form:
+
+               stagingcloud<X> (Devel:Cloud:X:Staging)
+               develcloud<X> (Devel:Cloud:X)
+               GM<X> (official GM)
+               GM<X>+up (official GM plus Cloud-Updates)
+               cloud9MX (cloud 9 milestones)
+
+      - bool:
+          name: deploy_cloud
+          default: '{deploy|true}'
+          description: >-
+            If left unchecked, the cloud deployment steps will be skipped. This option can be
+            used if you only need to set up the infrastructure and configure the cloud media and
+            repositories, but skip the actual cloud deployment, e.g. for testing purposes.
+
+      - bool:
+          name: updates_test_enabled
+          default: '{updates_test_enabled|false}'
+          description: >-
+            Enable SLES/Cloud test update repos (the Cloud test update repos will
+            be enabled only when cloudsource is GM based)
+
+      - validating-string:
+          name: maint_updates
+          default: ''
+          regex: '([0-9]+(,[0-9]+)*)*'
+          msg: The entered value failed validation
+          description: List of maintenance update IDs separated by comma (eg. 7396,7487)
+
+      - choice:
+          name: scenario_name
+          choices:
+            - '{scenario_name|crowbar}'
+            - crowbar
+          description: >-
+            The name of one of the available scenarios that can be used to generate input models.
+            If this parameter is set, the following parameters may also be set to different values, to control
+            various aspects of the generated input model: controllers, computes.
+
+
+            NOTE: use this parameter only if you want to use a generated input model. To use an existing input model instead,
+            leave this field empty and use the 'model' parameter instead.
+
+      - validating-string:
+          name: controllers
+          default: '{controllers|1}'
+          regex: '[0-3]'
+          msg: The entered value failed validation
+          description: |
+            The number of controller nodes in the generated input model (0-3).
+
+            Input model generator scenarios using this parameter: standard, entry-scale-kvm.
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
+
+      - validating-string:
+          name: computes
+          default: '{computes|1}'
+          regex: '[0-9]+'
+          msg: The entered value failed validation
+          description: |
+            The number of SLES compute nodes in the generated input model.
+
+            Input model generator scenarios using this parameter: all
+
+            NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
+            using one of the available input model generator scenarios.
+
+      - validating-string:
+          name: extra_repos
+          default: ''
+          regex: '((http(s)?:\/\/[^ ,]+\.repo)(,http(s)?:\/\/[^ ,]+\.repo)*)*'
+          msg: The entered value failed validation
+          description: >-
+            A comma separated list of repository urls (ending with .repo) to be
+            added on the deployer node
+
+      - bool:
+          name: rc_notify
+          default: '{rc_notify|false}'
+          description: >-
+            Notify RocketChat when deployment starts/finishes.
+
+      - choice:
+          name: cleanup
+          choices:
+            - '{cleanup|on success}'
+            - 'never'
+            - 'always'
+            - 'on success'
+            - 'on failure'
+          description: >-
+            Configure the conditions that trigger the virtual environment cleanup. Possible values are:
+              - never
+              - always
+              - on success
+              - on failure
+
+      - string:
+          name: git_automation_repo
+          default: '{git_automation_repo|https://github.com/SUSE-Cloud/automation.git}'
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: '{git_automation_branch|master}'
+          description: >-
+            The git automation branch
+
+      - string:
+          name: os_cloud
+          default: '{os_cloud|engcloud-cloud-ci-private}'
+          description: >-
+            The OpenStack API credentials used to manage virtual clouds (leave
+            empty to use the default shared 'cloud' ECP account).
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${{git_automation_repo}}
+            branches:
+              - ${{git_automation_branch}}
+            browser: auto
+            wipe-workspace: false
+      script-path: jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+      lightweight-checkout: false

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -46,6 +46,16 @@ cp_prefix: cp1
 max_host_prefix_len: "{{ 33-(cp_prefix|length) }}"
 host_prefix: "{{ ('ardana-' ~ ardana_env)[:max_host_prefix_len|int-1] if ardana_env is defined else 'ardana' }}"
 
+# First two octets of the generated subnet prefixes for Ardana networks
+subnet_prefix: 192.168
+# Start value for the third octet for the generated subnet prefixes and also
+# start of generated VLAN IDs for Ardana networks
+gen_subnet_start: 100
+# Start value for the fourth octet for the generated server IP addresses
+gen_ip_start: 100
+# Gap to be left between the generated IP for the admin node and the rest of the nodes
+gen_ip_gap: 1
+
 service_component_groups:
   COMMON:
     - lifecycle-manager-target

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
@@ -19,7 +19,7 @@
 
   networks:
 
-{% set ns = namespace(net_id=100) %}
+{% set ns = namespace(net_id=gen_subnet_start) %}
 {% for network_group in scenario['network_groups'] %}
 {%   if network_group.rack_network|default(False) %}
 {%     for az in range(scenario.availability_zones) %}
@@ -38,16 +38,16 @@
 {%   endif %}
       tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
 {%   if (ipv6 | default(false)) == true %}
-{%   if ns.net_id != 100 %}
+{%   if ns.net_id != gen_subnet_start %}
       cidr: fd00:0:0:{{ ns.net_id }}::/64
       gateway-ip: fd00:0:0:{{ ns.net_id }}::1
 {%   else %}
-      cidr: 192.168.{{ ns.net_id }}.0/24
-      gateway-ip: 192.168.{{ ns.net_id }}.1
+      cidr: {{ subnet_prefix }}.{{ ns.net_id }}.0/24
+      gateway-ip: {{ subnet_prefix }}.{{ ns.net_id }}.1
 {%   endif %}
 {%   else  %}
-      cidr: 192.168.{{ ns.net_id }}.0/24
-      gateway-ip: 192.168.{{ ns.net_id }}.1
+      cidr: {{ subnet_prefix }}.{{ ns.net_id }}.0/24
+      gateway-ip: {{ subnet_prefix }}.{{ ns.net_id }}.1
 {%   endif %}
 {%   endif %}
       network-group: {{ network_group.name|upper }}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -35,8 +35,7 @@
 {%     endif %}
 {%   endfor %}
 {% else %}
-        neutron_provider_networks:
-{% set ns = namespace(mgmt_net_id=0, physnet_id=0, net_id=30, vlan_id=100+scenario.network_groups|length) %}
+{% set ns = namespace(provider_nets_hdr=False, ext_nets_hdr=False, mgmt_net_id=0, physnet_id=0, net_id=30, vlan_id=100+scenario.network_groups|length) %}
 {% for network_group in scenario.network_groups %}
 {%   if 'MANAGEMENT' in network_group.component_endpoints %}
 {%     set ns.mgmt_net_id = loop.index0+100 %}
@@ -45,6 +44,10 @@
 {% for network_group in scenario.network_groups %}
 {%   if 'NEUTRON-VLAN' in network_group.component_endpoints %}
 {%     set ns.physnet_id = ns.physnet_id+1 %}
+{%     if not ns.provider_nets_hdr %}
+{%       set ns.provider_nets_hdr=True %}
+        neutron_provider_networks:
+{%     endif %}
 
           - name: NEUTRON-{{ network_group.name|upper }}-VLAN-NET
             provider:
@@ -78,8 +81,16 @@
 {%   endif %}
 {%   endif %}
 {% endfor %}
-        neutron_external_networks:
+{%     if not ns.provider_nets_hdr %}
+        neutron_provider_networks: []
+{%     endif %}
+
 {% for network_group in scenario.network_groups if 'NEUTRON-EXT' in network_group.component_endpoints %}
+{%     if not ns.ext_nets_hdr %}
+{%       set ns.ext_nets_hdr=True %}
+        neutron_external_networks:
+{%     endif %}
+
           - name: ext-net{{ loop.index0 | ternary(loop.index0, '') }}
 {% if (ipv6 | default(false)) == true %}
             cidr: fd00:0:0:{{ ns.net_id }}::/64
@@ -96,4 +107,8 @@
 {%   set ns.net_id = ns.net_id+1 %}
 {% endif %}
 {% endfor %}
+{%     if not ns.ext_nets_hdr %}
+        neutron_external_networks: []
+{%     endif %}
+
 {% endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -35,10 +35,10 @@
 {%     endif %}
 {%   endfor %}
 {% else %}
-{% set ns = namespace(provider_nets_hdr=False, ext_nets_hdr=False, mgmt_net_id=0, physnet_id=0, net_id=30, vlan_id=100+scenario.network_groups|length) %}
+{% set ns = namespace(provider_nets_hdr=False, ext_nets_hdr=False, mgmt_net_id=0, physnet_id=0, net_id=30, vlan_id=gen_subnet_start+scenario.network_groups|length) %}
 {% for network_group in scenario.network_groups %}
 {%   if 'MANAGEMENT' in network_group.component_endpoints %}
-{%     set ns.mgmt_net_id = loop.index0+100 %}
+{%     set ns.mgmt_net_id = loop.index0+gen_subnet_start %}
 {%   endif %}
 {% endfor  %}
 {% for network_group in scenario.network_groups %}
@@ -74,7 +74,7 @@
                 end: 172.{{ ns.net_id }}.1.250
             host_routes:
             # route to management network
-              - destination: 192.168.{{ ns.mgmt_net_id }}.0/24
+              - destination: {{ subnet_prefix }}.{{ ns.mgmt_net_id }}.0/24
                 nexthop:  172.{{ ns.net_id }}.1.1
 {%     set ns.net_id = ns.net_id+1 %}
 {%     set ns.vlan_id = ns.vlan_id+1 %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/octavia/octavia_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/octavia/octavia_config.yml
@@ -21,13 +21,16 @@
     - name: OCTAVIA-CONFIG-CP1
       services:
         - octavia
-      data:
 {% if bm_info is defined %}
+      data:
         amp_network_name: OCTAVIA-MGMT-NET
 {% else %}
 {%   set ns = namespace(octavia_ng={}) %}
 {%   for network_group in scenario.network_groups if 'NEUTRON-VLAN' in network_group.component_endpoints and not ns.octavia_ng %}
 {%     set ns.octavia_ng = network_group %}
 {%   endfor  %}
+{%   if ns.octavia_ng %}
+      data:
         amp_network_name: NEUTRON-{{ ns.octavia_ng.name|upper }}-VLAN-NET
+{%   endif %}
 {% endif %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/servers.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/servers.yml
@@ -17,13 +17,13 @@
 {% set ns = namespace(clm_net_id=0, server_idx=0) %}
 {% for network_group in scenario['network_groups'] %}
 {%   if 'CLM' in network_group['component_endpoints'] %}
-{%     set ns.clm_net_id = loop.index0+100 %}
+{%     set ns.clm_net_id = loop.index0+gen_subnet_start %}
 {%   endif %}
 {% endfor %}
 {% if ns.clm_net_id == 0  %}
 {%   for network_group in scenario['network_groups'] %}
 {%     if 'MANAGEMENT' in network_group['component_endpoints'] %}
-{%       set ns.clm_net_id = loop.index0+100 %}
+{%       set ns.clm_net_id = loop.index0+gen_subnet_start %}
 {%     endif %}
 {%   endfor  %}
 {% endif %}
@@ -32,14 +32,14 @@
 
   baremetal:
     netmask: {{ bm_info.networks.bm_netmask if bm_info is defined else '255.255.255.0' }}
-    subnet: 192.168.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.0
+    subnet: {{ subnet_prefix }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.0
 
   servers:
 {% for service_group in scenario['service_groups'] if service_group['member_count']|int %}
 {%   for idx in range(service_group['member_count']|int) %}
 {%     set server_id = "%s-%04d"|format(service_group.name, idx+1) %}
     - id: {{ bm_info.servers[ns.server_idx].id if bm_info is defined else server_id }}
-      ip-addr: 192.168.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.{{ bm_info.networks.bm_subnet_start + ns.server_idx if bm_info is defined else ns.server_idx + 100 }}
+      ip-addr: {{ subnet_prefix }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.{{ bm_info.networks.bm_subnet_start + ns.server_idx if bm_info is defined else ns.server_idx + gen_ip_start }}
       role: {{ service_group.name|upper }}-ROLE
       server-group: RACK{{ (idx%3)+1 }}
       nic-mapping: {{ bm_info.servers[ns.server_idx].nic_mapping if bm_info is defined else 'HEAT' }}
@@ -52,12 +52,12 @@
       # Generate dummy iLO credentials until bsc#1091459 is fixed
       ilo-user: 'ilouser'
       ilo-password: 'ilopasswd'
-      ilo-ip: 10.1.1.{{ ns.server_idx + 100 }}
+      ilo-ip: 10.1.1.{{ ns.server_idx + gen_ip_start }}
 {% endif %}
 {% if service_group.distro_id is defined and 'sles' not in service_group.distro_id %}
       distro-id: {{ service_group.distro_id }}
 {% endif %}
-{%     set ns.server_idx = ns.server_idx+1 %}
+{%     set ns.server_idx = ns.server_idx + (gen_ip_gap if ns.server_idx == 0 else 1) %}
 
 {%   endfor %}
 {% endfor %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/crowbar.yml
@@ -4,6 +4,12 @@
 controllers: 1
 computes: 1
 
+subnet_prefix: 192.168
+gen_subnet_start: 124
+gen_ip_start: 10
+# The gap to be left between the admin node IP and the rest of the nodes
+gen_ip_gap: 70
+
 scenario:
   name: crowbar
   cloud_name: crowbar

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/crowbar.yml
@@ -1,0 +1,20 @@
+---
+
+# Scenario parameters and default values
+controllers: 1
+computes: 1
+
+scenario:
+  name: crowbar
+  cloud_name: crowbar
+  description: >
+    Crowbar PoC scenario.
+  audit_enabled: False
+  use_cinder_volume_disk: False
+  use_glance_cache_disk: False
+  availability_zones: "{{ availability_zones }}"
+
+  service_template: crowbar
+  network_template: crowbar
+  disk_template: compact
+  interface_template: crowbar

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/crowbar.yml
@@ -1,0 +1,11 @@
+---
+
+interface_models:
+  - name: ALL
+    service_groups:
+      - admin
+      - controller
+      - compute
+    network_interfaces:
+      - network_groups:
+          - MANAGEMENT

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/crowbar.yml
@@ -1,0 +1,13 @@
+---
+
+network_groups:
+  - name: MANAGEMENT
+    hostname_suffix: mgmt
+    tagged_vlan: false
+    component_endpoints:
+      - CLM
+      - MANAGEMENT
+      - INTERNAL-API
+      - EXTERNAL-API
+    routes:
+      - default

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/crowbar.yml
@@ -1,0 +1,33 @@
+#
+# Standard Crowbar scenario service template with variable number of controller,
+# and compute nodes.
+#
+# Template parameters:
+#   controllers: number of controller nodes (default: 1)
+#   computes: number of compute nodes (default: 1)
+#
+---
+
+service_groups:
+  - name: admin
+    type: cluster
+    prefix: c0
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: 1
+    service_components:
+      - CLM
+  - name: controller
+    type: cluster
+    prefix: c1
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-controller"
+    member_count: '{{ controllers|default(1) }}'
+    service_components:
+      - CORE
+  - name: compute
+    type: resource
+    prefix: sles-comp
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ computes|default(1) }}'
+    min_count: 0
+    service_components:
+      - COMPUTE


### PR DESCRIPTION
This PR creates a very basic `openstack-crowbar` Jenkins pipeline
job gluing together the various components that are required
to implement a working automated deployment of Crowbar in the
engineering cloud ([SCRD-7366](https://jira.suse.de/browse/SCRD-7366)):

- input model generator and heat template generator components
from Ardana
- the ECP heat stack creation and deletion component from Ardana
- the Ardana component that sets up SSH keys on the admin node
- place-holders for the Crowbar specific steps (not included):
    
  - Crowbar admin node set up
  - Crowbar cloud nodes set up
  - Crowbar installation on admin node
  - Crowbar cloud node registration
  - Crowbar proposal deployment
  - running tests

Also included is an Ardana input model generator scenario that corresponds to the
default, 2 node use-case employed by Crowbar (part of [SCRD-7364](https://jira.suse.de/browse/SCRD-7364)) and a couple of input model generator fixes
and changes required to generate virtual environments that are closer to the Crowbar
defaults.

TBD (#3153):
 - use a variable to differentiate between Crowbar and Ardana in the ansible playbooks
 - the Crowbar specific steps need to be executed on the admin node and some of them even on the Crowbar cloud nodes, whereas all the info on how those nodes can be accessed comes from ansible. A shim layer is needed, most likely implemented in ansible, to SSH on those nodes and execute the required crowbar scripts, also passing them the variables collected from the Jenkins environment  