### PR TITLE
openstack-ardana: report unreachable nodes better

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -93,6 +93,13 @@
           wait_for_connection:
             sleep: 10
             timeout: 300
+          register: _connection
+
+        - name: Fail if one or more hosts are unreacheable
+          fail:
+          when: hostvars[item]['_connection']['failed']
+          loop: "{{ ansible_play_hosts_all }}"
+          run_once: True
 
         - name: Gather facts
           setup:
@@ -161,6 +168,7 @@
       rescue:
         - include_role:
             name: rocketchat_notify
+          delegate_to: "{{ ardana_env }}"
           vars:
             rc_action: "finished"
             rc_state: "Failed"


### PR DESCRIPTION
A couple of changes that will improve the log output when one ore
more of the Ardana cloud nodes are unreachable:
 - fail immediately after finding an unreachable node, rather than
 continue to execute remaining tasks on reachable nodes
 - don't run the rocketchat role on cloud nodes, because it will
 fail a second time in case of unreachable nodes. Delegate it to
 the deployer instead.

NOTE: this change was implemented to address difficulties with
debugging failures such as https://ci.suse.de/blue/organizations/jenkins/cloud-ardana9-job-std-min-x86_64/detail/cloud-ardana9-job-std-min-x86_64/534/pipeline/117