### PR TITLE
Add support for MML input model for baremetal QE environments

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/baremetal/disks.yml.j2
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/baremetal/disks.yml.j2
@@ -138,7 +138,7 @@
               fstype: ext4
               mkfs-opts: -O large_file
 
-{%   elif 'core' in service_group.name %}
+{%   elif service_group.name == 'core' %}
         - name: ardana-vg
           physical-volumes:
             - /dev/sda_root
@@ -168,6 +168,46 @@
             - name: /dev/sdc
           consumer:
             name: cinder
+{%     endif %}
+
+{%   elif service_group.name == 'mml-core' %}
+        - name: ardana-vg
+          physical-volumes:
+            - /dev/sda_root
+          consumer:
+             name: os
+          logical-volumes:
+            - name: root
+              size: 12%
+              fstype: ext4
+              mount: /
+            - name: crash
+              size: 10%
+              mount: /var/crash
+              fstype: ext4
+              mkfs-opts: -O large_file
+            - name: log
+              size: 10%
+              mount: /var/log
+              fstype: ext4
+              mkfs-opts: -O large_file
+      device-groups:
+      - name: swiftobj
+        devices:
+          - name: /dev/sdb
+        consumer:
+          name: swift
+          attrs:
+            rings:
+              - account
+              - container
+              - object-0
+{%     if cinder_lvm_enabled | bool %}
+      - name: cinder-volume
+        devices:
+          - name: /dev/sdc
+        consumer:
+          name: cinder
 {%     endif %}
 
 {%   elif 'neutron' in service_group.name %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm-mml.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm-mml.yml
@@ -1,0 +1,25 @@
+---
+core_nodes: 2
+lmm_nodes: 3
+dbmq_nodes: 3
+sles_computes: 1
+rhel_computes: 0
+
+scenario:
+  name: entry-scale-kvm-mml
+  cloud_name: entry-scale-kvm-mml
+  description: >
+    Multi-cluster scenario with all services enabled, {{ clm_model }} CLM node, {{ core_nodes }} OpenStack core nodes,
+    {{ dbmq_nodes }} database nodes, {{ lmm_nodes }} LMM nodes, {{ sles_computes }} SLES compute nodes and
+    {{ rhel_computes }} RHEL compute nodes.
+  audit_enabled: False
+  ses_enabled: "{{ ses_enabled | default(False) }}"
+  availability_zones: "{{ availability_zones }}"
+  use_cinder_volume_disk: False
+  use_glance_cache_disk: False
+
+
+  service_template: mml-core
+  network_template: compact
+  interface_template: mml-core
+

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/mml-core.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/interface/mml-core.yml
@@ -1,0 +1,52 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+interface_models:
+  - name: CLM
+    service_groups:
+      - clm
+    network_interfaces:
+      - network_groups:
+          - MANAGEMENT
+        forced_network_groups:
+          - EXTERNAL-API
+
+  - name: CORE
+    service_groups:
+      - mml-core
+      - dbmq
+      - lmm
+    network_interfaces:
+      - network_groups:
+          - EXTERNAL-API
+          - GUEST
+          - MANAGEMENT
+      - network_groups:
+          - EXTERNAL-VM
+          - TENANT-VLAN
+
+  - name: COMPUTE
+    service_groups:
+      - sles-compute
+      - rhel-compute
+    network_interfaces:
+      - network_groups:
+          - GUEST
+          - MANAGEMENT
+      - network_groups:
+          - EXTERNAL-VM
+          - TENANT-VLAN

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/mml-core.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/mml-core.yml
@@ -1,0 +1,51 @@
+---
+service_groups:
+  - name: clm
+    type: cluster
+    prefix: c0
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ (clm_model == "standalone") | ternary(1, 0) }}'
+    service_components:
+      - CLM
+  - name: mml-core
+    type: cluster
+    prefix: c1
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-controller"
+    member_count: '{{ core_nodes|default(2) }}'
+    service_components:
+      - '{{ (clm_model == "integrated") | ternary("CLM", '') }}'
+      - CORE
+      - SWPAC
+      - SWOBJ
+      - NEUTRON
+  - name: lmm
+    type: cluster
+    prefix: lmm
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ lmm_nodes|default(3) }}'
+    service_components:
+      - LMM
+  - name: dbmq
+    type: cluster
+    prefix: dbmq
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-minimal"
+    member_count: '{{ dbmq_nodes|default(3) }}'
+    service_components:
+      - DBMQ
+  - name: sles-compute
+    type: resource
+    prefix: sles-comp
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ sles_computes|default(1) }}'
+    min_count: 0
+    service_components:
+      - COMPUTE
+  - name: rhel-compute
+    type: resource
+    prefix: rhel-comp
+    distro_id: rhel73-x86_64
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ rhel_computes|default(1) }}'
+    min_count: 0
+    service_components:
+      - COMPUTE

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/deploy.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/deploy.yml
@@ -100,6 +100,11 @@ _field_nodes_values:
     SWIFT: {{ swift_nodes }}
     NEUTRON: {{ neutron_nodes }}
     Computes: {{ sles_computes}} (SLES) / {{ rhel_computes }} (RHEL)
+  entry-scale-kvm-mml: |
+    Core: {{ core_nodes }}
+    LMM: {{ lmm_nodes }}
+    DBMQ: {{ dbmq_nodes }}
+    Computes: {{ sles_computes}} (SLES) / {{ rhel_computes }} (RHEL)
 
 _field_nodes:
   - title: Nodes


### PR DESCRIPTION
This change supports generating an input model called the entry-scale-kvm-mml model as described in the example in the ardana-input-model repo.
http://git.suse.provo.cloud/cgit/ardana/ardana-input-model/tree/2.0/examples/entry-scale-kvm-mml/

This change is only applicable for the baremetal environment and not virtualized cloud.