### PR TITLE
change backends from lvm to default

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/cinder-parallel.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/cinder-parallel.sh.j2
@@ -23,9 +23,10 @@ rm $test_log
 rm $subunit_log
 
 # however they do need an environment which cinder-tests-all 
-# can set up, noting it needs a backend to be defined so for
-# note we'll use lvm
-$test_dir/cinder-tests-all lvm init
+# can set up, noting we're NOT specifying 'default' for the
+# backend and as a result cinder commands will not specify
+# a backend type.
+$test_dir/cinder-tests-all default init
 
 source $HOME/service.osrc
 cd $test_dir

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/cinder.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/cinder.sh.j2
@@ -5,7 +5,10 @@
 #
 # Usage: cinder-tests-all.sh backend-type subunit-logname
 
-backend="lvm"
+# rather than try to figured out cinder's default backend
+# type to pass to cinder-tests-all, just use 'default'
+# which will result in no volume-type in cinder commands.
+backend="default"
 
 work_dir={{ ardana_qe_test_work_dir }}
 test_dir={{ ardana_qe_tests_dir }}/ardana-qa-tests/cinder-new

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/nova-attach.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/nova-attach.sh.j2
@@ -5,7 +5,10 @@
 #
 # Usage: nova-attach-and-move.py PLUS too many options to list
 
-backend="lvm"
+# since we don't know the specific volume type set up in cinder
+# let's just say 'default' which means the cinder commands will
+# in turn not specify volume-type.
+backend="default"
 
 test_name="nova-attach"
 work_dir={{ ardana_qe_test_work_dir }}


### PR DESCRIPTION
The way my test scripts for cinder work, they require the environment to be initialized by running the script cinder-tests-all and passing it a cinder backend type which ultimately gets used to create a unique cinder backend type and then use it in cinder calls with --volume-type set to that type. At the time I wrote these, all our backends were running LVM and that's what I hardcoded the type too.

Since then we've been running a lot of ses backends and when called with 'lvm', initialization fails along with the test. As an enhancement I had modified the initialization script awhile ago to accept a backend type of 'default' which in turn suppresses the --volume-type switch entirely, resulting in cinder simply using its default backend. But I never remembered to make a similar change to these, hence this update.