### PR TITLE
remove ssh driver from ironic proposal

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2758,7 +2758,11 @@ function custom_configuration
             fi
         ;;
         ironic)
-            proposal_set_value ironic default "['attributes']['ironic']['enabled_drivers']" "['pxe_ipmitool', 'pxe_ssh']"
+            if ! iscloudver 9plus ; then
+                local maybe_agent_driver=''
+                [[ $deployswift ]] && maybe_agent_driver=", 'agent_ipmitool'"
+                proposal_set_value ironic default "['attributes']['ironic']['enabled_drivers']" "['pxe_ipmitool' $maybe_agent_driver]"
+            fi
         ;;
         *) echo "No hooks defined for service: $proposal"
         ;;


### PR DESCRIPTION
SSH drivers were deprecated in Ironic long time ago and proposal validation fails
with these. In addition, agent_* drivers could be enabled if Swift is deployed.

SOC9+ uses new "hardware types" instead of classic drivers and these should have
decent defaults so no need to set anything for that. This part could be extended
in the future if custom values are needed.