### PR TITLE
openstack-ardana-gerrit-events: add support for QE-Review label

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
@@ -10,7 +10,7 @@
                 exclude-drafts: true
                 exclude-no-code-change: false
             - comment-added-contains-event:
-                comment-contains-value: 'Code-Review|Workflow|Verified'
+                comment-contains-value: 'Code-Review|Workflow|Verified|QE-Review'
             - comment-added-contains-event:
                 comment-contains-value: '^reverify$'
           silent: true

--- a/scripts/jenkins/ardana/gerrit/README.md
+++ b/scripts/jenkins/ardana/gerrit/README.md
@@ -181,6 +181,12 @@ approved by the project submit rules configured on the Gerrit server, In the cas
 *NOTE*: the `submittable` and `mergeable` flags do not reflect the status of [implicit dependencies](#implicit-dependencies),
 when these are present. These flags only reflect the status of the change on its own.
 
+*UPDATE*: with the introduction of the `QE-Review` label, the `gerrit.suse.provo.cloud`
+submit rules were modified to also include the following for branches corresponding to released Cloud versions:
+
+ * at least one `QE-Review+1` label value
+ * no `QE-Review-1` label values
+
 4. all changes representing direct and indirect [implicit](#implicit-dependencies) and [explicit](#explicit-dependencies)
 dependencies are merged.
 

--- a/scripts/jenkins/ardana/gerrit/gerrit_review.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit_review.py
@@ -35,7 +35,8 @@ def main():
                              'supplied, the latest patch will be used')
     parser.add_argument('--label',
                         default=None,
-                        choices=['Code-Review', 'Verified', 'Workflow'],
+                        choices=['Code-Review', 'Verified',
+                                 'Workflow', 'QE-Review'],
                         help='a label to use for voting')
     parser.add_argument('--vote',
                         default='1',


### PR DESCRIPTION
Small change required to trigger the `openstack-ardana-gerrit-events`
job, that is responsible for merging Gerrit changes, also in the event
of `QE-Review` label changes.

Included in this commit are documentation updates and support for
using the new label when manually running the gerrit scripts.