### PR TITLE
rename qa_devstack_{fork,branch} to automation_{fork,branch}

### DIFF
--- a/docs/devstack/README.md
+++ b/docs/devstack/README.md
@@ -70,8 +70,8 @@ To boot `devstack` on SLES 12 SP3 using modified versions of
         -t scripts/heat/devstack-heat-template.yaml \
         --parameter key_name=$KEY_NAME \
         --parameter image_name=SLES12-SP3-JeOS.x86_64 \
-        --parameter qa_devstack_fork=$USER
-        --parameter qa_devstack_branch=devstack-sle
+        --parameter automation_fork=$USER
+        --parameter automation_branch=devstack-sle
         --parameter devstack_fork=$USER
         --parameter devstack_branch=sles-support \
         $USER-devstack-sles12-sp3

--- a/scripts/heat/devstack-heat-template.yaml
+++ b/scripts/heat/devstack-heat-template.yaml
@@ -35,16 +35,20 @@ parameters:
     description: Set to 'True' to run Tempest tests.  Defaults to 'False'.
     default: False
 
-  qa_devstack_fork:
+  automation_fork:
     type: string
     label: qa_devstack.sh fork
-    description: GitHub user/organization from which to fetch qa_devstack.sh
+    description: >-
+      GitHub user/organization from which to fetch the automation repo
+      which contains qa_devstack.sh.
     default: SUSE-Cloud
 
-  qa_devstack_branch:
+  automation_branch:
     type: string
     label: qa_devstack.sh branch
-    description: GitHub branch from which to fetch qa_devstack.sh
+    description: >-
+      GitHub branch from which to fetch the automation repo
+      which contains qa_devstack.sh.
     default: master
 
   devstack_fork:
@@ -174,9 +178,9 @@ resources:
                   https://raw.githubusercontent.com/$fork/automation/$branch/scripts/jenkins/qa_devstack.sh
               params:
                 $fork:
-                  get_param: qa_devstack_fork
+                  get_param: automation_fork
                 $branch:
-                  get_param: qa_devstack_branch
+                  get_param: automation_branch
           - chmod 755 /home/stack/qa_devstack.sh
 
           - chown -R stack:stack /home/stack


### PR DESCRIPTION
This more accurately describes the repository being cloned.