### PR TITLE
openstack-ardana: JENKINS-52638 bug workaround

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -60,6 +60,11 @@ pipeline {
               lock(label: ardana_env,
                    variable: 'reserved_env',
                    quantity: 1) {
+                echo "Reserved resource: " + env.reserved_env
+                if (reserved_env == null) {
+                  error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
+                }
+
                 ardana_lib.trigger_build("cloud-ardana${version}-job-std-min-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),
@@ -85,6 +90,11 @@ pipeline {
               lock(label: ardana_env,
                    variable: 'reserved_env',
                    quantity: 1) {
+                echo "Reserved resource: " + env.reserved_env
+                if (reserved_env == null) {
+                  error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
+                }
+
                 ardana_lib.trigger_build("cloud-ardana${version}-job-std-3cp-devel-staging-updates-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
             script: 'echo $(date +%s)'
           ).trim()
 
-          ardana_lib = load "automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
         }
       }
     }
@@ -57,14 +57,8 @@ pipeline {
               // reserve a resource here for the openstack-ardana job, to avoid
               // keeping a cloud-ardana-ci worker busy while waiting for a
               // resource to become available.
-              lock(label: ardana_env,
-                   variable: 'reserved_env',
-                   quantity: 1) {
-                echo "Reserved resource: " + env.reserved_env
-                if (reserved_env == null) {
-                  error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
-                }
-
+              ardana_lib.run_with_reserved_env(true, ardana_env, null) {
+                reserved_env ->
                 ardana_lib.trigger_build("cloud-ardana${version}-job-std-min-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),
@@ -87,14 +81,8 @@ pipeline {
               // reserve a resource here for the openstack-ardana job, to avoid
               // keeping a cloud-ardana-ci worker busy while waiting for a
               // resource to become available.
-              lock(label: ardana_env,
-                   variable: 'reserved_env',
-                   quantity: 1) {
-                echo "Reserved resource: " + env.reserved_env
-                if (reserved_env == null) {
-                  error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
-                }
-
+              ardana_lib.run_with_reserved_env(true, ardana_env, null) {
+                reserved_env ->
                 ardana_lib.trigger_build("cloud-ardana${version}-job-std-3cp-devel-staging-updates-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -71,8 +71,13 @@ The following links can also be used to track the results:
           lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
                variable: 'reserved_env',
                quantity: reserve_env == 'true' ? 1:0 ) {
-            if (env.reserved_env && reserved_env != null) {
-              env.ardana_env = reserved_env
+            if (reserve_env == 'true') {
+              echo "Reserved resource: " + env.reserved_env
+              if (env.reserved_env && reserved_env != null) {
+                env.ardana_env = reserved_env
+              } else {
+                error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
+              }
             }
 
             def slaveJob = build job: 'openstack-ardana', parameters: [

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-maintenance-gating.Jenkinsfile
@@ -57,8 +57,13 @@ pipeline {
               lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
                 variable: 'reserved_env', quantity: reserve_env == 'true' ? 1:0 ) {
                   def ardana_env = "${ardana_env}-deploy"
-                  if (env.reserved_env && reserved_env != null) {
-                    ardana_env = reserved_env
+                  if (reserve_env == 'true') {
+                    echo "Reserved resource: " + env.reserved_env
+                    if (env.reserved_env && reserved_env != null) {
+                      env.ardana_env = reserved_env
+                    } else {
+                      error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
+                    }
                   }
                   def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
                     string(name: 'ardana_env', value: "$ardana_env"),
@@ -91,8 +96,13 @@ pipeline {
               lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
                 variable: 'reserved_env', quantity: reserve_env == 'true' ? 1:0 ) {
                   def ardana_env = "${ardana_env}-update"
-                  if (env.reserved_env && reserved_env != null) {
-                    ardana_env = reserved_env
+                  if (reserve_env == 'true') {
+                    echo "Reserved resource: " + env.reserved_env
+                    if (env.reserved_env && reserved_env != null) {
+                      env.ardana_env = reserved_env
+                    } else {
+                      error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
+                    }
                   }
                   def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
                     string(name: 'ardana_env', value: "$ardana_env"),

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-maintenance-gating.Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
 
-          ardana_lib = load "automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
         }
       }
     }
@@ -52,31 +52,20 @@ pipeline {
               // reserve a resource here for the openstack-ardana job, to avoid
               // keeping a cloud-ardana-ci worker busy while waiting for a
               // resource to become available.
-              // if not instructed to reserve a resource, use a dummy resource and a zero quantity
-              // to fool Jenkins into thinking it reserved a resourcewhen in fact it didn't
-              lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
-                variable: 'reserved_env', quantity: reserve_env == 'true' ? 1:0 ) {
-                  def ardana_env = "${ardana_env}-deploy"
-                  if (reserve_env == 'true') {
-                    echo "Reserved resource: " + env.reserved_env
-                    if (env.reserved_env && reserved_env != null) {
-                      env.ardana_env = reserved_env
-                    } else {
-                      error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
-                    }
-                  }
-                  def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
-                    string(name: 'ardana_env', value: "$ardana_env"),
-                    string(name: 'reserve_env', value: "false"),
-                    string(name: 'cloudsource', value: "$cloudsource"),
-                    string(name: 'maint_updates', value: "$maint_updates"),
-                    string(name: 'update_after_deploy', value: "false"),
-                    string(name: 'rc_notify', value: "true"),
-                    string(name: 'cleanup', value: "on success"),
-                    string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                    string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                    string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
-                  ], false)
+              ardana_lib.run_with_reserved_env(reserve_env == 'true', ardana_env, "${ardana_env}-deploy") {
+                reserved_env ->
+                def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
+                  string(name: 'ardana_env', value: reserved_env),
+                  string(name: 'reserve_env', value: "false"),
+                  string(name: 'cloudsource', value: "$cloudsource"),
+                  string(name: 'maint_updates', value: "$maint_updates"),
+                  string(name: 'update_after_deploy', value: "false"),
+                  string(name: 'rc_notify', value: "true"),
+                  string(name: 'cleanup', value: "on success"),
+                  string(name: 'git_automation_repo', value: "$git_automation_repo"),
+                  string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                  string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
+                ], false)
               }
             }
           }
@@ -91,31 +80,20 @@ pipeline {
               // reserve a resource here for the openstack-ardana job, to avoid
               // keeping a cloud-ardana-ci worker busy while waiting for a
               // resource to become available.
-              // if not instructed to reserve a resource, use a dummy resource and a zero quantity
-              // to fool Jenkins into thinking it reserved a resourcewhen in fact it didn't
-              lock(label: reserve_env == 'true' ? ardana_env:'dummy-resource',
-                variable: 'reserved_env', quantity: reserve_env == 'true' ? 1:0 ) {
-                  def ardana_env = "${ardana_env}-update"
-                  if (reserve_env == 'true') {
-                    echo "Reserved resource: " + env.reserved_env
-                    if (env.reserved_env && reserved_env != null) {
-                      env.ardana_env = reserved_env
-                    } else {
-                      error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
-                    }
-                  }
-                  def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
-                    string(name: 'ardana_env', value: "$ardana_env"),
-                    string(name: 'reserve_env', value: "false"),
-                    string(name: 'cloudsource', value: "$cloudsource"),
-                    string(name: 'maint_updates', value: "$maint_updates"),
-                    string(name: 'update_after_deploy', value: "true"),
-                    string(name: 'rc_notify', value: "true"),
-                    string(name: 'cleanup', value: "on success"),
-                    string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                    string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                    string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
-                  ], false)
+              ardana_lib.run_with_reserved_env(reserve_env == 'true', ardana_env, "${ardana_env}-update") {
+                reserved_env ->
+                def slaveJob = ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-maintenance-update-x86_64", [
+                  string(name: 'ardana_env', value: reserved_env),
+                  string(name: 'reserve_env', value: "false"),
+                  string(name: 'cloudsource', value: "$cloudsource"),
+                  string(name: 'maint_updates', value: "$maint_updates"),
+                  string(name: 'update_after_deploy', value: "true"),
+                  string(name: 'rc_notify', value: "true"),
+                  string(name: 'cleanup', value: "on success"),
+                  string(name: 'git_automation_repo', value: "$git_automation_repo"),
+                  string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                  string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
+                ], false)
               }
             }
           }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -33,8 +33,13 @@ pipeline {
           if (ardana_env == '') {
             error("Empty 'ardana_env' parameter value.")
           }
-          if (env.reserved_env && reserved_env != null) {
-            env.ardana_env = reserved_env
+          if (reserve_env == 'true') {
+            echo "Reserved resource: " + env.reserved_env
+            if (env.reserved_env && reserved_env != null) {
+              env.ardana_env = reserved_env
+            } else {
+              error("Jenkins bug (JENKINS-52638): couldn't reserve a resource with label $ardana_env")
+            }
           }
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
           if ( ardana_env.startsWith("qe") || ardana_env.startsWith("pcloud") ) {


### PR DESCRIPTION
There's a bug in the Lockable Resources plugin that sometimes
causes a Null value to be returned by the `lock` function called
to reserve a resource [1][2]. This has been known to happen for
example when the Jenkins server is restarted, or when a resource
that was previously manually reserved is released and immediately
reserved by one of the jobs waiting in queue.

We don't yet have a fix for this bug, nor a way around it, but we
can at least abort the jobs immediately if this bug is detected,
rather than having them continue to run without a locked resource.

[1] https://issues.jenkins-ci.org/browse/JENKINS-52638
[2] https://issues.jenkins-ci.org/browse/JENKINS-43002