### PR TITLE
fix qa_devstack.sh for SLES12 SP4

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -115,7 +115,7 @@ function h_setup_extra_disk {
 }
 
 function h_setup_devstack {
-    if [[ $DIST_VERSION == 12-SP3 ]]; then
+    if [[ $DIST_VERSION == 12-SP[34] ]]; then
         $zypper --no-gpg-checks in http://download.opensuse.org/repositories/openSUSE:/Leap:/42.3/standard/noarch/git-review-1.25.0-6.2.noarch.rpm
     fi
     $zypper in git-core which ca-certificates-mozilla net-tools git-review


### PR DESCRIPTION
Without this `zypper install` of `git-review` from a 42.3 repo, the subsequent `zypper install` will fail.