### PR TITLE
check openvswitch.ko kernel module is available

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -123,6 +123,12 @@ function h_setup_devstack {
         $zypper in 'group(nogroup)'
     fi
 
+    if ! modinfo openvswitch >/dev/null; then
+        echo "openvswitch kernel module is not available; maybe you are" \
+             "running a -base kernel?  Aborting." >&2
+        exit 1
+    fi
+
     if ! [ -e $DEVSTACK_DIR ]; then
         git clone \
             -b $DEVSTACK_BRANCH \


### PR DESCRIPTION
Some SLES images default to `kernel-default-base` which has a minimal set of kernel modules which does not include `openvswitch`, e.g. see [bsc#1124839 (SP4 JeOS image is missing openvswitch.ko kernel module](https://bugzilla.suse.com/show_bug.cgi?id=1124839)).

In this case we know devstack will fail when it gets to the neutron setup, so bail early to avoid wasting people's time, and give them a potentially helpful tip.
