### PR TITLE
Reduce total runtime for neutron qe tests.

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/neutron.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/neutron.sh.j2
@@ -35,6 +35,6 @@ if $ESX; then
      test_port test_router test_overlapping_ips test_neutron_rbac \
      test_neutron_quotas test_vm_esx --concurrency=1 | tee {{ ardana_qe_test_log }}
 else
-    ${STESTR} run -t ./ --black-regex 'esx' --concurrency=1 | tee {{ ardana_qe_test_log }}
+    ${STESTR} run -t ./ --black-regex 'esx' | tee {{ ardana_qe_test_log }}
 fi
 ${STESTR} last --subunit > {{ ardana_qe_test_subunit }}

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/neutron.yml
@@ -15,7 +15,6 @@
 #
 ---
 # Adding longer timeout as neutron tests run in sequence.
-ardana_qe_test_timeout: 480
 ardana_qe_test_venv_requires:
   - 'pymysql'
   - 'python-subunit'


### PR DESCRIPTION
Neutron qe tests have been refactored to run in parallel to reduce total run time.
Patch - https://gerrit.suse.provo.cloud//#/c/5614/