### PR TITLE
qa_crowbarsetup: Add "want_osprofiler"

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -245,6 +245,11 @@
           default: ''
           description: The database backend sql_engine to be used
 
+      - string:
+          name: want_osprofiler
+          default:
+          description: Set to 1 will setup osprofiler
+
       ################################################
       # neutron
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2377,6 +2377,14 @@ function custom_configuration
             if [[ $hacloud = 1 ]] ; then
                 proposal_set_value keystone default "['deployment']['keystone']['elements']['keystone-server']" "['cluster:$clusternameservices']"
             fi
+            if [[ $want_osprofiler = 1 ]] ; then
+                if iscloudver 9M11plus ; then
+                    proposal_set_value keystone default "['attributes']['keystone']['osprofiler']['enabled']" "true"
+                    proposal_set_value keystone default "['attributes']['keystone']['osprofiler']['trace_sqlalchemy']" "true"
+                else
+                    echo "Warning: osprofiler currently is only available in 9M11plus. Not enabling it"
+                fi
+            fi
             if [[ $want_ldap = 1 ]] ; then
                 local machine
                 for machine in $(get_all_discovered_nodes); do


### PR DESCRIPTION
This is useful to deploy a cloud with osprofiler[1] support. This
needs https://github.com/crowbar/crowbar-openstack/pull/2009 which
adds basic support for osprofiler to Keystone.

Note: Once this is merged and tested, there will be another PR which
will enable osprofiler for one of the gating jobs.

[1] https://docs.openstack.org/osprofiler/latest/