### PR TITLE
Add Jira helper scripts to the automation repo

### DIFF
--- a/jira/validators/fixversion.groovy
+++ b/jira/validators/fixversion.groovy
@@ -1,0 +1,26 @@
+import org.apache.log4j.Level
+
+log.setLevel(Level.DEBUG)
+log.info("Start FixVersion Validation")
+
+// If resolution is not Fixed or Done return always true
+if (!(issue.resolutionObject.name == "Fixed" || issue.resolutionObject.name == "Done")) {
+    log.info("Status is not Fixed or Done (true)")
+    return true
+}
+
+// Check that we have FixedVersions
+if (issue.getFixVersions().isEmpty()) {
+    log.info("FixedVersions is empty (false)")
+    return false
+}
+
+// Check that all AffectedVersions are Fixed
+def versions = issue.getAffectedVersions().minus(issue.getFixVersions())
+if (versions.isEmpty()) {
+    log.info("All AffectedVersions are fixed (true)")
+    return true
+}
+
+log.info("Not all AffectedVersions are Fixed (false)")
+return false

--- a/jira/validators/subtasks.groovy
+++ b/jira/validators/subtasks.groovy
@@ -1,0 +1,19 @@
+import org.apache.log4j.Level
+
+log.setLevel(Level.DEBUG)
+log.info("Start Sub-Tasks Validation")
+
+if (issue.isSubTask()) {
+    log.info("Issue is no Sub-Task (true)")
+    return true
+}
+
+issue.subTaskObjects.each {
+    if (it.resolution == 0) {
+        log.info("Issue has open Sub-Tasks (false)")
+        return false
+    }
+}
+
+log.info("End Sub-Tasks Validation (true)")
+return true

--- a/jira/validators/worker.groovy
+++ b/jira/validators/worker.groovy
@@ -1,0 +1,19 @@
+import org.apache.log4j.Level
+import com.atlassian.jira.component.ComponentAccessor
+import com.atlassian.jira.user.ApplicationUser
+import com.opensymphony.workflow.WorkflowContext
+
+log.setLevel(Level.DEBUG)
+log.info("Start Worker Validation")
+
+// Check that we have a Worker
+def customFieldManager = ComponentAccessor.getCustomFieldManager()
+def workerCf = customFieldManager.getCustomFieldObjectByName("Worker")
+def worker = issue.getCustomFieldValue(workerCf)
+if (worker && worker != "unassigned") {
+    log.info("Worker is assigned (true)")
+    return true
+}
+
+log.info("Worker is empty (false)")
+return false


### PR DESCRIPTION
So fa our Jira Script Runner scripts are only maintaned directly in
Jira. This has the downside that we don't have backups nor have version
controll.