### PR TITLE
openstack-prepare-staging: print error details

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-prepare-staging.yaml
+++ b/jenkins/ci.opensuse.org/openstack-prepare-staging.yaml
@@ -14,3 +14,4 @@
     wrappers:
       - build-name:
           name: '#${BUILD_NUMBER} / C:O:${ENV,var="openstack_project"}'
+      - timestamps


### PR DESCRIPTION
Use the osc.babysitter to get the same error handling as the osc cli.
This will e.g. print some part of the body of an errored HTTP request.

This was found because osc release failed, because a package in Staging
had a conflict. That conclict was a race between trackupstream and
prepare-staging which went like this: release Staging to ToTest;
trackupstream changes Staging; release ToTest to non-staging -> merge
conflict.

Check the return code to abort early if osc release failed.

Enable timestamps for this job.