### PR TITLE
openstack-ardana: add extra_params parameter

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -96,6 +96,19 @@
           description: >-
             Cloud version number (8, 9 etc.)
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/openstack-ardana-heat.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-heat.yaml
@@ -83,6 +83,20 @@
             The OpenStack API credentials used to manage virtual clouds (leave
             empty to use the default shared 'cloud' ECP account).
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -50,6 +50,20 @@
           default: master
           description: The git automation branch
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -152,6 +152,20 @@
             The OpenStack API credentials used to manage virtual clouds (leave
             empty to use the default shared 'cloud' ECP account).
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -151,6 +151,20 @@
             The OpenStack API credentials used to manage virtual clouds (leave
             empty to use the default shared 'cloud' ECP account).
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -119,6 +119,20 @@
             The OpenStack API credentials used to manage virtual clouds (leave
             empty to use the default shared 'cloud' ECP account).
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
           ).trim()
 
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
         }
       }
     }
@@ -65,7 +66,8 @@ pipeline {
                   string(name: 'cleanup', value: "never"),
                   string(name: 'rc_notify', value: "true"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                  string(name: 'git_automation_branch', value: "$git_automation_branch")
+                  string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                  text(name: 'extra_params', value: extra_params)
                 ], false)
               }
             }
@@ -89,7 +91,8 @@ pipeline {
                   string(name: 'cleanup', value: "never"),
                   string(name: 'rc_notify', value: "true"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                  string(name: 'git_automation_branch', value: "$git_automation_branch")
+                  string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                  text(name: 'extra_params', value: extra_params)
                 ], false)
               }
             }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
           ''')
 
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
         }
 
         sh('''
@@ -89,7 +90,8 @@ The following links can also be used to track the results:
               string(name: 'ses_enabled', value: "true"),
               string(name: 'ses_rgw_enabled', value: "false"),
               string(name: 'tempest_filter_list', value: "$tempest_filter_list"),
-              string(name: 'os_cloud', value: "$os_cloud")
+              string(name: 'os_cloud', value: "$os_cloud"),
+              text(name: 'extra_params', value: extra_params)
             ])
           }
         }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -36,10 +36,9 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${heat_action} ${ardana_env}"
           sh('''
             git clone $git_automation_repo --branch $git_automation_branch automation-git
-            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-            ansible_playbook load-job-params.yml
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.ansible_playbook('load-job-params')
         }
       }
     }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-heat.Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
             git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
           ardana_lib.ansible_playbook('load-job-params')
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
@@ -63,9 +63,9 @@ pipeline {
       steps {
         script {
           def slaveJob = build job: openstack_ardana_job, parameters: [
-              string(name: 'sles_image', value: "${sles_image}-update"),
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
-              string(name: 'git_automation_branch', value: "$git_automation_branch")
+              string(name: 'git_automation_branch', value: "$git_automation_branch"),
+              text(name: 'extra_vars', value: "sles_image=${sles_image}-update")
           ], propagate: true, wait: true
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
@@ -3,6 +3,9 @@
  *
  * This job creates test IBS packages corresponding to supplied Gerrit patches.
  */
+
+def ardana_lib = null
+
 pipeline {
 
   // skip the default checkout, because we want to use a custom path
@@ -31,6 +34,8 @@ pipeline {
           sh('''
             git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
+          ardana_lib = load "automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
         }
       }
     }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
              git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
           ardana_lib.ansible_playbook('load-job-params')
           ardana_lib.ansible_playbook('setup-ssh-access')
           ardana_lib.get_deployer_ip()

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
@@ -43,11 +43,10 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
           sh('''
              git clone $git_automation_repo --branch $git_automation_branch automation-git
-             source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-             ansible_playbook load-job-params.yml
-             ansible_playbook setup-ssh-access.yml -e @input.yml
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.ansible_playbook('load-job-params')
+          ardana_lib.ansible_playbook('setup-ssh-access')
           ardana_lib.get_deployer_ip()
 
           // Generate stages for Tempest tests

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -42,11 +42,10 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
           sh('''
             git clone $git_automation_repo --branch $git_automation_branch automation-git
-            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-            ansible_playbook load-job-params.yml
-            ansible_playbook setup-ssh-access.yml -e @input.yml
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.ansible_playbook('load-job-params')
+          ardana_lib.ansible_playbook('setup-ssh-access')
           ardana_lib.get_deployer_ip()
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update-and-test.Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
             git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
           ardana_lib.ansible_playbook('load-job-params')
           ardana_lib.ansible_playbook('setup-ssh-access')
           ardana_lib.get_deployer_ip()

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
@@ -33,12 +33,10 @@ pipeline {
           currentBuild.displayName = "#${BUILD_NUMBER}: ${ardana_env}"
           sh('''
             git clone $git_automation_repo --branch $git_automation_branch automation-git
-            source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-            ansible_playbook load-job-params.yml
-            ansible_playbook setup-ssh-access.yml -e @input.yml
           ''')
-
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.ansible_playbook('load-job-params')
+          ardana_lib.ansible_playbook('setup-ssh-access')
           ardana_lib.get_deployer_ip()
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-update.Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
             git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
           ardana_lib.ansible_playbook('load-job-params')
           ardana_lib.ansible_playbook('setup-ssh-access')
           ardana_lib.get_deployer_ip()

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -61,14 +61,12 @@ pipeline {
             if [ -n "$github_pr" ] ; then
               scripts/jenkins/ardana/pr-update.sh
             fi
-
-            source scripts/jenkins/ardana/jenkins-helper.sh
-            ansible_playbook load-job-params.yml \
-              -e jjb_file=$WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml \
-              -e jjb_type=job-template
-            ansible_playbook notify-rc-pcloud.yml -e @input.yml
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.ansible_playbook('load-job-params',
+                                      "-e jjb_type=job-template -e jjb_file=$WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml"
+                                      )
+          ardana_lib.ansible_playbook('notify-rc-pcloud')
         }
       }
     }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
             fi
           ''')
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
           ardana_lib.ansible_playbook('load-job-params',
                                       "-e jjb_type=job-template -e jjb_file=$WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml"
                                       )
@@ -129,7 +130,8 @@ pipeline {
                 text(name: 'heat_template', value: heat_template),
                 string(name: 'git_automation_repo', value: "$git_automation_repo"),
                 string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                string(name: 'os_cloud', value: "$os_cloud")
+                string(name: 'os_cloud', value: "$os_cloud"),
+                text(name: 'extra_params', value: extra_params)
               ], false)
             }
           }
@@ -144,7 +146,8 @@ pipeline {
               def slaveJob = ardana_lib.trigger_build('openstack-ardana-testbuild-gerrit', [
                 string(name: 'gerrit_change_ids', value: "$gerrit_change_ids"),
                 string(name: 'git_automation_repo', value: "$git_automation_repo"),
-                string(name: 'git_automation_branch', value: "$git_automation_branch")
+                string(name: 'git_automation_branch', value: "$git_automation_branch"),
+                text(name: 'extra_params', value: extra_params)
               ], false)
               env.test_repository_url = "http://download.suse.de/ibs/Devel:/Cloud:/Testbuild:/ardana-ci-${slaveJob.getNumber()}/standard/Devel:Cloud:Testbuild:ardana-ci-${slaveJob.getNumber()}.repo"
               if (extra_repos == '') {
@@ -277,7 +280,8 @@ pipeline {
                 string(name: 'heat_action', value: "delete"),
                 string(name: 'git_automation_repo', value: "$git_automation_repo"),
                 string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                string(name: 'os_cloud', value: "$os_cloud")
+                string(name: 'os_cloud', value: "$os_cloud"),
+                text(name: 'extra_params', value: extra_params)
               ], propagate: false, wait: false
             } else {
               if (reserve_env == 'true') {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
@@ -2,6 +2,19 @@
  * The openstack-ardana Jenkins pipeline library
  */
 
+
+// Loads the list of extra parameters into the environment
+def load_extra_params_as_vars(extra_params) {
+  if (extra_params) {
+    def props = readProperties text: extra_params
+    for(key in props.keySet()) {
+      value = props["${key}"]
+      env."${key}" = "${value}"
+    }
+  }
+}
+
+
 def ansible_playbook(playbook, params='') {
   sh("""
     cd $WORKSPACE

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
@@ -6,8 +6,12 @@ def ansible_playbook(playbook, params='') {
   sh("""
     cd $WORKSPACE
     source automation-git/scripts/jenkins/ardana/jenkins-helper.sh
-    ansible_playbook """+playbook+""".yml -e @input.yml """+params
-  )
+    if [[ -e automation-git/scripts/jenkins/ardana/ansible/input.yml ]]; then
+      ansible_playbook """+playbook+""".yml -e @input.yml """+params+"""
+    else
+      ansible_playbook """+playbook+""".yml """+params+"""
+    fi
+  """)
 }
 
 def trigger_build(job_name, parameters, propagate=true, wait=true) {

--- a/jenkins/ci.suse.de/pipelines/openstack-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-maintenance-gating.Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
           ''')
 
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
+          ardana_lib.load_extra_params_as_vars(extra_params)
         }
       }
     }
@@ -64,7 +65,8 @@ pipeline {
                   string(name: 'cleanup', value: "on success"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
                   string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                  string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
+                  string(name: 'os_cloud', value: "engcloud-cloud-ci-private"),
+                  text(name: 'extra_params', value: extra_params)
                 ], false)
               }
             }
@@ -92,7 +94,8 @@ pipeline {
                   string(name: 'cleanup', value: "on success"),
                   string(name: 'git_automation_repo', value: "$git_automation_repo"),
                   string(name: 'git_automation_branch', value: "$git_automation_branch"),
-                  string(name: 'os_cloud', value: "engcloud-cloud-ci-private")
+                  string(name: 'os_cloud', value: "engcloud-cloud-ci-private"),
+                  text(name: 'extra_params', value: extra_params)
                 ], false)
               }
             }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-gating-template.yaml
@@ -51,6 +51,20 @@
           description: >-
             Cloud version number (8, 9 etc.)
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     logrotate:
       numToKeep: -1
       daysToKeep: 14

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -93,6 +93,20 @@
             The OpenStack API credentials used to manage virtual clouds (leave
             empty to use the default shared 'cloud' ECP account).
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -448,12 +448,19 @@
           description: >-
             Use ipv6 networks in the cloud input model.
 
-      - string:
-          name: sles_image
-          default: ''
+      - text:
+          name: extra_params
+          default:
           description: >-
-            Use this parameter to override the default SLES OpenStack image used for SLES
-            virtual cloud nodes.
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
 
     pipeline-scm:
       scm:

--- a/scripts/jenkins/ardana/ansible/load-job-params.yml
+++ b/scripts/jenkins/ardana/ansible/load-job-params.yml
@@ -31,9 +31,20 @@
         create: yes
         line: "{{ (item.key == 'bool') | ternary(bool_line, default_line) }}"
       with_dict: "{{ jjb.0[jjb_type].parameters }}"
-      when: lookup('env', item.value.name)
+      when: item.value.name != 'extra_params' and lookup('env', item.value.name)
       loop_control:
         label: "{{ item.value.name }}"
+
+    - name: Load extra parameters
+      lineinfile:
+        path: "./input.yml"
+        create: yes
+        line: "{{ item.split('=')[0] }}: {{ lookup('env', item.split('=')[0]) }}"
+        regexp: "^{{ item.split('=')[0] }}: "
+      loop: "{{ lookup('env', 'extra_params').splitlines() }}"
+      when: lookup('env', 'extra_params') is defined and item.split('=')[0] != ''
+      loop_control:
+        label: "{{ item.split('=')[0] }}"
 
     - include_role:
         name: jenkins_artifacts


### PR DESCRIPTION
Add an `extra_params` job parameter to all Ardana jobs to be used
as a means of injecting additional parameters into existing Jenkins
job. The extra parameters will be reflected in the list of Jenkins
environment variables and also ansible variables for jobs that are
implemented using ansible.
    
The new parameter can be used for various purposes:
 - as an alternative to testing changes to JJB job parameters that
 does not require updating the official Jenkins jobs or creating
 temporary copies of official jobs in order to test e.g. new job
 parameters. This will support running customized versions of the
 "CI for CI" gating job
 - to run job builds that use custom values for global ansible
 variables or shell environment variables that are not otherwise
 reflected in the existing job parameters (the `openstack-ardana-image-update`
 job is modified in this PR to exemplify this).

The new parameter will also remove the need to update the JJB
definitions with new parameters in order to support all options
available in the back-end scripts. The list of parameters in JJB
files can be kept short, while more advanced options can be unlocked
through the `extra_params` parameter.
    
Partially implements: https://jira.suse.de/browse/SCRD-4307
