### PR TITLE
qa_crowbarsetup: Set static hmac_key for osprofiler

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2380,6 +2380,7 @@ function custom_configuration
             if [[ $want_osprofiler = 1 ]] ; then
                 if iscloudver 9M11plus ; then
                     proposal_set_value keystone default "['attributes']['keystone']['osprofiler']['enabled']" "true"
+                    proposal_set_value keystone default "['attributes']['keystone']['osprofiler']['hmac_keys']" "['SECRET']"
                     proposal_set_value keystone default "['attributes']['keystone']['osprofiler']['trace_sqlalchemy']" "true"
                 else
                     echo "Warning: osprofiler currently is only available in 9M11plus. Not enabling it"


### PR DESCRIPTION
Set a static key (the key is "SECRET") so it's easier to use
osprofiler when it got deployed via mkcloud/qa_crowbarsetup.
That way, you don't have to search for the password to generate trace
points.