### PR TITLE
glance-registry is deprecated and removed in Cloud9 (SCRD-7639)

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -40,6 +40,8 @@ versioned_features:
   # designate zone/pool (Cloud8) or worker/producer (Cloud9)
   designate_worker_producer:
     enabled: "{{ when_cloud9 }}"
+  glance-registry:
+    enabled: "{{ when_cloud8 }}"
 
 input_model_versioned_features:
   - manila
@@ -47,3 +49,4 @@ input_model_versioned_features:
   - heat-api-cloudwatch
   - nova-console-auth
   - ceilometer-api
+  - glance-registry


### PR DESCRIPTION
We have completed the deprecation of the glance-resitry in Cloud9
and removed support for deploying it, therefore we should only be
generating service component entries for it in Cloud8 deployments
and not in Cloud9.