### PR TITLE
openstack-ardana: wait for BM nodes to power off

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-pcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-pcloud-nodes.yml
@@ -48,6 +48,9 @@
           register: _node_status
           failed_when: "not ('off' in _node_status.stdout)"
           changed_when: False
+          retries: 10
+          until: _node_status is succeeded
+          delay: 5
           when: "'ilo_user' in item"
           loop: "{{ bm_info.servers }}"
           loop_control:


### PR DESCRIPTION
The bootrstrap-pcloud-nodes playbook was failing as we do not give it
time enough to finish powering it off.

This change adds retries to this task so we chek again after 5 seconds
for 10 times if the node is really powered off.