### PR TITLE
SCRD-5899 Only run wipe_disks.yml in physical deployments

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
@@ -24,6 +24,7 @@ ardana_openstack_playbooks:
 
 ardana_scratch_playbooks:
   - play: "wipe_disks.yml -e automate=true"
+    when: "{{ is_physical_deploy }}"
   - play: "site.yml"
   - play: "ardana-cloud-configure.yml"
 


### PR DESCRIPTION
The virtual deployment setup process for the non-deployer nodes is
not setting up the basic distro repos so we cannot install any new
packages on those nodes until after the osconfig plays have setup
the distro repos. As a result the wipe_disks.yml playbooks will
fail for those nodes because they cannot install any packages.

Note that if we want the virtual CI to "emulate" what a customer
deployment process would look like, we probably should be explicitly
setting up at least the distro repos before osconfig runs.