### PR TITLE
IPv6: Allow mkvlan support a netmask for ipv6

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -412,6 +412,7 @@ function setcloudnetvars
         : ${adminip:=${net}:5054:ff:fe77:7770}
         : ${admin_end_range:=${net}:5054:ff:fe77:7771}
         : ${admingw:=${net}${ip_sep}${ip_sep}1}
+        : ${publicgw:=${net_public}${ip_sep}${ip_sep}1}
         : ${ironicgw:=${net_ironic}${ip_sep}${ip_sep}1}
     else
         net_fixed=${net_fixed:-192.168.123}
@@ -425,6 +426,7 @@ function setcloudnetvars
         : ${defaultnetmask:=255.255.255.0}
         : ${adminip:=${net}${ip_sep}10}
         : ${admingw:=${net}${ip_sep}1}
+        : ${publicgw:=${net_public}${ip_sep}1}
         : ${ironicgw:=${net_ironic}${ip_sep}1}
     fi
 }

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -655,10 +655,15 @@ function mkvlan
     local defvlan=$1 ; shift
     local ip=$1 ; shift
     local intf=$cloudbr.$defvlan
+    if (( $want_ipv6 > 0 )); then
+        local netmask=$defaultnetmask
+    else
+        local netmask=24
+    fi
     $sudo ip link add link $cloudbr name $intf type vlan id $defvlan
     safely $sudo ip link set $intf up
-    if ! ip addr show $intf | grep -q $ip/24; then
-        safely $sudo ip addr add $ip/24 dev $intf
+    if ! ip addr show $intf | grep -q $ip/$netmask; then
+        safely $sudo ip addr add $ip/$netmask dev $intf
     fi
 }
 
@@ -666,7 +671,7 @@ function setuppublicnet
 {
     # workaround https://bugzilla.novell.com/show_bug.cgi?id=845496
     echo 0 > /proc/sys/net/bridge/bridge-nf-call-iptables
-    mkvlan $vlan_public $net_public.1
+    mkvlan $vlan_public $publicgw
     if [[ $mkch_physcloudif ]] ; then
         $sudo brctl addif $cloudbr $mkch_physcloudif
         $sudo ip link set dev $mkch_physcloudif up


### PR DESCRIPTION
Currently the mkcloud mkvlan function hardcodes a netmask
of 24. This patch uses the $defaultnetmask if $want_ipv6
is set, which defaults to 64.
Otherwise it remains the 24 default.

This patch also adds an $admingw like we do for ironic and
admin ip. Which makes it easier to manage IPv4 and IPv6
addresses on the mkcloud host.