### PR TITLE
Job to create a CaaSP Cluster with multiple masters

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -236,7 +236,7 @@ pipeline {
 
     stage ('Prepare tests') {
       when {
-        expression { tempest_filter_list != '' || qa_test_list != '' || want_caasp == 'true' }
+        expression { tempest_filter_list != '' || qa_test_list != '' || deploy_caasp != ''}
       }
       steps {
         script {
@@ -245,7 +245,7 @@ pipeline {
           // Generate stages for QA tests
           ardana_lib.generate_qa_tests_stages(env.qa_test_list)
           // Generate stage for CaaSP deployment
-          if (want_caasp == 'true') {
+          if (deploy_caasp != '') {
             stage('Deploy CaaSP') {
               ardana_lib.ansible_playbook('deploy-caasp')
             }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -396,11 +396,17 @@
 
                <change_number>[/<patchset_number>]
 
-      - bool:
-          name: want_caasp
-          default: false
+      - choice:
+          name: deploy_caasp
+          choices: 
+            - '{deploy_caasp|}'
+            - 'single-master'
+            - 'multiple-masters'
           description: >-
-            Deploy CaaSP using the caasp-openstack-heat-templates.
+            Deploy CaaSP using the caasp-openstack-heat-templates. Possible values are:
+            - '' - do not deploy CaaSP
+            - 'single-master' - deploy CaaSP with single master
+            - 'multiple-masters' - deploy CaaSP multiple masters and loadbalancer
 
       - choice:
           name: cleanup

--- a/scripts/jenkins/ardana/ansible/deploy-caasp.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-caasp.yml
@@ -8,17 +8,16 @@
     caasp_image_url: "http://provo-clouddata.cloud.suse.de/images/openstack/x86_64/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"
     caasp_image_path: "/tmp/SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"
     image_name: "SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud"
-    stack_name: "caasp-stack"
   tasks:
   - name: Install caasp-openstack-heat-templates
-    always_run: True
+    check_mode: no
     become: yes
     zypper:
       name: caasp-openstack-heat-templates
       state: present
 
   - name: Download CaaSP image
-    always_run: True
+    check_mode: no
     get_url:
       url: "{{ caasp_image_url }}"
       dest: "{{ caasp_image_path }}"
@@ -29,18 +28,59 @@
     delay: 2
 
   - name: Upload CaaSP image to glance
-    always_run: True
+    check_mode: no
     shell: |
       source ~ardana/service.osrc
       if ! openstack image list | grep "{{ image_name }}"; then openstack image create --public --disk-format qcow2 --container-format bare --file "{{ caasp_image_path }}" "{{ image_name }}"; fi
     args:
       executable: /bin/bash
 
-  - name: Create heat stack for CaaSP deployment
-    always_run: True
+  - name: Set caasp heat stack common parameters
+    set_fact:
+      timeout: "120"
+      admin_flavor: "m1.medium"
+      master_flavor: "m1.medium"
+      worker_flavor: "m1.medium"
+      worker_count: "1"
+      root_password: "linux"
+      external_net: "ext-net"
+      internal_net_cidr: "172.28.0.0/24"
+      dns_nameserver: "172.28.0.2"
+
+  - name: Set caasp heat stack single master parameters
+    set_fact:
+      stack_name: "caasp-stack"
+      stack_template: "caasp-stack.yaml"
+      stack_name: "caasp-stack"
+      master_count_parameter: ""
+    when:
+      - deploy_caasp == 'single-master'
+
+  - name: Set caasp heat stack multiple master parameters
+    set_fact:
+      stack_name: "caasp-multi-master-stack"
+      stack_template: "caasp-multi-master-stack.yaml"
+      master_count_parameter: "--parameter master_count=2"
+    when:
+      - deploy_caasp == 'multiple-masters'
+
+  - name: Create caasp heat stack
+    check_mode: no
     shell: |
       source ~ardana/service.osrc
-      openstack stack create --wait --timeout 120 -t caasp-stack.yaml -e caasp-environment.yaml --parameter image="{{ image_name }}" "{{ stack_name }}"
+      openstack stack create --wait --timeout {{ timeout }} \
+      -t {{ stack_template }} \
+      --parameter image="{{ image_name }}" \
+      --parameter admin_flavor={{ admin_flavor }} \
+      --parameter master_flavor={{ master_flavor }} \
+      --parameter worker_flavor={{ worker_flavor }} \
+      --parameter worker_count={{ worker_count }} \
+      --parameter root_password={{ root_password }} \
+      --parameter external_net={{ external_net }} \
+      --parameter internal_net_cidr={{ internal_net_cidr }} \
+      --parameter dns_nameserver={{ dns_nameserver }} \
+      {{ master_count_parameter}} \
+      "{{ stack_name }}"
       openstack stack show "{{ stack_name }}"
       status=$(openstack stack show "{{ stack_name }}" | grep -w stack_status | awk '{print $4}')
       if [ $status = 'CREATE_COMPLETE' ]; then echo "CaaSP stack created successfully."; else echo "Failed to create stack: $status"; exit 1; fi
@@ -49,7 +89,7 @@
       chdir: /usr/share/caasp-openstack-heat-templates/
 
   - name: Delete downloaded image
-    always_run: True
+    check_mode: no
     file:
       state: absent
       path: "{{ caasp_image_path }}"

--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -19,9 +19,8 @@ heat_stack_name: "openstack-ardana-{{ ardana_env }}"
 heat_template_file: "{{ workspace_path }}/heat-stack-{{ scenario_name | default(model) }}.yml"
 os_cloud: "engcloud-cloud-ci"
 
-
-want_caasp: False
-virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
+deploy_caasp: ""
+virt_config_file_name: "{{ 'caasp.yml' if (deploy_caasp != '') else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
 virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 
 want_lvm: True

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/tasks/main.yml
@@ -57,7 +57,7 @@
   when:
     - not is_physical_deploy
     - virt_config_file != ''
-    - not want_caasp
+    - deploy_caasp == ''
 
 - name: Remove versioned features from input model when not enabled
   replace:


### PR DESCRIPTION
- modified jenkins job builder template
  * removed "want_caasp" option and replaced it by "deploy_caasp"
    choice option
  * added a new deploy_caasp choice option which can be set to
    'single-master' or 'multiple-masters'
  * if the "deploy_caasp" is not set, then CaaSP cluster is
    not created.
- deploy-caasp ansible playbook now looks at 'deploy_caasp'
  parameter to spin up single master or multiple master
  CaaSP cluster