### PR TITLE
openstack-ardana-image-update: share image (SCRD-6094)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -267,7 +267,7 @@
     ardana_image_update_job: '{name}'
     triggers:
     openstack_ardana_job: cloud-ardana8-job-std-min-x86_64
-    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images_SLE_12_SP3/ardana-jeos-SLE12SP3.x86_64.qcow2.xz
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP3/ardana-jeos-SLE12SP3.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP3
     jobs:
         - '{ardana_image_update_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -246,7 +246,7 @@
     ardana_image_update_job: '{name}'
     triggers:
     openstack_ardana_job: cloud-ardana9-job-std-min-x86_64
-    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images_SLE_12_SP4/ardana-jeos-SLE12SP4.x86_64.qcow2.xz
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP4/ardana-jeos-SLE12SP4.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP4
     jobs:
         - '{ardana_image_update_job}'

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
@@ -32,21 +32,28 @@ pipeline {
         sh '''
           wget -qO- ${download_image_url} | xz -d > ${sles_image}.qcow2
 
-          # The cloud-ci user cannot create public images or change their
-          # membership; until that is resolved by updating its privileges,
-          # resort to doing everything twice, once for the 'cloud-ci'
-          # project and a second time for the 'cloud' project
-          for os_cloud in engcloud-cloud-ci-private engcloud-cloud-ci; do
-              openstack --os-cloud $os_cloud image show ${sles_image}-update && \
-                  openstack --os-cloud $os_cloud image delete ${sles_image}-update
+          openstack --os-cloud $os_cloud image show ${sles_image}-update && \
+              openstack --os-cloud $os_cloud image delete ${sles_image}-update
 
-              openstack --os-cloud $os_cloud image create \
-                  --file ${sles_image}.qcow2 \
-                  --disk-format qcow2 \
-                  --container-format bare \
-                  --private \
-                  ${sles_image}-update
-          done
+          openstack --os-cloud $os_cloud image create \
+              --file ${sles_image}.qcow2 \
+              --disk-format qcow2 \
+              --container-format bare \
+              --${image_visibility} \
+              ${sles_image}-update
+
+          if [[ $image_visibility == shared ]]; then
+              # Share the image will all the other projects that the default CI user has access to
+              image_props=($(openstack --os-cloud $os_cloud image show -f value -c id -c owner ${sles_image}-update))
+              image_uuid=${image_props[0]}
+              image_owner=${image_props[1]}
+              other_projects=$(openstack --os-cloud $os_cloud --os-interface public project list -f value -c ID | grep -v "${image_owner}")
+
+              for project in $other_projects; do
+                  openstack --os-cloud $os_cloud --os-interface public image add project ${sles_image}-update $project
+                  openstack --os-cloud $os_cloud --os-project-id $project image set --accept $image_uuid
+              done
+          fi
         '''
       }
     }
@@ -66,20 +73,14 @@ pipeline {
   post {
     success {
       sh '''
-          # The cloud-ci user cannot create public images or change their
-          # membership; until that is resolved by updating its privileges,
-          # resort to doing everything twice, once for the 'cloud-ci'
-          # project and a second time for the 'cloud' project
-          for os_cloud in engcloud-cloud-ci-private engcloud-cloud-ci; do
-              openstack --os-cloud $os_cloud image set \
-                  --name ${sles_image}-$(date +%Y%m%d) \
-                  --deactivate \
-                  ${sles_image}
+          openstack --os-cloud $os_cloud image set \
+              --name ${sles_image}-$(date +%Y%m%d) \
+              --deactivate \
+              ${sles_image}
 
-              openstack --os-cloud $os_cloud image set \
-                  --name ${sles_image} \
-                  ${sles_image}-update
-          done
+          openstack --os-cloud $os_cloud image set \
+              --name ${sles_image} \
+              ${sles_image}-update
       '''
     }
     cleanup {

--- a/jenkins/ci.suse.de/templates/cloud-ardana-image-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-image-update-template.yaml
@@ -23,6 +23,16 @@
           description: >-
             The URL pointing to the updated image file
 
+      - choice:
+          name: image_visibility
+          choices:
+            - 'shared'
+            - 'private'
+          description: >-
+            The visibility used for the image. Possible values are:
+              - shared - installs an image shared with all the other projects that the user is associated with
+              - private - installs a private image
+
       - string:
           name: openstack_ardana_job
           default: '{openstack_ardana_job|openstack-ardana}'
@@ -40,6 +50,12 @@
           default: '{git_automation_branch|master}'
           description: >-
             The git automation branch
+
+      - hidden:
+          name: os_cloud
+          default: '{os_cloud|engcloud-cloud-ci-private}'
+          description: >-
+            The OpenStack API credentials for the target OpenStack cloud.
 
     pipeline-scm:
       scm:


### PR DESCRIPTION
We're currently using two sets of SLES CI images in the
ECP cloud, due to the fact that we cannot create public
images with the `cloud-ci` ECP user, which is used to
automate image update, and the image membership support
was thought to be broken in Newton (i.e. because
`openstack --os-cloud engcloud-cloud-ci image set --accept <image>`
didn't have the desire effect).

After further investigations, it turns out that the explanation
for the above failure was simple: we just had to use a
project UUID instead of the project name when sharing
the image.

This commit makes the image update automation use shared
images by default and also removes the need to have OpenStack
cloud configuration files preconfigured for the other
projects with which the image needs to be shared.

The only pre-requisite is that the OpenStack user used by the
automated job (`cloud-ci` in our particular case) also needs
to be associated with the other projects.