### PR TITLE
Revert "glance-registry is deprecated and removed in Cloud9 (SCRD-7639)"

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -40,8 +40,6 @@ versioned_features:
   # designate zone/pool (Cloud8) or worker/producer (Cloud9)
   designate_worker_producer:
     enabled: "{{ when_cloud9 }}"
-  glance-registry:
-    enabled: "{{ when_cloud8 }}"
 
 input_model_versioned_features:
   - manila
@@ -49,4 +47,3 @@ input_model_versioned_features:
   - heat-api-cloudwatch
   - nova-console-auth
   - ceilometer-api
-  - glance-registry


### PR DESCRIPTION
Reverts SUSE-Cloud/automation#3183

I was too quick to merge this. It still needs changes in `ardana-input-model` (see https://ci.suse.de/blue/organizations/jenkins/openstack-ardana/detail/openstack-ardana/3330/pipeline)