### PR TITLE
openstack-ardana: fix setup-ssh-access for pcloud

### DIFF
--- a/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
+++ b/scripts/jenkins/ardana/ansible/setup-ssh-access.yml
@@ -38,7 +38,7 @@
             cacheable: True
           loop: "{{ (heat_stack_output is defined) | ternary(heat_stack_output_queries, os_stack_output.results) }}"
           loop_control:
-            label: "{{ item.item | replace('-', '_') }}: {{ (item.stdout == 'None') | ternary([], item.stdout | from_yaml) }}"
+            label: "{{ item.item | replace('-', '_') }}: {{ ('stdout' in item and item.stdout == 'None') | ternary([], item.stdout | default('') | from_yaml) }}"
           when: not is_physical_deploy
 
         - name: Ensure deployer on ansible inventory file when virtual deploy


### PR DESCRIPTION
Fix an issue when running setu-ssh-access playbook on bare-metal
environments.

The playbook fails because the loop label is set using the output value
provided by item, which is not defined on bare-metal.