### PR TITLE
work around checksum mismatch during cleanvm

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -10,7 +10,10 @@ fi
 
 : ${MODE:=kvm}
 ARCH=$(uname -i)
-: ${repomirror:=http://download.opensuse.org}
+# Default is one mirror we know is updated fast enough instead of the
+# redirector because some mirrors lag and cause a checksum mismatch for rpms
+# that keep name and size and only change content.
+: ${repomirror:=http://downloadcontent.opensuse.org}
 : ${imagemirror:=http://149.44.161.38/images} # ci1-opensuse
 : ${cirros_base_url:="$imagemirror"} # could also be "http://download.cirros-cloud.net/0.3.4/"
 cloudopenstackmirror=$repomirror/repositories/Cloud:/OpenStack:


### PR DESCRIPTION
Default to one mirror we know is updated fast enough instead of the
redirector because some mirrors lag and cause a checksum mismatch for rpms
that keep name and size and only change content.

This happened only on Leap 15 for Rocky when using osc release based
copy to the ToTest project, probably because otherwise changes like this
don't happen often enough.

Example from the log (the received checksum was from the day before):

Warning: Digest verification failed for file 'openstack-suse-sudo-2015.2-lp150.2.1.noarch.rpm'
[/var/tmp/AP_0xqwI2Is/noarch/openstack-suse-sudo-2015.2-lp150.2.1.noarch.rpm]

  expected 388d766a8213163cb1ab36c4705f8a16958a9c8f3abfd10b715df2cf996a44cf
  but got  d95494a9af9ae19810c4f0a818c01b1ec09fa53458739d26c0e1a53ad16c0bcc