### PR TITLE
openstack-ardana-testbuild-gerrit: job improvements (SCRD-6210)

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -2,13 +2,6 @@
     name: openstack-ardana-testbuild-gerrit
     project-type: pipeline
     concurrent: true
-    wrappers:
-      - timestamps
-      - timeout:
-          timeout: 20
-          type: no-activity
-          abort: true
-          write-description: "Job aborted due to 20 minutes of inactivity."
 
     logrotate:
       numToKeep:  300
@@ -67,10 +60,3 @@
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
       lightweight-checkout: false
-
-    publishers:
-      - workspace-cleanup:
-          clean-if:
-            - failure: false
-            - aborted: false
-            - unstable: false


### PR DESCRIPTION
Improves the job that builds CI test packages for Gerrit
changes:
 - moves the job to run on the `cloud-ardana-ci` agent
 instead of the `cloud-trackupstream-sle12` agent, which
 only has one worker configured and acts as a bottleneck
 - times out the package build after 30 minutes of inactivity
 - improve UI usability by printing out useful URLs about built
 repositories and projects