### PR TITLE
Temporarily disable periodic installs on 102

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -174,8 +174,7 @@
       keystone-k2k-config,keystone-websso-config,keystone-x509-config,\
       service-ansible-playbooks,enable_tls,tempest_cleanup,nova_guest_image"
     rc_notify: 'true'
-    triggers:
-     - timed: 'H H * * *'
+    triggers: []
     jobs:
         - '{ardana_job}'
 


### PR DESCRIPTION
Some of the cloud 9 QE environments are down,
disabling periodic installs on 102 so we can use
this environment on demand installs.