### PR TITLE
qa_crowbarsetup: Add "want_l3_ha"

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -271,6 +271,11 @@
           default:
           description: Set to 1 to deploy neutron with Distributed Virtual Router
 
+      - string:
+          name: want_l3_ha
+          default:
+          description: Set to 1 to deploy neutron with l3 HA
+
       ################################################
       # storage
 

--- a/scripts/lib/qa_crowbarsetup-help.sh
+++ b/scripts/lib/qa_crowbarsetup-help.sh
@@ -6,6 +6,8 @@ function qacrowbarsetup_help
     cat <<EOUSAGE
     crowbar_networkingmode=single         (default single)
         set the networking mode for Crowbar.
+    want_l3_ha=1         (default 0)
+        Use the upstream l3 HA solution (with VRRP/keepalived)
     want_neutronsles12=1 (default 0)
         if there is a SLE12 node, deploy neutron-network role into the SLE12 node
     want_mtu_size=<size> (default='')

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2606,6 +2606,14 @@ function custom_configuration
             fi
             proposal_set_value neutron default "['attributes']['neutron']['use_lbaas']" "true"
 
+            if [[ $want_l3_ha = 1 ]]; then
+                if grep -q use_l3_ha /opt/dell/chef/data_bags/crowbar/template-neutron.json ; then
+                    proposal_set_value neutron default "['attributes']['neutron']['l3_ha']['use_l3_ha']" "true"
+                else
+                    echo "Warning: l3 HA not available in this installation. Not enabling it"
+                fi
+            fi
+
             if [ $networkingplugin = openvswitch ] ; then
                 if [[ $networkingmode = vxlan ]] || iscloudver 6plus; then
                     proposal_set_value neutron default "['attributes']['neutron']['ml2_type_drivers']" "['vxlan','vlan', 'gre']"


### PR DESCRIPTION
This is useful to deploy a cloud with the upstream solution for l3 HA.
This requires https://github.com/crowbar/crowbar-openstack/pull/2005
which adds l3 HA support to Crowbar.

Note: If this PR and the crowbar PR are merged, another PR is needed
to enable l3 HA by default for the gating jobs.