### PR TITLE
 openstack-ardana: Add script to deploy ardana without jenkins (SCRD-4903)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,13 @@ mkcloud.*
 .artifacts
 pids/
 screenlog*
+
+scripts/jenkins/ardana/manual/ansible-venv
+scripts/jenkins/ardana/manual/mitogen
+scripts/jenkins/ardana/ansible/ansible_facts
+scripts/jenkins/ardana/ansible/*-virt-config.yml
+scripts/jenkins/ardana/ansible/input_model
+scripts/jenkins/ardana/ansible/heat-stack-*.yml
+
+scripts/jenkins/ses/ansible/ansible_facts
+scripts/jenkins/ses/ansible/ses-stack-template.yml

--- a/docs/ardana/testing.md
+++ b/docs/ardana/testing.md
@@ -1,7 +1,7 @@
 # Ardana automated testing
 
-Starting with SOC8, Ardana can be deployed and tested using sources coming from the 
-[internal build service](https://build.suse.de/project/show/Devel:Cloud:8:Staging), 
+Starting with SOC8, Ardana can be deployed and tested using sources coming from the
+[internal build service](https://build.suse.de/project/show/Devel:Cloud:8:Staging),
 automated through jobs running in the [ci.nue.suse.com Jenkins service](https://ci.nue.suse.com/job/openstack-ardana)
 and consuming the virtualized resources in [the engineering cloud](https://engcloud.prv.suse.net/project/stacks/).
 This process is implemented by the [Jenkins pipeline jobs](https://github.com/SUSE-Cloud/automation/blob/master/jenkins/ci.suse.de/pipelines)
@@ -148,6 +148,8 @@ To be able to deploy an Ardana environment using the Ardana automation ansible p
 Setting up a local Ardana test environment:
 
 * clone the [automation repository](https://github.com/SUSE-Cloud/automation) locally
+* for building test packages from gerrit changes, the osc utility needs to be correctly installed and configured on
+the local host.
 * set up an OpenStack cloud configuration reflecting your engineering cloud credentials (for virtual Ardana environments).
 To do that, create an `~/.config/openstack/clouds.yaml` file with the following contents reflecting your engineering cloud account:
 
@@ -166,13 +168,6 @@ clouds:
     cacert: /usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem
 ```
 
-* create and activate a local python virtualenv and install the following packages:
-  * python-openstackclient
-  * python-heatclient
-  * python-neutronclient
-  * ansible
-  * netaddr
-
 To verify that the test environment is properly set up:
 
 * run an openstack CLI command, e.g.:
@@ -181,17 +176,39 @@ To verify that the test environment is properly set up:
 openstack --os-cloud engcloud-cloud-ci stack list
 ```
 
-* run an ansible playbook, e.g.:
-
-```
-cd automation/scripts/jenkins/ardana/ansible
-ansible_playbook clone-input-model.yml -e model=standard
-```
-
-
 ### Manual Ardana deployment
 
-TBD: how to run the ansible playbooks
+A bash script is provided to help deploying Ardana manually. The script sets up a virtual environment with ansible and all
+requirements and mimics the steps of the openstack-ardana job by calling the ansible playbooks in the appropriate
+sequence with the appropriate parameters, which are taken from `input.yml`.
+
+Before running the script you need to configure the parameters in the `input.yml` file to fit how you want ardana to be
+deployed. The options available are basically a subset of the inputs from the openstack-ardana jenkins job.
+
+Deploying Ardana:
+
+* Go to `scripts/jenkins/ardana/manual` directory
+* Edit the `input.yml` file
+* Run `deploy-ardana.sh`
+
+```
+cd scripts/jenkins/ardana/manual
+vim input.yml
+./deploy-ardana.sh
+```
+
+Alternatively you can also call each step individually (after configuring `input.yml`) by sourcing the script library.
+E.g.:
+
+```
+cd scripts/jenkins/ardana/manual
+source lib.sh
+setup_ansible_venv
+mitogen_enable
+prepare_input_model
+prepare_infra
+...
+```
 
 
 ## Ardana CI jobs
@@ -204,7 +221,7 @@ especially useful in the Blue Ocean Jenkins UI
 * more flexible
 * TBD
 
-### 
+###
 
 
 TBD: describe the existing jobs, their purpose, triggers,
@@ -230,7 +247,7 @@ link to the detailed pipeline description for every job.
 
 ### Integration pipeline
 
-Describe the pipeline job, stages, link to detail docs for various features/roles., 
+Describe the pipeline job, stages, link to detail docs for various features/roles.,
 Diagram with job stages/hierarchy.
 
 ### Gerrit pipeline
@@ -243,5 +260,3 @@ Prepare BM cloud
 Some extra checks are automatically run by the Jenkins job:
 
 - [rpm file checks](rpm-file-checks.md)
-
-

--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -89,10 +89,16 @@
 
   tasks:
     - block:
+        # Do not use the wait_for_connection module here as it is not reliable when
+        # using mitogen through bastion hosts.
         - name: Wait for cloud nodes to be accessible
-          wait_for_connection:
-            sleep: 10
-            timeout: 300
+          delegate_to: localhost
+          wait_for:
+            host: "{{ ansible_ssh_host }}"
+            port: 22
+            search_regex: OpenSSH
+            state: started
+            delay: 10
           register: _connection
 
         - name: Fail if one or more hosts are unreacheable

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -28,7 +28,7 @@ ses_rgw_enabled: False
 ardana_ses_integration_version: 2
 cinder_lvm_enabled: '{{ not ses_enabled }}'
 
-workspace_path: "{{ lookup('env', 'WORKSPACE') | default('.', true) }}"
+workspace_path: "{{ lookup('env', 'WORKSPACE') | default(playbook_dir, true) }}"
 input_model_path: "{{ workspace_path }}/input_model"
 
 is_physical_deploy: "{{ ardana_env in groups['qe_all'] }}"

--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
@@ -118,10 +118,11 @@
 
 - name: Print starting partition size
   command: parted --script {{ root_fs_base_dev }} print
+  changed_when: false
   register: vm_partitions
 
 - debug:
-    var: vm_partitions
+    var: vm_partitions.stdout
 
 - name: Print starting filesystem size
   command: df -h /
@@ -129,7 +130,7 @@
   changed_when: False
 
 - debug:
-    var: vm_filesystems
+    var: vm_filesystems.stdout
 
 - name: Change fdisk start field number for single partition layout
   set_fact:
@@ -208,7 +209,10 @@
   when:
     - vm_resize_partition is not skipped
 
-- debug: var=vm_partitions
+- debug:
+    var: vm_partitions.stdout
+  when:
+    - vm_resize_partition is not skipped
 
 - name: Print finishing filesystem size
   command: df -h /
@@ -216,4 +220,7 @@
   when:
     - vm_resize_filesystem is not skipped
 
-- debug: var=vm_filesystems
+- debug:
+    var: vm_filesystems.stdout
+  when:
+    - vm_resize_filesystem is not skipped

--- a/scripts/jenkins/ardana/gerrit/gerrit.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 
 try:
@@ -10,7 +11,8 @@ except ImportError:
 import requests
 
 GERRIT_URL = 'https://gerrit.suse.provo.cloud'
-GERRIT_VERIFY = True
+
+GERRIT_VERIFY = os.environ.get('GERRIT_VERIFY', True) in ['true', '1', True]
 
 # We use a more complex regex that matches both formats of Depends-On so that
 # we preserve the order in which they are discovered.

--- a/scripts/jenkins/ardana/manual/deploy-ardana.sh
+++ b/scripts/jenkins/ardana/manual/deploy-ardana.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+source lib.sh
+
+validate_input
+setup_ansible_venv
+mitogen_enable
+prepare_input_model
+prepare_infra
+
+trap exit_msg EXIT
+
+build_test_packages
+bootstrap_clm
+deploy_ses_vcloud
+bootstrap_nodes
+deploy_cloud
+update_cloud
+run_tempest
+run_qa_tests

--- a/scripts/jenkins/ardana/manual/input.yml
+++ b/scripts/jenkins/ardana/manual/input.yml
@@ -1,0 +1,163 @@
+---
+#============= Eng. Cloud =============#
+# The OpenStack API credentials used to manage virtual clouds
+# (leave empty to use the default shared 'cloud' ECP account).
+os_cloud: 'engcloud-cloud-ci'
+
+# The virtual or hardware environment identifier. This field should either be set to one
+# of the value that will identify the created virtual environment.
+# WARNING: if a virtual environment associated with the supplied ardana_env already
+# exists, it will be replaced.
+ardana_env: ''
+
+# If left unchecked, the cloud deployment steps will be skipped. This option can be used
+# if you only need to set up the infrastructure and configure the cloud media and
+# repositories, but skip the actual cloud deployment, e.g. for testing purposes.
+deploy_cloud: true
+
+
+#============= Repositories =============#
+# The cloud repository (from provo-clouddata) to be used for testing. This value can take
+# the following form:
+#   stagingcloud<X> (Devel:Cloud:X:Staging)
+#   develcloud<X> (Devel:Cloud:X)
+#   GM<X> (official GM)
+#   GM<X>+up (official GM plus Cloud-Updates)
+#   cloud9MX (cloud 9 milestones)
+cloudsource: 'GM8+up'
+
+# Enable SLES/Cloud test update repos (the Cloud test update repos will be enabled only
+# when cloudsource is GM based)
+updates_test_enabled: false
+
+# Run ardana update after the cloud is deployed. If true the MU's will be applied only
+# after the cloud is deployed.
+update_after_deploy: false
+
+# Only valid if update_after_deploy is true. The cloud repository (from provo-clouddata)
+# to be used to update.
+# This opention takes the same values as cloudsource.
+update_to_cloudsource: ''
+
+# List of maintenance update IDs separated by comma (eg. 7396,7487)
+maint_updates: ''
+
+# A comma separated list of repository urls (ending with .repo) to be added on the deployer node.
+extra_repos: ''
+
+
+#============= Gerrit =============#
+# A comma separated list of IDs for changes in gerrit.suse.provo.cloud to test.
+# The patchset may be supplied as part of the change ID in the form: <change_number>[/<patchset_number>]
+gerrit_change_ids: ''
+
+# Project in IBS that will act as the parent project for the newly generated test project.
+# E.g. 'home:<username>'
+homeproject: ''
+
+
+#============= Input model =============#
+# The name of the one of the available 'ardana-ci' input models to use from
+# the ardana-input-model git repository.
+# NOTE: use this parameter only if you want to use an existing input model.
+# To generate an input model instead, leave this field empty and use the
+# 'scenario_name' parameter instead.
+model: ''
+
+# The name of one of the available scenarios that can be used to generate input models.
+# If this parameter is set, the following parameters may also be set to different values,
+# to control various aspects of the generated input model: clm_model, controllers, core_nodes,
+# lmm_nodes, dbmq_nodes, neutron_nodes, swift_nodes, sles_computes, rhel_computes and
+# disabled_services.
+# NOTE: use this parameter only if you want to use a generated input model. To use an existing
+# input model instead, leave this field empty and use the 'model' parameter instead.
+# Possible values:
+#   - entry-scale-kvm
+#   - mid-scale-kvm
+#   - standard
+#   - std-split
+scenario_name: 'entry-scale-kvm'
+
+# The type of deployer node deployment to use for the generated input model.
+# Possible values:
+#  - standalone: one node dedicated for CLM
+#  - integrated: the first controller node will also be used as a CLM node
+# Input model generator scenarios using this parameter : all
+# NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter
+#  about using one of the available input model generator scenarios.
+clm_model: 'integrated'
+
+# The number of controller nodes in the generated input model (0-3).
+# Input model generator scenarios using this parameter: standard, entry-scale-kvm.
+controllers: '3'
+
+# The number of SLES compute nodes in the generated input model.
+# Input model generator scenarios using this parameter: all
+sles_computes: '2'
+
+# The number of RHEL (CentOS) compute nodes in the generated input model.
+# Input model generator scenarios using this parameter: all
+rhel_computes: '0'
+
+# The OS distribution and version to use for Ardana RHEL compute nodes.
+# Possible values:
+#   - CentOS_73
+#   - CentOS_75
+#   - RHEL_73 (only for BM deployments)
+#   - RHEL_75 (only for BM deployments)
+rhel_os: 'CentOS_75'
+
+# The number of OpenStack core services nodes in the generated input model (0-3).
+# Input model generator scenarios using this parameter: mid-scale-kvm, std-split.
+core_nodes: ''
+
+# The number of LMM services nodes in the generated input model (0-3).
+# Input model generator scenarios using this parameter: mid-scale-kvm, std-split.
+lmm_nodes: ''
+
+# The number of database & rabbitmq service nodes in the generated input model (0-3).
+# Input model generator scenarios using this parameter: mid-scale-kvm, std-split.
+dbmq_nodes: ''
+
+# The number of neutron network nodes in the generated input model (0-3).
+# Input model generator scenarios using this parameter: mid-scale-kvm.
+neutron_nodes: ''
+
+# The number of swift proxy/account/container/object service nodes in the generated input model (0-3).
+# Input model generator scenarios using this parameter: mid-scale-kvm.
+swift_nodes: ''
+
+# Regex matching service components and component groups to exclude from the generated input model.
+# Input model generator scenarios using this parameter: all
+# Example for disabling monasca, ceilometer, freezer and octavia set:
+# disabled_services: 'monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer|octavia'
+disabled_services: ''
+
+# Use ipv6 networks in the cloud input model.
+ipv6: false
+
+
+#============= SES =============#
+# Configure SES backend for glance, cinder, cinder-backup and nova
+ses_enabled: true
+
+# Configure object-store service with RADOS Gateway. This only takes effect
+# if ses_enabled is set to true.
+ses_rgw_enabled: false
+
+
+#============= Tests =============#
+# Name of the filter file to use for tempest.
+# Comma separated values will run tempest for each selected value.
+# Use an empty value to skip running tempest.
+tempest_filter_list: ''
+
+# Name of the QA tests to run.
+# Comma separated values will run QA tests for each selected value.
+# Use an empty value to skip running QA tests.
+qa_test_list: ''
+
+
+#============= Rocketchat =============#
+# Notify RocketChat when deployment starts/finishes.
+rc_notify: false

--- a/scripts/jenkins/ardana/manual/lib.sh
+++ b/scripts/jenkins/ardana/manual/lib.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+WORK_DIR=${WORK_DIR:-$PWD}
+AUTOMATION_DIR=${AUTOMATION_DIR:-"$(git rev-parse --show-toplevel)"}
+ANSIBLE_VENV=${ANSIBLE_VENV:-"$WORK_DIR/ansible-venv"}
+ARDANA_INPUT=${ARDANA_INPUT:-"$WORK_DIR/input.yml"}
+MITOGEN_URL=${MITOGEN_URL:-"https://github.com/dw/mitogen/archive/master.tar.gz"}
+ANSIBLE_CFG_ARDANA=${ANSIBLE_CFG_ARDANA:-"$AUTOMATION_DIR/scripts/jenkins/ardana/ansible/ansible.cfg"}
+ANSIBLE_CFG_SES=${ANSIBLE_CFG_SES:-"$AUTOMATION_DIR/scripts/jenkins/ses/ansible/ansible.cfg"}
+
+
+function get_from_input {
+  echo $(grep -v "^#" $ARDANA_INPUT | awk -v var=$1 '$0 ~ var{ print $2 }' | tr -d "'")
+}
+
+function is_defined {
+  value=$(get_from_input $1)
+  if [[ ! -z "${value// }" ]]; then
+    true
+  else
+    false
+  fi
+}
+
+function setup_ansible_venv {
+  if [ ! -d "$ANSIBLE_VENV" ]; then
+    virtualenv $ANSIBLE_VENV
+    $ANSIBLE_VENV/bin/pip install --upgrade pip
+    $ANSIBLE_VENV/bin/pip install -r $WORK_DIR/requirements.txt
+  fi
+}
+
+function mitogen_enable {
+  if [ ! -d "mitogen" ]; then
+    wget -qO- $MITOGEN_URL | tar -xz
+    mv mitogen-* mitogen
+  fi
+
+  for cfg in "${ANSIBLE_CFG_ARDANA}" "${ANSIBLE_CFG_SES}"; do
+    if ! grep -Fq "strategy_plugins=" ${cfg}; then
+      sed -i "/^\[defaults\]/a\strategy_plugins=$WORK_DIR/mitogen/ansible_mitogen/plugins/strategy" \
+        $cfg
+    fi
+    if ! grep -Fxq "strategy=mitogen_linear" $cfg; then
+      sed -i "/^\[defaults\]/a\strategy=mitogen_linear" $cfg
+    fi
+  done
+}
+
+function mitogen_disable {
+  if [ -d "mitogen" ]; then
+    rm -rf mitogen
+  fi
+  for cfg in "${ANSIBLE_CFG_ARDANA}" "${ANSIBLE_CFG_SES}"; do
+    if grep -Fq "strategy_plugins=" ${cfg}; then
+      sed -i "/strategy_plugins=/d" \
+        $cfg
+    fi
+    if grep -Fxq "strategy=mitogen_linear" $cfg; then
+      sed -i "/strategy=mitogen_linear/d" $cfg
+    fi
+  done
+}
+
+function ansible_playbook {
+  if ! is_defined ardana_env; then
+    echo "ERROR: ardana_env must be defined - please check all variables on input.yml"
+    return 1
+  else
+    source $ANSIBLE_VENV/bin/activate
+    if [[ "$PWD" != *scripts/jenkins/ardana/ansible ]]; then
+      pushd $AUTOMATION_DIR/scripts/jenkins/ardana/ansible
+    fi
+    echo "Running: ansible-playbook -e @$ARDANA_INPUT ${@}"
+    ansible-playbook -e @$ARDANA_INPUT "${@}"
+    popd
+  fi
+}
+
+function ansible_playbook_ses {
+  if ! is_defined ardana_env; then
+    echo "ERROR: ardana_env must be defined - please check all variables on input.yml"
+    return 1
+  else
+    source $ANSIBLE_VENV/bin/activate
+    if [[ "$PWD" != *scripts/jenkins/ses/ansible ]]; then
+      pushd $AUTOMATION_DIR/scripts/jenkins/ses/ansible
+    fi
+    echo "Running: ansible-playbook ${@}"
+    ansible-playbook "${@}"
+    popd
+  fi
+}
+
+function is_physical_deploy {
+  ardana_env=$(get_from_input ardana_env)
+  [[ $ardana_env == qe* ]] || [[ $ardana_env == pcloud* ]]
+}
+
+function get_deployer_ip {
+  grep -oP "^$(get_from_input ardana_env)\\s+ansible_host=\\K[0-9\\.]+" \
+    $AUTOMATION_DIR/scripts/jenkins/ardana/ansible/inventory
+}
+
+function get_ses_ip {
+  grep -oP "^openstack-ses-$(get_from_input ardana_env)\\s+ansible_host=\\K[0-9\\.]+" \
+    $AUTOMATION_DIR/scripts/jenkins/ses/ansible/inventory
+}
+
+function delete_stack {
+  if ! is_physical_deploy; then
+    ansible_playbook heat-stack.yml -e heat_action=delete
+  fi
+}
+
+function prepare_input_model {
+  if is_defined scenario_name; then
+    ansible_playbook generate-input-model.yml
+  else
+    ansible_playbook clone-input-model.yml
+  fi
+}
+
+function prepare_infra {
+  if is_physical_deploy; then
+    ansible_playbook start-deployer-vm.yml
+  else
+    ansible_playbook generate-heat-template.yml
+    delete_stack
+    ansible_playbook heat-stack.yml
+  fi
+}
+
+function build_test_packages {
+  if is_defined gerrit_change_ids; then
+    if ! is_defined homeproject; then
+      echo "ERROR: homeproject must be defined - please check all variables on input.yml"
+      return 1
+    else
+      pushd $AUTOMATION_DIR/scripts/jenkins/ardana/gerrit
+      source $ANSIBLE_VENV/bin/activate
+      gerrit_change_ids=$(get_from_input gerrit_change_ids)
+      GERRIT_VERIFY=0 PYTHONWARNINGS="ignore:Unverified HTTPS request" \
+        python -u build_test_package.py --buildnumber local \
+        --homeproject $(get_from_input homeproject) -c ${gerrit_change_ids//,/ -c }
+      popd
+    fi
+  fi
+}
+
+function bootstrap_clm {
+  test_repo_url=""
+  if is_defined gerrit_change_ids; then
+    homeproject=$(get_from_input homeproject)
+    test_repo_url="http://download.suse.de/ibs/$(sed 's#\b:\b#&/#' <<< $homeproject):/ardana-ci-local/standard/$(get_from_input homeproject):ardana-ci-local.repo"
+  fi
+  extra_repos=$(sed -e "s/^,//" -e "s/,$//" <<< "$(get_from_input extra_repos),${test_repo_url}")
+  ansible_playbook bootstrap-clm.yml -e extra_repos="${extra_repos}"
+}
+
+function deploy_ses_vcloud {
+  if ! is_physical_deploy && $(get_from_input ses_enabled); then
+    ses_id=$(get_from_input ardana_env)
+    network="openstack-ardana-${ses_id}_management_net"
+    ansible_playbook_ses ses-heat-stack.yml -e "ses_id=$ses_id network=$network"
+    ansible_playbook_ses bootstrap-ses-node.yml -e ses_id=$ses_id
+    for i in {1..3}; do
+      ansible_playbook_ses ses-deploy.yml -e ses_id=$ses_id && break || sleep 5
+    done
+  fi
+}
+
+function bootstrap_nodes {
+  if is_physical_deploy; then
+    ansible_playbook bootstrap-pcloud-nodes.yml
+  else
+    ansible_playbook bootstrap-vcloud-nodes.yml
+  fi
+}
+
+function deploy_cloud {
+  if $(get_from_input deploy_cloud); then
+    ansible_playbook deploy-cloud.yml
+  fi
+}
+
+function update_cloud {
+  if $(get_from_input deploy_cloud) && $(get_from_input update_after_deploy); then
+    ansible_playbook ardana-update.yml -e cloudsource=$(get_from_input update_to_cloudsource)
+  fi
+}
+
+function run_tempest {
+  if $(is_defined tempest_filter_list); then
+    tempest_filter_list=($(echo "$(get_from_input tempest_filter_list)" | tr ',' '\n'))
+    for filter in "${tempest_filter_list[@]}"; do
+      ansible_playbook run-tempest.yml -e tempest_run_filter=$filter
+    done
+  fi
+}
+
+function run_qa_tests {
+  if $(is_defined qa_test_list); then
+    qa_test_list=($(echo "$(get_from_input qa_test_list)" | tr ',' '\n'))
+    for qa_test in "${qa_test_list[@]}"; do
+      ansible_playbook run-ardana-qe-tests.yml -e test_name=$qa_test
+    done
+  fi
+}
+
+function validate_input {
+  if ! is_defined ardana_env; then
+    echo "ERROR: ardana_env must be defined - please check all variables on input.yml"
+    return 1
+  else
+    echo "
+  *****************************************************************************************
+  ** Ardana will be deployed using the following config:
+$(cat input.yml| grep -v "^#\|''\|^[[:space:]]*$" | sed -e 's/^/  ** /')
+  *****************************************************************************************
+    "
+    read -p "Continue (y/n)?" choice
+    case "$choice" in
+      y|Y ) return 0;;
+      * ) return 1;;
+    esac
+  fi
+}
+
+function exit_msg {
+  DEPLOYER_IP=$(get_deployer_ip)
+  if ! is_physical_deploy && $(get_from_input ses_enabled); then
+    SES_IP=$(get_ses_ip)
+    echo "
+  *****************************************************************************************
+  ** The '$(get_from_input ardana_env)' SES environment is reachable at:
+  **
+  **        ssh root@${SES_IP}
+  **
+  ** Please delete the 'openstack-ses-$(get_from_input ardana_env)' stack when you're done,
+  ** by loging into the ECP at https://engcloud.prv.suse.net/project/stacks/
+  ** and deleting the heat stack.
+  *****************************************************************************************
+    "
+  fi
+
+  echo "
+  *****************************************************************************************
+  ** The deployer for the '$(get_from_input ardana_env)' environment is reachable at:
+  **
+  **        ssh ardana@${DEPLOYER_IP}
+  **        or
+  **        ssh root@${DEPLOYER_IP}
+  **
+  ** Please delete the 'openstack-ardana-$(get_from_input ardana_env)' stack when you're done,
+  ** by by using one of the following methods:
+  **
+  **  1. log into the ECP at https://engcloud.prv.suse.net/project/stacks/
+  **  and delete the stack manually, or
+  **
+  **  2. call the delete_stack function from the script library:
+  **    $ source lib.sh
+  **    $ delete_stack
+  *****************************************************************************************
+  "
+}

--- a/scripts/jenkins/ardana/manual/requirements.txt
+++ b/scripts/jenkins/ardana/manual/requirements.txt
@@ -1,0 +1,4 @@
+ansible
+netaddr
+openstacksdk
+sh


### PR DESCRIPTION
This change adds a bash script that mimics the steps followed by the
openstack-ardana job to deploy ardana on ECP.

The intent of the script is to make easy deploying ardana on ECP from
the workstation (without the need of jenkins). This change also
adds a library that provides functions similar to the openstack-ardana
jenkins job steps, which can be called to execute the each step
individually.