### PR TITLE
openstack-ardana-gerrit: fix pipeline job report

### DIFF
--- a/scripts/jenkins/jenkins-job-pipeline-report.py
+++ b/scripts/jenkins/jenkins-job-pipeline-report.py
@@ -133,23 +133,24 @@ def generate_summary(server, job_name, build_number,
 
         sub_summary = ''
         if recursive and stage['status'] not in ['ABORTED', 'SKIPPED']:
-            # Figure out if the stage wraps a downstream job
+            # Figure out if the stage wraps one or more downstream jobs
             nodes = stage_info.get('stageFlowNodes')
-            if nodes and nodes[0]['name'].startswith('Building '):
-                log = server.get_workflow_stage_log(
-                    job_name, build_number, nodes[0]['id'])
+            for node in nodes:
+                if node['name'].startswith('Building '):
+                    log = server.get_workflow_stage_log(
+                        job_name, build_number, node['id'])
 
-                downstream_jobs = re.findall(
-                    "href='(/job/([\w-]+)/([\d]+)/)'",
-                    log['text'])
-                if downstream_jobs:
-                    d_job_name = downstream_jobs[0][1]
-                    d_build_number = int(downstream_jobs[0][2])
-                    sub_summary = generate_summary(
-                        server, d_job_name, d_build_number,
-                        filter_stages, recursive, depth+1)
-                    stage_url = server.get_pipeline_url(d_job_name,
-                                                        d_build_number)
+                    downstream_jobs = re.findall(
+                        "href='(/job/([\w-]+)/([\d]+)/)'",
+                        log['text'])
+                    if downstream_jobs:
+                        d_job_name = downstream_jobs[0][1]
+                        d_build_number = int(downstream_jobs[0][2])
+                        sub_summary = generate_summary(
+                            server, d_job_name, d_build_number,
+                            filter_stages, recursive, depth+1)
+                        stage_url = server.get_pipeline_url(d_job_name,
+                                                            d_build_number)
         if stage_url is not None:
             stage_url = stage_url.replace('ci.suse.de', 'ci.nue.suse.com')
         summary += '{}  - {}: {}{}\n'.format(


### PR DESCRIPTION
The `jenkins-job-pipeline-report` script that is generating
the execution summary report of a pipeline job was not detecting
downstream jobs properly. This patch fixes the script such that
any number of downstream jobs can be triggered from a pipeline
stage and they will all be included in the report regardless of
their position in the set of steps comprising the stage.

NOTE: the Gerrit pipeline report was broken starting with #3172,
which introduced an additional "Print Message" step before the
"Building ..." step that triggered the downstream job (see [this job](https://ci.suse.de/job/openstack-ardana-gerrit-cloud9/1232/execution/node/29/wfapi/describe)
for example)