### PR TITLE
jjb: add timeout for testbuild-pr-trigger

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -77,4 +77,5 @@
               ;;
           esac
 
-          ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugfilterchain --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_crowbar.yaml
+          # timeout should be less than the interval (currently 10m)
+          timeout 500 ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugfilterchain --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_crowbar.yaml


### PR DESCRIPTION
Without the timeout a build that got stuck (this happened) would block the following builds.
So rather exit the one that is stuck to allow for a new run.

The timeout should be less than the interval used for the job. Currently the interval is
10 minutes and the timeout of 500 seconds is about 8 minutes.
Normal runtime of this job is 2 - 3 minutes.