### PR TITLE
Added support for ceilomter in cloud 9 on ardana_qe_tests role

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -139,7 +139,7 @@
       ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,\
       magnum,manila,monasca,network,neutron-api,swift"
     qa_test_list: "\
-      iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
+      iverify,monasca-ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
       heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,\
       nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,\
       barbican-functional,horizon,keystone-api,keystone-ldap,\

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -74,7 +74,7 @@
             barbican-functional,horizon,freezer,
             keystone-api,keystone-ldap,keystone-k2k-config,keystone-websso-config,keystone-x509-config,
             remove_compute_node,add_compute_node,tempest_cleanup,service-ansible-playbooks,enable_tls,
-            change_credentials,nova_guest_image
+            change_credentials,nova_guest_image,monasca-ceilometer
           description: >-
             Select QA tests to run
 

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -122,7 +122,7 @@
             nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,
             barbican-functional,horizon,freezer,keystone-soapui,
             remove_compute_node,add_compute_node,tempest_cleanup,service-ansible-playbooks,
-            change_credentials,nova_guest_image
+            change_credentials,nova_guest_image,monasca-ceilometer
           description: >-
             Select QA tests to run. Use an empty value to skip running QA tests.
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/monasca-ceilometer.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/monasca-ceilometer.sh.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Wrapper script to execute the example test
+# within the venv
+#
+# Usage: template.sh run_filter_filename
+
+set -o pipefail
+VENV={{ ardana_qe_test_venv }}
+STESTR={{  ardana_qe_test_venv }}/bin/stestr
+
+# Activate the virtual environment
+source ${VENV}/bin/activate
+
+# Set environment variables
+source ~/service.osrc
+
+# Run the test
+cd {{ ardana_qe_tests_dir }}/ardana-qa-tests/ceilometer/ceilometer-test-python-scripts
+${STESTR} init
+${STESTR} run -t ./ --no-discover test_ceilometer_meters.py --concurrency=1 | tee {{ ardana_qe_test_log }}
+${STESTR} last --subunit > {{ ardana_qe_test_subunit }}

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/monasca-ceilometer.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/vars/monasca-ceilometer.yml
@@ -1,0 +1,22 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+ardana_qe_test_venv_requires:
+  - 'python-subunit'
+  - 'stestr'
+
+ardana_qe_test_get_failed_cmd: "grep FAILED {{ ardana_qe_test_log }} || echo 'None'"


### PR DESCRIPTION
Ceilometer API is removed in C9. Add new test script to test ceilometer via monasca.