### PR TITLE
openstack-ardana-image-update: set hw_rng_model (SCRD-7764)

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
               --disk-format qcow2 \
               --container-format bare \
               --${image_visibility} \
+              --property hw_rng_model='virtio' \
               ${sles_image}-update
 
           if [[ $image_visibility == shared ]]; then


### PR DESCRIPTION
The job that automates updating the ECP images used for the
Ardana CI wasn't setting the `hw_rng_model=virtio` property
on the installed images, which in combination with the
`hw_rng:allowed=True` flavor property is required to increase
the entropy level on VMs, especially during boot.