### PR TITLE
Disable invalid_guest_state emulation

### DIFF
--- a/scripts/create-vm.sh
+++ b/scripts/create-vm.sh
@@ -175,7 +175,8 @@ main () {
                 echo "Running as root, invoking modprobe kvm_$plat."
                 if [ $plat = "intel" ] ; then
                     if ! grep -q nested /etc/modprobe.d/80-kvm-intel.conf ; then
-                        echo "options kvm_intel nested=1" | sudo tee /etc/modprobe.d/80-kvm-intel.conf
+                        echo "options kvm_intel nested=1 emulate_invalid_guest_state=0" | \
+                            sudo tee /etc/modprobe.d/80-kvm-intel.conf
                         modprobe -r kvm_intel
                     fi
                 fi

--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -3,7 +3,8 @@ function libvirt_modprobe_kvm()
     if [[ $(uname -m) = x86_64 ]]; then
         $sudo modprobe kvm-amd
         if [ ! -e /etc/modprobe.d/80-kvm-intel.conf ] ; then
-            echo "options kvm-intel nested=1" | $sudo dd of=/etc/modprobe.d/80-kvm-intel.conf
+            echo "options kvm-intel nested=1 emulate_invalid_guest_state=0" | \
+                $sudo dd of=/etc/modprobe.d/80-kvm-intel.conf
             $sudo rmmod kvm-intel
         fi
         $sudo modprobe kvm-intel


### PR DESCRIPTION
At least with kernel 4.20+ this seems to cause emulation errors in L1
guest KVM. As we don't really need it (only really needed for real mode
emulation) it seems safer to turn it off.