### PR TITLE
openstack-ardana-image-update: improvements

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -259,7 +259,7 @@
     ardana_image_update_job: '{name}'
     triggers:
     openstack_ardana_job: cloud-ardana8-job-std-min-x86_64
-    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP3/ardana-jeos-SLE12SP3.x86_64.qcow2.xz
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP3/ardana-jeos-lvm-SLE12SP3.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP3
     jobs:
         - '{ardana_image_update_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -246,7 +246,7 @@
     ardana_image_update_job: '{name}'
     triggers:
     openstack_ardana_job: cloud-ardana9-job-std-min-x86_64
-    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP4/ardana-jeos-SLE12SP4.x86_64.qcow2.xz
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP4/ardana-jeos-lvm-SLE12SP4.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP4
     jobs:
         - '{ardana_image_update_job}'

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
@@ -30,7 +30,11 @@ pipeline {
     stage('upload new image version') {
       steps {
         sh '''
-          wget -qO- ${download_image_url} | xz -d > ${sles_image}.qcow2
+          if [[ $download_image_url == *".xz" ]]; then
+              wget -qO- ${download_image_url} | xz -d > ${sles_image}.qcow2
+          else
+              wget -q ${download_image_url} -O ${sles_image}.qcow2
+          fi
 
           openstack --os-cloud $os_cloud image show ${sles_image}-update && \
               openstack --os-cloud $os_cloud image delete ${sles_image}-update

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
           def slaveJob = build job: openstack_ardana_job, parameters: [
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
               string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              text(name: 'extra_params', value: "sles_image=${sles_image}-update")
+              text(name: 'extra_params', value: "$extra_params\nsles_image=${sles_image}-update")
           ], propagate: true, wait: true
         }
       }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-image-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-image-update-template.yaml
@@ -57,6 +57,20 @@
           description: >-
             The OpenStack API credentials for the target OpenStack cloud.
 
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
A couple of improvements for the `openstack-ardana-image-update`
job, which are required to automate updating regular (non-LVM) SLES
images:
 - adds `extra_params` support to the `openstack-ardana-image-update` jobs.
 - support both QCOW2 and XZ archived images

