### PR TITLE
Move manila-share to controller (SCRD-7771)

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -42,6 +42,8 @@ versioned_features:
     enabled: "{{ when_cloud9 }}"
   glance-registry:
     enabled: "{{ when_cloud8 }}"
+  manila-share:
+    enabled: "{{ when_cloud8 }}"
 
 input_model_versioned_features:
   - manila
@@ -50,3 +52,4 @@ input_model_versioned_features:
   - nova-console-auth
   - ceilometer-api
   - glance-registry
+  - manila-share

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -126,6 +126,7 @@ service_component_groups:
     - octavia-health-manager
     - ops-console-web
     - manila-api
+    - manila-share
   DBMQ:
     - mysql
     - rabbitmq
@@ -172,7 +173,6 @@ service_component_groups:
     - neutron-metadata-agent
     - neutron-openvswitch-agent
     - neutron-lbaasv2-agent
-    - manila-share
   RHEL_COMPUTE:
     - nova-compute-kvm
     - nova-compute


### PR DESCRIPTION
Move manila-share to controller for new CI template. This will apply only to
c8. According to the ticket, we make this decision in order to be
consistent with SOC. As for c9, we deprecate manila-share in the input model.
Due to manila-api and manila-share residing on the same host, both ansible
roles can use reference from each other and doesn't have to use MNL-SHR host
explicitly.

1. Move manila-share to controller
2. Add filter to enable manila-share only on c8