### PR TITLE
openstack-ardana-gerrit: custom Gerrit integration testing

### DIFF
--- a/docs/ardana/testing.md
+++ b/docs/ardana/testing.md
@@ -260,8 +260,6 @@ This parameter may be used to override the default
 jobs currently employed by the Ardana CI to run integration tests.
 If the custom integration job also requires its parameters to be overridden,
 this can be achieved via the `extra_params` parameter.
-If this parameter is reset to an empty value, no integration tests will
-be run (to be used with caution !).
 
 * `git_automation_repo` and `git_automation_branch` - can be used to
 point Jenkins to a different automation repository branch or fork.
@@ -370,16 +368,6 @@ the list of `-gerrit-x86_64` jobs predefined for
 [cloud8](https://github.com/SUSE-Cloud/automation/blob/master/jenkins/ci.suse.de/cloud-ardana8-gerrit.yaml)
 and/or [cloud9](https://github.com/SUSE-Cloud/automation/blob/master/jenkins/ci.suse.de/cloud-ardana9-gerrit.yaml),
 and thus enable other users to point to it by name.
-
-Ultimately, some Gerrit changes might not require integration testing
-at all, for example because the code changes do not affect any functionality
-areas (e.g. documentation or git configuration changes). For this cases,
-the CI supports skipping the integration testing completely, by starting
-a manual voting Gerrit job and supplying an empty `integration_test_job`
-value. **IMPORTANT**: this feature should not be abused. Most times it's
-better to rely on the default Ardana Jenkins CI behavior then to try to
-skip the integration tests.
-
 
 ### Custom package repositories
 

--- a/jenkins/ci.suse.de/cloud-ardana8-gerrit.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8-gerrit.yaml
@@ -67,6 +67,7 @@
     ardana_env: cloud-ardana-gerrit-slot
     reserve_env: true
     voting: true
+    gerrit_context: std-min
     integration_test_job: cloud-ardana8-job-std-min-gerrit-x86_64
     version: '8'
     triggers:

--- a/jenkins/ci.suse.de/cloud-ardana8-gerrit.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8-gerrit.yaml
@@ -1,0 +1,92 @@
+- project:
+    name: cloud-ardana8-job-std-min-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: develcloud8
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '2'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana8-job-std-min-centos-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: develcloud8
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '2'
+    sles_computes: '0'
+    rhel_computes: '2'
+    ses_enabled: false
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana8-job-entry-scale-kvm-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: develcloud8
+    scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    rhel_computes: '0'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana8-job-std-3cp-update-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: develcloud8
+    update_after_deploy: true
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: openstack-ardana-gerrit-cloud8
+    ardana_gerrit_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    reserve_env: true
+    voting: true
+    integration_test_job: cloud-ardana8-job-std-min-gerrit-x86_64
+    version: '8'
+    triggers:
+      - gerrit:
+          server-name: 'gerrit.suse.provo.cloud'
+          trigger-on:
+            - patchset-created-event:
+                exclude-drafts: true
+                exclude-no-code-change: false
+            - draft-published-event
+            - comment-added-contains-event:
+                comment-contains-value: '^suse_recheck$'
+            - comment-added-contains-event:
+                comment-contains-value: '^recheck$'
+          silent: true
+          projects:
+            - project-compare-type: 'REG_EXP'
+              project-pattern: !include-raw: gerrit-project-regexp.txt
+              branches:
+                - branch-compare-type: 'PLAIN'
+                  branch-pattern: 'stable/pike'
+    jobs:
+        - '{ardana_gerrit_job}'

--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -227,34 +227,6 @@
         - '{ardana_job}'
 
 - project:
-    name: openstack-ardana-gerrit-cloud8
-    ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-gerrit-slot
-    cloudsource: develcloud8
-    gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
-    triggers:
-      - gerrit:
-          server-name: 'gerrit.suse.provo.cloud'
-          trigger-on:
-            - patchset-created-event:
-                exclude-drafts: true
-                exclude-no-code-change: false
-            - draft-published-event
-            - comment-added-contains-event:
-                comment-contains-value: '^suse_recheck$'
-            - comment-added-contains-event:
-                comment-contains-value: '^recheck$'
-          silent: true
-          projects:
-            - project-compare-type: 'REG_EXP'
-              project-pattern: !include-raw: gerrit-project-regexp.txt
-              branches:
-                - branch-compare-type: 'PLAIN'
-                  branch-pattern: 'stable/pike'
-    jobs:
-        - '{ardana_gerrit_job}'
-
-- project:
     name: cloud-ardana8-job-image-update
     ardana_image_update_job: '{name}'
     triggers:

--- a/jenkins/ci.suse.de/cloud-ardana9-gerrit.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9-gerrit.yaml
@@ -67,6 +67,7 @@
     ardana_env: cloud-ardana-gerrit-slot
     reserve_env: true
     voting: true
+    gerrit_context: std-min
     integration_test_job: cloud-ardana9-job-std-min-gerrit-x86_64
     version: '8'
     triggers:

--- a/jenkins/ci.suse.de/cloud-ardana9-gerrit.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9-gerrit.yaml
@@ -1,0 +1,92 @@
+- project:
+    name: cloud-ardana9-job-std-min-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: develcloud9
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '2'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana9-job-std-min-centos-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: develcloud9
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '2'
+    sles_computes: '0'
+    rhel_computes: '2'
+    ses_enabled: false
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana9-job-entry-scale-kvm-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: develcloud9
+    scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    rhel_computes: '0'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana9-job-std-3cp-update-gerrit-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    cloudsource: develcloud9
+    update_after_deploy: true
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: openstack-ardana-gerrit-cloud9
+    ardana_gerrit_job: '{name}'
+    ardana_env: cloud-ardana-gerrit-slot
+    reserve_env: true
+    voting: true
+    integration_test_job: cloud-ardana9-job-std-min-gerrit-x86_64
+    version: '8'
+    triggers:
+      - gerrit:
+          server-name: 'gerrit.suse.provo.cloud'
+          trigger-on:
+            - patchset-created-event:
+                exclude-drafts: true
+                exclude-no-code-change: false
+            - draft-published-event
+            - comment-added-contains-event:
+                comment-contains-value: '^suse_recheck$'
+            - comment-added-contains-event:
+                comment-contains-value: '^recheck$'
+          silent: true
+          projects:
+            - project-compare-type: 'REG_EXP'
+              project-pattern: !include-raw: gerrit-project-regexp.txt
+              branches:
+                - branch-compare-type: 'PLAIN'
+                  branch-pattern: 'master'
+    jobs:
+        - '{ardana_gerrit_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -214,34 +214,6 @@
         - '{ardana_job}'
 
 - project:
-    name: openstack-ardana-gerrit-cloud9
-    ardana_gerrit_job: '{name}'
-    ardana_env: cloud-ardana-gerrit-slot
-    cloudsource: develcloud9
-    gerrit_change_ids: '${{GERRIT_CHANGE_NUMBER}}/${{GERRIT_PATCHSET_NUMBER}}'
-    triggers:
-      - gerrit:
-          server-name: 'gerrit.suse.provo.cloud'
-          trigger-on:
-            - patchset-created-event:
-                exclude-drafts: true
-                exclude-no-code-change: false
-            - draft-published-event
-            - comment-added-contains-event:
-                comment-contains-value: '^suse_recheck$'
-            - comment-added-contains-event:
-                comment-contains-value: '^recheck$'
-          silent: true
-          projects:
-            - project-compare-type: 'REG_EXP'
-              project-pattern: !include-raw: gerrit-project-regexp.txt
-              branches:
-                - branch-compare-type: 'PLAIN'
-                  branch-pattern: 'master'
-    jobs:
-        - '{ardana_gerrit_job}'
-
-- project:
     name: cloud-ardana9-job-image-update
     ardana_image_update_job: '{name}'
     triggers:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -23,51 +23,81 @@ pipeline {
     stage('Setup workspace') {
       steps {
         script {
-          currentBuild.displayName = "#${BUILD_NUMBER}: ${gerrit_change_ids}"
-
           sh('''
             git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
 
           ardana_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy"
           ardana_lib.load_extra_params_as_vars(extra_params)
-        }
 
-        sh('''
-          if [ -n "$GERRIT_CHANGE_NUMBER" ] ; then
-            # Post reviews only for jobs triggered by Gerrit
-            automation-git/scripts/jenkins/ardana/gerrit/gerrit_review.py \
-              --vote 0 \
-              --label 'Verified' \
-              --message "
-Started build (${JOB_NAME}): ${BUILD_URL}
+          if (GERRIT_CHANGE_NUMBER == '') {
+            error("Empty 'GERRIT_CHANGE_NUMBER' parameter value.")
+          }
+
+          if (env.GERRIT_PATCHSET_NUMBER == null) {
+            // Extract the current patchset number from the Gerrit change, if missing
+            env.GERRIT_PATCHSET_NUMBER = sh (
+              returnStdout: true,
+              script: '''
+                automation-git/scripts/jenkins/ardana/gerrit/gerrit_get.py \
+                  --attr patchset \
+                  ${GERRIT_CHANGE_NUMBER}
+              '''
+            ).trim()
+          }
+
+          if (gerrit_context == '') {
+            currentBuild.displayName = "#${BUILD_NUMBER}: $GERRIT_CHANGE_NUMBER/$GERRIT_PATCHSET_NUMBER"
+          } else {
+            currentBuild.displayName = "#${BUILD_NUMBER}: $GERRIT_CHANGE_NUMBER/$GERRIT_PATCHSET_NUMBER ($gerrit_context)"
+          }
+
+          sh('''
+            build_str="Build"
+            $voting || build_str="(Non-voting) build"
+            [[ -n $gerrit_context ]] && build_context=" ($gerrit_context)"
+            message="
+${build_str} started${build_context}: ${BUILD_URL}
 The following links can also be used to track the results:
 
 - live console output: ${BUILD_URL}console
 - live pipeline job view: ${RUN_DISPLAY_URL}
-" \
+"
+
+            $voting && gerrit_voting_params="--vote 0 --label Verified"
+            automation-git/scripts/jenkins/ardana/gerrit/gerrit_review.py \
+              --message "$message" \
+              $gerrit_voting_params \
               --patch ${GERRIT_PATCHSET_NUMBER} \
               ${GERRIT_CHANGE_NUMBER}
-          fi
-        ''')
+          ''')
+        }
       }
     }
 
     stage('validate commit message') {
-      when {
-        expression { env.GERRIT_CHANGE_COMMIT_MESSAGE != null }
-      }
       steps {
         sh '''
           export LC_ALL=C.UTF-8
           export LANG=C.UTF-8
 
-          echo $GERRIT_CHANGE_COMMIT_MESSAGE | base64 --decode | gitlint -C automation-git/scripts/jenkins/gitlint.ini
+          if [[ -n $GERRIT_CHANGE_COMMIT_MESSAGE ]]; then
+            commit_message=$(echo $GERRIT_CHANGE_COMMIT_MESSAGE | base64 --decode)
+          else
+            commit_message=$(automation-git/scripts/jenkins/ardana/gerrit/gerrit_get.py \
+              --attr commit_message \
+              ${GERRIT_CHANGE_NUMBER}/${GERRIT_PATCHSET_NUMBER})
+          fi
+
+          echo "$commit_message" | gitlint -C automation-git/scripts/jenkins/gitlint.ini
         '''
       }
     }
 
     stage('integration test') {
+      when {
+        expression { integration_test_job != '' }
+      }
       steps {
         script {
           // reserve a resource here for the openstack-ardana job, to avoid
@@ -75,22 +105,14 @@ The following links can also be used to track the results:
           // resource to become available.
           ardana_lib.run_with_reserved_env(reserve_env.toBoolean(), ardana_env, ardana_env) {
             reserved_env ->
-            ardana_lib.trigger_build('openstack-ardana', [
+            ardana_lib.trigger_build(integration_test_job, [
               string(name: 'ardana_env', value: reserved_env),
               string(name: 'reserve_env', value: "false"),
-              string(name: 'cleanup', value: "on success"),
-              string(name: 'gerrit_change_ids', value: "$gerrit_change_ids"),
+              string(name: 'gerrit_change_ids', value: "$GERRIT_CHANGE_NUMBER/$GERRIT_PATCHSET_NUMBER"),
+              string(name: 'cloudsource', value: "develcloud$version"),
+              string(name: 'extra_repos', value: "$extra_repos"),
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
               string(name: 'git_automation_branch', value: "$git_automation_branch"),
-              string(name: 'scenario_name', value: "standard"),
-              string(name: 'clm_model', value: "standalone"),
-              string(name: 'controllers', value: "2"),
-              string(name: 'sles_computes', value: "1"),
-              string(name: 'cloudsource', value: "$cloudsource"),
-              string(name: 'ses_enabled', value: "true"),
-              string(name: 'ses_rgw_enabled', value: "false"),
-              string(name: 'tempest_filter_list', value: "$tempest_filter_list"),
-              string(name: 'os_cloud', value: "$os_cloud"),
               text(name: 'extra_params', value: extra_params)
             ])
           }
@@ -108,37 +130,41 @@ The following links can also be used to track the results:
             --filter 'Declarative: Post Actions' \
             --filter 'Setup workspace' > pipeline-report.txt || :
 
-          # Post reviews only for jobs triggered by Gerrit
-          if [ -n "$GERRIT_CHANGE_NUMBER" ] ; then
-            if [[ $BUILD_RESULT == SUCCESS ]]; then
-              vote=+2
-              message="
-Build succeeded (${JOB_NAME}): ${BUILD_URL}
+          build_str="Build"
+          $voting || build_str="(Non-voting) build"
+          [[ -n $gerrit_context ]] && build_context=" ($gerrit_context)"
+
+          if [[ $BUILD_RESULT == SUCCESS ]]; then
+            vote=+2
+            message_result="succeeded"
+          elif [[ $BUILD_RESULT == ABORTED ]]; then
+            vote=
+            message_result="aborted"
+          else
+            vote=-2
+            message_result="failed"
+          fi
+
+          message="
+${build_str} ${message_result}${build_context}: ${BUILD_URL}
 
 "
-            else
-              vote=-2
-              message="
-Build failed (${JOB_NAME}): ${BUILD_URL}
 
-"
-            fi
-            automation-git/scripts/jenkins/ardana/gerrit/gerrit_review.py \
-              --vote $vote \
-              --label 'Verified' \
-              --message "$message" \
-              --message-file pipeline-report.txt \
+          $voting && [[ -n $vote ]] && gerrit_voting_params="--vote $vote --label Verified"
+
+          automation-git/scripts/jenkins/ardana/gerrit/gerrit_review.py \
+            --message "$message" \
+            --message-file pipeline-report.txt \
+            $gerrit_voting_params \
+            --patch $GERRIT_PATCHSET_NUMBER \
+            $GERRIT_CHANGE_NUMBER
+
+          if $voting && [[ $BUILD_RESULT == SUCCESS ]]; then
+            automation-git/scripts/jenkins/ardana/gerrit/gerrit_merge.py \
               --patch ${GERRIT_PATCHSET_NUMBER} \
               ${GERRIT_CHANGE_NUMBER}
-
-            if [[ $BUILD_RESULT == SUCCESS ]]; then
-              automation-git/scripts/jenkins/ardana/gerrit/gerrit_merge.py \
-                --patch ${GERRIT_PATCHSET_NUMBER} \
-                ${GERRIT_CHANGE_NUMBER}
-            fi
           fi
         ''')
-
       }
     }
     cleanup {

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -135,9 +135,6 @@ The following links can also be used to track the results:
     }
 
     stage('integration test') {
-      when {
-        expression { integration_test_job != '' }
-      }
       steps {
         script {
           // reserve a resource here for the openstack-ardana job, to avoid

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -33,6 +33,48 @@
           description: >-
             Reserve the 'ardana_env' lockable resource throughout the execution of this job
 
+      - validating-string:
+          name: GERRIT_CHANGE_NUMBER
+          default: ''
+          regex: '([0-9]+)'
+          msg: The entered value failed validation
+          description: >-
+            A Gerrit change number to test (the latest available patchset number is assumed).
+
+            For jobs triggered by Gerrit, the Gerrit change number and patchset number are
+            extracted from the GERRIT_CHANGE_NUMBER and GERRIT_PATCHSET_NUMBER environment
+            variables set by the trigger, which override this parameter.
+
+      - string:
+          name: gerrit_context
+          default: ''
+          description: >-
+            A short description of the job to be reported back to Gerrit. It can be useful
+            when multiple jobs are running simultaneously on the same Gerrit change, to
+            differentiate between their corresponding Gerrit reports.
+
+      - bool:
+          name: voting
+          default: '{voting|false}'
+          description: >-
+            Determines if this job posts Verified labels on target Gerrit changes.
+
+      - string:
+          name: integration_test_job
+          default: '{integration_test_job}'
+          description: >-
+            The Ardana Jenkins integration job triggered to validate the Gerrit change.
+            Leave empty to skip integration testing.
+
+      - validating-string:
+          name: extra_repos
+          default: ''
+          regex: '((http(s)?:\/\/[^ ,]+\.repo)(,http(s)?:\/\/[^ ,]+\.repo)*)*'
+          msg: The entered value failed validation
+          description: >-
+            A comma separated list of repository urls (ending with .repo) to be
+            added on the deployer node
+
       - string:
           name: git_automation_repo
           default: '{git_automation_repo|https://github.com/SUSE-Cloud/automation.git}'
@@ -44,54 +86,6 @@
           default: '{git_automation_branch|master}'
           description: >-
             The git automation branch
-
-      - validating-string:
-          name: gerrit_change_ids
-          default: '{gerrit_change_ids}'
-          regex: '([0-9]+(/[0-9]+)?)(,[0-9]+(/[0-9]+)?)*'
-          msg: The entered value failed validation
-          description: >-
-            A comma separated list of IDs for changes in gerrit.suse.provo.cloud
-            to test. The patchset may be supplied as part of the change ID in the form:
-
-               <change_number>[/<patchset_number>]
-
-      - string:
-          name: cloudsource
-          default: '{cloudsource|develcloud9}'
-          description: >-
-            The cloud repository (from provo-clouddata) to be used for testing.
-            This value can take the following form:
-
-               stagingcloud<X> (Devel:Cloud:X:Staging)
-               develcloud<X> (Devel:Cloud:X)
-               GM<X> (official GM)
-
-      - bool:
-          name: ses_enabled
-          default: '{ses_enabled|false}'
-          description: Configure SES backend for glance, cinder, cinder-backup and nova
-
-      - bool:
-          name: ses_rgw_enabled
-          default: '{ses_rgw_enabled|false}'
-          description: |
-            Configure object-store service with RADOS Gateway. This only takes effect
-            if ses_enabled is set to true.
-
-      - string:
-          name: tempest_filter_list
-          default: '{tempest_filter_list|ci}'
-          description: >-
-            Name of the filter file to use for tempest. Use an empty value to
-            skip running tempest.
-
-      - string:
-          name: os_cloud
-          default: '{os_cloud|engcloud-cloud-ci-private}'
-          description: >-
-            The OpenStack API credentials used to manage virtual clouds (leave
-            empty to use the default shared 'cloud' ECP account).
 
       - text:
           name: extra_params
@@ -106,6 +100,12 @@
             This should not be used by default or regularly. It is meant to run job build customized in ways
             not already supported by the job's parameters, such as testing automation git pull requests
             with special configurations.
+
+      - hidden:
+          name: version
+          default: '{version}'
+          description: >-
+            Cloud version number (8, 9 etc.)
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -70,12 +70,14 @@
             change number. The most recent job will automatically abort those
             that are already running for the same Gerrit change number.
 
-      - string:
+      - validating-string:
           name: integration_test_job
           default: '{integration_test_job}'
+          regex: '[A-Za-z0-9-_]+'
+          msg: >-
+            Empty or malformed Jenkins job name (only alphanumeric, '-' and '_' characters are allowed).
           description: >-
             The Ardana Jenkins integration job triggered to validate the Gerrit change.
-            Leave empty to skip integration testing.
 
             NOTE: there can be at most one non-voting Gerrit job running the same
             integration test job for a Gerrit change number. The most recent job

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -45,13 +45,20 @@
             extracted from the GERRIT_CHANGE_NUMBER and GERRIT_PATCHSET_NUMBER environment
             variables set by the trigger, which override this parameter.
 
-      - string:
+      - validating-string:
           name: gerrit_context
-          default: ''
+          default: '{gerrit_context}'
+          regex: '[A-Za-z0-9-_]+'
+          msg: >-
+            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
           description: >-
-            A short description of the job to be reported back to Gerrit. It can be useful
-            when multiple jobs are running simultaneously on the same Gerrit change, to
-            differentiate between their corresponding Gerrit reports.
+            Unique job identifier. This string label uniquely identifies a job build within
+            the set of builds running against the same Gerrit change.
+
+            This value determines which of the job builds currently running for a Gerrit change
+            are superseded and automatically canceled when a new job build is started.
+            The rule is: there can be at most one job with a given 'gerrit_context' value running
+            at any given time for a Gerrit change, voting or otherwise.
 
       - bool:
           name: voting
@@ -59,12 +66,21 @@
           description: >-
             Determines if this job posts Verified labels on target Gerrit changes.
 
+            NOTE: there can be at most one voting Gerrit job running for a Gerrit
+            change number. The most recent job will automatically abort those
+            that are already running for the same Gerrit change number.
+
       - string:
           name: integration_test_job
           default: '{integration_test_job}'
           description: >-
             The Ardana Jenkins integration job triggered to validate the Gerrit change.
             Leave empty to skip integration testing.
+
+            NOTE: there can be at most one non-voting Gerrit job running the same
+            integration test job for a Gerrit change number. The most recent job
+            will automatically abort those that are already running for the same
+            Gerrit change number and integration test job.
 
       - validating-string:
           name: extra_repos

--- a/scripts/jenkins/ardana/gerrit/gerrit_get.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit_get.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+from gerrit import GerritChange, argparse_gerrit_change_type  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Get a Gerrit change attribute')
+    parser.add_argument('change', type=argparse_gerrit_change_type,
+                        help='the Gerrit change number and an optional patch '
+                             'number (e.g. 1234 or 1234/1). If the patch '
+                             'number is not supplied, the latest patch will '
+                             'be used')
+    parser.add_argument('--attr',
+                        required=True,
+                        help='GerritChange object attribute name')
+
+    args = parser.parse_args()
+
+    change = GerritChange(args.change)
+    print(getattr(change, args.attr))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/jenkins/jenkins-job-cancel
+++ b/scripts/jenkins/jenkins-job-cancel
@@ -18,17 +18,12 @@
 # Cancels all running builds with the supplied parameter values except the
 # most recent one, via the API.
 
+import argparse
 import jenkins
 import json
 import os
 import sys
-
-
-def usage():
-    print("Error: No job name defined as first parameter.\n" +
-              "Add parameters as needed:\n" +
-              "  jenkins-job-cancel <job_name> [ para1=val1 [ para2=val2 ]... ]")
-    sys.exit(1)
+import time
 
 
 def get_build_params(build):
@@ -47,15 +42,13 @@ def get_build_params(build):
             if elem.get('_class') == 'hudson.model.ParametersAction':
                 parameters = elem.get('parameters', {})
                 break
-        return set([(str(pair['name']), str(pair.get('value')),) for pair in parameters])
-
+        return set([(str(pair['name']), str(pair.get('value')),)
+                    for pair in parameters])
     return set()
 
 
-def jenkins_cancel_job(job_name, job_args=[]):
-    if not job_name:
-        usage()
-
+def jenkins_cancel_job(job_name, job_args=[], older_than=None,
+                       dry_run=False, wait=0):
     config_files = ('/etc/jenkinsapi.conf', './jenkinsapi.conf')
     config = dict()
     job_parameters = set()
@@ -67,7 +60,8 @@ def jenkins_cancel_job(job_name, job_args=[]):
             config.update(json.load(f))
 
     if not config:
-        print('Error: No config file could be loaded. Please create either of: %s' %
+        print('Error: No config file could be loaded. '
+              'Please create either of: %s' %
               ', '.join(config_files))
         sys.exit(1)
 
@@ -80,25 +74,66 @@ def jenkins_cancel_job(job_name, job_args=[]):
                              password=config['jenkins_api_token'])
 
     job_info = server.get_job_info(job_name)
-    skipped_latest_build = False
+    stopped_jobs = []
     for build in job_info['builds']:
         build = server.get_build_info(job_name, build['number'])
-        if build['building']:
-            if job_parameters and \
-               job_parameters.issubset(get_build_params(build)):
-                if not skipped_latest_build:
-                    skipped_latest_build = True
-                    continue
-                server.stop_build(job_name, build['number'])
+        if not build['building']:
+            continue
+        if older_than and build['number'] >= older_than:
+            continue
+        if not job_parameters or \
+           not job_parameters.issubset(get_build_params(build)):
+            continue
+
+        print('Stopping job {}/{}'.format(
+            job_name, build['number']
+        ))
+        if not dry_run:
+            server.stop_build(job_name, build['number'])
+            stopped_jobs.append(build['number'])
+
+    while wait > 0:
+        for stopped_job in stopped_jobs:
+            build = server.get_build_info(job_name, stopped_job)
+            if build['building']:
+                print('Waiting for job {}/{} to stop...'.format(
+                    job_name, stopped_job
+                ))
+                break
+        else:
+            break
+        time.sleep(30)
+        wait -= 10
 
 
 def main():
-    if len(sys.argv) < 2:
-        usage()
-    args = list()
-    if len(sys.argv) > 2:
-        args.extend(sys.argv[2:])
-    jenkins_cancel_job(sys.argv[1], args)
+
+    parser = argparse.ArgumentParser(
+        description='Cancel one or more running Jenkins jobs')
+    parser.add_argument('job', default=os.environ.get('JOB_NAME'), nargs='?',
+                        help='the Jenkins job name. If not supplied, the '
+                             'JOB_NAME environment variable is used.')
+    parser.add_argument('-p', '--with-param', action='append',
+                        required=False, default=[],
+                        help='Parameter name-regexp pair used to filter jobs'
+                             '(e.g. some_param=some-regexp)')
+    parser.add_argument('--older-than-build', type=int,
+                        help="Only cancel builds older than the indicated "
+                             "build number.")
+    parser.add_argument('--wait', type=int, default=0,
+                        help="Number of seconds to wait until jobs are "
+                             "stopped.")
+    parser.add_argument('--dry-run', default=False, action='store_true',
+                        help='do a dry run')
+    args = parser.parse_args()
+
+    if not args.job:
+        print("Error: Job name could not be determined from the JOB_NAME "
+              "environment variable.")
+        sys.exit(1)
+
+    jenkins_cancel_job(args.job, args.with_param,
+                       args.older_than_build, args.dry_run, args.wait)
 
 
 if __name__ == "__main__":

--- a/scripts/jenkins/jenkins-job-pipeline-report.py
+++ b/scripts/jenkins/jenkins-job-pipeline-report.py
@@ -146,6 +146,8 @@ def generate_summary(server, job_name, build_number,
                     if downstream_jobs:
                         d_job_name = downstream_jobs[0][1]
                         d_build_number = int(downstream_jobs[0][2])
+                        stage['name'] = '{} ({})'.format(stage['name'],
+                                                         d_job_name)
                         sub_summary = generate_summary(
                             server, d_job_name, d_build_number,
                             filter_stages, recursive, depth+1)


### PR DESCRIPTION
Adds the ability to run custom integration testing on
Gerrit changes, in addition to or replacing the default
official Gerrit integration jobs used by the Ardana CI.

This is an intermediate phase on the way to making the
Ardana Jenkins Gerrit CI more dynamic by reading meta-data
directly from the commit message (similar to `Depends-On` 
meta-data modeling cross-repository dependencies) and using
that meta-data to decide at runtime what integration test scenarios
need to be run against the Gerrit change (see [SCRD-7138](https://jira.suse.de/browse/SCRD-7138)).

The following parameters have been added to the
`openstack-ardana-gerrit-cloud[8|9]` jobs to support
this:

 - `GERRIT_CHANGE_NUMBER` (replaces `gerrit_change_ids`).
 When manually triggered, this parameter must be set
 to a valid Gerrit change number value. This parameter
 has the advantage that it's also set by Gerrit automatically
 when the job is triggered by the Gerrit trigger plugin
 (hence the uppercase name).

 - `gerrit_context` - a string value that differentiates
 between several Gerrit jobs running on the same Gerrit
 change. When set, it is included both in the Gerrit build
 status reports and the Jenkins build description.

 - `voting` - controls whether the Gerrit job posts `Verify`
 label values on the Gerrit change. Non-voting jobs will still
 post messages, but will not affect the `Verify` label value.

 - `integration_test_job` - the name of the Ardana job that
 will be called to run integration tests on the target Gerrit
 change. By making this configurable, the user may now override
 the default `cloud-ardana[8|9]-job-std-min-gerrit-x86_64` job
 previously used by the Ardana CI to test all Gerrit changes.
 If left empty, no integration tests will be run.

 - `extra_repos` - just like the `openstack-ardana` parameter,
 this one enables the user to use custom zypper repositories
 in addition to those implied by the target cloud source.

The other parameters were removed because they are already
encoded into the downstream `integration_test_job` Ardana Jenkins
jobs.

A number of `openstack-ardana` variant Jenkins jobs are created,
to be used as `integration_test_job` alternatives.

This pull request also adds better support for cancelling redundant
Gerrit jobs running against the same Gerrit change (fixes [SCRD-5847](https://jira.suse.de/browse/SCRD-5847)).