### PR TITLE
mkcloud/xen: avoid IDE disks with identical path

### DIFF
--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -29,7 +29,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1'/>
       <target dev='sda' bus='ide'/>
-      
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
       <boot order='3'/>
     </disk>
 
@@ -39,7 +39,7 @@
       <driver name='qemu' type='raw' cache='unsafe'/>
       <source dev='/dev/cloud/cloud.node1-ceph1'/>
       <target dev='sdb' bus='ide'/>
-      
+      <address type='drive' controller='0' bus='1' target='0' unit='0'/>
     </disk>
 
 

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -246,7 +246,8 @@ def compute_config(args, cpu_flags=cpuflags()):
         targetdevprefix = "sd"
         configopts['target_bus'] = 'ide'
         configopts['memballoon'] = "    <memballoon model='none' />"
-        target_address = ""
+        target_address = "<address type='drive' controller='0' " \
+            "bus='{0}' target='0' unit='0'/>"
 
     # override nic model for ironic setups
     if args.ironicnic >= 0:
@@ -320,6 +321,13 @@ def compute_config(args, cpu_flags=cpuflags()):
                                  os.path.join(TEMPLATE_DIR, "ipmi-device.xml"))
     else:
         ipmi_config = ''
+
+    if not hypervisor_has_virtio(libvirt_type):
+        target_address = target_address.format('0')
+        # map virtio addr to ide:
+        raidvolume = raidvolume.replace("bus='0x17'", "bus='1'")
+        cephvolume = cephvolume.replace("bus='0x17'", "bus='1'")
+        drbdvolume = drbdvolume.replace("bus='0x17'", "bus='1'")
 
     values = dict(
         cloud=args.cloud,


### PR DESCRIPTION
/dev/disk/by-path entries are used by crowbar to determine the boot disk
and without the patch, Xen installs would fail half of the time
because the 2nd disk got the OS, but only the 1st was marked bootable
in libvirt

So we use different bus IDs to avoid IDE disks with identical path.

Only 2 HDDs are supported.

xen mkcloud run was very good. only tempest returned an error.

This is a bit of a workaround for the flawed disk selection logic in crowbar.