### PR TITLE
ipv6: Be absolutely clear about steps to execute

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ipv6-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ipv6-template.yaml
@@ -21,6 +21,6 @@
             cloudsource=develcloud{version}
             nodenumber=2
             want_ipv6=1
-            mkcloudtarget=instcrowbar
+            mkcloudtarget=cleanup prepare setupadmin prepareinstcrowbar bootstrapcrowbar
             label={label}
             job_name=cloud-mkcloud{version}-job-ipv6-{arch}


### PR DESCRIPTION
It turns out the steps to execute are literally passed to mkcloud, which
results in behaviour that isn't conducive to testing anything at all.
Specify all of the steps for the job we want to be run.

Drop instcrowbar for the time being since Crowbar installation fails on
IPv6 admin nodes.