### PR TITLE
ironic: Direct interface only with Swift

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2886,7 +2886,12 @@ function custom_configuration
             fi
         ;;
         ironic)
-            if ! iscloudver 9plus ; then
+            # cloud9+ use hardware types instead of classic drivers
+            if iscloudver 9plus ; then
+                local maybe_direct_interface=''
+                [[ $deployswift ]] && maybe_direct_interface=", 'direct'"
+                proposal_set_value ironic default "['attributes']['ironic']['enabled_deploy_interfaces']" "['iscsi' $maybe_direct_interface]"
+            else
                 local maybe_agent_driver=''
                 [[ $deployswift ]] && maybe_agent_driver=", 'agent_ipmitool'"
                 proposal_set_value ironic default "['attributes']['ironic']['enabled_drivers']" "['pxe_ipmitool' $maybe_agent_driver]"


### PR DESCRIPTION
Direct deploy interface requires Swift. Proposal will fail validation
if "direct" is enabled without Swift.