### PR TITLE
openstack-ardana: std-lmm input model scenario and jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -79,6 +79,23 @@
         - '{ardana_job}'
 
 - project:
+    name: cloud-ardana8-job-std-min-lmm-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: stagingcloud8
+    scenario_name: std-lmm
+    clm_model: standalone
+    controllers: '2'
+    lmm_nodes: '1'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
     name: cloud-ardana8-job-demo-x86_64
     ardana_job: '{name}'
     cloudsource: stagingcloud8

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -65,6 +65,22 @@
         - '{ardana_job}'
 
 - project:
+    name: cloud-ardana9-job-std-min-lmm-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    scenario_name: std-lmm
+    clm_model: standalone
+    controllers: '2'
+    lmm_nodes: '1'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
     name: cloud-ardana9-job-demo-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -155,6 +155,7 @@
             - entry-scale-kvm
             - mid-scale-kvm
             - standard
+            - std-lmm
             - std-split
           description: >-
             The name of one of the available scenarios that can be used to generate input models.
@@ -217,7 +218,7 @@
           description: |
             The number of LMM services nodes in the generated input model (0-3).
 
-            Input model generator scenarios using this parameter: mid-scale-kvm, std-split.
+            Input model generator scenarios using this parameter: mid-scale-kvm, std-split, std-lmm.
 
             NOTE: this parameter is used to generate input models. See the 'scenario_name' parameter about
             using one of the available input model generator scenarios.

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/std-lmm.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/std-lmm.yml
@@ -1,0 +1,40 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+# Scenario parameters and default values
+controllers: 3
+lmm_nodes: 3
+sles_computes: 3
+rhel_computes: 0
+swobj_devices: 3
+
+scenario:
+  name: std-lmm
+  cloud_name: std-lmm
+  description: >
+    Standard scenario with all services enabled and LMM services running in a separate cluster,
+    {{ clm_model }} CLM node, {{ controllers }} controller nodes, {{ lmm_nodes }} LMM nodes,
+    {{ sles_computes }} SLES compute nodes and {{ rhel_computes }} RHEL compute nodes.
+  audit_enabled: False
+  use_cinder_volume_disk: False
+  use_glance_cache_disk: False
+  availability_zones: "{{ availability_zones }}"
+
+  service_template: std-lmm
+  network_template: standard
+  disk_template: compact
+  interface_template: standard

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/std-lmm.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/service/std-lmm.yml
@@ -1,0 +1,73 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#
+# Standard scenario service template with standalone CLM node and LMM
+# services running in a separate cluster: all services enabled
+# and variable number of controller, LMM nodes, SLES compute and RHEL compute
+# nodes.
+#
+# Template parameters:
+#   controllers: number of controller nodes (default: 3)
+#   lmm_nodes: number of nodes in the LMM cluster (default: 1)
+#   sles_computes: number of SLES compute nodes (default: 1)
+#   rhel_computes: number of RHEL compute nodes (default: 1)
+#
+---
+
+service_groups:
+  - name: clm
+    type: cluster
+    prefix: c0
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ (clm_model == "standalone") | ternary(1, 0) }}'
+    service_components:
+      - CLM
+  - name: controller
+    type: cluster
+    prefix: c1
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-controller"
+    member_count: '{{ controllers|default(3) }}'
+    service_components:
+      - '{{ (clm_model == "integrated") | ternary("CLM", '') }}'
+      - CORE
+      - DBMQ
+      - SWPAC
+      - NEUTRON
+      - SWOBJ
+  - name: lmm
+    type: cluster
+    prefix: c2
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ lmm_nodes|default(3) }}'
+    service_components:
+      - LMM
+  - name: sles-compute
+    type: resource
+    prefix: sles-comp
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ sles_computes|default(1) }}'
+    min_count: 0
+    service_components:
+      - COMPUTE
+  - name: rhel-compute
+    type: resource
+    prefix: rhel-comp
+    distro_id: "{{ rhel_distro_id }}"
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    member_count: '{{ rhel_computes|default(1) }}'
+    min_count: 0
+    service_components:
+      - RHEL_COMPUTE

--- a/scripts/jenkins/ardana/manual/input.yml
+++ b/scripts/jenkins/ardana/manual/input.yml
@@ -75,6 +75,7 @@ model: ''
 #   - entry-scale-kvm
 #   - mid-scale-kvm
 #   - standard
+#   - std-lmm
 #   - std-split
 scenario_name: 'entry-scale-kvm'
 
@@ -112,7 +113,8 @@ rhel_os: 'CentOS_75'
 core_nodes: ''
 
 # The number of LMM services nodes in the generated input model (0-3).
-# Input model generator scenarios using this parameter: mid-scale-kvm, std-split.
+# Input model generator scenarios using this parameter: mid-scale-kvm, std-split,
+# std-lmm.
 lmm_nodes: ''
 
 # The number of database & rabbitmq service nodes in the generated input model (0-3).


### PR DESCRIPTION
Creates a new input model generator scenario, `std-lmm`,
which is similar to the `standard` scenario, with the only
difference that the LMM services are configured in a separate
cluster.

This scenario moves LMM services away from the controller nodes,
in an attempt to make the CI jobs more reliable by elliminating
the instability caused by running resource intensive LMM services
on the same nodes as the other control plane services.

Two period jobs are also added, using the new input model generator
scenario, one for cloud8 and another for cloud9. If these jobs prove
to be more stable than the `std-min` jobs used by Gerrit and IBS gating
jobs, the next step will be to switch them to use the `std-lmm` jobs
instead.