### PR TITLE
openstack-ardana-heat: make openstack-ardana-heat more robust

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
@@ -16,7 +16,6 @@
 ---
 
 heat_action: "create"
-api_timeout: "600"
 
 heat_stack_create_timeout: 480
 heat_stack_name: "openstack-ardana-{{ ardana_env }}"

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/create.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/create.yml
@@ -22,5 +22,4 @@
     state: present
     template: "{{ heat_template_file }}"
     timeout: "{{ heat_stack_create_timeout }}"
-    api_timeout: "{{ api_timeout }}"
   register: heat_stack_create

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/delete.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/delete.yml
@@ -23,41 +23,10 @@
         cloud: "{{ os_cloud }}"
         name: "{{ heat_stack_name }}"
         state: absent
-        api_timeout: "{{ api_timeout }}"
-  rescue:
-    - name: Force delete stack resources when delete failed
-      shell: |
-         openstack --os-cloud {{ os_cloud }} stack resource list --filter \
-           type={{ item.type }} -f value -c physical_resource_id {{ heat_stack_name }} |\
-           awk '{print "openstack --os-cloud '{{ os_cloud }}' {{ item.name }} \
-           delete {{ item.opt_args | default('') }} "$1 }' | sh -x || :
-      loop:
-        - name: "server"
-          type: "OS::Nova::Server"
-          opt_args: "--wait"
-        - name: "volume"
-          type: "OS::Cinder::Volume"
-        - name: "network trunk"
-          type: "OS::Neutron::Trunk"
-        - name: "port"
-          type: "OS::Neutron::Port"
-        - name: "router"
-          type: "OS::Neutron::Router"
-        - name: "subnet"
-          type: "OS::Neutron::Subnet"
-        - name: "network"
-          type: "Neutron::Net"
-
-    - name: Retry delete stack
-      os_stack:
-        cloud: "{{ os_cloud }}"
-        name: "{{ heat_stack_name }}"
-        state: absent
-        api_timeout: "{{ api_timeout }}"
       register: stack_status
-      retries: 3
+      retries: 2
       until: stack_status is success
-      delay: 5
+      delay: 2
 
   always:
     - include_tasks: monitor.yml


### PR DESCRIPTION
Improve the logic handling timeout conditions and retries in the
`openstack-ardana-heat` job. The following changes are made:

 - use `activity: true` in the Jenkinsfile `timeout` block, which
 will issue an error only if the specified amount of time is exceeded
 without any logging activity (i.e. if the ansible task is stuck
 waiting for a stack to be deleted or created and the heat stack
 timeout value didn't have any effect - in other words, a heat bug).
 With this in place, the timeout value in the Jenkinsfile only needs
 to be slightly higher than the heat stack creation/deletion timeout
 (which is currently set to 8 minutes).
 - disable retrying in the Jenkinsfile and use `retry` in the ansible
 task instead
 - remove the ansible tasks that were forcefully deleting heat stack
 resources. These are no longer needed (have not even been executed)
 since the ECP cloud was upgraded to Pike
 - remove the `api_timeout` parameter which was not even implemented
 by the os_stack ansible module and had no effect