### PR TITLE
mkcloud: remove murano_proposal option

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud8-job-simpletest-s390x.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8-job-simpletest-s390x.yaml
@@ -30,6 +30,5 @@
             want_barbican_proposal=0
             want_magnum_proposal=0
             want_sahara_proposal=0
-            want_murano_proposal=0
             want_aodh_proposal=0
             want_node_roles=controller=1

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -391,11 +391,6 @@
           description: set to 1 to deploy sahara
 
       - string:
-          name: want_murano_proposal
-          default:
-          description: set to 1 to deploy murano
-
-      - string:
           name: want_aodh_proposal
           default: '1'
           description: set to 0 to not deploy aodh

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-vproduction-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-vproduction-template.yaml
@@ -34,7 +34,6 @@
             want_ceilometer_proposal=0
             want_magnum_proposal=0
             want_manila_proposal=0
-            want_murano_proposal=0
             want_sahara_proposal=0
             mkcloudtarget=all_noreboot
             networkingplugin=openvswitch

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -732,7 +732,6 @@ fi
 : ${want_designate_proposal:=0}
 : ${want_magnum_proposal:=0}
 : ${want_monasca_proposal:=0}
-: ${want_murano_proposal:=0}
 : ${want_trove_proposal:=0}
 
 [ -z "$want_test_updates" -a -n "$TESTHEAD" ] && export want_test_updates=1

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1284,7 +1284,6 @@ Optional
         want_designate_proposal=1 (Cloud9+ only)
         want_magnum_proposal=1
         want_monasca_proposal=1   (Cloud7+ only)
-        want_murano_proposal=1
         want_trove_proposal=1
     want_horizon_integration_test=1 (default='')
         Execute selenium integration tests for Horizon after Tempest. This test is in beta, and

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2335,7 +2335,7 @@ function custom_configuration
     esac
 
     case "$proposal" in
-        keystone|glance|neutron|cinder|swift|nova|horizon|nova_dashboard|sahara|murano|aodh)
+        keystone|glance|neutron|cinder|swift|nova|horizon|nova_dashboard|sahara|aodh)
             if [[ $want_all_debug = 1 ]] || eval [[ \$want_${proposal}_debug = 1 ]] ; then
                 enable_debug_generic $proposal
             fi
@@ -2702,11 +2702,6 @@ function custom_configuration
         designate)
             if [[ $hacloud = 1 ]] && iscloudver 9plus ; then
                 proposal_set_value designate default "['deployment']['designate']['elements']['designate-server']" "['cluster:$clusternameservices']"
-            fi
-        ;;
-        murano)
-            if [[ $hacloud = 1 ]] && ( iscloudver 7 || iscloudver 8 ) ; then
-                proposal_set_value murano default "['deployment']['murano']['elements']['murano-server']" "['cluster:$clusternameservices']"
             fi
         ;;
         neutron)
@@ -3201,12 +3196,6 @@ function deploy_single_proposal
                 return
             fi
             ;;
-        murano)
-            if ! ( iscloudver 7 || iscloudver 8 ) ; then
-                echo "Murano is SOC 7 and 8 only. Skipping"
-                return
-            fi
-            ;;
         ironic)
             [[ $want_ironic = 1 ]] || return
             if ! iscloudver 7plus; then
@@ -3269,7 +3258,7 @@ function onadmin_proposal
     safely oncontroller check_crm_failcounts
     # For all remaining proposals, check for HA failures after each deployment
     for proposal in horizon ceilometer heat manila trove \
-        designate barbican magnum sahara murano aodh tempest; do
+        designate barbican magnum sahara aodh tempest; do
         deploy_single_proposal $proposal
         safely oncontroller check_crm_failcounts
     done


### PR DESCRIPTION
There is no murano barclamp planned for cloud9 or older, and
it wasn't enabled by default anyway