### PR TITLE
openstack-ardana: include SLES test-updates by default (SCRD-8295)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -157,6 +157,7 @@
     disabled: false
     reserve_env: false
     cloudsource: GM8+up
+    updates_test_enabled: false
     scenario_name: entry-scale-kvm
     tempest_filter_list: "smoke,full"
     qa_test_list: "iverify"
@@ -169,6 +170,7 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: GM8+up
+    updates_test_enabled: false
     scenario_name: standard
     clm_model: standalone
     controllers: '2'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -183,6 +183,7 @@
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: develcloud9
+    updates_test_enabled: true
     update_after_deploy: true
     update_to_cloudsource: stagingcloud9
     scenario_name: standard

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -33,6 +33,9 @@ pipeline {
           if (ardana_env == '') {
             error("Empty 'ardana_env' parameter value.")
           }
+          if (updates_test_enabled == 'true' && maint_updates != '') {
+            error("Maintenance updates and test-updates cannot be applied at the same time.")
+          }
           if (reserve_env == 'true') {
             echo "Reserved resource: " + env.reserved_env
             if (env.reserved_env && reserved_env != null) {

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -76,7 +76,7 @@
 
       - bool:
           name: updates_test_enabled
-          default: '{updates_test_enabled|false}'
+          default: '{updates_test_enabled|true}'
           description: >-
             Enable SLES/Cloud test update repos (the Cloud test update repos will
             be enabled only when cloudsource is GM based)
@@ -87,6 +87,8 @@
           description: >-
             Run ardana update after the cloud is deployed. If true the MU's will
             be applied only after the cloud is deployed.
+            If `updates_test_enabled` is true, the test updates will be
+            applied post-deployment only if the cloudsource is GM based.
 
       - choice:
           name: update_to_cloudsource

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/README.md
@@ -28,8 +28,10 @@ the SLES repositories will be configured according to the cloud version
 As there is no HOS version for cloud 9, `cloudsource` values for HOS are limited
 to cloud 8.
 
-For other columns `X` menas thet the repository will be added and `*` means that
-it will be added only when setting `updates_test_enabled` to True.
+For other columns:
+ * `X` means that the repository will always be added
+ * `*` means that the repository will always be added unless the
+ `updates_test_enabled` parameter is explicitly set to False.
 
 ### Update-test Repositories
 
@@ -48,6 +50,8 @@ variables with a list of MU ID's (separeted by comma).
 ```sh
 maint_updates: "1234,4321,2233"
 ```
+
+IMPORTANT: `updates_test_enabled` must be disabled when testing maintenance updates.
 
 ### Extra Repositories
 

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -62,7 +62,7 @@ cloud_test_repos:
 
 cloud_update_repos_enabled: "{{ '+up' in cloudsource }}"
 updates_test_enabled: False
-sles_test_repos_enabled: "{{ updates_test_enabled and ((task == 'deploy' and not update_after_deploy) or (task == 'update')) }}"
+sles_test_repos_enabled: "{{ updates_test_enabled and ((task == 'deploy' and not (update_after_deploy and 'GM' in cloudsource)) or (task == 'update')) }}"
 cloud_test_repos_enabled: "{{ updates_test_enabled and 'GM' in cloudsource and ((task == 'deploy' and not update_after_deploy) or (task == 'update')) }}"
 
 repos_to_mount: "{{ repos_to_add | select('search', '.*-Pool$') | list }}"


### PR DESCRIPTION
Change the default behaviour of all Ardana Jenkins jobs
to include SLES test-updates by default.

This is required to align the Ardana and Crowbar CIs
(Crowbar has been doing that for a long time already)
and prevent situations that break the Ardana CI but not
the Crowbar CI, or vice-versa, because of SLES maintenance
updates that are in a `testing` state (i.e. not yet released
but already validated by automated OpenQA tests).

The downside of this change is if there's a SLES package
test-update package that breaks one job, it will break all
jobs - Gerrit CI, IBS gating, periodic regression jobs etc.,
most likely for both Crowbar and Ardana. The upside of this
is that by breaking the CI early, we force everyone to be
proactive instead of re-active and fix potential problems
before candidate SLES package updates are released to
customers.

This change also updates the documentation and covers the
use-case of jobs that test the maintenance update scenario:

- jobs that test updating a cloud from the devel cloudsource to
the staging cloudsource (e.g. the cloud8 update gating job)
always install SLES test-updates during the deploy phase
- jobs that test updating a cloud from GM+up to GM+up+test-updates
always install SLES test-updates during the update phase