### PR TITLE
openstack-ardana: switch jenkins node of gerrit jobs (SCRD-8042)

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
@@ -27,7 +27,7 @@
       numToKeep: -1
       daysToKeep: 30
 
-    node: cloud-pipeline
+    node: cloud-ardana-ci-trigger
 
     parameters:
       - string:

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
   agent {
     node {
-      label 'cloud-pipeline'
+      label 'cloud-ardana-ci-trigger'
       customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
     }
   }


### PR DESCRIPTION
Due to the issues reported on [1] a new jenkins worker node was setup on
the eng. cloud similar to the cloud-swarm-ardana-ci node which does not
have such issues.

This change update the label of the ardana gerrit jobs to use this new
jenkins worker node.

1. https://jira.suse.de/browse/SCRD-8042