### PR TITLE
openstack-ardana: add support for retrying tempest failed tests

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
@@ -18,18 +18,14 @@
 ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
 
 tempest_run_filter: smoke
+tempest_retry_failed: False
 tempest_results_log: "/opt/stack/tempest/logs/testr_results_region1.log"
 tempest_results_subunit: "/opt/stack/tempest/logs/testrepository_region1.subunit"
-tempest_results_awk_collect:
-  - "'/^Ran:/ { print $2 }'"
-  - "'/- Passed:/ { print $3 }'"
-  - "'/- Skipped:/ { print $3 }'"
-  - "'/- Failed:/ { print $3 }'"
 
 tempest_qe_run_filters:
   - full
 
-subunit2junit_venv: "~/subunit2junit"
+subunit_tools_venv: "/var/lib/ardana/subunit-tools-venv"
 
 defcore_tests_url: "https://refstack.openstack.org/api/v1/guidelines/2018.02/tests"
 defcore_refstackclient_git_url: "https://github.com/openstack/refstack-client.git"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
@@ -29,10 +29,10 @@
 - name: Fail if something went wrong during tempest execution
   fail:
     msg: "Something went wrong with tempest."
-  when: tempest_results_processed.results.0.stdout == ''
+  when: tempest_test_results.total == ''
   register: tempest_status
 
 - name: Fail if any tempest test has failed
   fail:
-    msg: "{{ tempest_results_processed.results.3.stdout }} tests failed."
-  when: tempest_results_processed.results.3.stdout | int > 0
+    msg: "{{ tempest_test_results.failed }} tests failed."
+  when: tempest_test_results.failed | int > 0

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/retry_failed.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/retry_failed.yml
@@ -1,0 +1,49 @@
+- block:
+    - name: Generate filter with failed tests
+      template:
+        src: "run_filter_retry.txt.j2"
+        dest: "/opt/stack/tempest/run_filters/{{ tempest_run_filter }}_retry_serial.txt.j2"
+        owner: tempest
+        group: tempest
+        mode: 0644
+      become: yes
+
+    - name: Create fake run filter to force running tests serially
+      copy:
+        content: "-.*"
+        dest: "/opt/stack/tempest/run_filters/{{ tempest_run_filter }}_retry.txt.j2"
+        owner: tempest
+        group: tempest
+        mode: 0644
+      become: yes
+
+    - name: Save previous tempest run outputs
+      copy:
+        src: "/opt/stack/tempest/logs/{{ item }}"
+        dest: "/opt/stack/tempest/logs/{{ item }}.previous"
+        remote_src: True
+        owner: tempest
+        group: tempest
+        mode: 0644
+      become: yes
+      loop:
+        - "testr_results_region1.log"
+        - "testrepository_region1.subunit"
+
+    - name: Rerun tempest for '{{ tempest_run_filter }}' failed tests
+      shell: |
+        ansible-playbook -i hosts/verb_hosts tempest-run.yml \
+                     -e run_filter="{{ tempest_run_filter }}_retry"
+      args:
+        chdir: "{{ ardana_scratch_path }}"
+  rescue:
+    - name: Get list of failed tempest tests
+      shell: "grep -B1 -- '------' {{ tempest_results_log }} | awk -F '\n' 'ln ~ /^$/ { ln = \"matched\"; print $1 } $1 ~ /^--$/ { ln = \"\" }'"
+      register: tempest_failed_tests
+  always:
+    - name: Combine test outputs
+      shell: |
+        {{ subunit_tools_venv }}/bin/subunit-filter -fs {{ tempest_results_subunit }}.previous >> {{ tempest_results_subunit }}
+        cat {{ tempest_results_log }}.previous {{ tempest_results_log  }} > {{ tempest_results_log }}.tmp
+        mv {{ tempest_results_log }}.tmp {{ tempest_results_log }} && chown tempest.tempest {{ tempest_results_log }}
+      become: yes

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/run_tempest.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/run_tempest.yml
@@ -27,6 +27,14 @@
       with_items: "{{ tempest_qe_run_filters }}"
       when: tempest_run_filter in tempest_qe_run_filters
 
+    - name: Ensure subunit tools venv exists
+      pip:
+        name: "{{ item }}"
+        virtualenv: "{{ subunit_tools_venv }}"
+      loop:
+        - "junitxml"
+        - "python-subunit"
+
     - name: Run tempest '{{ tempest_run_filter }}'
       shell: |
         ansible-playbook -i hosts/verb_hosts tempest-run.yml \
@@ -37,17 +45,13 @@
     - name: Get list of failed tempest tests
       shell: "grep -B1 -- '------' {{ tempest_results_log }} | awk -F '\n' 'ln ~ /^$/ { ln = \"matched\"; print $1 } $1 ~ /^--$/ { ln = \"\" }'"
       register: tempest_failed_tests
-  always:
-    - name: Ensure virtualenv with subunit2junit
-      pip:
-        name: "{{ item }}"
-        virtualenv: "{{ subunit2junit_venv }}"
-      loop:
-        - "junitxml"
-        - "python-subunit"
 
+    - include_tasks: retry_failed.yml
+      when: tempest_retry_failed
+
+  always:
     - name: Generate xml subunit results
-      shell: "{{ subunit2junit_venv }}/bin/subunit2junitxml {{ tempest_results_subunit }} > {{ subunit_xml_results }}"
+      shell: "{{ subunit_tools_venv }}/bin/subunit2junitxml {{ tempest_results_subunit }} > {{ subunit_xml_results }}"
       changed_when: false
       failed_when: false
 
@@ -56,7 +60,15 @@
       changed_when: false
       failed_when: false
 
-    - name: Process tempest result
-      shell: "awk {{ item }} {{ tempest_results_log }}"
-      with_items: "{{ tempest_results_awk_collect }}"
-      register: tempest_results_processed
+    - name: Get '{{ tempest_run_filter }}' results from subunit
+      command: "{{ subunit_tools_venv }}/bin/subunit-stats {{ tempest_results_subunit }}"
+      failed_when: false
+      register: _test_results
+
+    - name: Process test results from subunit
+      set_fact:
+        tempest_test_results: "{{ tempest_test_results | default({}) | combine({item.split()[0] | lower: item.split()[-1]}) }}"
+      when: "'tests' in item"
+      loop: "{{ _test_results.stdout_lines }}"
+      loop_control:
+        label: "{{ item.split()[0] | lower }}: {{ item.split()[-1] }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
@@ -1,0 +1,7 @@
+{% set regexp = '\[.*]$' %}
+{% for test in tempest_failed_tests.stdout_lines %}
+{% if test.startswith('setUpClass') %}
+{% set regexp = '.*\(|\)$' %}
+{% endif %}
++{{ test | regex_replace(regexp, '') }}
+{% endfor %}

--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/tempest.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/vars/tempest.yml
@@ -57,16 +57,16 @@ rc_msg_fields_finished_temp:
     value: "{{ tempest_run_filter }}"
     short: True
   - title: Ran
-    value: "{{ tempest_results_processed.results.0.stdout if tempest_results_processed is defined else 'Not available' }}"
+    value: "{{ tempest_test_results.total if tempest_test_results is defined else 'Not available' }}"
     short: True
   - title: Passed
-    value: "{{ tempest_results_processed.results.1.stdout if tempest_results_processed is defined else 'Not available' }}"
+    value: "{{ tempest_test_results.passed if tempest_test_results is defined else 'Not available' }}"
     short: True
   - title: Skipped
-    value: "{{ tempest_results_processed.results.2.stdout if tempest_results_processed is defined else 'Not available' }}"
+    value: "{{ tempest_test_results.skipped if tempest_test_results is defined else 'Not available' }}"
     short: True
   - title: Failed
-    value: "{{ tempest_results_processed.results.3.stdout if tempest_results_processed is defined else 'Not available' }}"
+    value: "{{ tempest_test_results.failed if tempest_test_results is defined else 'Not available' }}"
     short: True
   - title: OpenStack-Health
     value: "{{ os_health_url_msg }}"

--- a/scripts/jenkins/ardana/ansible/run-tempest.yml
+++ b/scripts/jenkins/ardana/ansible/run-tempest.yml
@@ -70,5 +70,5 @@
           name: rocketchat_notify
         vars:
           rc_action: "finished"
-          rc_state: "{{ (tempest_results_processed.results.3.stdout | int > 0) | ternary('Failed', 'Success' )}}"
+          rc_state: "{{ (tempest_test_results.failed | int > 0) | ternary('Failed', 'Success' )}}"
         when: rc_notify


### PR DESCRIPTION
Due to the instability of tempest (e.g. different tests fails/succeeds
on consecutive runs on the same environment), this change adds an option
(disabled by default) to automatically rerun tempest for the failed
tests serially and combine its results.