### PR TITLE
qa_crowbarsetup.sh: Run tempest last

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4628,16 +4628,18 @@ function onadmin_testsetup
     # use local cache whenever possible
     oncontroller mount_localreposdir
 
+    keystoneret=0
+
+    if iscloudver 7plus && [[ $cloudsource =~ 'develcloud' ]] ; then
+        test_keystone_toggle_ssl
+        keystoneret=$?
+    fi
+
     oncontroller testsetup
     ret=$?
 
-    # Run endpoint toggle after crm failcount check, this is expected to be
-    # disruptive to services.
-    if iscloudver 7plus && [[ $cloudsource =~ 'develcloud' ]] ; then
-        test_keystone_toggle_ssl
-    fi
-
     echo "Tests on controller: $ret"
+    echo "Keystone Toggle SSL: $keystoneret"
     echo "Ceph Tests: $cephret"
     echo "RadosGW S3 Tests: $s3radosgwret"
 


### PR DESCRIPTION
we want to ensure that the keystone toggling did not break
services, so we run tempest after doing the operation to
ensure that the cloud is still working. Also this reduces
scrolling to find a tempest failure in CI logs