### PR TITLE
Allow pass thru of arguments to iverify.sh (SCRD-5854)

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -29,6 +29,7 @@ ardana_qa_tests_branch: "{{ cloud_git_branch[cloud_release] }}"
 ardana_qe_test_log: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.log"
 ardana_qe_test_subunit: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.subunit"
 ardana_qe_test_script: "{{ ardana_qe_test_work_dir }}/{{ test_name }}.sh"
+ardana_qe_test_script_args: "{{ lookup('env', (test_name | upper | replace('-','_')) ~ '_ARGS') | default('') }}"
 ardana_qe_test_timeout: 120
 
 ardana_qe_test_venv: "{{ ardana_qe_base_dir }}/{{ test_name }}/venv"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/iverify.sh.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/templates/tests/iverify.sh.j2
@@ -14,7 +14,7 @@ WORK_HOME={{ ardana_qe_test_work_dir }}
 AUTO_ID="AUTO`date +'%y%m%d%H%M%S'`"
 
 # Run the test
-{{ ardana_qe_tests_dir }}/ardana-qa-tests/iverify/iverify.sh -n $AUTO_ID | tee \
+{{ ardana_qe_tests_dir }}/ardana-qa-tests/iverify/iverify.sh ${@} -n $AUTO_ID | tee \
   ${WORK_HOME}/iverify.log
 
 res=$?


### PR DESCRIPTION
While investigating fwaas issues for SCRD-5854 I found that it was
useful to be able to pass command line arguments through to the
underlying iverify command from the wrapper script.