### PR TITLE
cloud-automation-pr-trigger: add timeout

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -42,6 +42,12 @@
       numToKeep: 300
       daysToKeep: -1
 
+    wrappers:
+      - timeout:
+          fail: true
+          timeout: 120
+      - timestamps
+
     builders:
       - shell: |
           ## THIS IS A TRIGGER JOB ONLY - NO WORKER CODE IN HERE - DO NOT DARE TO ADD SOME


### PR DESCRIPTION
and timestamps

It hung for 14 hours without any output at github_pr.rb.