### PR TITLE
openstack-ardana-gerrit: enable SES for Gerrit CentOS integration job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8-gerrit.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8-gerrit.yaml
@@ -23,7 +23,7 @@
     controllers: '2'
     sles_computes: '0'
     rhel_computes: '2'
-    ses_enabled: false
+    ses_enabled: true
     ses_rgw_enabled: false
     triggers:
     jobs:

--- a/jenkins/ci.suse.de/cloud-ardana9-gerrit.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9-gerrit.yaml
@@ -23,7 +23,7 @@
     controllers: '2'
     sles_computes: '0'
     rhel_computes: '2'
-    ses_enabled: false
+    ses_enabled: true
     ses_rgw_enabled: false
     triggers:
     jobs:


### PR DESCRIPTION
SES was mistakenly disabled for the `cloud-ardana[8|9]-job-std-min-centos-gerrit-x86_64` jobs.