### PR TITLE
openstack-ardana: update defcore list of tests to 2018.11

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
@@ -27,7 +27,7 @@ tempest_qe_run_filters:
 
 subunit_tools_venv: "/var/lib/ardana/subunit-tools-venv"
 
-defcore_tests_url: "https://refstack.openstack.org/api/v1/guidelines/2018.02/tests"
+defcore_tests_url: "https://refstack.openstack.org/api/v1/guidelines/2018.11/tests"
 defcore_refstackclient_git_url: "https://github.com/openstack/refstack-client.git"
 defcore_refstack_url: "https://10.86.0.98"
 defcore_results: "~/refstack_results.subunit"


### PR DESCRIPTION
Update the list of defcore tets according to the 2018.11 guide line.