### PR TITLE
Disable failing SOC6 mkcloud tests

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud6.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud6.yaml
@@ -1,12 +1,13 @@
 - project:
     name: cloud-mkcloud6-gating
+    disabled: true
     version: 6
     previous_version: 5
     jobs:
         - 'cloud-mkcloud{version}-gating'
 - project:
     name: cloud-mkcloud6-x86_64
-    disabled: false
+    disabled: true
     version: 6
     previous_version: 5
     arch: x86_64
@@ -21,7 +22,7 @@
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
 - project:
     name: cloud-mkcloud6-ha-x86_64
-    disabled: false
+    disabled: true
     version: 6
     previous_version: 5
     arch: x86_64


### PR DESCRIPTION
Tests fails in heat deployment for 2 months:
Problem: nothing provides python-docker-pycreds >= 0.2.1 needed by python-docker-py-1.10.6-29.3.1.noarch
 Solution 1: do not install openstack-heat-plugin-heat_docker-5.0.4~a0~dev1-9.628.noarch
 Solution 2: break python-docker-py-1.10.6-29.3.1.noarch by ignoring some of its dependencies