### PR TITLE
cleanvm/repocheck: Add SLE15 support for Master

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -20,6 +20,7 @@
             - SLE_12_SP2
             - SLE_12_SP3
             - SLE_12_SP4
+            - SLE_15
             - openSUSE-Leap-42.3
             - openSUSE-Leap-15.0
       - axis:
@@ -35,7 +36,7 @@
         || ( openstack_project=="Pike" && (image=="SLE_12_SP3" || image=="openSUSE-Leap-42.3"))
         || ( openstack_project=="Queens" && (image=="SLE_12_SP3" || image=="openSUSE-Leap-42.3"))
         || ( openstack_project=="Rocky" && (image=="SLE_12_SP4" || image=="openSUSE-Leap-15.0"))
-        || ( openstack_project=="Master" && (image=="SLE_12_SP4" || image=="openSUSE-Leap-15.0"))
+        || ( openstack_project=="Master" && (image=="SLE_15" || image=="openSUSE-Leap-15.0"))
         ))
       sequential: true
     builders:

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -44,7 +44,7 @@
       combination-filter: |
        !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP2"].contains(repository) ||
          ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3", "openSUSE_Leap_15.0", "SLE_12_SP4"].contains(repository) ||
-         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["SLE_12_SP2", "openSUSE_Leap_15.0", "SLE_12_SP4"].contains(repository) ||
+         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4"].contains(repository) ||
          ["Cloud:OpenStack:Queens", "Cloud:OpenStack:Queens:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4"].contains(repository) ||
          ["Cloud:OpenStack:Rocky", "Cloud:OpenStack:Rocky:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3" ].contains(repository)
        )

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -31,6 +31,7 @@
             - SLE_12_SP2
             - SLE_12_SP3
             - SLE_12_SP4
+            - SLE_15
             - openSUSE_Leap_42.3
             - openSUSE_Leap_15.0
       - axis:
@@ -43,10 +44,10 @@
       # to a branch here only if you want to "exclude" it for the given branch.
       combination-filter: |
        !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP2"].contains(repository) ||
-         ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3", "openSUSE_Leap_15.0", "SLE_12_SP4"].contains(repository) ||
-         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4"].contains(repository) ||
-         ["Cloud:OpenStack:Queens", "Cloud:OpenStack:Queens:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4"].contains(repository) ||
-         ["Cloud:OpenStack:Rocky", "Cloud:OpenStack:Rocky:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3" ].contains(repository)
+         ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3", "openSUSE_Leap_15.0", "SLE_12_SP4", "SLE_15"].contains(repository) ||
+         ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4", "SLE_15"].contains(repository) ||
+         ["Cloud:OpenStack:Queens", "Cloud:OpenStack:Queens:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4", "SLE_15"].contains(repository) ||
+         ["Cloud:OpenStack:Rocky", "Cloud:OpenStack:Rocky:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3", "SLE_15"].contains(repository)
        )
       sequential: true
     builders:

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -45,7 +45,7 @@
        !(["Cloud:OpenStack:Master"].contains(project) && ["SLE_12_SP2"].contains(repository) ||
          ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3", "openSUSE_Leap_15.0", "SLE_12_SP4"].contains(repository) ||
          ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["SLE_12_SP2", "openSUSE_Leap_15.0", "SLE_12_SP4"].contains(repository) ||
-         ["Cloud:OpenStack:Queens", "Cloud:OpenStack:Queens:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP4"].contains(repository) ||
+         ["Cloud:OpenStack:Queens", "Cloud:OpenStack:Queens:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4"].contains(repository) ||
          ["Cloud:OpenStack:Rocky", "Cloud:OpenStack:Rocky:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3" ].contains(repository)
        )
       sequential: true


### PR DESCRIPTION
We want to test Cloud:OpenStack:Master with cleanvm on SLE15 beside
the other distros. The repocheck job is adjusted accordingly to test
dependencies for SLE15 on Cloud:OpenStack:Master .