### PR TITLE
openstack-crowbar: Add Monasca TSDB choice option

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -380,6 +380,12 @@
           default:
           description: Deploy with Monasca
 
+      - choice:
+          name: want_monasca_tsdb
+          choices:
+            - influxdb
+            - cassandra
+
       - string:
           name: want_barbican_proposal
           default:

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1336,6 +1336,8 @@ Optional
         individual services using want_{proposal}_ssl.
     want_ssl_trusted (default='1' for cloud7+)
         If set, does not use the --insecure flag in openstack CLI commands.
+    want_monasca_tsdb (Cloud9+ only)
+        Allows setting time-series DB used for Monasca [influxdb|cassandra].
 EOUSAGE
     qacrowbarsetup_help
     exit 1

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2594,6 +2594,9 @@ function custom_configuration
             if [[ $hacloud = 1 ]] ; then
                 echo "Warning: Monasca currently is not HA ready"
             fi
+            if iscloudver 9plus && [[ $want_monasca_tsdb = cassandra ]]; then
+                proposal_set_value monasca default "['attributes']['monasca']['tsdb']" "'$want_monasca_tsdb'"
+            fi
             ;;
 
         barbican)


### PR DESCRIPTION
The change adds Jenkins parameter to allow running tests with a
specified TSDB.