### PR TITLE
re-create fastest_clouddata_server file when empty

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -566,7 +566,7 @@ get_nodenumbercontroller()
 find_fastest_clouddata_server()
 {
     local cache=~/.mkcloud/fastest_clouddata_server
-    if [[ -r $cache ]] && [[ $cache -nt $BASH_SOURCE ]] ; then
+    if [[ -r $cache ]] && [[ -s $cache ]] && [[ $cache -nt $BASH_SOURCE ]] ; then
         exec cat $cache || exit 100
     fi
     mkdir -p ~/.mkcloud


### PR DESCRIPTION
If for some reason file `~/.mkcloud/fastest_clouddata_server` is empty mkcloud will not retrigger run of `scripts_lib_dir/find_fastest_server.pl` and then mkcloud uses empty hostname and fails.

We encounter empty file generated on one of our qam machines.