### PR TITLE
trackupstream: Use SLE_12_SP4 for building COM packages

### DIFF
--- a/scripts/jenkins/track-upstream.sh
+++ b/scripts/jenkins/track-upstream.sh
@@ -34,10 +34,13 @@ case $OBS_TYPE in
     OBS) OSCAPI="https://api.opensuse.org"
         OSC_BUILD_ARCH=x86_64
         case $OBS_PROJECT in
-            Cloud:OpenStack:Master|Cloud:OpenStack:Pike*|Cloud:OpenStack:Queens*)
+            Cloud:OpenStack:Pike*|Cloud:OpenStack:Queens*)
                 OSC_BUILD_DIST=SLE_12_SP3
                 ;;
             Cloud:OpenStack:Rocky*)
+                OSC_BUILD_DIST=SLE_12_SP4
+                ;;
+            Cloud:OpenStack:Master)
                 OSC_BUILD_DIST=SLE_12_SP4
                 ;;
             *)


### PR DESCRIPTION
There is no SLE_12_SP3 anymore for Cloud:OpenStack:Master (COM) so
currently openstack-trackupstream for Master packages fails with:

--> Now trying to build package.
SLE_12_SP3 is not a valid repository, use one of: SLE_12_SP4, \
  SLE_15, openSUSE_Leap_15.0, openSUSE_Leap_42.3