### PR TITLE
qa_openstack: Support SLE15 repos

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -92,8 +92,15 @@ if [ -f "/etc/os-release" ]; then
     case "$DIST_NAME" in
         "SLES")
             IFS=. read major minor <<< $VERSION
-            REPO="SLE_${major}_SP${minor}"
-            REPOVER="${major}-SP${minor}"
+            # SLE15 do not have a minor version (SP1 will have then)
+            # /etc/os-release contains: VERSION="15"
+            if [ -z "$minor" ]; then
+                REPO="SLE_${major}"
+                REPOVER="${major}"
+            else
+                REPO="SLE_${major}_SP${minor}"
+                REPOVER="${major}-SP${minor}"
+            fi
             # FIXME for SLE15 to not have SP0
             addrepofunc=addslesrepos
         ;;


### PR DESCRIPTION
/etc/os-release for SLE15 (SP0 if you want to call it that way) does
contain:

NAME="SLES"
VERSION="15"
VERSION_ID="15"

so there will be no $minor version. Adjust the REPO and REPOVER
variables to work correctly.

Note: On http://smt-internal.opensuse.org there are no SLE15 images
yet. This will be fixed hopefully soon.