### PR TITLE
openstack-crowbar: validate generated mkcloud.conf

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/crowbar_setup/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_setup/tasks/main.yml
@@ -2,7 +2,8 @@
 
 - name: Run the supplied qa_crowbarsetup.sh command on the admin node
   shell: |
-    . {{ admin_scripts_path }}/qa_crowbarsetup.sh
+    . {{ admin_mkcloud_config_file }}
+    . {{ admin_scripts_path }}/qa_crowbarsetup.sh 2>&1 | tee -a {{ qa_crowbarsetup_log }}
     {{ qa_crowbarsetup_cmd }} 2>&1 | tee -a {{ qa_crowbarsetup_log }}
     exit ${PIPESTATUS[0]}
   args:


### PR DESCRIPTION
The `mkcloud.conf` file is generated based on user input, which
might not be valid. Sourcing the `mkcloud.conf` separately and
also including stdout/stderr output from sourcing `qa_crowbarsetup.sh`
in the logs will help detect such failures.