### PR TITLE
deploy ceilometer only with monasca

### DIFF
--- a/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
@@ -140,19 +140,6 @@ proposals:
     elements:
       barbican-controller:
       - @@controller@@
-- barclamp: ceilometer
-  attributes:
-  deployment:
-    elements:
-      ceilometer-agent:
-      - @@compute-kvm@@
-      ceilometer-agent-hyperv: []
-      ceilometer-central:
-      - @@controller@@
-      ceilometer-server:
-      - @@controller@@
-      ceilometer-swift-proxy-middleware:
-      - @@controller@@
 - barclamp: magnum
   attributes:
     cert:

--- a/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
@@ -165,21 +165,6 @@ proposals:
     elements:
       barbican-controller:
       - cluster:services
-- barclamp: ceilometer
-  attributes:
-  deployment:
-    elements:
-      ceilometer-agent:
-      - @@compute1@@
-      - @@compute2@@
-      ceilometer-agent-hyperv: []
-      ceilometer-central:
-      - cluster:services
-      ceilometer-server:
-      - cluster:services
-      ceilometer-swift-proxy-middleware:
-      - @@controller1@@
-      - @@controller2@@
 - barclamp: manila
   attributes:
     default_share_type: default


### PR DESCRIPTION
ceilometer has a hard dependance on monasca as monasca is the default
storage engine for ceilometer.

The yaml file from qa scenario still refer to ceilometer, as I am not sure which scenarios should include monasca and where to remove ceilometer