### PR TITLE
ardana-heat-generator: plug the external API net into the external router

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/README.md
@@ -424,6 +424,11 @@ The following are networks that are special and/or require special handling:
     no conflicts between DHCP allocated addresses and the addresses that Ardana allocates for cloud
     nodes and virtual IPs
 
+* the Ardana "external API" network:
+  * identification: the input model network that has a network group associated with a public
+  load-balancer
+  * the openstack subnet must be connected to the external router to provide external access
+
 * neutron external "bridge" networks:
 
   * identification: networks tagged with `neutron.l3_agent.external_network_bridge`

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -685,6 +685,10 @@ def generate_heat_model(input_model, virt_config):
             heat_network['allocation_pools'] = \
                 [[str(mgmt_net_last - EXTERNAL_MGMT_ADDR_RANGE),
                   str(mgmt_net_last - 1)]]
+        elif True in [('public' in lb['roles'])
+                      for lb in network['network-group'].get('load-balancers',
+                                                             [])]:
+            heat_network['external'] = True
 
         heat_networks[network['name']] = heat_network
 


### PR DESCRIPTION
The magnum VM needs to access the OpenStack public API. Plugging the external API network into the external router, to which the external neutron network is also attached enables that.