### PR TITLE
Skip adding dns_servers into heat template for ipv6.

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -90,10 +90,12 @@ resources:
 {%     endfor %}
 {%   endif  %}
 {%   if network.external and dns_servers is defined %}
+{%   if (ipv6 | default(false)) == false %}
       dns_nameservers:
 {%     for dns_server in dns_servers %}
         - {{ dns_server }}
 {%     endfor %}
+{%   endif  %}
 {%   endif  %}
 
 


### PR DESCRIPTION
Adding dns server (147.2.2.2) for ipv6 network breaks heat template deployment due to mismatch of ip version. This PR will only add dns server for ipv4 deployment.

Without fix:
https://ci.suse.de/job/openstack-ardana-heat/9308/console

With fix:
https://ci.suse.de/job/openstack-ardana-heat/9309/console