### PR TITLE
openstack-ardana: install SLES-SDK Updates-test

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -55,6 +55,8 @@ sles_cloud_version:
 rhel_os: CentOS_75
 rhel_os_version: "{{ rhel_os.split('_')[1] }}"
 
+updates_test_enabled: False
+
 update_after_deploy: False
 maintenance_updates_path:
   Cloud: "SUSE_Updates_{{ cloud_repo_path }}_{{ sles_cloud_version[ansible_distribution_version] }}_x86_64"
@@ -62,6 +64,12 @@ maintenance_updates_path:
 
 maint_updates_list: "{{ maint_updates.split(',') if maint_updates is defined and maint_updates | length else [] }}"
 maintenance_updates_server: "dist.suse.de"
+
+sles_sdk_repos:
+  - name: "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
+  - name: "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
+  - name: "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates-test"
+    enable: "{{ updates_test_enabled }}"
 
 ntp_servers:
   - ntp.suse.de

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/defaults/main.yml
@@ -40,10 +40,6 @@ ardana_qe_tests_requires:
   - "gcc"
   - "python-devel"
 
-sles_sdk_repos:
-  - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
-  - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"
-
 ardana_qe_test_run_filters: "{{ role_path }}/files/run_filters/{{ test_name }}"
 
 ardana_qe_tests_admin_osrc_values:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/qe_test_requires.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_qe_tests/tasks/qe_test_requires.yml
@@ -18,12 +18,13 @@
 
 - name: Ensure SLES-SDK repos {{ ardana_qe_tests_requires_state }}
   zypper_repository:
-    name: "{{ item }}"
-    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item }}/"
+    name: "{{ item.name }}"
+    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item.name }}/"
     runrefresh: yes
     priority: 9999
     state: "{{ ardana_qe_tests_requires_state }}"
   loop: "{{ sles_sdk_repos }}"
+  when: item.enabled | default(true)
   become: yes
 
 - name: Ensure requirements for ardana-qe-tests {{ ardana_qe_tests_requires_state }}

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/defaults/main.yml
@@ -28,7 +28,3 @@ os_health_requires_state: "present"
 os_health_requires:
   - "gcc"
   - "python-devel"
-
-sles_sdk_repos:
-  - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Pool"
-  - "SLE{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-SDK-Updates"

--- a/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
+++ b/scripts/jenkins/ardana/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
@@ -18,12 +18,13 @@
 
 - name: Ensure SLES-SDK repos {{ os_health_requires_state }}
   zypper_repository:
-    name: "{{ item }}"
-    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item }}/"
+    name: "{{ item.name }}"
+    repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item.name }}/"
     runrefresh: yes
     priority: 9999
     state: "{{ os_health_requires_state }}"
   loop: "{{ sles_sdk_repos }}"
+  when: item.enabled | default(true)
   become: yes
 
 - name: Ensure requirements for subunit2sql {{ os_health_requires_state }}

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -61,7 +61,6 @@ cloud_test_repos:
   - "{{ repository_mnemonics[cloud_release]['Cloud-Updates-test'] }}"
 
 cloud_update_repos_enabled: "{{ '+up' in cloudsource }}"
-updates_test_enabled: False
 sles_test_repos_enabled: "{{ updates_test_enabled and ((task == 'deploy' and not (update_after_deploy and 'GM' in cloudsource)) or (task == 'update')) }}"
 cloud_test_repos_enabled: "{{ updates_test_enabled and 'GM' in cloudsource and ((task == 'deploy' and not update_after_deploy) or (task == 'update')) }}"
 


### PR DESCRIPTION
When `updates_test_enabled` is set and the SLES-SDK-Updates
repository is installed, the SLES-SDK-Updates-test repository
is also required, otherwise there will be broken package
dependencies (e.g. `python-devel` vs. `python-base`).

NOTE: this fixes the issue currently breaking all Ardana jobs that
perform any type of update that involves the test updates repository.