### PR TITLE
Re-source the crowbar variables after commit

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3024,6 +3024,10 @@ function crowbar_proposal_commit
     local proposal="$1"
     local proposaltype="${2:-default}"
     safely crowbarctl proposal commit "$proposal" "$proposaltype"
+
+    # crowbar may have changed the install key in /etc/crowbar.install.key,
+    # which is needed for the 'crowbar' command, so refresh it.
+    [ -e /etc/profile.d/crowbar.sh ] && . /etc/profile.d/crowbar.sh
 }
 
 # configure and commit one proposal


### PR DESCRIPTION
The 'crowbar' command uses the CROWBAR_KEY environment variable to
authenticate. With this upcoming change in crowbar-core[1], the content
of the key is subject to change, so we need to refresh the key between
crowbar commits. This is a simpler path than converting to the
crowbarctl command, which uses the crowbarrc file which does not change.

[1] https://github.com/crowbar/crowbar-core/pull/1802