### PR TITLE
jenkins-job-cancel: handle unicode in job params

### DIFF
--- a/scripts/jenkins/jenkins-job-cancel
+++ b/scripts/jenkins/jenkins-job-cancel
@@ -42,7 +42,9 @@ def get_build_params(build):
             if elem.get('_class') == 'hudson.model.ParametersAction':
                 parameters = elem.get('parameters', {})
                 break
-        return set([(str(pair['name']), str(pair.get('value')),)
+
+        return set([(pair['name'],
+                     u"{0}".format(pair.get('value')),)
                     for pair in parameters])
     return set()
 


### PR DESCRIPTION
Handle unicode values correctly in job parameters.

Cancelling Gerrit jobs is currently failing with:

```
UnicodeEncodeError: 'ascii' codec can't encode
character u'\xe1' in position 4: ordinal not in range(128)
```


, because the `jenkins-job-cancel` python script
doesn't handle cases where job parameter values have
unicode characters that cannot be cleanly converted
into ascii.