### PR TITLE
openstack-ardana: enable nova migrate

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
@@ -15,6 +15,8 @@
 #
 ---
 
+ardana_nova_migrate_enabled: True
+
 ardana_openstack_path: "~/openstack/ardana/ansible"
 ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
 
@@ -25,7 +27,7 @@ ardana_openstack_playbooks:
 ardana_scratch_playbooks:
   - play: "wipe_disks.yml -e automate=true"
     when: "{{ is_physical_deploy }}"
-  - play: "site.yml"
+  - play: "site.yml -e nova_migrate_enabled={{ ardana_nova_migrate_enabled }}"
   - play: "ardana-cloud-configure.yml"
 
 ardana_third_party_playbooks:


### PR DESCRIPTION
By default, ardana is deployed with nova migrate disabled making the CI
unable to cover that feature.

This change introduces a new ansible variable (`ardana_nova_migrate_enabled`)
which makes possible enabling/disabling nova migrate. By default it is
set to true (nova migrate enabled).