### PR TITLE
openstack-staging: refactor jobs for better usability (SCRD-8548)

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -1,91 +1,49 @@
-- job:
-    name: 'openstack-cleanvm'
-    project-type: matrix
 
-    logrotate:
-      numToKeep: -1
-      daysToKeep: 10
+- project:
+    name: openstack-cleanvm-Newton
+    disabled: false
+    release: Newton
+    image:
+      - SLE_12_SP2
+    jobs:
+      - 'openstack-cleanvm-{release}'
 
-    parameters:
-      - string:
-          name: openstack_project
-          default: None
-          description: name of the main project that should be updated with packages from its staging project
+- project:
+    name: openstack-cleanvm-Pike
+    disabled: false
+    release: Pike
+    image:
+      - SLE_12_SP3
+      - openSUSE-Leap-42.3
+    jobs:
+      - 'openstack-cleanvm-{release}'
 
-    axes:
-      - axis:
-          type: user-defined
-          name: image
-          values:
-            - SLE_12_SP2
-            - SLE_12_SP3
-            - SLE_12_SP4
-            - SLE_15
-            - openSUSE-Leap-42.3
-            - openSUSE-Leap-15.0
-      - axis:
-          type: slave
-          name: slave
-          values:
-            - cloud-cleanvm
-    execution-strategy:
-      combination-filter: |
-        (
-        slave=="cloud-cleanvm" && (
-           ( openstack_project=="Newton" && (image=="SLE_12_SP2" ))
-        || ( openstack_project=="Pike" && (image=="SLE_12_SP3" || image=="openSUSE-Leap-42.3"))
-        || ( openstack_project=="Queens" && (image=="SLE_12_SP3" || image=="openSUSE-Leap-42.3"))
-        || ( openstack_project=="Rocky" && (image=="SLE_12_SP4" || image=="openSUSE-Leap-15.0"))
-        || ( openstack_project=="Master" && (image=="SLE_15" || image=="openSUSE-Leap-15.0"))
-        ))
-      sequential: true
-    builders:
-      - update-automation
-      - shell: |
-          export automationrepo=~/github.com/SUSE-Cloud/automation
-          export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
-          # We need a workaround for the cleanvm job.
-          # The job will run on a host with SLE11 installed.
-          # There are no packages for ruby available to run jtsync.
-          export jtsync_fix="ssh root@tu-sle12"
+- project:
+    name: openstack-cleanvm-Queens
+    disabled: false
+    release: Queens
+    image:
+      - SLE_12_SP3
+      - openSUSE-Leap-42.3
+    jobs:
+      - 'openstack-cleanvm-{release}'
 
-          # Workaround to get only the name of the job:
-          # https://issues.jenkins-ci.org/browse/JENKINS-39189
-          # When the JOB_BASE_NAME contains only in ex. "openstack-cleanvm", this
-          # workaround can be removed.
-          echo "$JOB_BASE_NAME"
-          main_job_name=${JOB_NAME%%/*}
+- project:
+    name: openstack-cleanvm-Rocky
+    disabled: false
+    release: Rocky
+    image:
+      - SLE_12_SP4
+      - openSUSE-Leap-15.0
+    jobs:
+      - 'openstack-cleanvm-{release}'
 
-          function exec_jtsync {
-            # only enable jtsync when build is not manually triggered
-            if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
-              $jtsync_fix "$jtsync --ci opensuse --matrix $1,$2,$3 $4" || :
-            fi
-          }
-
-          sudo /usr/local/sbin/freshvm cleanvm $image
-          sleep 100
-          cloudsource=openstack$(echo $openstack_project | tr '[:upper:]' '[:lower:]')
-          oshead=1
-          set -u
-          set +e
-          scp ~/github.com/SUSE-Cloud/automation/scripts/jenkins/qa_openstack.sh root@cleanvm:
-          ssh root@cleanvm "export cloudsource=$cloudsource; export OSHEAD=$oshead; export NONINTERACTIVE=1; bash -x ~/qa_openstack.sh"
-          ret=$?
-          if [ "$ret" != 0 ] ; then
-            virsh shutdown cleanvm
-            # wait for clean shutdown
-            n=20 ; while [[ $n > 0 ]] && virsh list |grep cleanvm.*running ; do sleep 2 ; n=$(($n-1)) ; done
-            virsh destroy cleanvm
-            # cleanup old images
-            find /mnt/cleanvmbackup -mtime +5 -type f | xargs --no-run-if-empty rm
-            # backup /dev/vg0/cleanvm disk image
-            file=/mnt/cleanvmbackup/${BUILD_NUMBER}-${openstack_project}-${image}.raw.gz
-            time gzip -c1 /dev/vg0/cleanvm > $file
-            du $file
-            exec_jtsync ${main_job_name} ${openstack_project} ${BUILD_NUMBER} 1
-            exit 1
-          fi
-
-          exec_jtsync ${main_job_name} ${openstack_project} ${BUILD_NUMBER} $ret
-          exit $ret
+- project:
+    name: openstack-cleanvm-Master
+    disabled: false
+    release: Master
+    image:
+      - SLE_15
+      - openSUSE-Leap-15.0
+    jobs:
+      - 'openstack-cleanvm-{release}'

--- a/jenkins/ci.opensuse.org/openstack-staging.yaml
+++ b/jenkins/ci.opensuse.org/openstack-staging.yaml
@@ -1,44 +1,12 @@
-- job:
-    name: 'openstack-staging'
-    project-type: matrix
+- project:
+    name: openstack-staging
+    disabled: false
+    release:
+      - Newton
+      - Pike
+      - Queens
+      - Rocky
+      - Master
+    jobs:
+      - 'openstack-staging-{release}'
 
-    triggers:
-      - timed: 'H 4 * * *'
-
-    logrotate:
-      numToKeep: -1
-      daysToKeep: 10
-
-    axes:
-      - axis:
-          type: user-defined
-          name: openstack_project
-          values:
-            - Newton
-            - Pike
-            - Queens
-            - Rocky
-            - Master
-      - axis:
-          type: slave
-          name: slave
-          values:
-            - openstack
-    execution-strategy:
-      sequential: true
-    builders:
-      - trigger-builds:
-        - project: openstack-prepare-staging
-          block: true
-          predefined-parameters:
-            openstack_project=${openstack_project}
-      - trigger-builds:
-        - project: openstack-cleanvm
-          block: true
-          predefined-parameters:
-            openstack_project=${openstack_project}
-      - trigger-builds:
-        - project: openstack-submit
-          condition: SUCCESS
-          predefined-parameters:
-            openstack_project=${openstack_project}

--- a/jenkins/ci.opensuse.org/templates/openstack-cleanvm-template.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-cleanvm-template.yaml
@@ -1,0 +1,26 @@
+- job-template:
+    name: 'openstack-cleanvm-{release}'
+    project-type: matrix
+    disabled: '{obj:disabled|False}'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 10
+
+    axes:
+      - axis:
+          type: user-defined
+          name: image
+          values: "{image}"
+      - axis:
+          type: slave
+          name: slave
+          values:
+            - cloud-cleanvm
+
+    builders:
+      - update-automation
+      - shell: |
+          export openstack_project={release}
+          export automationrepo=~/github.com/SUSE-Cloud/automation
+          exec ${{automationrepo}}/scripts/jenkins/cleanvm/openstack-cleanvm.builder.sh

--- a/jenkins/ci.opensuse.org/templates/openstack-staging-template.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-staging-template.yaml
@@ -1,0 +1,28 @@
+- job-template:
+    name: 'openstack-staging-{release}'
+    node: openstack
+    disabled: '{obj:disabled|False}'
+
+    triggers:
+      - timed: 'H 4 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 10
+
+    builders:
+      - trigger-builds:
+        - project: openstack-prepare-staging
+          block: true
+          predefined-parameters:
+            openstack_project={release}
+      - trigger-builds:
+        - project: openstack-cleanvm-{release}
+          block: true
+
+    publishers:
+      - trigger-parameterized-builds:
+        - project: openstack-submit
+          condition: SUCCESS
+          predefined-parameters:
+            openstack_project={release}

--- a/scripts/jenkins/cleanvm/openstack-cleanvm.builder.sh
+++ b/scripts/jenkins/cleanvm/openstack-cleanvm.builder.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
+# We need a workaround for the cleanvm job.
+# The job will run on a host with SLE11 installed.
+# There are no packages for ruby available to run jtsync.
+export jtsync_fix="ssh root@tu-sle12"
+
+# Workaround to get only the name of the job:
+# https://issues.jenkins-ci.org/browse/JENKINS-39189
+# When the JOB_BASE_NAME contains only in ex. "openstack-cleanvm", this
+# workaround can be removed.
+echo "$JOB_BASE_NAME"
+main_job_name=cleanvm
+
+function exec_jtsync {
+  # only enable jtsync when build is not manually triggered
+  if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
+    $jtsync_fix "$jtsync --ci opensuse --matrix $1,$2,$3 $4" || :
+  fi
+}
+
+sudo /usr/local/sbin/freshvm cleanvm $image
+sleep 100
+cloudsource=openstack$(echo $openstack_project | tr '[:upper:]' '[:lower:]')
+oshead=1
+set -u
+set +e
+scp ${automationrepo}/scripts/jenkins/qa_openstack.sh root@cleanvm:
+ssh root@cleanvm "export cloudsource=$cloudsource; export OSHEAD=$oshead; export NONINTERACTIVE=1; bash -x ~/qa_openstack.sh"
+ret=$?
+if [ "$ret" != 0 ] ; then
+  virsh shutdown cleanvm
+  # wait for clean shutdown
+  n=20 ; while [[ $n > 0 ]] && virsh list |grep cleanvm.*running ; do sleep 2 ; n=$(($n-1)) ; done
+  virsh destroy cleanvm
+  # cleanup old images
+  find /mnt/cleanvmbackup -mtime +5 -type f | xargs --no-run-if-empty rm
+  # backup /dev/vg0/cleanvm disk image
+  file=/mnt/cleanvmbackup/${BUILD_NUMBER}-${openstack_project}-${image}.raw.gz
+  time gzip -c1 /dev/vg0/cleanvm > $file
+  du $file
+  exec_jtsync ${main_job_name} ${openstack_project} ${BUILD_NUMBER} 1
+  exit 1
+fi
+
+exec_jtsync ${main_job_name} ${openstack_project} ${BUILD_NUMBER} $ret
+exit $ret


### PR DESCRIPTION
Refactor the `openstack-staging` and `openstack-cleanvm` matrix
jobs to make it easier to monitor and debug them:
 - replaces the `openstack-staging` matrix job with a set of
 regular jobs named `openstack-staging-<release>`, one for every
 supported OpenStack release
 - replaces the `openstack-cleanvm` matrix job with a set of
 matrix jobs named `openstack-cleanvm-<release>`, one for
 every supported OpenStack release. Every such job is configured
 to run only against the SLES or OpenSUSE distros that are
 applicable
 - moves the implementation of the `openstack-cleanvm` job to
 a script file stored in the automation repository instead of a JJB
 inline shell script
 - corrects the name of the job used for Trello reports

A preview for this new job organization for Queens is available [here](https://ci.opensuse.org/job/openstack-staging-Queens/).