### PR TITLE
[CCP] Add some needed variables to cloud-socok8s

### DIFF
--- a/scripts/socok8s/run.sh
+++ b/scripts/socok8s/run.sh
@@ -32,11 +32,14 @@ git --no-pager show | sed 's/^/|@| /'
 export PREFIX=socok8s-ci-${pr_id}-${sha1}
 export OS_CLOUD=engcloud-cloud-ci
 export KEYNAME=engcloud-cloud-ci
+export INTERNAL_SUBNET=ccpci-subnet
+export ANSIBLE_RUNNER_DIR="${HOME}/${PREFIX}-deploy"
 echo "Prefix set to ${PREFIX}"
+echo "ANSIBLE_RUNNER_DIR set to ${ANSIBLE_RUNNER_DIR}"
 ./run.sh
 ret=$?
 
 # cleanup
 popd
-rm -rf "$pr_dir"
+rm -rf "$pr_dir" "$ANSIBLE_RUNNER_DIR"
 exit "$ret"


### PR DESCRIPTION
We need to set the INTERNAL_SUBNET variable for the deploy to work,
and set a unique ANSIBLE_RUNNER_DIR for each job to prevent cross-test
environment pollution.