### PR TITLE
openstack-ardana: delete servers when heat stack delete fails

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/delete.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/delete.yml
@@ -23,10 +23,20 @@
         cloud: "{{ os_cloud }}"
         name: "{{ heat_stack_name }}"
         state: absent
-      register: stack_status
-      retries: 2
-      until: stack_status is success
-      delay: 2
+
+  rescue:
+    - name: Force delete servers from stack '{{ heat_stack_name }}'
+      shell: |
+         openstack --os-cloud {{ os_cloud }} stack resource list --filter \
+           type=OS::Nova::Server -f value -c physical_resource_id {{ heat_stack_name }} |\
+           awk '{print "openstack --os-cloud '{{ os_cloud }}' server \
+           delete --wait "$1 }' | sh -x || :
+
+    - name: Retry delete stack '{{ heat_stack_name }}'
+      os_stack:
+        cloud: "{{ os_cloud }}"
+        name: "{{ heat_stack_name }}"
+        state: absent
 
   always:
     - include_tasks: monitor.yml


### PR DESCRIPTION
The mapping of volumes on servers created by the ardana heat stacks does
not always reflect what openstack expects (e.g. attaching volume mapped
to /dev/vdb can get mapped to /dev/vdc) this cause issues
when deleting the heat stack as when deleting the attachment openstack
tries to delete /dev/vdb which does not exist, leaving heat stacks in
'Delete failed' state.

This change add a task to delete the servers created by the heat stack,
when the delete sack task fails, and then tries to delete the stack again.