### PR TITLE
openstack-ardana: set nova cpu_model for virtual deployments

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
@@ -20,6 +20,8 @@ ses_rgw_port: 8081
 
 ardana_extra_vars:
   nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"
+  nova_cpu_mode: custom
+  nova_cpu_model: Westmere
   keystone_wsgi_admin_process_count: 2
   keystone_wsgi_public_process_count: 6
   neutron_api_workers: 2


### PR DESCRIPTION
Running live migration tests on ardana deployments on ECP occasionally
fails due to CPU incompatibility (e.g. one compute is scheduled to a sandy
bridge host and another to a westmere host).

This change sets the cpu model to Westmere on the deployed ardana computes,
making sure that it always possible to do livre migration on the
deployed ardana cloud.