### PR TITLE
jenkins: Remove Cloud 6 to Cloud 7 Upgrade Jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -26,7 +26,6 @@
         - 'cloud-mkcloud{version}-job-monasca-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'
         - 'cloud-mkcloud{version}-job-ssl-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-disruptive-{arch}'
         - 'cloud-mkcloud{version}-job-xen-{arch}'
 - project:
     name: cloud-mkcloud7-ha-x86_64
@@ -50,13 +49,6 @@
         - 'cloud-mkcloud{version}-job-ha-ironic-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-agent-{arch}'
         - 'cloud-mkcloud{version}-job-ha-vproduction-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-disruptive-ha-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-ceph-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-ceph-compute_ha-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-dvr-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-lbaasv2-{arch}'
-        - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
 - project:
     name: cloud-mkcloud7-tempestfull-x86_64
     disabled: false


### PR DESCRIPTION
Cloud 6 is EOL since quite some time and therefore we can safly remove
the Cloud 6 to Cloud 7 upgrade jobs.