### PR TITLE
openstack-crowbar: support for HA deployments (SCRD-8462)

### DIFF
--- a/scripts/jenkins/ardana/ansible/_create-vcloud-inventory.yml
+++ b/scripts/jenkins/ardana/ansible/_create-vcloud-inventory.yml
@@ -17,8 +17,6 @@
         ansible_host: "{{ item.1 }}"
         ansible_password: "linux"
         group: "{{ item.0.group }}, cloud_virt_hosts"
-        cloud_node_role: "{{ item.0.group }}"
-        cloud_node_alias: "{{ virtual_node_group_aliases[item.0.group] | default(item.0.group) }}{{ (item.0.ips | length > 1) | ternary(item.0.ips.index(item.1) + 1, '') }}"
       loop: "{{ virtual_hosts | subelements('ips') }}"
       loop_control:
         label: "{{ item.0.group }}{{ item.0.ips.index(item.1) + 1 }} - {{ item.1 }}"

--- a/scripts/jenkins/ardana/ansible/bootstrap-crowbar-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-crowbar-nodes.yml
@@ -19,6 +19,7 @@
 
 - name: Bootstrap crowbar cloud nodes
   hosts: cloud_virt_hosts
+  any_errors_fatal: true
   remote_user: root
   # NOTE: don't gather facts before nodes become accessible
   gather_facts: false

--- a/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-vcloud-nodes.yml
@@ -64,6 +64,7 @@
 
 - name: Bootstrap other virtual nodes for ardana
   hosts: cloud_virt_hosts
+  any_errors_fatal: true
   remote_user: root
   # NOTE: don't gather facts before nodes become accessible
   gather_facts: false

--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -49,10 +49,3 @@ heat_stack_output_queries:
    stdout: "{{ heat_stack_output | default([]) | selectattr('output_key', 'equalto', 'controller-conf-ips') | map(attribute='output_value') | list | flatten }}"
  - item: "compute-conf-ips"
    stdout: "{{ heat_stack_output | default([]) | selectattr('output_key', 'equalto', 'compute-conf-ips') | map(attribute='output_value') | list | flatten }}"
-
-virtual_node_group_aliases:
-  controller: 'controller'
-  # need to use different group aliases, because Crowbar uses 'compute-kvm'
-  # instead of 'compute' in the crowbar batch scenario files used by the gating jobs
-  # FIXME: control this from the generated scenario instead
-  compute: "{{ (cloud_product == 'ardana') | ternary('compute', 'compute-kvm') }}"

--- a/scripts/jenkins/ardana/ansible/register-crowbar-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/register-crowbar-nodes.yml
@@ -22,8 +22,10 @@
           vars:
             qa_crowbarsetup_cmd: "onadmin_{{ command }}"
           loop:
+            - allocate
             - waitcloud
             - post_allocate
+            - setup_aliases
           loop_control:
             loop_var: command
 

--- a/scripts/jenkins/ardana/ansible/register-crowbar-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/register-crowbar-nodes.yml
@@ -4,6 +4,7 @@
 
 - name: Register crowbar cloud nodes
   hosts: cloud_virt_hosts
+  any_errors_fatal: true
   remote_user: root
   gather_facts: True
   vars:

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_register/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_register/tasks/main.yml
@@ -52,18 +52,16 @@
   delegate_to: "{{ ardana_env }}"
   shell: knife node list | tr -d ' '
   register: _register_tmp
-  failed_when: "_register_tmp.rc != 0 or crowbar_node_name not in _register_tmp.stdout_lines"
+  # The more nodes we have, the longer this will take
+  retries: "{{ 2 * ( groups['cloud_virt_hosts'] | length ) }}"
+  until: _register_tmp.rc == 0 and crowbar_node_name in _register_tmp.stdout_lines
+  delay: 10
 
 - name: Check that node is ready
   delegate_to: "{{ ardana_env }}"
   shell: "knife node show -a state {{ crowbar_node_name }} | awk '{ print $2 }'"
   register: _register_tmp
-  failed_when: "_register_tmp.rc != 0 or _register_tmp.stdout != 'ready'"
-
-- name: Set node alias and role
-  shell: |
-    . {{ admin_scripts_path }}/qa_crowbarsetup.sh
-    set_node_alias_and_role {{ crowbar_node_name }} {{ cloud_node_alias }} {{ cloud_node_role }}
-  args:
-    executable: "/bin/bash"
-  delegate_to: "{{ ardana_env }}"
+  # The more nodes we have, the longer this will take
+  retries: "{{ 2 * ( groups['cloud_virt_hosts'] | length ) }}"
+  until: _register_tmp.rc == 0 and _register_tmp.stdout == 'ready'
+  delay: 10

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_register/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_register/tasks/main.yml
@@ -4,6 +4,22 @@
   set_fact:
     crowbar_node_name: "d{{ hostvars[inventory_hostname]['ansible_%s' | format(admin_interface)].macaddress | replace(':', '-') }}.{{ cloud_fqdn }}"
 
+- name: Create crowbar node list properly sorted
+  set_fact:
+    crowbar_node_list: "{{ crowbar_node_list | default('crowbar.' + cloud_fqdn) }} {{ hostvars[item]['crowbar_node_name'] }}"
+  loop: "{{ groups['cloud_virt_hosts'] }}"
+  delegate_to: "{{ ardana_env }}"
+  run_once: true
+
+- name: Fill in custom crowbar node list in mkcloud.conf
+  lineinfile:
+    dest: "{{ admin_mkcloud_config_file }}"
+    regexp: "^export custom_crowbar_node_order"
+    line: "export custom_crowbar_node_order='{{ crowbar_node_list }}'"
+    state: present
+  delegate_to: "{{ ardana_env }}"
+  run_once: true
+
 - name: Reserve node admin IP addresses in Crowbar
   include_tasks: reserve_admin_ip.yml
 

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_register/tasks/reserve_admin_ip.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_register/tasks/reserve_admin_ip.yml
@@ -25,6 +25,8 @@
       {%- set _ret = admin_network_databag -%}
       {%- set _entry = { hostvars[item]['crowbar_node_name']: hostvars[item]['admin_network_databag_entry'] } -%}
       {%- set _ = admin_network_databag['allocated_by_name'].update( _entry ) -%}
+      {%- set _entry = { hostvars[item]['ansible_host']: hostvars[item]['admin_network_databag_entry'] } -%}
+      {%- set _ = admin_network_databag['allocated'].update( _entry ) -%}
       {{ _ret }}
   loop: "{{ groups['cloud_virt_hosts'] }}"
   run_once: true

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_setup/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_setup/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Run the supplied qa_crowbarsetup.sh command on the admin node
+- name: Run 'qa_crowbarsetup.sh {{ qa_crowbarsetup_cmd }}' on the admin node
   shell: |
     . {{ admin_scripts_path }}/qa_crowbarsetup.sh
     {{ qa_crowbarsetup_cmd }} 2>&1 | tee -a {{ qa_crowbarsetup_log }}
@@ -9,4 +9,5 @@
     executable: "/bin/bash"
   delegate_to: "{{ ardana_env }}"
   register: _qa_crowbarsetup_result
+  run_once: true
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/mkcloud.config.j2
@@ -92,6 +92,12 @@ export nodenumber={{ controllers | int + computes | int }}
 # export clusterconfig=
 # export ironicnetmask=
 
+# Use this to override the crowbar node list order in qa_crowbarsetup.sh
+export custom_crowbar_node_order=
+
+export want_node_roles=controller={{ controllers | int }},compute={{ computes | int }}
+export want_node_aliases=controller={{ controllers | int }},compute-kvm={{ computes | int }}
+
 export want_test_updates={{ updates_test_enabled | ternary (1, 0) }}
 export want_swift=1
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/mkcloud.config.j2
@@ -32,7 +32,10 @@ export cloudsource={{ cloudsource }}
 
 # export mkclouddriver=
 # export adminip=
-# export hacloud=
+{% if controllers | int > 1 %}
+export hacloud=1
+export want_sbd=1
+{% endif %}
 export libvirt_type=physical
 # export firmware_type=
 # export networkingplugin=
@@ -89,7 +92,9 @@ export UPDATEREPOS={{ extra_repos.split(',') | join('+') }}
 export nodenumber={{ controllers | int + computes | int }}
 # export nodenumberlonelynode=
 # export nodenumberironicnode=
-# export clusterconfig=
+{% if controllers | int > 1 %}
+export clusterconfig="services+data+network={{ controllers | int }}"
+{% endif %}
 # export ironicnetmask=
 
 # Use this to override the crowbar node list order in qa_crowbarsetup.sh

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1775,7 +1775,7 @@ function onadmin_post_allocate
         done
 
         if [[ $want_sbd = 1 ]] ; then
-            $zypper -p http://download.opensuse.org/repositories/devel:/languages:/python/$slesdist/ install python-sh
+            $zypper -p http://download.opensuse.org/repositories/devel:/languages:/python:/backports/$slesdist/ install python-sh
             chmod +x $SCRIPTS_DIR/iscsictl.py
             $SCRIPTS_DIR/iscsictl.py --service target --host $(hostname) --no-key
 
@@ -3305,6 +3305,12 @@ function set_node_alias
     fi
 }
 
+function get_node_alias
+{
+    local node_name=$1
+    safely crowbarctl node list --plain | grep $node_name | cut -d " " -f 2
+}
+
 function set_node_alias_and_role
 {
     local node_name=$1
@@ -3688,7 +3694,7 @@ function oncontroller_run_integration_test()
     safely $zypper in 'MozillaFirefox<47'
 
     # Add Devel:Languages:Python repo (no GPG checks) to install Selenium
-    local dlp="http://download.opensuse.org/repositories/devel:/languages:/python/$slesdist/"
+    local dlp="http://download.opensuse.org/repositories/devel:/languages:/python:/backports/$slesdist/"
     $zypper ar --no-gpgcheck --refresh $dlp python
     safely $zypper in python-selenium
     safely $zypper in python-nose
@@ -5734,6 +5740,25 @@ function onadmin_install_ca_certificates
 function onadmin_batch
 {
     pre_hook $FUNCNAME
+
+    if [[ $hacloud = 1 ]] ; then
+        onadmin_set_source_variables
+        cluster_node_assignment
+
+        if [[ $want_sbd = 1 ]] ; then
+            local cluster
+            local clustername
+            local nodealias
+            for clustername in data network services ; do
+                eval "cluster=\$clusternodes$clustername"
+                for node in $cluster ; do
+                    nodealias=$(get_node_alias $node)
+                    sbd_device=$(ssh $node echo '/dev/disk/by-id/scsi-$(lsscsi -i |grep LIO|head -n 1| tr -s " " |cut -d " " -f7)')
+                    sed -i "s|##sbd_device_${clustername}_${nodealias}##|${sbd_device}|g" ${scenario}
+                done
+            done
+        fi
+    fi
 
     sed -i "s/##hypervisor_ip##/$admingw/g" ${scenario}
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -387,7 +387,15 @@ function get_disk_id_by_serial_and_libvirt_type
 
 function get_all_nodes
 {
-    safely crowbarctl node list --no-meta --plain | LC_ALL=C sort
+    crowbar_node_list=$(safely crowbarctl node list --no-meta --plain | LC_ALL=C sort)
+    if [ -n "$custom_crowbar_node_order" ]; then
+        # return only the nodes that are registered
+        for onenode in $custom_crowbar_node_order ; do
+            printf "%s\n" ${crowbar_node_list[@]} | grep $onenode
+        done
+    else
+        printf "%s\n" ${crowbar_node_list[@]}
+    fi
 }
 
 function get_all_suse_nodes

--- a/scripts/scenarios/cloud8/cloud8-5nodes-default.yml
+++ b/scripts/scenarios/cloud8/cloud8-5nodes-default.yml
@@ -1,0 +1,226 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          @@controller1@@:
+            devices:
+            - "##sbd_device_services_controller1##"
+          @@controller2@@:
+            devices:
+            - "@@sbd_device_services_controller2##"
+          @@controller3@@:
+            devices:
+            - "##sbd_device_services_controller3##"
+        watchdog_module: softdog
+      per_node:
+        nodes:
+          @@controller1@@:
+            params: ''
+          @@controller2@@:
+            params: ''
+          @@controller3@@:
+            params: ''
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - @@controller1@@
+      - @@controller2@@
+      - @@controller3@@
+      hawk-server:
+      - @@controller1@@
+      - @@controller2@@
+      - @@controller3@@
+- barclamp: database
+  attributes:
+    sql_engine: mysql
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+- barclamp: rabbitmq
+  attributes:
+    client:
+      enable_notifications: true
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+- barclamp: keystone
+  attributes:
+    api:
+      region: 'CustomRegion'
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+- barclamp: swift
+  attributes:
+    zones: 1
+    replicas: 2
+    keystone_delay_auth_decision: true
+    allow_versions: true
+    middlewares:
+      crossdomain:
+        enabled: true
+      formpost:
+        enabled: true
+      staticweb:
+        enabled: true
+      tempurl:
+        enabled: true
+  deployment:
+    elements:
+      swift-dispersion: []
+      swift-proxy:
+      - cluster:services
+      swift-ring-compute:
+      - @@controller1@@
+      swift-storage:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: glance
+  attributes:
+    default_store: swift
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: local
+      backend_name: default
+      local:
+        volume_name: cinder-volumes
+        file_name: "/var/lib/cinder/volume.raw"
+        file_size: 2000
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: neutron
+  attributes:
+    ml2_type_drivers:
+    - gre
+    - vxlan
+    - vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    kvm:
+      ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
+  deployment:
+    elements:
+      ec2-api:
+      - cluster:services
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - @@compute-kvm1@@
+      - @@compute-kvm2@@
+      nova-compute-qemu: []
+      nova-compute-xen: []
+- barclamp: horizon
+  attributes:
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+- barclamp: heat
+  attributes:
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+- barclamp: barbican
+  deployment:
+    elements:
+      barbican-controller:
+      - cluster:services
+- barclamp: ceilometer
+  attributes:
+  deployment:
+    elements:
+      ceilometer-agent:
+      - @@compute-kvm1@@
+      - @@compute-kvm2@@
+      ceilometer-agent-hyperv: []
+      ceilometer-central:
+      - cluster:services
+      ceilometer-server:
+      - cluster:services
+      ceilometer-swift-proxy-middleware:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: aodh
+  attributes:
+  deployment:
+    elements:
+      aodh-server:
+      - cluster:services
+- barclamp: manila
+  attributes:
+    default_share_type: default
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: ##tenant_net_name_or_ip##
+        service_instance_password: linux
+        share_volume_fstype: ext3
+        path_to_private_key: ""
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: trove
+  attributes:
+  deployment:
+    elements:
+      trove-server:
+      - @@controller1@@
+- barclamp: magnum
+  attributes:
+    cert:
+      cert_manager_type: barbican
+  deployment:
+    elements:
+      magnum-server:
+      - cluster:services
+- barclamp: sahara
+  attributes:
+  deployment:
+    elements:
+      sahara-server:
+      - cluster:services
+- barclamp: tempest
+  attributes:
+  deployment:
+    elements:
+      tempest:
+      - @@controller1@@

--- a/scripts/scenarios/cloud9/cloud9-5nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-5nodes-default.yml
@@ -1,0 +1,201 @@
+---
+proposals:
+- barclamp: pacemaker
+  name: services
+  attributes:
+    stonith:
+      mode: sbd
+      sbd:
+        nodes:
+          @@controller1@@:
+            devices:
+            - "##sbd_device_services_controller1##"
+          @@controller2@@:
+            devices:
+            - "##sbd_device_services_controller2##"
+          @@controller3@@:
+            devices:
+            - "##sbd_device_services_controller3##"
+        watchdog_module: softdog
+      per_node:
+        nodes:
+          @@controller1@@:
+            params: ''
+          @@controller2@@:
+            params: ''
+          @@controller3@@:
+            params: ''
+  deployment:
+    elements:
+      pacemaker-cluster-member:
+      - @@controller1@@
+      - @@controller2@@
+      - @@controller3@@
+      hawk-server:
+      - @@controller1@@
+      - @@controller2@@
+      - @@controller3@@
+- barclamp: database
+  attributes:
+    sql_engine: mysql
+  deployment:
+    elements:
+      database-server:
+      - cluster:services
+- barclamp: rabbitmq
+  attributes:
+    client:
+      enable_notifications: true
+  deployment:
+    elements:
+      rabbitmq-server:
+      - cluster:services
+- barclamp: keystone
+  attributes:
+    api:
+      region: 'CustomRegion'
+  deployment:
+    elements:
+      keystone-server:
+      - cluster:services
+- barclamp: swift
+  attributes:
+    zones: 1
+    replicas: 2
+    keystone_delay_auth_decision: true
+    allow_versions: true
+    middlewares:
+      crossdomain:
+        enabled: true
+      formpost:
+        enabled: true
+      staticweb:
+        enabled: true
+      tempurl:
+        enabled: true
+  deployment:
+    elements:
+      swift-dispersion: []
+      swift-proxy:
+      - cluster:services
+      swift-ring-compute:
+      - @@controller1@@
+      swift-storage:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: glance
+  attributes:
+    default_store: swift
+  deployment:
+    elements:
+      glance-server:
+      - cluster:services
+- barclamp: cinder
+  attributes:
+    volumes:
+    - backend_driver: local
+      backend_name: default
+      local:
+        volume_name: cinder-volumes
+        file_name: "/var/lib/cinder/volume.raw"
+        file_size: 2000
+  deployment:
+    elements:
+      cinder-controller:
+      - cluster:services
+      cinder-volume:
+      - @@controller1@@
+      - @@controller2@@
+      - @@controller3@@
+
+- barclamp: neutron
+  attributes:
+    ml2_type_drivers:
+    - gre
+    - vxlan
+    - vlan
+  deployment:
+    elements:
+      neutron-server:
+      - cluster:services
+      neutron-network:
+      - cluster:services
+- barclamp: nova
+  attributes:
+    itxt_instance: ''
+    use_migration: true
+    kvm:
+      ksm_enabled: true
+    metadata:
+      vendordata:
+        json: '{"custom-key": "custom-value"}'
+  deployment:
+    elements:
+      ec2-api:
+      - cluster:services
+      nova-controller:
+      - cluster:services
+      nova-compute-hyperv: []
+      nova-compute-kvm:
+      - @@compute-kvm1@@
+      - @@compute-kvm2@@
+      nova-compute-qemu: []
+      nova-compute-xen: []
+- barclamp: horizon
+  attributes:
+  deployment:
+    elements:
+      horizon-server:
+      - cluster:services
+- barclamp: heat
+  attributes:
+  deployment:
+    elements:
+      heat-server:
+      - cluster:services
+- barclamp: barbican
+  deployment:
+    elements:
+      barbican-controller:
+      - cluster:services
+- barclamp: manila
+  attributes:
+    default_share_type: default
+    shares:
+    - backend_driver: generic
+      backend_name: backend1
+      generic:
+        service_instance_user: root
+        service_instance_name_or_id: ##manila_instance_name_or_id##
+        service_net_name_or_ip: ##service_net_name_or_ip##
+        tenant_net_name_or_ip: ##tenant_net_name_or_ip##
+        service_instance_password: linux
+        share_volume_fstype: ext3
+        path_to_private_key: ""
+  deployment:
+    elements:
+      manila-server:
+      - cluster:services
+      manila-share:
+      - @@controller1@@
+      - @@controller2@@
+- barclamp: magnum
+  attributes:
+    cert:
+      cert_manager_type: barbican
+  deployment:
+    elements:
+      magnum-server:
+      - cluster:services
+- barclamp: sahara
+  attributes:
+  deployment:
+    elements:
+      sahara-server:
+      - cluster:services
+- barclamp: tempest
+  attributes:
+  deployment:
+    elements:
+      tempest:
+      - @@controller1@@


### PR DESCRIPTION
Add support for HA deployments to the `openstack-crowbar` core job:
 - set the `hacloud`, `clusterconfig` and `want_sbd` variables in
 the generated mkcloud.conf when two or more controllers are configured
 - fix the `want_sbd` logic in `qa_crowbarsetup.sh`:
   - fix repository URL for `python-sh`
   - add logic to the `onadmin_batch` function to fill in the SBD
   device info in the batch scenario files
 - update the `cloud{8|9}-5nodes-compute-ha.yml` files to use SBD and
 reflect the `openstack-crowbar` generated environments (e.g node
 aliases, no support for NFS shared storage yet)

The node ordering that `qa_crowbarsetup.sh` uses to determine
which nodes are controllers, which are computes etc. is not
deterministic, because it's based on sorting the hostnames of the
nodes, which are generated based on the MAC address of their
admin interface. 
This PR also solves the node ordering problem by implementing a
new `custom_crowbar_node_order` environment variable, which can
be used to override the order of nodes that `qa_crowbarsetup.sh` uses.
This variable is then set in the Crowbar ECP CI so that it corresponds
to the node list in the generated heat stack.

With the correct node order in place, the Crowbar ECP CI no longer
needs to explicitly set up the roles and aliases. It can rely on the
`qa_crowbarsetup.sh` logic, same as mkcloud.

This PR also includes a few other minor fixes and improvements
required to get HA cloud configurations to deploy successfully:
 - fix for the cloud node address reservation: the admin address
 reservation logic that adds the address mappings in the crowbar
 `admin_network` databag needs to update both `allocated` and
 `allocated_by_name` maps, otherwise the VIP allocation logic will
 choose an address that conflicts with one of the cloud nodes
 - wait more for nodes to register: having more cloud nodes means
 it takes more time to register them
 - exit early in case of failures while registering cloud nodes, to
 make debugging easier
 - run `qa_crowbarsetup` commands only once when targeting
 multiple ansible hosts
 
NOTE: deploying HA Crowbar setups in the ECP also requires [this crowbar-ha](https://github.com/crowbar/crowbar-ha/pull/353) bug fix.