### PR TITLE
Update LBaaS deployment from Cloud9

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -41,6 +41,10 @@ versioned_features:
     enabled: "{{ when_cloud8 }}"
   manila-share:
     enabled: "{{ when_cloud8 }}"
+  neutron-lbaasv2-agent:
+    enabled: "{{ when_cloud8 }}"
+  octavia-client:
+    enabled: "{{ when_cloud9 }}"
 
 input_model_versioned_features:
   - manila
@@ -50,3 +54,5 @@ input_model_versioned_features:
   - ceilometer-api
   - glance-registry
   - manila-share
+  - neutron-lbaasv2-agent
+  - octavia-client

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -83,6 +83,7 @@ service_component_groups:
     - nova-client
     - swift-client
     - manila-client
+    - octavia-client
   CORE:
     - ntp-server
     - ip-cluster


### PR DESCRIPTION
For Cloud-9, add octavia-client and  remove the deprecated
neutron-lbaasv2-agent.