### PR TITLE
openstack-ardana: configure env for specific tempest filters (SCRD-7496)

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/defaults/main.yml
@@ -19,6 +19,7 @@ ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
 
 tempest_run_filter: smoke
 tempest_retry_failed: False
+tempest_run_concurrency: 4
 tempest_results_log: "/opt/stack/tempest/logs/testr_results_region1.log"
 tempest_results_subunit: "/opt/stack/tempest/logs/testrepository_region1.subunit"
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/main.yml
@@ -18,10 +18,18 @@
 - include_tasks: pre_defcore.yml
   when: tempest_run_filter == 'defcore'
 
+- include_tasks: reconfigure_neutron.yml
+  vars:
+    extra_vars: "-e router_distributed=False"
+  when: tempest_run_filter in ['vpnaas', 'fwaas']
+
 - include_tasks: import_octavia_image.yml
-  when: tempest_run_filter == 'lbaas'
+  when: tempest_run_filter in ['lbaas', 'heat']
 
 - include_tasks: run_tempest.yml
+
+- include_tasks: reconfigure_neutron.yml
+  when: tempest_run_filter in ['vpnaas', 'fwaas']
 
 - include_tasks: post_defcore.yml
   when: tempest_run_filter == 'defcore'

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
@@ -1,0 +1,22 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Run neutron-reconfigure
+  shell: |
+    ansible-playbook neutron-reconfigure.yml {{ extra_vars | default('') }}
+  args:
+    chdir: "{{ ardana_scratch_path }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/run_tempest.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/run_tempest.yml
@@ -16,6 +16,13 @@
 ---
 
 - block:
+    - name: Set number of tempest workers to '{{ tempest_run_concurrency }}'
+      lineinfile:
+        path: "/opt/stack/tempest/bin/ardana-tempest.sh"
+        regexp: "^run_concurrency="
+        line: "run_concurrency={{ tempest_run_concurrency }}"
+      become: yes
+
     - name: Drop QE run filters
       copy:
         src: "{{ item }}.txt.j2"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/run_tempest.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/run_tempest.yml
@@ -34,6 +34,14 @@
       with_items: "{{ tempest_qe_run_filters }}"
       when: tempest_run_filter in tempest_qe_run_filters
 
+    - name: Create cert symlink required by Freezer tempest
+      file:
+        src: "/etc/ssl/ca-bundle.pem"
+        dest: "/etc/ssl/certs/ca-certificates.crt"
+        state: link
+      become: yes
+      when: tempest_run_filter == 'freezer'
+
     - name: Ensure subunit tools venv exists
       pip:
         name: "{{ item }}"


### PR DESCRIPTION
This change adds some steps for configuring the environment according to the requirements for running tempest for specific services. It also sets the number of tempest workers to 4 to keep the results in line when comparing tempest results from different environments.