### PR TITLE
openstack-ardana: install package updates serially

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/main.yml
@@ -15,6 +15,18 @@
 #
 ---
 
+- name: Get list of non-deployer nodes
+  shell: |
+    deployer=`grep -A 1 ARD-SVC--first-member hosts/verb_hosts | tail -1`
+    for line in $(awk '/resources/' RS= hosts/verb_hosts); do
+      if [[ $deployer != *$line* ]]; then
+        echo $line
+      fi
+    done
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  register: ardana_nodes
+
 - include_tasks: add_mu_repos.yml
   when: maint_updates_list | length
 

--- a/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/reboot_nodes.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/reboot_nodes.yml
@@ -32,19 +32,7 @@
   args:
     chdir: "{{ ardana_scratch_path }}"
 
-- name: Get list of remaining nodes to reboot
-  shell: |
-    deployer=`grep -A 1 ARD-SVC--first-member hosts/verb_hosts | tail -1`
-    for line in $(awk '/resources/' RS= hosts/verb_hosts); do
-      if [[ $deployer != *$line* ]]; then
-        echo $line
-      fi
-    done
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  register: ardana_nodes
-
-- name: Reboot remaining nodes serially
+- name: Reboot non-deployer nodes serially
   command: |
     ansible-playbook ardana-reboot.yml --limit {{ item }}
   args:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/update_nodes.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/update_nodes.yml
@@ -41,10 +41,10 @@
   include_tasks: _update-clm.yml
   when: _clm_pkg_updates is changed
 
-- name: Run ardana-update-pkgs playbook for all nodes except deployer
+- name: Run ardana-update-pkgs playbook for non-deployer nodes serially
   shell: |
     ansible-playbook ardana-update-pkgs.yml \
-      -l 'resources:!ARD-SVC--first-member' -e \
+      --limit {{ item }} -e \
       "zypper_update_method={{ update_method }}
        zypper_update_gpg_checks={{ update_gpg_checks }}
        zypper_update_licenses_agree={{ update_gpg_checks }}
@@ -54,6 +54,7 @@
   environment:
     SKIP_REPO_CHECKS: 1
     SKIP_SINGLE_HOST_CHECKS: 1
+  loop: "{{ ardana_nodes.stdout_lines }}"
 
 - name: Get update status
   shell: |


### PR DESCRIPTION
Installing package updates in parallel on all nodes has the
undesired effect that it breaks the galera cluster.

This change was tested twice:
 - with manila enabled (which is now failing the update job): https://ci.suse.de/blue/organizations/jenkins/cloud-ardana8-job-std-3cp-devel-staging-updates-x86_64/detail/cloud-ardana8-job-std-3cp-devel-staging-updates-x86_64/305/pipeline
 - with manila disabled: https://ci.suse.de/blue/organizations/jenkins/cloud-ardana8-job-std-3cp-devel-staging-updates-x86_64/detail/cloud-ardana8-job-std-3cp-devel-staging-updates-x86_64/315/tests/


