### PR TITLE
openstack-ardana: re-add Octavia to demo jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -104,7 +104,7 @@
     clm_model: integrated
     controllers: '1'
     sles_computes: '1'
-    disabled_services: 'monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer|octavia'
+    disabled_services: 'monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer'
     ses_enabled: true
     ses_rgw_enabled: false
     triggers:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -88,7 +88,7 @@
     clm_model: integrated
     controllers: '1'
     sles_computes: '1'
-    disabled_services: 'monasca|logging|ceilometer|cassandra|kafka|spark|storm|octavia'
+    disabled_services: 'monasca|logging|ceilometer|cassandra|kafka|spark|storm'
     ses_enabled: true
     ses_rgw_enabled: false
     triggers:


### PR DESCRIPTION
The tight coupling between Octavia and Monasca has been corrected [1][2],
so we can re-add that service to the `demo` jobs (i.e. the jobs
that have MML services disabled).

[1] https://gerrit.suse.provo.cloud/#/c/5905/
[2] https://gerrit.suse.provo.cloud/#/c/5909/