### PR TITLE
glance: Use Swift in glance if ironic is deployed

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2548,6 +2548,9 @@ function custom_configuration
                 fi
                 proposal_set_value glance default "['deployment']['glance']['elements']['glance-server']" "['cluster:$clusternameservices']"
             fi
+            if [[ $want_ironic = 1 && $deployswift ]]; then
+                proposal_set_value glance default "['attributes']['glance']['default_store']" "'swift'"
+            fi
         ;;
         manila)
             if [[ $hacloud = 1 ]] ; then


### PR DESCRIPTION
If Ironic is deployed with Swift, it will try to use all features
using Swift (e.g. agent based deployment). This requires glance to
use Swift as default image store.