### PR TITLE
Add Cloud:OpenStack:Stein

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -39,6 +39,16 @@
       - 'openstack-cleanvm-{release}'
 
 - project:
+    name: openstack-cleanvm-Stein
+    disabled: false
+    release: Stein
+    image:
+      - SLE_15
+      - openSUSE-Leap-15.0
+    jobs:
+      - 'openstack-cleanvm-{release}'
+
+- project:
     name: openstack-cleanvm-Master
     disabled: false
     release: Master

--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -22,6 +22,8 @@
             - Cloud:OpenStack:Queens:Staging
             - Cloud:OpenStack:Rocky
             - Cloud:OpenStack:Rocky:Staging
+            - Cloud:OpenStack:Stein
+            - Cloud:OpenStack:Stein:Staging
             - Cloud:OpenStack:Master
             - Cloud:Tools
       - axis:
@@ -47,7 +49,8 @@
          ["Cloud:OpenStack:Newton", "Cloud:OpenStack:Newton:Staging"].contains(project) && ["openSUSE_Leap_42.3", "openSUSE_Leap_15.0", "SLE_12_SP4", "SLE_15"].contains(repository) ||
          ["Cloud:OpenStack:Pike", "Cloud:OpenStack:Pike:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4", "SLE_15"].contains(repository) ||
          ["Cloud:OpenStack:Queens", "Cloud:OpenStack:Queens:Staging"].contains(project) && ["openSUSE_Leap_15.0", "SLE_12_SP2", "SLE_12_SP4", "SLE_15"].contains(repository) ||
-         ["Cloud:OpenStack:Rocky", "Cloud:OpenStack:Rocky:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3", "SLE_15"].contains(repository)
+         ["Cloud:OpenStack:Rocky", "Cloud:OpenStack:Rocky:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3", "SLE_15"].contains(repository) ||
+         ["Cloud:OpenStack:Stein", "Cloud:OpenStack:Stein:Staging"].contains(project) && ["SLE_12_SP2", "SLE_12_SP3", "SLE_12_SP4", "openSUSE_Leap_42.3"].contains(repository)
        )
       sequential: true
     builders:

--- a/jenkins/ci.opensuse.org/openstack-staging.yaml
+++ b/jenkins/ci.opensuse.org/openstack-staging.yaml
@@ -6,6 +6,7 @@
       - Pike
       - Queens
       - Rocky
+      - Stein
       - Master
     jobs:
       - 'openstack-staging-{release}'

--- a/jenkins/ci.opensuse.org/openstack-submit.yaml
+++ b/jenkins/ci.opensuse.org/openstack-submit.yaml
@@ -42,6 +42,9 @@
             Cloud:OpenStack:[R]*)
               OSCBUILDDIST=SLE_12_SP4
             ;;
+            Cloud:OpenStack:[S]*)
+              OSCBUILDDIST=SLE_15
+            ;;
             *) echo "Please add support for the project: $openstack_project"
               exit 1
             ;;


### PR DESCRIPTION
trackupstream is left out on purpose as we haven't branched
the packaging yet.