### PR TITLE
openstack-ardana: override OpenStack service worker count (SCRD-7496)

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -33,6 +33,8 @@ ses_rgw_enabled: False
 ardana_ses_integration_version: 2
 cinder_lvm_enabled: '{{ not ses_enabled }}'
 
+ardana_nova_migrate_enabled: True
+
 workspace_path: "{{ lookup('env', 'WORKSPACE') | default(playbook_dir, true) }}"
 input_model_path: "{{ workspace_path }}/input_model"
 

--- a/scripts/jenkins/ardana/ansible/group_vars/qe_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/qe_all.yml
@@ -16,3 +16,6 @@
 ---
 
 ses_cluster_id: "qe"
+
+ardana_extra_vars:
+  nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"

--- a/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
@@ -17,3 +17,6 @@
 
 ses_cluster_id: "virt"
 ses_rgw_port: 8081
+
+ardana_extra_vars:
+  nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"

--- a/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
@@ -20,3 +20,16 @@ ses_rgw_port: 8081
 
 ardana_extra_vars:
   nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"
+  keystone_wsgi_admin_process_count: 2
+  keystone_wsgi_public_process_count: 6
+  neutron_api_workers: 2
+  neutron_rpc_workers: 1
+  neutron_metadata_workers: 2
+  barbican_api_max_worker_count: 2
+  nova_api_workers: 2
+  nova_metadata_workers: 2
+  nova_conductor_workers: 2
+  osapi_volume_worker_count: 2
+  swift_worker_count: 2
+  num_engine_worker_count: 2
+  glance_worker_count: 2

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/defaults/main.yml
@@ -15,8 +15,6 @@
 #
 ---
 
-ardana_nova_migrate_enabled: True
-
 ardana_openstack_path: "~/openstack/ardana/ansible"
 ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
 
@@ -27,8 +25,8 @@ ardana_openstack_playbooks:
 ardana_scratch_playbooks:
   - play: "wipe_disks.yml -e automate=true"
     when: "{{ is_physical_deploy }}"
-  - play: "site.yml -e nova_migrate_enabled={{ ardana_nova_migrate_enabled }}"
-  - play: "ardana-cloud-configure.yml"
+  - play: "site.yml -e '{{ ardana_extra_vars|to_json }}'"
+  - play: "ardana-cloud-configure.yml -e '{{ ardana_extra_vars|to_json }}'"
 
 ardana_third_party_playbooks:
   - "third-party-deploy.yml"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/import_octavia_image.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/import_octavia_image.yml
@@ -22,7 +22,8 @@
 - name: Import octavia amphora image
   shell: |
     ansible-playbook -i hosts/verb_hosts service-guest-image.yml \
-                 -e service_package=`{{ octavia_amphora_image_rpm }}`
+                 -e service_package=`{{ octavia_amphora_image_rpm }}` \
+                 -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
   when: octavia_amphora_image_is_present.stdout == ""

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
@@ -17,6 +17,7 @@
 
 - name: Run neutron-reconfigure
   shell: |
-    ansible-playbook neutron-reconfigure.yml {{ extra_vars | default('') }}
+    ansible-playbook neutron-reconfigure.yml {{ extra_vars | default('') }} \
+      -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/reboot_nodes.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/reboot_nodes.yml
@@ -28,19 +28,19 @@
 
 - name: Run post-reboot playbook on deployer
   command: |
-    ansible-playbook _ardana-post-reboot.yml --limit ARD-SVC--first-member
+    ansible-playbook _ardana-post-reboot.yml --limit ARD-SVC--first-member  -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
 
 - name: Reboot non-deployer nodes serially
   command: |
-    ansible-playbook ardana-reboot.yml --limit {{ item }}
+    ansible-playbook ardana-reboot.yml --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
   loop: "{{ ardana_nodes.stdout_lines }}"
 
 - name: Ensure spark running on all nodes (bsc#1091479)
   command: |
-    ansible-playbook spark-start.yml
+    ansible-playbook spark-start.yml -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"

--- a/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/update_nodes.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_update/tasks/update_nodes.yml
@@ -76,7 +76,7 @@
 
 - name: Run ardana-update playbook to update services on all nodes
   command: |
-    ansible-playbook ardana-update.yml
+    ansible-playbook ardana-update.yml -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
   environment:


### PR DESCRIPTION
The number of API and RPC workers configured for various OpenStack
services in Ardana is dynamically calculated based on the number
of CPUs. However, the formula is currently incorrect and leads
to a huge number of processes being created on the virtual Ardana
cloud installations - there are 4 times as many workers as there
should be - which has negative side effects on the overall
performance.

To make a simple comparison, the general formula used by Ardana to
calculate the number of workers is:

```
  min(ansible_processor_count * ansible_processor_cores * 2, max_workers)
```

where `max_workers` has a value of `10` for most services, but sometimes
can be `20` and sometimes `8`, whereas the OpenStack Ansible formula is:

```
  min(ansible_processor_vcpus / 2, 16)
```
and the general rule used for Crowbar is:

```
  min(max(node["cpu"]["total"], 2), 4)
```
This change overrides the worker count by passing a number of extra
ansible variables when calling Ardana playbooks such as `site.yml`
and `ardana-update.yml`. The values correspond to the current flavor
used for controller nodes, which has 4 vCPUs.

NOTE: this measure is hopefully temporary. It can be removed if
and when the formula used to calculate the number of workers is
corrected in Ardana. However, the number of changes required for that
is extensive (one for each service), so this approach will be used
instead for the time being.