### PR TITLE
Revert "Re-source the crowbar variables after commit"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3047,10 +3047,6 @@ function crowbar_proposal_commit
     local proposal="$1"
     local proposaltype="${2:-default}"
     safely crowbarctl proposal commit "$proposal" "$proposaltype"
-
-    # crowbar may have changed the install key in /etc/crowbar.install.key,
-    # which is needed for the 'crowbar' command, so refresh it.
-    [ -e /etc/profile.d/crowbar.sh ] && . /etc/profile.d/crowbar.sh
 }
 
 # configure and commit one proposal


### PR DESCRIPTION
We chose a different direction that did not involve changing the crowbar
install key at all, so there is no need to refresh the CROWBAR_KEY
environment variable.

This reverts commit 5b74c1c3980fb9f91d332fc840ceddb6487e7b7b.