### PR TITLE
cleanvm: add messages to better understand the script output

### DIFF
--- a/scripts/jenkins/cleanvm/openstack-cleanvm.builder.sh
+++ b/scripts/jenkins/cleanvm/openstack-cleanvm.builder.sh
@@ -29,7 +29,9 @@ set +e
 scp ${automationrepo}/scripts/jenkins/qa_openstack.sh root@cleanvm:
 ssh root@cleanvm "export cloudsource=$cloudsource; export OSHEAD=$oshead; export NONINTERACTIVE=1; bash -x ~/qa_openstack.sh"
 ret=$?
+echo "Exit code of cleanvm run: $ret"
 if [ "$ret" != 0 ] ; then
+  echo "The cleanvm run failed. Now trying to cleanup before we let this job fail."
   virsh shutdown cleanvm
   # wait for clean shutdown
   n=20 ; while [[ $n > 0 ]] && virsh list |grep cleanvm.*running ; do sleep 2 ; n=$(($n-1)) ; done
@@ -41,6 +43,7 @@ if [ "$ret" != 0 ] ; then
   time gzip -c1 /dev/vg0/cleanvm > $file
   du $file
   exec_jtsync ${main_job_name} ${openstack_project} ${BUILD_NUMBER} 1
+  echo "End of cleanup. Now the job will fail."
   exit 1
 fi
 

--- a/scripts/jenkins/cleanvm/openstack-cleanvm.builder.sh
+++ b/scripts/jenkins/cleanvm/openstack-cleanvm.builder.sh
@@ -32,16 +32,15 @@ ret=$?
 echo "Exit code of cleanvm run: $ret"
 if [ "$ret" != 0 ] ; then
   echo "The cleanvm run failed. Now trying to cleanup before we let this job fail."
-  virsh shutdown cleanvm
+  virsh shutdown cleanvm 2>/dev/null
   # wait for clean shutdown
   n=20 ; while [[ $n > 0 ]] && virsh list |grep cleanvm.*running ; do sleep 2 ; n=$(($n-1)) ; done
-  virsh destroy cleanvm
+  virsh destroy cleanvm 2>/dev/null
   # cleanup old images
   find /mnt/cleanvmbackup -mtime +5 -type f | xargs --no-run-if-empty rm
   # backup /dev/vg0/cleanvm disk image
   file=/mnt/cleanvmbackup/${BUILD_NUMBER}-${openstack_project}-${image}.raw.gz
-  time gzip -c1 /dev/vg0/cleanvm > $file
-  du $file
+  gzip -c1 /dev/vg0/cleanvm > $file
   exec_jtsync ${main_job_name} ${openstack_project} ${BUILD_NUMBER} 1
   echo "End of cleanup. Now the job will fail."
   exit 1


### PR DESCRIPTION
The cleanup section did not show any messages.
Failures in the cleanup section were misinterpreted as being cleanvm errors.

This commit adds messages to better show the status of the cleanvm run and the cleanup.