### PR TITLE
qa_openstack: Fix disk size for default flavors used by tempest

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -272,9 +272,9 @@ fi
 
 NOVA_FLAVOR="m1.nano"
 nova flavor-delete $NOVA_FLAVOR || :
-nova flavor-create $NOVA_FLAVOR 42 128 0 1
+nova flavor-create $NOVA_FLAVOR 42 128 1 1
 nova flavor-delete m1.micro || :
-nova flavor-create m1.micro 84 256 0 1
+nova flavor-create m1.micro 84 256 1 1
 
 # make sure glance is working
 for i in $(seq 1 5); do


### PR DESCRIPTION
Since stein, the default flavors have a disk size > 0. This is needed
to pass the tempest test:

  tempest.api.compute.servers.test_attach_interfaces.\
  AttachInterfacesUnderV243Test.test_add_remove_fixed_ip

which would fail with:

  Details: {u'message': u'Only volume-backed servers are allowed for \
  flavors with zero disk.', u'code': 403}

See also https://docs.openstack.org/releasenotes/nova/stein.html and
https://bugs.launchpad.net/nova/+bug/1739646