### PR TITLE
openstack-ardana-gating: full tempest and entry-scale-kvm

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -131,20 +131,42 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana8-job-std-3cp-devel-staging-updates-x86_64
+    name: cloud-ardana8-job-entry-scale-kvm-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: stagingcloud8
+    scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    rhel_computes: '0'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    tempest_filter_list: "\
+      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,vpnaas,\
+      designate,heat,ceilometer,magnum,freezer,monasca"
+    triggers: []
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana8-job-entry-scale-kvm-update-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot
     cloudsource: develcloud8
     update_after_deploy: true
     update_to_cloudsource: stagingcloud8
-    scenario_name: standard
+    scenario_name: entry-scale-kvm
     clm_model: standalone
     controllers: '3'
-    sles_computes: '1'
+    sles_computes: '2'
+    rhel_computes: '0'
     ses_enabled: true
     ses_rgw_enabled: false
-    triggers:
-     - timed: 'H H * * *'
+    tempest_filter_list: "\
+      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,vpnaas,\
+      designate,heat,ceilometer,magnum,freezer,monasca"
+    triggers: []
     jobs:
         - '{ardana_job}'
 
@@ -176,7 +198,9 @@
     cloudsource: GM8+up
     updates_test_enabled: false
     scenario_name: entry-scale-kvm
-    tempest_filter_list: "smoke,full"
+    tempest_filter_list: "\
+      smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,vpnaas,\
+      designate,heat,ceilometer,magnum,freezer,monasca"
     qa_test_list: "iverify"
     triggers: []
     jobs:
@@ -214,15 +238,8 @@
     rhel_computes: '0'
     ses_enabled: true
     tempest_filter_list: "\
-      ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,\
-      magnum,manila,monasca,network,neutron-api,swift"
-    qa_test_list: "\
-      iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
-      heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,\
-      nova_server,nova_services,nova_flavor,nova_image,barbican-cli-func,\
-      barbican-functional,horizon,keystone-api,keystone-ldap,\
-      keystone-k2k-config,keystone-websso-config,keystone-x509-config,\
-      service-ansible-playbooks,enable_tls,tempest_cleanup,nova_guest_image"
+      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,vpnaas,\
+      designate,heat,ceilometer,magnum,freezer,monasca"
     rc_notify: 'true'
     triggers: []
     jobs:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -122,14 +122,34 @@
     controllers: '3'
     sles_computes: '2'
     rhel_computes: '0'
-    tempest_filter_list: 'ci'
     ses_enabled: true
     ses_rgw_enabled: false
-    qa_test_list: "\
-      iverify,cinder,heat,magnum,neutron,nova-attach,nova_volume,nova_server,\
-      nova_services,nova_flavor,nova_image,tempest_cleanup,nova_guest_image"
-    triggers:
-     - timed: 'H H * * *'
+    tempest_filter_list: "\
+      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,\
+      designate,heat,magnum,monasca"
+    triggers: []
+    jobs:
+        - '{ardana_job}'
+
+
+- project:
+    name: cloud-ardana9-job-entry-scale-kvm-update-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: develcloud9
+    update_after_deploy: true
+    update_to_cloudsource: stagingcloud9
+    scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    rhel_computes: '0'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    tempest_filter_list: "\
+      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,\
+      designate,heat,magnum,monasca"
+    triggers: []
     jobs:
         - '{ardana_job}'
 
@@ -167,8 +187,8 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,\
-      magnum,manila,monasca,network,neutron-api,swift"
+      ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,\
+      designate,heat,magnum,monasca"
     qa_test_list: "\
       iverify,monasca-ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
       heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,\
@@ -195,8 +215,8 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,identity,lbaas,\
-      magnum,manila,monasca,network,neutron-api,swift"
+      ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,\
+      designate,heat,magnum,monasca"
     qa_test_list: "\
       iverify,ceilometer,ceilometer_capacity_management,cinder,cinder-parallel,getput,\
       heat,magnum,logging,monasca,neutron,nova-attach,nova_volume,nova_migrate,\
@@ -206,25 +226,6 @@
       service-ansible-playbooks,enable_tls,tempest_cleanup,nova_guest_image"
     rc_notify: 'true'
     triggers: []
-    jobs:
-        - '{ardana_job}'
-
-- project:
-    name: cloud-ardana9-job-std-3cp-devel-staging-updates-x86_64
-    ardana_job: '{name}'
-    ardana_env: cloud-ardana-ci-slot
-    cloudsource: develcloud9
-    updates_test_enabled: true
-    update_after_deploy: true
-    update_to_cloudsource: stagingcloud9
-    scenario_name: standard
-    clm_model: standalone
-    controllers: '3'
-    sles_computes: '1'
-    ses_enabled: true
-    ses_rgw_enabled: false
-    triggers:
-     - timed: 'H H * * *'
     jobs:
         - '{ardana_job}'
 

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -52,9 +52,8 @@
           multi-select-delimiter: ','
           default-value: ''
           value: >-
-            ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,
-            identity,lbaas,magnum,manila,monasca,network,neutron-api,periodic,
-            periodic-virtual,refstack,swift,tests2skip,tests-ci,upgrade-ci,upgrade
+            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,
+            fwaas,vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -91,9 +91,8 @@
           multi-select-delimiter: ','
           default-value: ''
           value: >-
-            ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,
-            identity,lbaas,magnum,manila,monasca,network,neutron-api,periodic,
-            periodic-virtual,refstack,swift,tests2skip,tests-ci,upgrade-ci,upgrade
+            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,
+            fwaas,vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-gating.Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
               // resource to become available.
               ardana_lib.run_with_reserved_env(true, ardana_env, null) {
                 reserved_env ->
-                ardana_lib.trigger_build("cloud-ardana${version}-job-std-min-x86_64", [
+                ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),
                   string(name: 'cleanup', value: "never"),
@@ -85,7 +85,7 @@ pipeline {
               // resource to become available.
               ardana_lib.run_with_reserved_env(true, ardana_env, null) {
                 reserved_env ->
-                ardana_lib.trigger_build("cloud-ardana${version}-job-std-3cp-devel-staging-updates-x86_64", [
+                ardana_lib.trigger_build("cloud-ardana${version}-job-entry-scale-kvm-update-x86_64", [
                   string(name: 'ardana_env', value: reserved_env),
                   string(name: 'reserve_env', value: "false"),
                   string(name: 'cleanup', value: "never"),

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -318,9 +318,8 @@
           multi-select-delimiter: ','
           default-value: '{tempest_filter_list|ci}'
           value: >-
-            ci,smoke,smoke-upstream,defcore,full,barbican,compute,designate,
-            identity,lbaas,magnum,manila,monasca,network,neutron-api,periodic,
-            periodic-virtual,refstack,swift,tests2skip,tests-ci,upgrade-ci,upgrade
+            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,
+            fwaas,vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.


### PR DESCRIPTION
This change replace the `std-min` and `std-3cp` input models
currently employed by the Ardana gating jobs with an
entry-scale-kvm input model and replaces the 'ci' tempest
filter with a full set of tempest filters.
    
With the recent cleanup of Ardana tempest filters [1] [2] and the
efforts to stabilize the CI, we can finally have a full tempest
coverage in the gate. The `entry-scale-kvm` input model is
also better suited for a gating job, because it is closer to
what customers use.
    
This change also updates all other jobs to reflect the new
tempest filters and run only those that are applicable [3].

These are the main differences between the `standard` and
`entry-scale-kvm` input model scenarios:
 - there is no dedicated CLM (CONF) network in `entry-scale-kvm`.
 It is part of the MANAGEMENT network
 - there is only one neutron VLAN tenant network in `entry-scale-kvm`,
 which is not associated with the management network. This prevents
 problems with Neutron having to reconfigure the interface associated
 with the management network
 - there is no dedicated SWIFT network in `entry-scale-kvm`, swift services
 use the same management network as the rest of the services
 - last but not least, there is an important difference in the interface models: 
 `entry-scale-kvm` only uses two NICs, whereas the `standard` one basically
 has one interface per network group per server. Another important difference
 is the fact that `entry-scale-kvm` does not exercise interface bonding.

[1] https://gerrit.prv.suse.net/c/ardana/tempest-ansible/+/5904
[2] https://gerrit.prv.suse.net/c/ardana/tempest-ansible/+/5986
[3] https://confluence.suse.de/display/qualityperformance/Tempest+Test+Coverage+on+Ardana
