### PR TITLE
openstack-crowbar: fix the 2 nodes SES scenario

### DIFF
--- a/scripts/scenarios/cloud9/cloud9-2nodes-ses.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-ses.yml
@@ -142,19 +142,6 @@ proposals:
     elements:
       barbican-controller:
       - @@controller@@
-- barclamp: ceilometer
-  attributes:
-  deployment:
-    elements:
-      ceilometer-agent:
-      - @@compute-kvm@@
-      ceilometer-agent-hyperv: []
-      ceilometer-central:
-      - @@controller@@
-      ceilometer-server:
-      - @@controller@@
-      ceilometer-swift-proxy-middleware:
-      - @@controller@@
 - barclamp: magnum
   attributes:
     cert:


### PR DESCRIPTION
Remove ceilometer from the cloud 9 2 nodes SES crowbar batch
scenario, to bring it to the same list of services as the default
2 nodes scenario used by the cloud 9 gating job.