### PR TITLE
mkcloud: Call addupdaterepo during crowbarrestore

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -990,6 +990,7 @@ function onhost_reset_admin
     safely onhost_cleanup_admin_node
     safely onhost_prepareadmin
     safely setupadmin
+    safely addupdaterepo
     safely prepareinstcrowbar
     safely bootstrapcrowbar
 }


### PR DESCRIPTION
Without this, there's no way to do CI on a patch that fix a bug in the
restore step as we will not use the patched package.