### PR TITLE
run HA PR testing with ssl

### DIFF
--- a/scripts/crowbar-testbuild.yaml
+++ b/scripts/crowbar-testbuild.yaml
@@ -27,6 +27,7 @@ parameters_template:
     label: openstack-mkcloud-ha-x86_64
     nodenumber: 5
     hacloud: 1
+    want_all_ssl: 1
     networkingmode: vxlan
     clusterconfig: "data+services+network=3"
   hyperv: &mkcloud_hyperv


### PR DESCRIPTION
We're testing HA with SSL in the gate as well, so
the PR should be tested the same way to avoid
regressions from only being caught post merge.