### PR TITLE
ci: Fix mkcloud-job-ha-linuxbridge-bonding

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -46,6 +46,7 @@
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
+        - 'cloud-mkcloud{version}-job-ha-linuxbridge-bonding-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-agent-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-disruptive-ha-mariadb-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -45,6 +45,7 @@
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
         - 'cloud-mkcloud{version}-job-ha-compute-{arch}'
         - 'cloud-mkcloud{version}-job-ha-linuxbridge-{arch}'
+        - 'cloud-mkcloud{version}-job-ha-linuxbridge-bonding-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ironic-agent-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-bonding-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-bonding-template.yaml
@@ -20,13 +20,12 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber={nodenumber}
-            clusterconfig=data+network+services=2
+            clusterconfig=data+network+services=3
             storage_method=swift
             hacloud=1
             mkcloudtarget=all_noreboot
             networkingplugin=linuxbridge
             networkingmode=vxlan
             crowbar_networkingmode=team
-            want_node_aliases=controller={nodenumber_controller},compute=2
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-linuxbridge-{arch}


### PR DESCRIPTION
This will deploy mariadb, and therefore needs at least 3 nodes of the HA
control plane.