### PR TITLE
openstack-ardana: mariadb performance tunings (SCRD-7496)

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/vcloud.yml
@@ -34,6 +34,15 @@ want_lvm: "{{ cloud_product == 'ardana' }}"
 vcloud_image_name_prefix: "{{ 'cleanvm-jeos-lvm' if want_lvm else 'cleanvm-jeos' }}"
 vcloud_flavor_name_prefix: "{{ 'cloud-ardana-job-lvm' if want_lvm else 'cloud-ardana-job' }}"
 
+# For virtual cloud deployments, all volumes are implemented on top of
+# shared storage, with the exception of the root partition, which uses the
+# ephemeral volume, which could be set up on the underlying cloud compute node
+# instead of also being a shared storage volume. Set this to true to have mariadb
+# and rabbitmq use the root partition rather than a separate volume (which has
+# higher latency and is more prone to performance issues when implemented using
+# shared storage).
+ardana_dbmq_use_root_volume: true
+
 cli_stack_queries:
   - "admin-floating-ip"
   - "admin-conf-ip"

--- a/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
@@ -33,3 +33,7 @@ ardana_extra_vars:
   swift_worker_count: 2
   num_engine_worker_count: 2
   glance_worker_count: 2
+  # When the mariadb is running on top of shared storage, decouple commit and
+  # flush operations, to account for its high latency and prevent performance
+  # issues
+  innodb_flush_log_at_trx_commit: "{{ ardana_dbmq_use_root_volume | ternary(1, 2) }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
@@ -121,7 +121,7 @@
             fstype: ext4
             mkfs-opts: -O large_file
 
-{%       elif service_component_group == 'DBMQ' %}
+{%       elif service_component_group == 'DBMQ' and not ardana_dbmq_use_root_volume %}
 {%         set ns.drive_idx = ns.drive_idx+1 %}
 
       - name: ardana-dbmq


### PR DESCRIPTION
When mariadb is running on top of shared (ceph) storage with the
default configuration values, there is a huge impact on its
performance, because database commit operations must wait until
disk flush operations are complete (and with shared storage,
that takes longer).

There are two solutions to this:

1. move the database to the root filesystem, which is not
currently implemented as a ceph volume (the ephemeral volume
in the ECP is still set up as a local volume on the compute node)

2. decouple the flush and commit operations, by tweaking the
innodb configuration (i.e. set the `innodb_flush_log_at_trx_commit`
configuration option [1] to 2). This option requires matching changes
in the `db-ansible` repository [2].

This commit implements both these options and adds a top-level
`ardana_dbmq_use_root_volume` ansible variable which can be used to
switch between them. The default choice is to use local storage,
because this doesn't depend on Ardana ansible package changes and
can be enabled immediately.

[1] https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
[2] https://gerrit.suse.provo.cloud//#/c/5957