### PR TITLE
Force fixed network for nova boot tests

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4187,7 +4187,7 @@ function oncontroller_testsetup
         nova secgroup-add-rule testvm udp 1 65535 0.0.0.0/0
     fi
 
-    timeout 10m nova boot --poll --image $image_name --flavor $flavor --key-name testkey --security-group testvm testvm | tee boot.out
+    timeout 10m nova boot --poll --image $image_name --flavor $flavor --key-name testkey --nic net-name=fixed --security-group testvm testvm | tee boot.out
     ret=${PIPESTATUS[0]}
     [ $ret != 0 ] && complain 43 "nova boot failed"
     instanceid=`perl -ne "m/ id [ |]*([0-9a-f-]+)/ && print \\$1" boot.out`


### PR DESCRIPTION
By default, nova would take any network it finds as long as there's
only one. If nova can't decide it fails with "Multiple possible
networks found" conflict.

This is especially important in Ironic case because there is "ironic"
network defined.