### PR TITLE
openstack-crowbar: workaround bug in zypper_repositories when adding repo

### DIFF
--- a/scripts/jenkins/ardana/ansible/run-crowbar-tests.yml
+++ b/scripts/jenkins/ardana/ansible/run-crowbar-tests.yml
@@ -30,9 +30,11 @@
             repo: "http://download.opensuse.org/repositories/devel:/languages:/python:/backports/SLE_{{ \
               (ansible_distribution_release != '') | \
               ternary(ansible_distribution_major_version ~ '_SP' ~ \
-              ansible_distribution_release , ansible_distribution_major_version) }}/"
-            name: temporal_python_backports
+              ansible_distribution_release , ansible_distribution_major_version\
+              ~ '/devel:languages:python:backports.repo')}}"
+            name: python_backports
             state: present
+            disable_gpg_check: yes
             runrefresh: yes
 
         - name: Ensure setuptools, virtualenv and subunit2html are installed
@@ -74,9 +76,11 @@
             repo: "http://download.opensuse.org/repositories/devel:/languages:/python:/backports/SLE_{{ \
               (ansible_distribution_release != '') | \
               ternary(ansible_distribution_major_version ~ '_SP' ~ \
-              ansible_distribution_release , ansible_distribution_major_version) }}/"
-            name: temporal_python_backports
+              ansible_distribution_release , ansible_distribution_major_version\
+              ~ '/devel:languages:python:backports.repo')}}"
+            name: python_backports
             state: absent
+            disable_gpg_check: yes
             runrefresh: yes
 
         - name: Generate xml subunit results

--- a/scripts/jenkins/ardana/ansible/run-crowbar-tests.yml
+++ b/scripts/jenkins/ardana/ansible/run-crowbar-tests.yml
@@ -73,14 +73,8 @@
       always:
         - name: Ensure repo for python-virtualenv is removed
           zypper_repository:
-            repo: "http://download.opensuse.org/repositories/devel:/languages:/python:/backports/SLE_{{ \
-              (ansible_distribution_release != '') | \
-              ternary(ansible_distribution_major_version ~ '_SP' ~ \
-              ansible_distribution_release , ansible_distribution_major_version\
-              ~ '/devel:languages:python:backports.repo')}}"
             name: python_backports
             state: absent
-            disable_gpg_check: yes
             runrefresh: yes
 
         - name: Generate xml subunit results


### PR DESCRIPTION
zypper_repositories doesn't seem to add repos if they are missing the .repo tail.
Moreover, disable gpg check for the repo or zypper_repositories will also fail.