### PR TITLE
openstack-ardana: use bigger SES volume for nova

### DIFF
--- a/jenkins/ci.suse.de/openstack-ses.yaml
+++ b/jenkins/ci.suse.de/openstack-ses.yaml
@@ -56,7 +56,7 @@
             SES instance flavor
       - string:
           name: volume_size
-          default: "40"
+          default: "70"
           description: >-
             Size of the volume to be attached to the SES instance
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
@@ -107,7 +107,7 @@
 
 {%         endif %}
 
-{%       elif service_component_group == 'COMPUTE' %}
+{%       elif service_component_group == 'COMPUTE' and not cinder_lvm_enabled %}
 {%         set ns.drive_idx = ns.drive_idx+1 %}
 
       - name: vg-comp


### PR DESCRIPTION
When the cinder LVM back-end is not enabled, the compute node
doesn't need the additional volume mounted to /var/lib/nova.
Instead, this additional storage can be added to the SES cluster.

This helps with running tempest, because it allows more workers
to run in parallel and create VMs without running into storage
limit.