### PR TITLE
Fix magnum tempest testsetup

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -12,6 +12,7 @@
     previous_version: 6
     arch: x86_64
     tempestoptions: --smoke
+    magnumoptions: --regex '^magnum.tests.functional.api'
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: postgresql
     jobs:

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -12,6 +12,7 @@
     previous_version: 7
     arch: x86_64
     tempestoptions: --smoke
+    magnumoptions: --regex '^magnum.tests.functional.api'
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: mysql
     jobs:
@@ -73,23 +74,6 @@
     tempestoptions: --smoke
     jobs:
         - 'cloud-mkcloud{version}-job-uefi-{arch}'
-- project:
-    name: cloud-mkcloud8-aarch64
-    disabled: false
-    version: 8
-    previous_version: 7
-    arch: aarch64
-    label: openstack-mkcloud-SLE12-{arch}
-    tempestoptions: --smoke
-    jobs:
-        - 'cloud-mkcloud{version}-job-2nodes-{arch}'
-        - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
-        - 'cloud-mkcloud{version}-job-btrfs-{arch}'
-        - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
-        - 'cloud-mkcloud{version}-job-magnum-{arch}'
-        - 'cloud-mkcloud{version}-job-raid-{arch}'
-        - 'cloud-mkcloud{version}-job-ssl-{arch}'
-
 - project:
     name: cloud-mkcloud8-s390x
     disabled: true

--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -12,6 +12,7 @@
     previous_version: 8
     arch: x86_64
     tempestoptions: --smoke
+    magnumoptions: --regex '^magnum_tempest_plugin.tests.api'
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: mysql
     jobs:
@@ -82,5 +83,4 @@
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
         - 'cloud-mkcloud{version}-job-btrfs-{arch}'
         - 'cloud-mkcloud{version}-job-crowbar_register-{arch}'
-        - 'cloud-mkcloud{version}-job-magnum-{arch}'
         - 'cloud-mkcloud{version}-job-raid-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-magnum-template.yaml
@@ -22,7 +22,7 @@
             nodenumber=4
             want_magnum_proposal=1
             storage_method=none
-            tempestoptions=--regex '^magnum.tests.functional.api'
+            tempestoptions={magnumoptions}
             mkcloudtarget=all
             label={label}
             job_name=cloud-mkcloud{version}-job-magnum-{arch}


### PR DESCRIPTION
magnum jobs on Cloud9+ fail with:

The specified regex doesn't match with anything

which is because the tests have been moved out of tree into a separate
magnum_tempest tests package. adjust regexp for rocky only, which
means we need to make it configurable and use the old values. Also
drop the aarch64 part because PM asked us to deinvest in aarch64 for
cloud8.