### PR TITLE
enable keystone ssl when want_all_ssl=1 is set

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2170,6 +2170,7 @@ function enable_ssl_generic
         ;;
         keystone)
             $p "$a['ssl']['ca_certs']" "'/etc/ssl/ca-bundle.pem'"
+            $p "$a['api']['protocol']" "'https'"
         ;;
         *)
             $p "$a['api']['protocol']" "'https'"


### PR DESCRIPTION
We never forgot enabled ssl in keystone when want_all_ssl=1
was set due to missing of the critical config setting being
done.