### PR TITLE
Crowbar ECP install MU before deployment

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-crowbar.yml
@@ -42,6 +42,13 @@
             regexp: "^ *#"
             state: absent
 
+        # add MU repos
+        - include_role:
+            name: setup_zypper_repos
+          when:
+            - not update_after_deploy
+            - maint_updates_list | length
+
         - include_role:
             name: frontail
 

--- a/scripts/jenkins/ardana/ansible/deploy-crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-crowbar.yml
@@ -30,6 +30,15 @@
             name: crowbar_setup
           vars:
             qa_crowbarsetup_cmd: onadmin_batch
+
+        - include_role:
+            name: reboot_node
+          vars:
+            reboot_target: cloud_nodes_crowbar
+          when:
+            - not update_after_deploy
+            - maint_updates_list | length
+
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -52,7 +52,8 @@ rc_notify: False
 rc_notify_start: True
 
 suse_release: "suse-{{ ansible_distribution_version }}"
-local_repos_base_dir: "/srv/www/{{ suse_release }}/{{ ansible_architecture }}/repos"
+local_repos_web_dir_prefix: "{{ (cloud_product == 'crowbar') | ternary('tftpboot','www') }}"
+local_repos_base_dir: "/srv/{{ local_repos_web_dir_prefix }}/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
 sles_cloud_version:
   "12.3": 8

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -18,8 +18,8 @@ ardana_env: localhost
 
 cloudsource: stagingcloud9
 
+# cloud product can be ardana or crowbar
 cloud_product: "ardana"
-#cloud_product: "crowbar"
 
 cloud_admin_user:
   ardana: ardana
@@ -52,7 +52,7 @@ rc_notify: False
 rc_notify_start: True
 
 suse_release: "suse-{{ ansible_distribution_version }}"
-local_repos_web_dir_prefix: "{{ (cloud_product == 'crowbar') | ternary('tftpboot','www') }}"
+local_repos_web_dir_prefix: "{{ (cloud_product == 'crowbar') | ternary('tftpboot', 'www') }}"
 local_repos_base_dir: "/srv/{{ local_repos_web_dir_prefix }}/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
 sles_cloud_version:

--- a/scripts/jenkins/ardana/ansible/group_vars/all/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/crowbar.yml
@@ -9,3 +9,4 @@ cloud_fqdn: "{{ ardana_env }}.prv.suse.net"
 scenario_file: ""
 
 mkcloud_config_file: "{{ workspace_path }}/mkcloud.config"
+cloud_repo_path: "OpenStack-Cloud-Crowbar"

--- a/scripts/jenkins/ardana/ansible/group_vars/all/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/crowbar.yml
@@ -9,4 +9,3 @@ cloud_fqdn: "{{ ardana_env }}.prv.suse.net"
 scenario_file: ""
 
 mkcloud_config_file: "{{ workspace_path }}/mkcloud.config"
-cloud_repo_path: "OpenStack-Cloud-Crowbar"

--- a/scripts/jenkins/ardana/ansible/install-crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/install-crowbar.yml
@@ -47,6 +47,17 @@
             - installcrowbar
           loop_control:
             loop_var: command
+
+        # reboot node after crowbar install
+        - include_role:
+            name: reboot_node
+          vars:
+            reboot_target: deployer
+          when:
+            - not update_after_deploy
+            - maint_updates_list | length
+
+
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/ardana/ansible/register-crowbar-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/register-crowbar-nodes.yml
@@ -40,6 +40,13 @@
           loop_control:
             loop_var: command
 
+        - include_role:
+            name: crowbar_update
+          when:
+            - not update_after_deploy
+            - maint_updates_list | length
+
+
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_update/Readme.md
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_update/Readme.md
@@ -1,0 +1,21 @@
+Crowbar_update
+==============
+
+Description
+-----------
+Role for updating crowbar nodes and adding repos to crowbar nodes.  
+Role depends on content of `maint_updates_list`.
+**NOTE** For now just add repos to the crowbar nodes.  
+
+TODO
+----
+Functionality will be enhanced via https://jira.suse.com/browse/SOC-8465.
+
+Vars
+----
+
+Tasks
+-----
+- main.yml (aggregator)
+- add_mu_repos_crowbar.yml (add repos to the crowbar nodes)
+

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_update/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_update/defaults/main.yml
@@ -23,3 +23,4 @@ update_include_reboot_patches: true
 
 deployer_repo_base_url: "http://{{ deployer_ip }}:8091/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
+cloud_repo_path: "OpenStack-Cloud-Crowbar"

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_update/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_update/defaults/main.yml
@@ -15,23 +15,11 @@
 #
 ---
 
-- name: Gather variables when milestone cloudsousrce
-  include_vars: "milestone.yml"
-  when: is_milestone
+deployer_ip: "{{ hostvars['localhost'].admin_conf_ip }}"
+update_method: "{{ (cloudsource | regex_search('devel|staging.*')) | ternary('update', 'patch') }}"
+update_gpg_checks: true
+update_licenses_agree: true
+update_include_reboot_patches: true
 
-- include_tasks: setup_sles_cloud_repos.yml
-  when: cloudsource != '' and cloud_product == 'ardana'
+deployer_repo_base_url: "http://{{ deployer_ip }}:8091/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
-- include_tasks: setup_repo_from_iso.yml
-  when: is_milestone and cloud_product == 'ardana'
-
-- include_tasks: setup_maint_update_repos.yml
-  when:
-    - include_maint_update
-    - maint_updates_list | length
-
-- include_tasks: add_extra_repos.yml
-  when: extra_repos_list | length
-
-- include_tasks: set_motd.yml
-  when: task == 'deploy'

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_update/tasks/add_mu_repos_crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_update/tasks/add_mu_repos_crowbar.yml
@@ -1,0 +1,36 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Check MU URL
+  uri:
+    url: "http://{{ maintenance_updates_server }}/ibs/SUSE:/Maintenance:/{{ item }}/"
+    return_content: yes
+  loop: "{{ maint_updates_list }}"
+  register: mu_url
+
+
+- name: Add MU zypper repositories - Crowbar on {{ ansible_host }}
+  zypper_repository:
+    name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
+    repo: "{{ deployer_repo_base_url }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
+    runrefresh: yes
+    state: present
+  loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+  #  notify:
+  #  - Apply all available patches
+  when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_update/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_update/tasks/main.yml
@@ -15,23 +15,17 @@
 #
 ---
 
-- name: Gather variables when milestone cloudsousrce
-  include_vars: "milestone.yml"
-  when: is_milestone
+- name: 'Check if crowbar product line'
+  fail: msg="the role is intended for crowbar only"
+  when: cloud_product != 'crowbar'
 
-- include_tasks: setup_sles_cloud_repos.yml
-  when: cloudsource != '' and cloud_product == 'ardana'
-
-- include_tasks: setup_repo_from_iso.yml
-  when: is_milestone and cloud_product == 'ardana'
-
-- include_tasks: setup_maint_update_repos.yml
+- include_tasks: add_mu_repos_crowbar.yml
   when:
-    - include_maint_update
     - maint_updates_list | length
 
-- include_tasks: add_extra_repos.yml
-  when: extra_repos_list | length
+# TODO: maybe worth to do that in future - upgrading cloud"
+#- include_tasks: pre_cloudsource_update.yml
+#  when:
+#    - cloudsource is defined
+#    - cloudsource != ''
 
-- include_tasks: set_motd.yml
-  when: task == 'deploy'

--- a/scripts/jenkins/ardana/ansible/roles/crowbar_update/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/crowbar_update/tasks/main.yml
@@ -15,8 +15,9 @@
 #
 ---
 
-- name: 'Check if crowbar product line'
-  fail: msg="the role is intended for crowbar only"
+- name: Check if crowbar product line
+  fail:
+    msg: "the role is intended for crowbar only"
   when: cloud_product != 'crowbar'
 
 - include_tasks: add_mu_repos_crowbar.yml

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/README.md
@@ -1,0 +1,25 @@
+Role Reboot node
+================
+
+Description
+-----------
+Simple playbook handling reboot of nodes with simple service ready check. 
+Takes variable which determine if deployer or nodes should be rebooted.  
+Determinates cloud_product based on `cloud_product` var. Role will reboot  
+node based on variable `reboot_target`.  
+For now rebooting works for **deployer** (works for both ardana & crowbar) and  
+**cloud_nodes_crowbar** (crowbar only).
+
+TODO
+----
+Modify ardana playbooks for updating to include this role or adjust roles `setup_zypper_repos` and `ardana_update`)
+
+Vars
+----
+`reboot_target` - deployer | cloud_nodes_crowbar
+
+Tasks
+-----
+- main.yml (agreggator)
+- reboot_deployer.yml (reboots ardana deployer or crowbar equivalent - admin node)
+- reboot_cloud_nodes_crowbar.yml (reboots crowbar nodes)

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/defaults/main.yml
@@ -14,24 +14,6 @@
 # under the License.
 #
 ---
-
-- name: Gather variables when milestone cloudsousrce
-  include_vars: "milestone.yml"
-  when: is_milestone
-
-- include_tasks: setup_sles_cloud_repos.yml
-  when: cloudsource != '' and cloud_product == 'ardana'
-
-- include_tasks: setup_repo_from_iso.yml
-  when: is_milestone and cloud_product == 'ardana'
-
-- include_tasks: setup_maint_update_repos.yml
-  when:
-    - include_maint_update
-    - maint_updates_list | length
-
-- include_tasks: add_extra_repos.yml
-  when: extra_repos_list | length
-
-- include_tasks: set_motd.yml
-  when: task == 'deploy'
+reboot_target_list:
+  - deployer
+  - cloud_nodes_crowbar

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/main.yml
@@ -24,6 +24,6 @@
   when: reboot_target == 'deployer'
 
 # reboot nodes - CROWBAR
-- include_tasks: reboot_cloud_nodes_crowbar.yml
-  when: cloud_product == 'crowbar' and reboot_target == 'cloud_nodes_crowbar'
+- include_tasks: reboot_cloud_nodes_{{ cloud_product }}.yml
+  when: reboot_target == 'cloud_nodes_{{ cloud_product }}'
 

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/main.yml
@@ -14,24 +14,16 @@
 # under the License.
 #
 ---
+- name: Fail when no reboot_target specified
+  fail:
+    msg: "{{ reboot_target }} not in {{ reboot_target_list }}"
+  when: reboot_target not in reboot_target_list
 
-- name: Gather variables when milestone cloudsousrce
-  include_vars: "milestone.yml"
-  when: is_milestone
+# reboot deployer/admin node
+- include_tasks: reboot_deployer.yml
+  when: reboot_target == 'deployer'
 
-- include_tasks: setup_sles_cloud_repos.yml
-  when: cloudsource != '' and cloud_product == 'ardana'
+# reboot nodes - CROWBAR
+- include_tasks: reboot_cloud_nodes_crowbar.yml
+  when: cloud_product == 'crowbar' and reboot_target == 'cloud_nodes_crowbar'
 
-- include_tasks: setup_repo_from_iso.yml
-  when: is_milestone and cloud_product == 'ardana'
-
-- include_tasks: setup_maint_update_repos.yml
-  when:
-    - include_maint_update
-    - maint_updates_list | length
-
-- include_tasks: add_extra_repos.yml
-  when: extra_repos_list | length
-
-- include_tasks: set_motd.yml
-  when: task == 'deploy'

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_cloud_nodes_crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_cloud_nodes_crowbar.yml
@@ -20,14 +20,15 @@
   shell: |
     crowbar_node_state status | awk '/^d/{print $1}'
   register: _list_of_crowbar_nodes
-  when: reboot_target == 'cloud_nodes_crowbar'
 
+- name: Reboot nodes
+  command: crowbarctl node reboot {{ item }}
+  loop: "{{ _list_of_crowbar_nodes.stdout_lines }}"
 
 - name: Wait for nodes to be 'Ready'
-  shell: crowbar_node_state status | awk '/{{item}}/{print $2}'
+  shell: crowbar_node_state status | awk '/{{ item }}/{print $2}'
   register: _cmd_ret
   retries: 10
   delay: 60
   until: _cmd_ret.stdout_lines | reject('search','^Ready$') | list | count == 0
   loop: "{{ _list_of_crowbar_nodes.stdout_lines }}"
-  when: reboot_target == 'cloud_nodes_crowbar'

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_cloud_nodes_crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_cloud_nodes_crowbar.yml
@@ -15,23 +15,19 @@
 #
 ---
 
-- name: Gather variables when milestone cloudsousrce
-  include_vars: "milestone.yml"
-  when: is_milestone
 
-- include_tasks: setup_sles_cloud_repos.yml
-  when: cloudsource != '' and cloud_product == 'ardana'
+- name: Get list of nodes
+  shell: |
+    crowbar_node_state status | awk '/^d/{print $1}'
+  register: _list_of_crowbar_nodes
+  when: reboot_target == 'cloud_nodes_crowbar'
 
-- include_tasks: setup_repo_from_iso.yml
-  when: is_milestone and cloud_product == 'ardana'
 
-- include_tasks: setup_maint_update_repos.yml
-  when:
-    - include_maint_update
-    - maint_updates_list | length
-
-- include_tasks: add_extra_repos.yml
-  when: extra_repos_list | length
-
-- include_tasks: set_motd.yml
-  when: task == 'deploy'
+- name: Wait for nodes to be 'Ready'
+  shell: crowbar_node_state status | awk '/{{item}}/{print $2}'
+  register: _cmd_ret
+  retries: 10
+  delay: 60
+  until: _cmd_ret.stdout_lines | reject('search','^Ready$') | list | count == 0
+  loop: "{{ _list_of_crowbar_nodes.stdout_lines }}"
+  when: reboot_target == 'cloud_nodes_crowbar'

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_deployer.yml
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_deployer.yml
@@ -1,0 +1,54 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Reboot deployer
+  shell: sleep 2 && shutdown -r now "{{cloud_product == 'crowbar'| ternary('Crowbar','Ardana')}} updates triggered"
+  async: 1
+  poll: 0
+  failed_when: false
+  become: yes
+
+- name: Wait for node after reboot
+  wait_for_connection:
+    delay: 5
+
+- name: Get host uptime
+  shell: cut -d " " -f 1 /proc/uptime
+  register: _hostuptime
+
+- name: Fail when uptime more then 2 minutes
+  fail:
+    msg: "Uptime more then 2 minutes - it looks like node didn't reboot"
+  when: _hostuptime.stdout|int > 120
+
+
+- name: Find cloud product
+  shell: "zypper pd | grep -m 1 'OpenStack Cloud' | cut -d'|' -f4"
+  args:
+    warn: False
+  register: _cloud_product
+
+
+- name: Check crowbar webui (http status)
+  uri:
+    url: http://127.0.0.1:3000/
+    status_code: 200
+  retries: 3
+  delay: 9
+  register: _uri_output
+  until: "(_uri_output.status == 200)"
+  when: "'Crowbar' in _cloud_product.stdout"

--- a/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_deployer.yml
+++ b/scripts/jenkins/ardana/ansible/roles/reboot_node/tasks/reboot_deployer.yml
@@ -35,13 +35,11 @@
     msg: "Uptime more then 2 minutes - it looks like node didn't reboot"
   when: _hostuptime.stdout|int > 120
 
-
 - name: Find cloud product
   shell: "zypper pd | grep -m 1 'OpenStack Cloud' | cut -d'|' -f4"
   args:
     warn: False
   register: _cloud_product
-
 
 - name: Check crowbar webui (http status)
   uri:

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2019 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -70,3 +70,7 @@ repos_to_sync: "{{ repos_to_add | difference(repos_to_mount) }}"
 extra_repos_list: "{{ extra_repos.split(',') if extra_repos is defined and extra_repos | length > 0 else [] }}"
 cloudsource_repo: "{{ (task == 'update' and cloudsource is defined and cloudsource != '') | ternary('Updates', 'Pool') }}"
 zypper_repo_name: "{{ item | regex_replace('devel.*', cloudsource_repo) }}"
+
+#media_versions
+ardana_media_version_src_file: "{{ local_repos_base_dir }}/{{ base_repos.0 | regex_replace('devel.*', 'Pool') }}/media.1/build"
+crowbar_media_version_src_file: "/etc/motd"

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/set_motd.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/set_motd.yml
@@ -17,7 +17,7 @@
 
 - name: Get media build version
   slurp:
-    src: "{{ local_repos_base_dir }}/{{ base_repos.0 | regex_replace('devel.*', 'Pool') }}/media.1/build"
+    src: "{{ (cloud_product == 'crowbar') | ternary(crowbar_media_version_src_file, ardana_media_version_src_file) }}"
   register: cloud_media_build_version
   when: not is_milestone
 

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
@@ -66,24 +66,13 @@
   until: mu_sync_result.rc != 24
   delay: 300
 
-- name: Add MU zypper repositories - Ardana
+- name: Add MU zypper repositories
   zypper_repository:
     name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
     repo: "{{ local_repos_base_dir }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
     runrefresh: yes
     state: present
-  when: " cloud_product == 'ardana' and maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+  when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
   loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
   notify:
     - Refresh all repos
-
-- name: Add MU zypper repositories - Crowbar (admin node)
-  zypper_repository:
-    name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
-    repo: "{{ local_repos_base_dir }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
-    runrefresh: yes
-    state: present
-  loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
-  notify:
-    - Refresh all repos
-  when: "inventory_hostname == ardana_env and cloud_product == 'crowbar' and maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
@@ -21,9 +21,15 @@
     warn: False
   register: cloud_repo_name
 
-- name: Set cloud MU repo path based on product
+- name: Set cloud MU repo path based on product - Ardana
   set_fact:
     cloud_repo_path: "{{ ('HPE-Helion' in cloud_repo_name.stdout) | ternary('HPE-Helion-OpenStack', 'OpenStack-Cloud') }}"
+  when: cloud_product != 'crowbar'
+
+- name: Set cloud MU repo path based on product - Crowbar
+  set_fact:
+    cloud_repo_path: "OpenStack-Cloud-Crowbar"
+  when: cloud_product == 'crowbar'
 
 - name: Check MU URL
   uri:
@@ -38,7 +44,7 @@
     path: "{{ local_repos_base_dir }}/{{ item }}"
   loop: "{{ maint_updates_list }}"
 
-# This tasks is responsible for fiding to which product the MUs are targeted for.
+# This tasks is responsible for finding to which product the MUs are targeted for.
 # This is done by combining the MU IDs with the MU paths (for Cloud and SLES)
 # and for each combination it checks if the Cloud or SLES MU path is present on
 # the MU page content which registered in the mu_url variable.
@@ -60,13 +66,24 @@
   until: mu_sync_result.rc != 24
   delay: 300
 
-- name: Add MU zypper repositories
+- name: Add MU zypper repositories - Ardana
   zypper_repository:
     name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
     repo: "{{ local_repos_base_dir }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
     runrefresh: yes
     state: present
-  when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+  when: " cloud_product == 'ardana' and maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
   loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
   notify:
     - Refresh all repos
+
+- name: Add MU zypper repositories - Crowbar (admin node)
+  zypper_repository:
+    name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
+    repo: "{{ local_repos_base_dir }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
+    runrefresh: yes
+    state: present
+  loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+  notify:
+    - Refresh all repos
+  when: "inventory_hostname == ardana_env and cloud_product == 'crowbar' and maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
@@ -5,9 +5,9 @@ Built by: {{ lookup('env', 'BUILD_URL') }}
 Media build version: {{ media_build_version }}
 Configured repositories:
 {% if cloud_product == 'ardana'%}
-   {% for repo in repos_to_add | sort %}
+{%   for repo in repos_to_add | sort %}
   - {{ repo }}
-   {% endfor %}
+{%   endfor %}
 {% endif %}
 {% if is_milestone %}
   - {{ media[cloud_release].name }}

--- a/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
+++ b/scripts/jenkins/ardana/ansible/roles/setup_zypper_repos/templates/motd.j2
@@ -4,9 +4,11 @@ Built by: {{ lookup('env', 'BUILD_URL') }}
 {% endif %}
 Media build version: {{ media_build_version }}
 Configured repositories:
-{% for repo in repos_to_add | sort %}
+{% if cloud_product == 'ardana'%}
+   {% for repo in repos_to_add | sort %}
   - {{ repo }}
-{% endfor %}
+   {% endfor %}
+{% endif %}
 {% if is_milestone %}
   - {{ media[cloud_release].name }}
 {% endif %}


### PR DESCRIPTION
PR enables adding MU repositories and installation of MU patches before the deployment. Most of the code reused from Ardana part(`setup_zypper_repo` role). To make it work I had to slightly change role `setup_zypper_repos` and some variables.

New roles has been created:
* crowbar_update 
  + add repos on the cloud nodes
  + update nodes (currently this is missing and will be done as part of SOC-8465)

* reboot_node
  + reboot deployer (possible ardana+crowbar)
  + reboot nodes (currently only crowbar cloud nodes)

Repositories are added in steps:
* On admin `bootstrap-crowbar.yml`  (bootstrap admin node in jenkins)
* On nodes `register-crowbar-nodes.yml` (register nodes in jenkins)

Reboot is done in steps:
* On admin `install-crowbar.yml`
* On nodes `deploy-crowbar.yml`



Crowbar POC ci job: 
* with defined MU numbers: https://ci.suse.de/blue/organizations/jenkins/openstack-crowbar/detail/openstack-crowbar/423/pipeline/67
* without defined MU number: https://ci.suse.de/blue/organizations/jenkins/openstack-crowbar/detail/openstack-crowbar/424/pipeline/67
Ardana POC ci job: https://ci.suse.de/blue/organizations/jenkins/cloud-maintenance-gating/detail/cloud-maintenance-gating/36/pipeline

BTW Ardana job failures happened during tempest, so they shouldn't be affected by this PR.