### PR TITLE
Append trusted CA to existing one

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2092,7 +2092,7 @@ function setup_trusted_cert
         scp $cn.key $node:$keyfile
     done
     for node in $(get_all_discovered_nodes); do
-        scp rootca.pem $node:/etc/pki/trust/anchors/rootca.pem
+        cat rootca.pem | ssh $node 'cat >> /etc/pki/trust/anchors/rootca.pem'
         ssh $node update-ca-certificates
     done
 }


### PR DESCRIPTION
Without this patch, when SSL is enabled, and then crowbar is backed up
and restored from backup, and then keystone's SSL endpoint is toggled
off and then on, the root CA that was generated during the initial
proposal step is not saved and mkcloud generates a new one for keystone.
This causes the keystone endpoint to work fine but means all the other
services have old certs that are not trusted by the new CA. This patch
fixes the issue by ensuring that if a new CA is generated, it is
appended to the old one rather than replacing it. This means that even
if keystone gets a new cert, all services should still work.