### PR TITLE
openstack-ardana: enable cloud 9 GM and updates

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -15,7 +15,6 @@
     concurrent: False
     version: '9'
     ardana_env: 'cloud-ardana-gate{version}-slot'
-    deploy_and_update: false
     jobs:
         - '{ardana_gating_job}'
 
@@ -223,6 +222,23 @@
     controllers: '2'
     sles_computes: '0'
     rhel_computes: '2'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana9-job-std-min-suse-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: GM9+up
+    updates_test_enabled: false
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '2'
+    sles_computes: '1'
     ses_enabled: true
     ses_rgw_enabled: false
     triggers:

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -58,6 +58,8 @@
             - hosGM8+up
             - stagingcloud9
             - develcloud9
+            - GM9
+            - GM9+up
             - cloud9M3
             - cloud9M4
             - cloud9M5

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -58,6 +58,8 @@
             - hosGM8+up
             - stagingcloud9
             - develcloud9
+            - GM9
+            - GM9+up
             - cloud9M3
             - cloud9M4
             - cloud9M5

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -44,6 +44,8 @@
             - hosGM8+up
             - stagingcloud9
             - develcloud9
+            - GM9
+            - GM9+up
             - cloud9M3
             - cloud9M4
             - cloud9M5

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -45,6 +45,8 @@
             - GM8+up
             - stagingcloud9
             - develcloud9
+            - GM9
+            - GM9+up
             - cloud9M3
             - cloud9M4
             - cloud9M5


### PR DESCRIPTION
Adds `GM9` and `GM9+up` to the available cloudsource values
and makes the devel-to-staging-update job a mandatory part
of the cloud 9 Ardana gating job.

Also creates a periodic `cloud-ardana9-job-std-min-suse-x86_64`
job running against GM9+up.