### PR TITLE
qa_crowbarsetup.sh: fix SSL for cloud 7

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2171,7 +2171,9 @@ function enable_ssl_generic
             return
         ;;
         keystone)
-            $p "$a['ssl']['ca_certs']" "'/etc/ssl/ca-bundle.pem'"
+            if iscloudver 8plus ; then
+                $p "$a['ssl']['ca_certs']" "'/etc/ssl/ca-bundle.pem'"
+            fi
             $p "$a['api']['protocol']" "'https'"
         ;;
         *)


### PR DESCRIPTION
Cloud 7 deployments still use the certificates generated and shipped
with the keystone package, the paths of which are still hard-coded
in several places to `/etc/keystone/ssl/certs/`, which is also the
default path. If a different path is used, the keystone barclamp
fails with the following error:

```
FATAL: Errno::ENOENT: ruby_block[synchronize signing keys for founder and remember them for non-HA case] (keystone::server line 347) had an error: Errno::ENOENT: No such file or directory @ rb_sysopen - /etc/keystone/ssl/certs/ca.pem
```

This change is meant to fix the SSL enabled cloud 7 Crowbar deployments (e.g. the [cloud-mkcloud7-job-ssl-x86_64](https://ci.suse.de/view/Cloud/view/Cloud7/job/cloud-mkcloud7-job-ssl-x86_64/) job).