### PR TITLE
try neutron proposal for controller, if nova does not exist

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3314,7 +3314,7 @@ function onadmin_proposal
     done
     # Set the $novacontroller global variable so that we
     # can execute actions from the controller
-    get_novacontroller
+    get_controller
 
     # use local cache whenever possible
     oncontroller mount_localreposdir
@@ -3410,6 +3410,16 @@ function get_cluster_name
                         ['elements']['nova-controller']"`
     local cluster=${element#cluster:}
     echo $cluster
+}
+
+function get_controller
+{
+    if [[ $want_nova_proposal != 1 ]]; then
+        get_neutron_server_node
+        novacontroller=$NEUTRON_SERVER
+    else
+        get_novacontroller
+    fi
 }
 
 function get_novacontroller


### PR DESCRIPTION
currently without nova, neutron and designate cannot be deployed, this is
a pretty hard requirement which does not really exist in the product.

One can have keystone and neutron working together to test the
integration, but having nova (glance, cinder) simply increases
deployment time as well as chef-client run time which makes
testing quick changes to the recipes painfully difficult

This patch just make sure novacontroller variable is pointed to the
correct host by looking at the neutron-server attribute of the neutron
proposal. This could be extended to other barclamps, but that is not the
aim of the patch.

The variable is not really a "nova controller" but just a simple
controller and it begs being renamed everywhere, but since the
variable has always been called novacontroller, i dare not change that.