### PR TITLE
heat-generator: handle load-balancer references and global var defaults

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -14,6 +14,9 @@
 # under the License.
 #
 ---
+ardana_env: localhost
+
+cloudsource: stagingcloud9
 
 cloud_product: "ardana"
 #cloud_product: "crowbar"

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/README.md
@@ -32,6 +32,16 @@ _Step 1._ provide the path of an input model definition:
       -e input_model_path=./ardana-input-model/2.0/ardana-ci/deployerincloud-lite \
       -e heat_template_file=heat.yaml
 
+NOTE: optionally, provide a `cloudsource` value (defaults to `stagingcloud9`) to control which flavors and
+images are used and an `ardana_env` value (defaults to `localhost`) to change how the heat stack resources are
+named:
+
+    ansible-playbook generate-heat-template.yml \
+      -e input_model_path=./ardana-input-model/2.0/ardana-ci/deployerincloud-lite \
+      -e heat_template_file=heat.yaml \
+      -e cloudsource=GM8+up \
+      -e ardana_env=my_dev_env
+
 _Step 2._ ...
 
 _Step 3._ profit: `heat.yml` has been generated and the input model was updated in-place with virtualized 

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -489,6 +489,15 @@ def enhance_input_model(input_model):
             neutron_networks,
             ref_list_attr='network-group-routes')
 
+        # Network groups may contain references to control plane load
+        # balancers, which we have to transform into object references
+        # explicitly here
+        for cp in input_model['control-planes'].values():
+            link_elements_by_foreign_key_list(
+                network_group, 'load-balancers',
+                cp['load-balancers'],
+                ref_list_attr=None)
+
     # Based on the collected neutron networks and network tags, identify
     # which network group is linked to which neutron network, by looking
     # at the provider physical network settings


### PR DESCRIPTION
Adds some code to properly handle load balancer references
in the network groups.

The `ardana-input-models` input models use load balancer
references in the network groups, rather than inline load
balancer definitions. The last heat generator patch [1] didn't
take that into account, causing the playbook to fail if such
an input model is used as input.

This PR also adds some defaults for global variables that
are required by the heat generator playbook and documents
how to override them.

[1] https://github.com/SUSE-Cloud/automation/pull/3288