### PR TITLE
repochecker: Adjust repochecker to be able to run with Leap/SLE15

### DIFF
--- a/scripts/repochecker
+++ b/scripts/repochecker
@@ -4,7 +4,7 @@
 # used for the openSUSE/SLE Cloud packages to check the dependencies for the
 # different repositories. Use it for instance with:
 #
-# REPCHECK_DIST_VERSION=13.2 REPCHECK_DIST_NAME=openSUSE \
+# REPCHECK_DIST_VERSION=15.0 REPCHECK_DIST_NAME=openSUSE \
 #     REPCHECK_PROJECT="Cloud:OpenStack:Kilo:Staging" repochecker
 
 set -e
@@ -14,8 +14,8 @@ set -e
 : ${REPCHECK_PROJECT:="Cloud:OpenStack:Master"}
 # openSUSE or SLE
 : ${REPCHECK_DIST_NAME:="openSUSE"}
-# i.e. 13.2 , Tumbleweed, 11_SP3, 12
-: ${REPCHECK_DIST_VERSION:="13.2"}
+# i.e. 13.2 , Tumbleweed, 12_SP3, 15
+: ${REPCHECK_DIST_VERSION:="15.0"}
 : ${REPCHECK_INSTCHECK_EXCLUDES:="-kmp-"}
 # buildservice instance used for $REPCHECK_PROJECT.
 # use "ibs" for SUSE internal buildservice. Otherwise leave blank
@@ -34,12 +34,19 @@ if [[ $REPCHECK_DIST_NAME == "openSUSE" ]]; then
         dv=${REPCHECK_DIST_VERSION,,}
         $zypper ar -f http://download.opensuse.org/${dv}/repo/oss/ Base || true
     else
-        $zypper ar -f http://download.opensuse.org/distribution/${REPCHECK_DIST_VERSION}/repo/oss/ Base || true
-        $zypper ar -f http://download.opensuse.org/update/${REPCHECK_DIST_VERSION}/${REPCHECK_DIST_NAME}:${REPCHECK_DIST_VERSION}:Update.repo || true
+        $zypper ar -f http://download.opensuse.org/distribution/leap/${REPCHECK_DIST_VERSION}/repo/oss/ Base || true
+        $zypper ar -f http://download.opensuse.org/update/leap/${REPCHECK_DIST_VERSION}/oss/${REPCHECK_DIST_NAME}:Leap:${REPCHECK_DIST_VERSION}:Update.repo || true
     fi
 fi
 
 if [[ $REPCHECK_DIST_NAME == "SLE" ]]; then
+    if [[ $REPCHECK_DIST_VERSION == 15* ]]; then
+        for prod in SLE-Product-SLES SLE-Module-Basesystem SLE-HA SLE-Module-Legacy SLE-Module-Development-Tools SLE-Module-Server-Applications; do
+            $zypper ar "http://smt-internal.opensuse.org/repo/\$RCE/SUSE/Products/$prod/${REPCHECK_DIST_VERSION}/x86_64/product/" ${prod}-Base || true
+            $zypper ar --refresh "http://smt-internal.opensuse.org/repo/\$RCE/SUSE/Updates/$prod/${REPCHECK_DIST_VERSION}/x86_64/update/" ${prod}-Updates || true
+        done
+    fi
+
     if [[ $REPCHECK_DIST_VERSION == 12* ]]; then
         $zypper ar -f "http://smt-internal.opensuse.org/repo/\$RCE/SUSE/Updates/SLE-SERVER/${REPCHECK_DIST_VERSION}/x86_64/update/" Updates || true
         $zypper ar -f "http://smt-internal.opensuse.org/repo/\$RCE/SUSE/Products/SLE-SERVER/${REPCHECK_DIST_VERSION}/x86_64/product" Base || true
@@ -60,7 +67,11 @@ else
 fi
 
 p=${REPCHECK_PROJECT//:/:\/}
-$zypper ar -f ${repo_url}/${p}/${REPCHECK_DIST_NAME}_${REPCHECK_DIST_VERSION}/${REPCHECK_PROJECT}.repo || true
+if [[ $REPCHECK_DIST_NAME == "openSUSE" ]]; then
+    $zypper ar -f ${repo_url}/${p}/${REPCHECK_DIST_NAME}_Leap_${REPCHECK_DIST_VERSION}/${REPCHECK_PROJECT}.repo || true
+else
+    $zypper ar -f ${repo_url}/${p}/${REPCHECK_DIST_NAME}_${REPCHECK_DIST_VERSION}/${REPCHECK_PROJECT}.repo || true
+fi
 
 # if it's a staging repo, also add the non-staging one
 if [[ "$REPCHECK_PROJECT" == *:Staging ]]; then


### PR DESCRIPTION
Some changes are needed to make repochecker usable again.
For checking Cloud:OpenStack:Stein , you can use now something like:

REPCHECK_DIST_NAME=SLE REPCHECK_DIST_VERSION=15 \
  REPCHECK_PROJECT=Cloud:OpenStack:Stein bash -x scripts/repochecker