### PR TITLE
Update /etc/hosts on controller nodes

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
@@ -97,9 +97,8 @@
   shell: grep  'public-KEY-API-extapi' /etc/hosts | awk {'print $1'}
   register: public_vip
 
-- name: Update /etc/hosts
-  lineinfile:
-    dest=/etc/hosts
-    line="{{ public_vip.stdout }}    {{ external_name }}"
-  become: yes
+- name: Update /etc/hosts on the deployer and controller nodes
+  shell: ansible -b -m lineinfile -a "dest=/etc/hosts line='{{ public_vip.stdout }}    {{ external_name }}'" OPS-LM--first-member,KEY-API
+  args:
+    chdir:"{{ ardana_scratch_path }}"
   when: external_name | default('') != ''


### PR DESCRIPTION
In a deployment where we specify an external
name for the public endpoints, the /etc/hosts
file need to be updated with this entry. Earlier,
we did this on only deployer node.
However, services like heat communicate to
keystone via the public endpoint. This requires
that the /etc/hosts file on the controller nodes
need to be updated as well.