### PR TITLE
trackupstream: Track OpenStack Stein release

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -17,6 +17,7 @@
             - Cloud:OpenStack:Pike:Staging
             - Cloud:OpenStack:Queens:Staging
             - Cloud:OpenStack:Rocky:Staging
+            - Cloud:OpenStack:Stein:Staging
             - Cloud:OpenStack:Master
       - axis:
           type: user-defined
@@ -106,7 +107,7 @@
             "python-vmware-nsxlib",
             "python-vmware-nsx"
             ].contains(component) ||
-            [ "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Pike:Staging" ].contains(project) &&
+            [ "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Pike:Staging" ].contains(project) &&
             [
               "python-heat-cfntools",
               "openstack-rally",
@@ -115,7 +116,7 @@
               "python-vmware-nsxlib",
               "python-vmware-nsx",
             ].contains(component) ||
-            [ "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging" ].contains(project) &&
+            [ "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging" ].contains(project) &&
             [
               "openstack-trove",
               "openstack-horizon-plugin-trove-ui",
@@ -126,13 +127,13 @@
               "openstack-horizon-plugin-neutron-vpnaas-ui",
               "openstack-neutron-vsphere",
             ].contains(component) ||
-            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Pike:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Rocky:Staging" ].contains(project) &&
+            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Pike:Staging" ].contains(project) &&
             [
               "openstack-horizon-plugin-murano-ui",
               "openstack-gnocchi",
               "openstack-monasca-transform"
             ].contains(component) ||
-            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Rocky:Staging" ].contains(project) &&
+            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging" ].contains(project) &&
             [
               "openstack-horizon-plugin-freezer-ui",
               "openstack-nova-virt-zvm"


### PR DESCRIPTION
We have OpenStack Stein packages now. So track the stable branches
for the packages.