### PR TITLE
openstack-crowbar/ardana: ipv6 support and periodic jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -141,7 +141,7 @@
     clm_model: standalone
     controllers: '2'
     sles_computes: '1'
-    ses_enabled: true
+    ses_enabled: false
     ses_rgw_enabled: false
     ipv6: true
     triggers:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -134,6 +134,22 @@
         - '{ardana_job}'
 
 - project:
+    name: cloud-ardana9-job-std-min-ipv6-x86_64
+    ardana_job: '{name}'
+    ardana_env: cloud-ardana-ci-slot
+    scenario_name: standard
+    clm_model: standalone
+    controllers: '2'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    ipv6: true
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
     name: cloud-ardana9-job-mid-scale-kvm-qe101-x86_64
     ardana_job: '{name}'
     concurrent: False

--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -14,6 +14,22 @@
         - '{crowbar_job}'
 
 - project:
+    name: cloud-crowbar9-job-ipv6-x86_64
+    crowbar_job: '{name}'
+    cloudsource: stagingcloud9
+    ardana_env: cloud-ardana-ci-slot
+    scenario_name: crowbar
+    scenario_file: cloud9/cloud9-2nodes-ses.yml
+    controllers: '1'
+    computes: '1'
+    ses_enabled: true
+    ipv6: true
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{crowbar_job}'
+
+- project:
     name: cloud-crowbar9-job-ha-x86_64
     crowbar_job: '{name}'
     cloudsource: stagingcloud9

--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -22,7 +22,7 @@
     scenario_file: cloud9/cloud9-2nodes-ses.yml
     controllers: '1'
     computes: '1'
-    ses_enabled: true
+    ses_enabled: false
     ipv6: true
     triggers:
      - timed: 'H H * * *'

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -427,9 +427,9 @@
 
       - bool:
           name: ipv6
-          default: false
+          default: '{ipv6|false}'
           description: >-
-            Use ipv6 networks in the cloud input model.
+            Enable ipv6 support in the cloud configuration
 
       - text:
           name: extra_params

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -144,6 +144,12 @@
           default: '{ses_enabled|true}'
           description: Configure SES backend for glance, cinder and nova
 
+      - bool:
+          name: ipv6
+          default: '{ipv6|false}'
+          description: >-
+            Enable ipv6 support in the cloud configuration
+
       - validating-string:
           name: extra_repos
           default: ''

--- a/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/all.yml
@@ -61,6 +61,8 @@ sles_cloud_version:
 rhel_os: CentOS_75
 rhel_os_version: "{{ rhel_os.split('_')[1] }}"
 
+ipv6: False
+
 updates_test_enabled: False
 
 update_after_deploy: False

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -21,11 +21,7 @@ parameters:
     type: string
     label: Default CIDR
     description: Default CIDR value to use for networks which do not have CIDR specified
-{%   if (ipv6 | default(false)) == true %}
-    default: "2001::/64"
-{%    else   %}
-    default: "1.1.1.0/24"
-{%    endif  %}
+    default: {{ ipv6 | ternary("2001::/64", "1.1.1.0/24") }}
 
 resources:
 
@@ -51,11 +47,7 @@ resources:
       name: {{ heat_resource_name_prefix }}_dummy_subnet
       network_id: { get_resource: default_network }
       cidr: { get_param: default_subnet_cidr }
-{%   if (ipv6 | default(false)) == true %}
-      ip_version: 6
-{%    else   %}
-      ip_version: 4
-{%    endif  %}
+      ip_version: {{ ipv6 | ternary(6, 4) }}
       enable_dhcp: False
 
   # networks and subnets
@@ -90,21 +82,15 @@ resources:
 {%     endfor %}
 {%   endif  %}
 {%   if network.external and dns_servers is defined %}
-{%   if (ipv6 | default(false)) == false %}
+{%     if not ipv6 %}
       dns_nameservers:
-{%     for dns_server in dns_servers %}
+{%       for dns_server in dns_servers %}
         - {{ dns_server }}
-{%     endfor %}
+{%       endfor %}
+{%     endif  %}
 {%   endif  %}
-{%   endif  %}
-
-
-{%   if (ipv6 | default(false)) == true %}
-{%   if network.is_conf %}
-      ip_version: 4
-{%   else   %}
+{%   if ipv6 and not network.is_conf %}
       ip_version: 6
-{%   endif  %}
 {%   else   %}
       ip_version: 4
 {%   endif  %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -46,8 +46,16 @@ cp_prefix: cp1
 max_host_prefix_len: "{{ 33-(cp_prefix|length) }}"
 host_prefix: "{{ ('ardana-' ~ ardana_env)[:max_host_prefix_len|int-1] if ardana_env is defined else 'ardana' }}"
 
-# First two octets of the generated subnet prefixes for Ardana networks
-subnet_prefix: 192.168
+# First octets of the generated subnet prefixes for Ardana networks
+subnet_prefix:
+  ipv4: 192.168
+  ipv6: fd00:0:0
+
+# First octets of the generated subnet prefixes for Ardana neutron networks
+neutron_subnet_prefix:
+  ipv4: 172
+  ipv6: fd00:1:0
+
 # Start value for the third octet for the generated subnet prefixes and also
 # start of generated VLAN IDs for Ardana networks
 gen_subnet_start: 100

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/networks.yml
@@ -37,18 +37,13 @@
       vlanid: {{ ns.net_id }}
 {%   endif %}
       tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
-{%   if (ipv6 | default(false)) == true %}
-{%   if ns.net_id != gen_subnet_start %}
-      cidr: fd00:0:0:{{ ns.net_id }}::/64
-      gateway-ip: fd00:0:0:{{ ns.net_id }}::1
-{%   else %}
-      cidr: {{ subnet_prefix }}.{{ ns.net_id }}.0/24
-      gateway-ip: {{ subnet_prefix }}.{{ ns.net_id }}.1
-{%   endif %}
-{%   else  %}
-      cidr: {{ subnet_prefix }}.{{ ns.net_id }}.0/24
-      gateway-ip: {{ subnet_prefix }}.{{ ns.net_id }}.1
-{%   endif %}
+{%     if ipv6 and ns.net_id != gen_subnet_start %}
+      cidr: {{ subnet_prefix.ipv6 }}:{{ ns.net_id }}::/64
+      gateway-ip: {{ subnet_prefix.ipv6 }}:{{ ns.net_id }}::1
+{%     else  %}
+      cidr: {{ subnet_prefix.ipv4 }}.{{ ns.net_id }}.0/24
+      gateway-ip: {{ subnet_prefix.ipv4 }}.{{ ns.net_id }}.1
+{%     endif %}
 {%   endif %}
       network-group: {{ network_group.name|upper }}
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/neutron/neutron_config.yml
@@ -56,26 +56,26 @@
                 segmentation_id: {{ ns.vlan_id }}
             no_gateway:  True
             enable_dhcp: True
-{% if (ipv6 | default(false)) == true %}
-            cidr: fd00:0:0:{{ ns.net_id }}::/64
+{%     if ipv6 %}
+            cidr: {{ neutron_subnet_prefix.ipv6 }}:{{ ns.net_id }}::/64
             allocation_pools:
-              - start: fd00:0:0:{{ ns.net_id }}::10
-                end: fd00:0:0:{{ ns.net_id }}::250
+              - start: {{ neutron_subnet_prefix.ipv6 }}:{{ ns.net_id }}::10
+                end: {{ neutron_subnet_prefix.ipv6 }}:{{ ns.net_id }}::250
             host_routes:
               # route to management network
-              - destination: fd00:0:0:{{ ns.mgmt_net_id }}::/64
-                nexthop:  fd00:0:0:{{ ns.net_id }}::1
-{%     set ns.net_id = ns.net_id+1 %}
-{%     set ns.vlan_id = ns.vlan_id+1 %}
-{% else %}
-            cidr: 172.{{ ns.net_id }}.1.0/24
+              - destination: {{ subnet_prefix.ipv6 }}:{{ ns.mgmt_net_id }}::/64
+                nexthop:  {{ neutron_subnet_prefix.ipv6 }}:{{ ns.net_id }}::1
+{%       set ns.net_id = ns.net_id+1 %}
+{%       set ns.vlan_id = ns.vlan_id+1 %}
+{%     else %}
+            cidr: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.0/24
             allocation_pools:
-              - start: 172.{{ ns.net_id }}.1.10
-                end: 172.{{ ns.net_id }}.1.250
+              - start: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.10
+                end: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.250
             host_routes:
             # route to management network
-              - destination: {{ subnet_prefix }}.{{ ns.mgmt_net_id }}.0/24
-                nexthop:  172.{{ ns.net_id }}.1.1
+              - destination: {{ subnet_prefix.ipv4 }}.{{ ns.mgmt_net_id }}.0/24
+                nexthop:  {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.1
 {%     set ns.net_id = ns.net_id+1 %}
 {%     set ns.vlan_id = ns.vlan_id+1 %}
 {%   endif %}
@@ -86,26 +86,26 @@
 {%     endif %}
 
 {% for network_group in scenario.network_groups if 'NEUTRON-EXT' in network_group.component_endpoints %}
-{%     if not ns.ext_nets_hdr %}
-{%       set ns.ext_nets_hdr=True %}
+{%   if not ns.ext_nets_hdr %}
+{%     set ns.ext_nets_hdr=True %}
         neutron_external_networks:
-{%     endif %}
+{%   endif %}
 
           - name: ext-net{{ loop.index0 | ternary(loop.index0, '') }}
-{% if (ipv6 | default(false)) == true %}
-            cidr: fd00:0:0:{{ ns.net_id }}::/64
-            gateway-ip: fd00:0:0:{{ ns.net_id }}::1
+{%   if ipv6 %}
+            cidr: {{ neutron_subnet_prefix.ipv6 }}:{{ ns.net_id }}::/64
+            gateway-ip: {{ neutron_subnet_prefix.ipv6 }}:{{ ns.net_id }}::1
 {%     set ns.net_id = ns.net_id+1 %}
-{% else %}
-            cidr: 172.{{ ns.net_id }}.0.0/16
-            gateway: 172.{{ ns.net_id }}.0.1
-{%   if not enable_external_network_bridge %}
+{%   else %}
+            cidr: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.0.0/16
+            gateway: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.0.1
+{%     if not enable_external_network_bridge %}
             provider:
             - network_type: flat
               physical_network: external{{ loop.index0 | ternary(loop.index0, '') }}
+{%     endif %}
+{%     set ns.net_id = ns.net_id+1 %}
 {%   endif %}
-{%   set ns.net_id = ns.net_id+1 %}
-{% endif %}
 {% endfor %}
 {%     if not ns.ext_nets_hdr %}
         neutron_external_networks: []

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/servers.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/servers.yml
@@ -32,14 +32,14 @@
 
   baremetal:
     netmask: {{ bm_info.networks.bm_netmask if bm_info is defined else '255.255.255.0' }}
-    subnet: {{ subnet_prefix }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.0
+    subnet: {{ subnet_prefix.ipv4 }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.0
 
   servers:
 {% for service_group in scenario['service_groups'] if service_group['member_count']|int %}
 {%   for idx in range(service_group['member_count']|int) %}
 {%     set server_id = "%s-%04d"|format(service_group.name, idx+1) %}
     - id: {{ bm_info.servers[ns.server_idx].id if bm_info is defined else server_id }}
-      ip-addr: {{ subnet_prefix }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.{{ bm_info.networks.bm_subnet_start + ns.server_idx if bm_info is defined else ns.server_idx + gen_ip_start }}
+      ip-addr: {{ subnet_prefix.ipv4 }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.{{ bm_info.networks.bm_subnet_start + ns.server_idx if bm_info is defined else ns.server_idx + gen_ip_start }}
       role: {{ service_group.name|upper }}-ROLE
       server-group: RACK{{ (idx%3)+1 }}
       nic-mapping: {{ bm_info.servers[ns.server_idx].nic_mapping if bm_info is defined else 'HEAT' }}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/mkcloud.config.j2
@@ -106,14 +106,19 @@ export want_node_aliases=controller={{ controllers | int }},compute-kvm={{ compu
 export want_test_updates={{ updates_test_enabled | ternary (1, 0) }}
 export want_swift=1
 
+export want_ipv6={{ ipv6 | ternary (1, 0) }}
+
 # FIXME: these need to be generated ouf of the scenario generator
 # for now, set them to match the crowbar scenario
 
-export net_public={{ subnet_prefix }}.{{ gen_subnet_start+1 }}
-export net_sdn={{ subnet_prefix }}.{{ gen_subnet_start+2 }}
-export net_storage={{ subnet_prefix }}.{{ gen_subnet_start+3 }}
-export net_fixed={{ subnet_prefix }}.{{ gen_subnet_start+4 }}
-export net_ceph={{ subnet_prefix }}.{{ gen_subnet_start+5 }}
+{% set ipsep = ipv6 | ternary (':', '.') %}
+{% set subnet_prefix = ipv6 | ternary (subnet_prefix.ipv6, subnet_prefix.ipv4) %}
+
+export net_public={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+1 }}
+export net_sdn={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+2 }}
+export net_storage={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+3 }}
+export net_fixed={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+4 }}
+export net_ceph={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+5 }}
 
 export vlan_public={{ gen_subnet_start+1 }}
 export vlan_sdn={{ gen_subnet_start+2 }}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/crowbar.yml
@@ -4,7 +4,10 @@
 controllers: 1
 computes: 1
 
-subnet_prefix: 192.168
+subnet_prefix:
+  ipv4: 192.168
+  ipv6: fd00:0:0
+
 gen_subnet_start: 124
 gen_ip_start: 10
 # The gap to be left between the admin node IP and the rest of the nodes

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/standard.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/templates/network/standard.yml
@@ -21,6 +21,8 @@ network_groups:
     tagged_vlan: false
     component_endpoints:
       - CLM
+    routes:
+      - default
 
   - name: MANAGEMENT
     hostname_suffix: mgmt
@@ -29,8 +31,6 @@ network_groups:
       - MANAGEMENT
       - INTERNAL-API
       - NEUTRON-VLAN
-    routes:
-      - default
 
   - name: EXTERNAL-API
     hostname_suffix: extapi


### PR DESCRIPTION
This PR add IPv6 support to the input model generator and heat generator,
so that it can be used by both Ardana and Crowbar.

This requires replacing some of the hard-coded IPv4/6 prefix values
with ansible variables and using those values in the generated
mkcloud.conf file.

For Ardana IPv6 environments to work properly, it was also necessary
to move the default route to the `CONF` network in all the scenarios
that use the `standard` network template (`standard`, `std-lmm`,
`std-split`). This has the effect that the default route is set
up on the same interface used by the lifecycle manager, which is
the same interface that is associated with the floating IP on
the deployer node. When IPv6 is enabled, the default route will
be IPv4, which allows the nodes to communicate with the outside
world.

The PR also creates a couple of periodic jobs with IPv6 enabled.

NOTE: SES integration is currently disabled for the IPv6 jobs, because
there is no support yet to create IPv6 SES clusters in the ECP.