### PR TITLE
Revert "qa_openstack: Add SLE15 HA product"

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -73,7 +73,7 @@ function addslesrepos {
         $zypper ar --refresh "http://smt-internal.opensuse.org/repo/\$RCE/SUSE/Updates/SLE-SERVER/$REPOVER/x86_64/update/" SLES$VERSION-Updates
         ;;
     *)
-        for prod in SLE-Product-SLES SLE-Module-Basesystem SLE-HA SLE-Module-Legacy SLE-Module-Development-Tools SLE-Module-Server-Applications; do
+        for prod in SLE-Product-SLES SLE-Module-Basesystem SLE-Module-Legacy SLE-Module-Development-Tools SLE-Module-Server-Applications; do
             $zypper ar "http://smt-internal.opensuse.org/repo/\$RCE/SUSE/Products/$prod/$REPOVER/x86_64/product/" $prod-$VERSION-Pool
             $zypper ar --refresh "http://smt-internal.opensuse.org/repo/\$RCE/SUSE/Updates/$prod/$REPOVER/x86_64/update/" $prod-$VERSION-Updates
         done


### PR DESCRIPTION
The intention of the cleanvm check is to see if the OpenStack
Cloud packages would install + pass testing on a default SLES
installation.

The HA product is not default subscribed for SLES customers, see
http://docserv.nue.suse.com/documents/SLES_15/SLES-modulesquick/single-html/#sec.modules.what.modules

for details.

This reverts commit 565bab6c8d46d6038e8e8e0f64e615aeba7f1600.