### PR TITLE
Use virtio multiqueue for the ardana CI images

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
               --container-format bare \
               --${image_visibility} \
               --property hw_rng_model='virtio' \
+              --property hw_vif_multiqueue_enabled='True' \
               ${sles_image}-update
 
           if [[ $image_visibility == shared ]]; then

--- a/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin-uefi.xml
@@ -37,6 +37,7 @@
       <target dev='cloud-a'/>
       <source network='cloud-admin'/>
       <model type='virtio'/>
+      <driver name="vhost" queues="2"/>
       <address type='pci' bus='0x01' slot='0x1'/>
     </interface>
     <serial type='pty'>

--- a/scripts/lib/libvirt/fixtures/cloud-admin.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-admin.xml
@@ -37,6 +37,7 @@
       <target dev='cloud-a'/>
       <source network='cloud-admin'/>
       <model type='virtio'/>
+      <driver name="vhost" queues="2"/>
       <address type='pci' bus='0x01' slot='0x1'/>
     </interface>
     <serial type='pty'>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-9pnet-mount.xml
@@ -48,6 +48,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='virtio'/>
+  <driver name="vhost" queues="2"/>
   <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-raid.xml
@@ -64,6 +64,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='virtio'/>
+  <driver name="vhost" queues="2"/>
   <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-uefi.xml
@@ -48,6 +48,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='virtio'/>
+  <driver name="vhost" queues="2"/>
   <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>

--- a/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1-xen.xml
@@ -48,6 +48,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='e1000'/>
+  
   <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>

--- a/scripts/lib/libvirt/fixtures/cloud-node1.xml
+++ b/scripts/lib/libvirt/fixtures/cloud-node1.xml
@@ -48,6 +48,7 @@
   <target dev='cloud-1-0'/>
   <source network='cloud-admin'/>
   <model type='virtio'/>
+  <driver name="vhost" queues="2"/>
   <address type='pci' bus='0x01' slot='0x1'/>
   <boot order='2'/>
 </interface>

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -180,6 +180,11 @@ def get_net_for_nic(args, index):
 def net_interfaces_config(args, nicmodel):
     nic_configs = []
     bootorderoffset = 2
+    nicdriver = ''
+
+    if 'virtio' in nicmodel:
+        nicdriver = '<driver name="vhost" queues="2"/>'
+
     for index, mac in enumerate(args.macaddress):
         mainnicaddress = get_mainnic_address(index)
         values = dict(
@@ -188,6 +193,7 @@ def net_interfaces_config(args, nicmodel):
             nicindex=index,
             net=get_net_for_nic(args, index),
             macaddress=mac,
+            nicdriver=nicdriver,
             nicmodel=nicmodel,
             bootorder=bootorderoffset + (index * 10),
             mainnicaddress=mainnicaddress)

--- a/scripts/lib/libvirt/templates/admin-node.xml
+++ b/scripts/lib/libvirt/templates/admin-node.xml
@@ -27,6 +27,7 @@ $cpuflags
       <target dev='$cloud-a'/>
       <source network='$cloud-admin'/>
       <model type='virtio'/>
+      <driver name="vhost" queues="2"/>
       $mainnicaddress
     </interface>
 $serialdevice

--- a/scripts/lib/libvirt/templates/net-interface.xml
+++ b/scripts/lib/libvirt/templates/net-interface.xml
@@ -3,6 +3,7 @@
   <target dev='$cloud-$nodecounter-$nicindex'/>
   <source network='$cloud-$net'/>
   <model type='$nicmodel'/>
+  $nicdriver
   $mainnicaddress
   <boot order='$bootorder'/>
 </interface>

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4169,11 +4169,13 @@ function oncontroller_testsetup
             if [ -n "${local_image_path}" -a -f "${local_image_path}" ] ; then
                 openstack image create --public --property hypervisor_type=kvm \
                 --disk-format qcow2 --container-format bare \
+                --property hw_vif_multiqueue_enabled='True' \
                 --file $local_image_path $image_name | tee glance.out
             else
                 curl -s \
                     $imageserver_url/$arch/$image_filename | \
                     openstack image create --public --property hypervisor_type=kvm \
+                    --property hw_vif_multiqueue_enabled='True' \
                     --disk-format qcow2 --container-format bare $image_name | tee glance.out
             fi
         fi


### PR DESCRIPTION
Enabling hw_vif_multiqueue_enabled makes OpenStack switch
to the vhost-net driver instead of virtio and also enable
multiqueue support there, which means we can have a much
higher peak throughput of packet I/O, and that should be
a good thing :-)