### PR TITLE
openstack-crowbar: add tempest-results ansible role

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/tempest_results/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/tempest_results/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+# OpenSUSE Leap version number corresponding to the cloud version
+leap_version:
+  cloud7: "42.2"
+  cloud8: "42.3"
+  cloud9: "15.0"
+
+leap_repo_url: "http://download.opensuse.org/distribution/leap/{{ leap_version[cloud_release] }}/repo/oss/"
+
+sle_packages:
+  - "python-setuptools"
+  - "python-os-testr" # includes subunit2html.py
+  - "python-python-subunit"
+
+leap_packages:
+  - "python-junitxml"

--- a/scripts/jenkins/ardana/ansible/roles/tempest_results/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/tempest_results/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+
+- name: Gather variables for '{{ cloud_product }}'
+  include_vars: "{{ cloud_product }}.yml"
+
+- name: Install SLE package dependencies
+  zypper:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ sle_packages }}"
+
+- name: Ensure Leap repo is in place
+  zypper_repository:
+    repo: "{{ leap_repo_url }}"
+    name: leap
+    state: present
+    disable_gpg_check: yes
+    runrefresh: yes
+
+- name: Install Leap package dependencies
+  zypper:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ leap_packages }}"
+
+- name: Remove Leap repo
+  zypper_repository:
+    name: leap
+    state: absent
+    runrefresh: yes
+
+- name: Generate xml subunit results
+  shell: "subunit2junitxml {{ tempest_results_subunit }} > {{ subunit_xml_results }}"
+  changed_when: false
+
+- name: Generate html subunit results
+  shell: "subunit2html {{ tempest_results_subunit }} {{ subunit_html_results }}"
+  changed_when: false
+
+- name: Get results from subunit
+  command: "subunit-stats {{ tempest_results_subunit }}"
+  register: _test_results
+
+- name: Process test results from subunit
+  set_fact:
+    tempest_test_results: "{{ tempest_test_results | default({}) | combine({item.split()[0] | lower: item.split()[-1]}) }}"
+  when: "'tests' in item"
+  loop: "{{ _test_results.stdout_lines }}"
+  loop_control:
+    label: "{{ item.split()[0] | lower }}: {{ item.split()[-1] }}"

--- a/scripts/jenkins/ardana/ansible/roles/tempest_results/vars/crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/roles/tempest_results/vars/crowbar.yml
@@ -1,0 +1,5 @@
+---
+
+tempest_results_subunit: "~/tempest.subunit.log"
+subunit_xml_results: "~/testr_crowbar.xml"
+subunit_html_results: "~/testr_crowbar.html"

--- a/scripts/jenkins/ardana/ansible/run-crowbar-tests.yml
+++ b/scripts/jenkins/ardana/ansible/run-crowbar-tests.yml
@@ -6,9 +6,7 @@
   gather_facts: True
   vars:
     task: "tempest"
-    tempest_results_subunit: "~/tempest.subunit.log"
-    subunit_xml_results: "~/testr_crowbar.xml"
-    subunit_html_results: "~/testr_crowbar.html"
+
 
   pre_tasks:
     - include_role:
@@ -23,36 +21,6 @@
         - name: Crowbar log stream at
           debug:
             msg: "http://{{ ansible_host }}:9091/"
-
-        - name: Install package dependencies
-          zypper:
-            name: "{{ item }}"
-            state: present
-          loop:
-            - "python-setuptools"
-            - "python-os-testr" # includes subunit2html.py
-            - "python-python-subunit"
-
-        - name: Ensure leap repo for python-junitxml is in place
-          zypper_repository:
-            repo: "http://download.opensuse.org/distribution/leap/\
-              {{ (ansible_distribution_major_version|int > 12) | ternary(ansible_distribution_major_version, ansible_distribution_major_version|int + 30) }}\
-              .{{ ansible_distribution_release }}/repo/oss/"
-            name: leap
-            state: present
-            disable_gpg_check: yes
-            runrefresh: yes
-
-        - name: Install python-junitxml
-          zypper:
-            name: python-junitxml
-            state: present
-
-        - name: Remove leap repo for python-junitxml
-          zypper_repository:
-            name: leap
-            state: absent
-            runrefresh: yes
 
         - include_role:
             name: crowbar_setup
@@ -72,28 +40,8 @@
             msg: "{{ task }} failed."
       always:
 
-        - name: Generate xml subunit results
-          shell: "subunit2junitxml {{ tempest_results_subunit }} > {{ subunit_xml_results }}"
-          changed_when: false
-          failed_when: false
-
-        - name: Generate html subunit results
-          shell: "subunit2html {{ tempest_results_subunit }} {{ subunit_html_results }}"
-          changed_when: false
-          failed_when: false
-
-        - name: Get results from subunit
-          command: "subunit-stats {{ tempest_results_subunit }}"
-          failed_when: false
-          register: _test_results
-
-        - name: Process test results from subunit
-          set_fact:
-            tempest_test_results: "{{ tempest_test_results | default({}) | combine({item.split()[0] | lower: item.split()[-1]}) }}"
-          when: "'tests' in item"
-          loop: "{{ _test_results.stdout_lines }}"
-          loop_control:
-            label: "{{ item.split()[0] | lower }}: {{ item.split()[-1] }}"
+        - include_role:
+            name: tempest_results
 
         - include_role:
             name: jenkins_artifacts
@@ -102,9 +50,9 @@
               - src: "{{ admin_mkcloud_config_file }}"
               - src: "{{ qa_crowbarsetup_log }}"
               - src: "~/tempest.log"
-              - src: "~/tempest.subunit.log"
-              - src: "~/testr_crowbar.html"
-              - src: "~/testr_crowbar.xml"
+              - src: "{{ tempest_results_subunit }}"
+              - src: "{{ subunit_xml_results }}"
+              - src: "{{ subunit_html_results }}"
           when: lookup("env", "WORKSPACE")
 
   post_tasks:


### PR DESCRIPTION
Moves the code responsible for collecting tempest results
and converting them in the proper formats to a standalone
ansible role that can be reused for Ardana in the future.

This PR also corrects the repositories where required packages
are installed from.
