### PR TITLE
openstack-ardana-gerrit: re-enable cert verification

### DIFF
--- a/scripts/jenkins/ardana/gerrit/gerrit.py
+++ b/scripts/jenkins/ardana/gerrit/gerrit.py
@@ -17,7 +17,7 @@ import requests
 
 GERRIT_URL = 'https://gerrit.prv.suse.net'
 
-GERRIT_VERIFY = os.environ.get('GERRIT_VERIFY', False) in ['true', '1', True]
+GERRIT_VERIFY = os.environ.get('GERRIT_VERIFY', True) in ['true', '1', True]
 
 # We use a more complex regex that matches both formats of Depends-On so that
 # we preserve the order in which they are discovered.


### PR DESCRIPTION
Re-enables certificate verification in the Gerrit API calls.

NOTE: a properly signed certificate needs to replace the self-signed certificate on the Gerrit server. The other change that needs to be reversed to fully re-enable certificate validation is the git configuration on the `ardana-ci-launcher` and `cloud-trackupstream-sle12` Jenkins nodes, which are currently set to bypass it - i.e. in `~/.gitconfig`:

```
[http "https://gerrit.prv.suse.net"]
        sslVerify = false
[http "https://git.suse.provo.cloud"]
        sslVerify = false
```
