### PR TITLE
ardana-trackupstream: remove freezer from c9

### DIFF
--- a/jenkins/ci.suse.de/ardana-trackupstream.yaml
+++ b/jenkins/ci.suse.de/ardana-trackupstream.yaml
@@ -70,19 +70,17 @@
           name: label
           values:
             - openstack-trackupstream
-    # execution-strategy:
-    #   combination-filter: |
-    #     !(
-    #       (
-    #         [
-    #           "Devel:Cloud:8:Staging"
-    #         ].contains(project) &&
-    #         [
-    #           "XXX"
-    #         ].contains(component)
-    #       )
-
-    #     )
-    #   sequential: true
+    execution-strategy:
+      combination-filter: |
+        !(
+          (
+            [
+              "Devel:Cloud:9:Staging"
+            ].contains(project) &&
+            [
+              "ardana-freezer"
+            ].contains(component)
+          )
+        )
     builders:
       - trackupstream


### PR DESCRIPTION
This PR removes freezer from cloud 9 in the trackupstream
matrix.