### PR TITLE
Correct example for input_model_path

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/README.md
@@ -35,7 +35,7 @@ Example:
 ```
     ansible-playbook generate-input-model.yml \
       -e scenario_name=standard \
-      -e input_model_dir=/path/to/input-model
+      -e input_model_path=/path/to/input-model
       -e virt_config_file=/path/to/virt-config.yml
 ```
 


### PR DESCRIPTION
the name of the variable used is input_model_path, not input_model_dir