### PR TITLE
openstack-cloud-image: periodic image update jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -247,10 +247,12 @@
 
 - project:
     name: cloud-ardana8-job-image-update
-    ardana_image_update_job: '{name}'
+    cloud_image_update_job: '{name}'
     triggers:
-    openstack_ardana_job: cloud-ardana8-job-std-min-x86_64
+    openstack_cloud_job: cloud-ardana8-job-std-min-x86_64
     download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP3/ardana-jeos-lvm-SLE12SP3.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP3
+    triggers:
+     - timed: 'H H * * H(6-7)'
     jobs:
-        - '{ardana_image_update_job}'
+        - '{cloud_image_update_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -264,10 +264,12 @@
 
 - project:
     name: cloud-ardana9-job-image-update
-    ardana_image_update_job: '{name}'
+    cloud_image_update_job: '{name}'
     triggers:
-    openstack_ardana_job: cloud-ardana9-job-std-min-x86_64
+    openstack_cloud_job: cloud-ardana9-job-std-min-x86_64
     download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP4/ardana-jeos-lvm-SLE12SP4.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP4
+    triggers:
+     - timed: 'H H * * H(6-7)'
     jobs:
-        - '{ardana_image_update_job}'
+        - '{cloud_image_update_job}'

--- a/jenkins/ci.suse.de/cloud-crowbar7.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar7.yaml
@@ -28,3 +28,14 @@
     jobs:
         - '{crowbar_job}'
 
+- project:
+    name: cloud-crowbar7-job-image-update
+    cloud_image_update_job: '{name}'
+    triggers:
+    openstack_cloud_job: cloud-crowbar7-job-x86_64
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP2/ardana-jeos-SLE12SP2.x86_64.qcow2.xz
+    sles_image: cleanvm-jeos-SLE12SP2
+    triggers:
+     - timed: 'H H * * H(6-7)'
+    jobs:
+        - '{cloud_image_update_job}'

--- a/jenkins/ci.suse.de/cloud-crowbar8.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar8.yaml
@@ -28,3 +28,14 @@
     jobs:
         - '{crowbar_job}'
 
+- project:
+    name: cloud-crowbar8-job-image-update
+    cloud_image_update_job: '{name}'
+    triggers:
+    openstack_cloud_job: cloud-crowbar8-job-x86_64
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP3/ardana-jeos-SLE12SP3.x86_64.qcow2.xz
+    sles_image: cleanvm-jeos-SLE12SP3
+    triggers:
+     - timed: 'H H * * H(6-7)'
+    jobs:
+        - '{cloud_image_update_job}'

--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -44,3 +44,14 @@
     jobs:
         - '{crowbar_job}'
 
+- project:
+    name: cloud-crowbar9-job-image-update
+    cloud_image_update_job: '{name}'
+    triggers:
+    openstack_cloud_job: cloud-crowbar9-job-x86_64
+    download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP4/ardana-jeos-SLE12SP4.x86_64.qcow2.xz
+    sles_image: cleanvm-jeos-SLE12SP4
+    triggers:
+     - timed: 'H H * * H(6-7)'
+    jobs:
+        - '{cloud_image_update_job}'

--- a/jenkins/ci.suse.de/pipelines/openstack-cloud-image-update.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-cloud-image-update.Jenkinsfile
@@ -1,5 +1,5 @@
 /**
- * The openstack-ardana-image-update Jenkins Pipeline
+ * The openstack-cloud-image-update Jenkins Pipeline
  * This job automates updating the base SLES image used by virtual cloud nodes.
  */
 
@@ -67,7 +67,7 @@ pipeline {
     stage('integration test') {
       steps {
         script {
-          def slaveJob = build job: openstack_ardana_job, parameters: [
+          def slaveJob = build job: openstack_cloud_job, parameters: [
               string(name: 'git_automation_repo', value: "$git_automation_repo"),
               string(name: 'git_automation_branch', value: "$git_automation_branch"),
               text(name: 'extra_params', value: "$extra_params\nsles_image=${sles_image}-update")

--- a/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{ardana_image_update_job}'
+    name: '{cloud_image_update_job}'
     project-type: pipeline
     disabled: '{obj:disabled|False}'
     concurrent: '{concurrent|False}'
@@ -34,10 +34,10 @@
               - private - installs a private image
 
       - string:
-          name: openstack_ardana_job
-          default: '{openstack_ardana_job|openstack-ardana}'
+          name: openstack_cloud_job
+          default: '{openstack_cloud_job}'
           description: >-
-            The Ardana job to use to validate the updated image
+            The cloud integration Jenkins job to use to validate the updated image
 
       - string:
           name: git_automation_repo
@@ -79,5 +79,5 @@
               - ${{git_automation_branch}}
             browser: auto
             wipe-workspace: false
-      script-path: jenkins/ci.suse.de/pipelines/openstack-ardana-image-update.Jenkinsfile
+      script-path: jenkins/ci.suse.de/pipelines/openstack-cloud-image-update.Jenkinsfile
       lightweight-checkout: false


### PR DESCRIPTION
Make the Jenkins pipeline that automates updating the ECP images
used by the Ardana (and now Crowbar) ECP CI independent of cloud
product and updates the Ardana image update jobs to run periodically
at the end of every week. Also creates periodic jobs for images
that are used by Crowbar (those initially used by the Ardana
CI when the root partition wasn't a prerequisite).

A periodic job is also responsible for cleaning up old and unused images,
which is also what this PR adds to the pipeline logic.