### PR TITLE
SCRD should be only at the end of a commit msg

### DIFF
--- a/scripts/jenkins/gitlint.ini
+++ b/scripts/jenkins/gitlint.ini
@@ -8,7 +8,7 @@ line-length=80
 words=wip,WIP
 
 [title-match-regex]
-regex=.*\(((bsc#|SCRD-)[0-9]+(,\s)?)+\)$
+regex=^(?!SCRD).*\(((bsc#|SCRD-)[0-9]+(,\s)?)+\)$
 
 [body-max-line-length]
 line-length=80


### PR DESCRIPTION
We only want the SCRD number once at the end of a commit msg.