### PR TITLE
Add periodic job for testing airship deploys

### DIFF
--- a/jenkins/ci.suse.de/cloud-socok8s.yaml
+++ b/jenkins/ci.suse.de/cloud-socok8s.yaml
@@ -6,4 +6,5 @@
     repo-credentials: c2350527-476a-45df-b406-84f028614682
     jobs:
       - '{name}-integration'
+      - '{name}-nightly-trigger'
       - '{name}-nightly'

--- a/jenkins/ci.suse.de/templates/cloud-socok8s-nightly.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-socok8s-nightly.yaml
@@ -1,16 +1,39 @@
 - job-template:
+    name: '{name}-nightly-trigger'
+    project-type: multijob
+    node: cloud-trigger
+    triggers:
+      - timed: "@midnight"
+
+    builders:
+      - trigger-builds:
+          - project: '{name}-nightly'
+            condition: ALWAYS
+            predifined-parameters: |
+              deployment=helm
+      - trigger-builds:
+          - project: '{name}-nightly'
+            condition: ALWAYS
+            predifined-parameters: |
+              deployment=airship
+
+- job-template:
     name: '{name}-nightly'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30
     branch: master
-    triggers:
-      - timed: "@midnight"
     parameters:
       - string:
           name: branch
           default: '{branch}'
           description: The branch to checkout
+      - choice:
+          name: deployment
+          choices:
+            - 'helm'
+            - 'airship'
+          description: Whether to deploy with airship or helm directly
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
Add a copy of cloud-ccp-full-periodic that exercises the
airship deployment path.