### PR TITLE
Make sure the Python venv is using Python 2

### DIFF
--- a/scripts/jenkins/ardana/manual/lib.sh
+++ b/scripts/jenkins/ardana/manual/lib.sh
@@ -38,7 +38,7 @@ function is_defined {
 
 function setup_ansible_venv {
   if [ ! -d "$ANSIBLE_VENV" ]; then
-    virtualenv $ANSIBLE_VENV
+    virtualenv --python=python2.7 $ANSIBLE_VENV
     $ANSIBLE_VENV/bin/pip install --upgrade pip
     $ANSIBLE_VENV/bin/pip install -r $WORK_DIR/requirements.txt
   fi


### PR DESCRIPTION
Things end badly (in load_input_model.py) if using Python 3.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>