### PR TITLE
mkcloud: Allow supplying a network.json patch

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -617,6 +617,7 @@ function prepareinstcrowbar
 {
     echo "connecting to crowbar admin server at $adminip"
     ! [ -e crowbar.patch ] || $scp crowbar.patch root@$(wrap_ip $adminip):
+    ! [ -e network.json.patch ] || $scp network.json.patch root@$(wrap_ip $adminip):
     onadmin prepareinstallcrowbar
     return $?
 }


### PR DESCRIPTION
qa_crowbarsetup already has support for patching
/etc/crowbar/network.json before deploying the admin node. However
currently that patch needed to be manually uploaded to the node. This
patch copies any "network.json.patch" that exists in the cwd into the
admin node (similar to what is already done for "crowbar.patch" and
applies it to /etc/crowbar/network.json.