### PR TITLE
openstack-ardana: improved neutron reconfigure (SCRD-9144)

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
@@ -21,3 +21,14 @@
       -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
+
+# FIXME: workaround for SCRD-9144
+- name: Wait a while to give neutron agents time to recover
+  pause:
+    minutes: 5
+
+- name: Run neutron-status
+  shell: |
+    ansible-playbook neutron-status.yml
+  args:
+    chdir: "{{ ardana_scratch_path }}"


### PR DESCRIPTION
Check the status of the neutron services after reconfiguring
neutron to use a centralized or distributed default router type.
As a workaround for SCRD-9144, this change also inserts a 5 minute
delay after reconfiguring neutron, to give the OVS agents enough
time to come back to life.