### PR TITLE
Use `items()` instead of `iteritems()`

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -21,6 +21,8 @@ from ansible.module_utils.basic import AnsibleModule
 
 from netaddr import IPAddress, IPNetwork
 
+from six import string_types
+
 DOCUMENTATION = '''
 ---
 module: generate_heat_model
@@ -83,7 +85,7 @@ references. The schema describing an element is structured as follows:
       'key': <name of attribute representing the key (default: name)>
       'foreign-keys': {
           <foreign key attribute>: {
-              'type': <foreign key atrribute data type: list|basestring>,
+              'type': <foreign key atrribute data type: list|string_types>,
               'target': [
                   <name of root element to which the key points>,
                   [<name of root element to which the key points>,]
@@ -110,7 +112,7 @@ input_model_schema = {
             'elements': {
                 'clusters': {
                     'foreign-keys': service_group_foreign_keys,
-                    },
+                },
                 'resources': {
                     'foreign-keys': service_group_foreign_keys,
                 },
@@ -121,13 +123,13 @@ input_model_schema = {
         'server-roles': {
             'foreign-keys': {
                 'disk-model': {
-                    'type': basestring,
+                    'type': string_types,
                     'target': [
                         'disk-models'
                     ]
                 },
                 'interface-model': {
-                    'type': basestring,
+                    'type': string_types,
                     'target': [
                         'interface-models'
                     ]
@@ -160,7 +162,7 @@ input_model_schema = {
         'networks': {
             'foreign-keys': {
                 'network-group': {
-                    'type': basestring,
+                    'type': string_types,
                     'target': [
                         'network-groups'
                     ]
@@ -173,19 +175,19 @@ input_model_schema = {
             'key': 'id',
             'foreign-keys': {
                 'role': {
-                    'type': basestring,
+                    'type': string_types,
                     'target': [
                         'server-roles'
                     ]
                 },
                 'nic-mapping': {
-                    'type': basestring,
+                    'type': string_types,
                     'target': [
                         'nic-mappings'
                     ]
                 },
                 'server-group': {
-                    'type': basestring,
+                    'type': string_types,
                     'target': [
                         'server-groups'
                     ]
@@ -301,7 +303,7 @@ def link_elements(element, target_element,
 def link_elements_by_foreign_key(element, foreign_key_attr, target_element_map,
                                  ref_list_attr, element_key=None):
     foreign_key = element.setdefault(foreign_key_attr)
-    if isinstance(foreign_key, basestring) and \
+    if isinstance(foreign_key, string_types) and \
             foreign_key in target_element_map:
         foreign_element = target_element_map[foreign_key]
         element[foreign_key_attr] = foreign_element
@@ -314,7 +316,7 @@ def link_elements_by_foreign_key_list(element, foreign_key_list_attr,
                                       element_key=None):
     foreign_key_list = element.setdefault(foreign_key_list_attr, [])
     for idx, foreign_key in enumerate(foreign_key_list):
-        if isinstance(foreign_key, basestring) and \
+        if isinstance(foreign_key, string_types) and \
                 foreign_key in target_element_map:
             foreign_element = target_element_map[foreign_key]
             foreign_key_list[idx] = foreign_element
@@ -354,7 +356,7 @@ def map_foreign_keys(root_element, element_name,
             input_model_schema['elements'][target]['prune'] = True
             if foreign_key['type'] == list:
 
-                if isinstance(element.get(attr_name), basestring):
+                if isinstance(element.get(attr_name), string_types):
                     element[attr_name] = [element[attr_name]]
                 link_elements_by_foreign_key_list(
                     element, attr_name,
@@ -362,7 +364,7 @@ def map_foreign_keys(root_element, element_name,
                     ref_list_attr_name,
                     element_key)
 
-            elif foreign_key['type'] == basestring:
+            elif foreign_key['type'] == string_types:
                 link_elements_by_foreign_key(
                     element, attr_name,
                     root_element[target],

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -679,10 +679,10 @@ def generate_heat_model(input_model, virt_config):
             end_addr = cidr[-2]
             for fixed_ip_addr in sorted(list(set(fixed_ip_addr_list))):
                 if start_addr <= fixed_ip_addr <= end_addr:
-                    if fixed_ip_addr-start_addr < end_addr-fixed_ip_addr:
-                        start_addr = fixed_ip_addr+1
+                    if fixed_ip_addr - start_addr < end_addr - fixed_ip_addr:
+                        start_addr = fixed_ip_addr + 1
                     else:
-                        end_addr = fixed_ip_addr-1
+                        end_addr = fixed_ip_addr - 1
             heat_network['allocation_pools'] = \
                 [[str(start_addr), str(end_addr)]]
 
@@ -949,7 +949,7 @@ def update_input_model(input_model, heat_template):
             physical_ports.append({
                 'logical-name': port['name'],
                 'type': 'simple-port',
-                'bus-address': "0000:00:{:02x}.0".format(port_idx+3)
+                'bus-address': "0000:00:{:02x}.0".format(port_idx + 3)
             })
 
         # Overwrite the mapping, if it's already defined

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/load_input_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/load_input_model.py
@@ -43,7 +43,7 @@ EXAMPLES = '''
 
 
 def merge_input_model(data, input_model):
-    for key, value in data.iteritems():
+    for key, value in data.items():
         if key in input_model and isinstance(input_model[key], list) and value:
             input_model[key] += value
         else:


### PR DESCRIPTION
For Python2/3 compatibility, replace the use of `iteritems()` which
was deprecated in Python3 with `items()`. These two methods are very
similar in Python2 with `items()` returning a list of tuples and
`iteritems()` returning an iterator of the tuples.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>