### PR TITLE
Replace `iteritems` with `items`

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -347,7 +347,7 @@ def map_foreign_keys(root_element, element_name,
     if element_key and parent_key:
         element_key = "-".join([parent_key, element_key])
 
-    for attr_name, foreign_key in foreign_keys.iteritems():
+    for attr_name, foreign_key in foreign_keys.items():
         for target in foreign_key['target']:
             ref_list_attr_name = foreign_key.get(
                 'reverse-ref-attr',


### PR DESCRIPTION
Python 3 removed `iteritems`. A call to `items` is essentially
equivalent but works for Python 2 and 3.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>