### PR TITLE
Replace deprecated `Exception.message`

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -965,7 +965,6 @@ def update_input_model(input_model, heat_template):
 
 
 def main():
-
     argument_spec = dict(
         input_model=dict(type='dict', required=True),
         virt_config=dict(type='dict', required=True)
@@ -979,7 +978,7 @@ def main():
         heat_template = generate_heat_model(enhanced_input_model, virt_config)
         input_model = update_input_model(input_model, heat_template)
     except Exception as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg="generate_heat_model.py: %s" % e)
     module.exit_json(rc=0, changed=False,
                      heat_template=heat_template,
                      input_model=input_model)

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/load_input_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/load_input_model.py
@@ -91,7 +91,7 @@ def main():
     try:
         input_model = load_input_model(input_model_path)
     except Exception as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg="load_input_model.py: %s" % e)
     module.exit_json(rc=0, changed=False, input_model=input_model)
 
 


### PR DESCRIPTION
As of Python 2.6, `BaseException.message` has been deprecated and it
was removed in Python 3. An alternative is to use `str()` instead.
This change also adds some information on where an Exception occurred.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>