### PR TITLE
Nice format Ansible output for debugging

### DIFF
--- a/scripts/jenkins/ardana/manual/lib.sh
+++ b/scripts/jenkins/ardana/manual/lib.sh
@@ -86,7 +86,7 @@ function ansible_playbook {
       pushd $AUTOMATION_DIR/scripts/jenkins/ardana/ansible
     fi
     echo "Running: ansible-playbook -e @$ARDANA_INPUT ${@}"
-    ansible-playbook -e @$ARDANA_INPUT "${@}"
+    ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook --verbose --extra-vars @$ARDANA_INPUT "${@}"
     popd
   fi
 }


### PR DESCRIPTION
Using the `debug` callback Ansible output is formatted in a more human
consumable way.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>