### PR TITLE
Add environment variable to add arguments to Ansible

### DIFF
--- a/scripts/jenkins/ardana/manual/lib.sh
+++ b/scripts/jenkins/ardana/manual/lib.sh
@@ -85,7 +85,7 @@ function ansible_playbook {
       pushd $AUTOMATION_DIR/scripts/jenkins/ardana/ansible
     fi
     echo "Running: ansible-playbook -e @$ARDANA_INPUT ${@}"
-    ansible-playbook -e @$ARDANA_INPUT "${@}"
+    ansible-playbook ${ANSIBLE_VERBOSE:-} --extra-vars @$ARDANA_INPUT "${@}"
     popd
   fi
 }


### PR DESCRIPTION
This change adds the environment variables `ANSIBLE_VERBOSE` to the
`ansible-playbook` call so that the user can control the verbosity
level by running, e.g.

      ANSIBLE_VERBOSE="--verbose" prepare_infra

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>