### PR TITLE
Convert `dict_view` into `list` for Python3

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -883,8 +883,8 @@ def generate_heat_model(input_model, virt_config):
         # and which are computes. This information is used e.g. to determine
         # the reboot order during the MU workflow and to identify flavors
         # unless explicitly specified for each server or server role
-        service_groups = server['role'].get('clusters', {}).values()
-        service_groups += server['role'].get('resources', {}).values()
+        service_groups = list(server['role'].get('clusters', {}).values())
+        service_groups += list(server['role'].get('resources', {}).values())
         for service_group in service_groups:
             # The CLM server is the first server hosting the lifecycle-manager
             # service component.


### PR DESCRIPTION
The `dict.values()` method returns a `list` in Python2 and a
`dict_view` in Python3. Convert a potential `dict_view` to a `list` in
case the code is run using Python3.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>