### PR TITLE
Update docs with unified Crowbar/Ardana CI info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ This project has several scripts for different automated tasks. Some of them are
 
 # Documentation
 
-## Crowbar deployments
+## Crowbar mkcloud deployments
 
 Find out more in [`/docs/mkcloud.md`](docs/mkcloud.md)
 
-## Ardana deployments
+## Unified Cloud deployments
 
 Find out more in [`/docs/ardana/`](docs/ardana/)
 


### PR DESCRIPTION
This PR updates the documentation to reflect that we have a unified automation toolchain that can be used to deploy both Crowbar and Ardana either in the ECP or the SUSE (Nuremberg) clouds.
