### PR TITLE
Install resize tools packages

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
@@ -18,16 +18,15 @@
 root_mount: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | first }}"
 
 # List of tools required for partition resizing
-resize_tools: "{{ root_mount.device.startswith('/dev/mapper') | ternary (basic_resize_tools + lvm_resize_tools, basic_resize_tools) }}"
-basic_resize_tools:
-  - fdisk
+resize_packages: "{{ root_mount.device.startswith('/dev/mapper') | ternary (basic_resize_packages + lvm_resize_packages, basic_resize_packages) }}"
+
+basic_resize_packages:
+  - util-linux
   - parted
   - growpart
 
-lvm_resize_tools:
-  - lvdisplay
-  - lvs
-  - vgs
+lvm_resize_packages:
+  - lvm2
 
 # if / is not on bootable partition, updated dynamically otherwise
 vm_fdisk_start_field: 2

--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/tasks/main.yml
@@ -20,28 +20,9 @@
 # the file system layout settings defined in the input model.
 ---
 
-- name: Check for required tools
-  shell: >
-    command -v {{ item }}
-  register: _which_result
-  changed_when: False
-  failed_when:
-    - _which_result.rc > 1
-  loop: "{{ resize_tools }}"
-
-- name: Fail if required tools not found
-  fail:
-    # NOTE: blank line at start of msg text is intentional
-    msg: |
-
-      Required tools are missing from the SLES VM image:
-      {% for r in _which_result.results %}
-      {%   if r.rc %}
-          {{ r.item }}
-      {%   endif %}
-      {% endfor %}
-  when:
-    - _which_result.results | selectattr("rc") | list | length > 0
+- name: Install required tools
+  zypper:
+    name: "{{ resize_packages }}"
 
 - name: Setup root fs settings for non-LVM
   set_fact:


### PR DESCRIPTION
Instead of checking whether the required binaries are present, install
their packages. This is faster.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>