### PR TITLE
openstack-ardana-gating: exclude lbaas tempest (SOC-9176)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -143,7 +143,7 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,vpnaas,\
+      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
       designate,heat,ceilometer,magnum,freezer,monasca"
     triggers: []
     jobs:
@@ -164,7 +164,7 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,vpnaas,\
+      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
       designate,heat,ceilometer,magnum,freezer,monasca"
     triggers: []
     jobs:
@@ -199,7 +199,7 @@
     updates_test_enabled: false
     scenario_name: entry-scale-kvm
     tempest_filter_list: "\
-      smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,vpnaas,\
+      smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
       designate,heat,ceilometer,magnum,freezer,monasca"
     qa_test_list: "iverify"
     triggers: []

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -125,7 +125,7 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,\
+      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
       designate,heat,magnum,monasca"
     triggers: []
     jobs:
@@ -147,7 +147,7 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,fwaas,\
+      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
       designate,heat,magnum,monasca"
     triggers: []
     jobs:


### PR DESCRIPTION
The LBaaS tempest test cases are still failing intermittently
in the gates.

As a temporary workaround, after this change, the gating jobs
will no longer run the `lbaas` tests until these issues are
understood better (see https://jira.suse.com/browse/SOC-9285).