### PR TITLE
Need to run ardana-ssh-keyscan before setup_mu_repos (SCRD-9290)

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/all/versioned.yml
@@ -45,6 +45,8 @@ versioned_features:
     enabled: "{{ when_cloud8 }}"
   octavia-client:
     enabled: "{{ when_cloud9 }}"
+  ardana-ssh-keyscan:
+    enabled: "{{ when_cloud9 }}"
 
 input_model_versioned_features:
   - manila

--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/setup_mu_repos.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/setup_mu_repos.yml
@@ -15,10 +15,18 @@
 #
 ---
 
-- name: Copy maintenance update playbook
+- name: Generate maintenance update playbook
   template:
     src: "maint_updates.yml.j2"
     dest: "{{ ardana_scratch_path }}/_maint_updates.yml"
+
+- name: Run version specific playbooks
+  command: "ansible-playbook {{ item }}.yml"
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  when: versioned_features[item].enabled
+  loop:
+    - ardana-ssh-keyscan
 
 - name: Add MU repos to all nodes
   command: "ansible-playbook _maint_updates.yml"


### PR DESCRIPTION
The dynamically generated _maint_updates.yml playbook will hang,
prompting for confirmation of SSH host key changes unless the
ardana-ssh-keyscan.yml playbook has already been run.

Update the name for the task generating _maint_updates.yml to
indicate that it is generating rather than copying the playbook.