### PR TITLE
For debugging, print a traceback on Exception

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -16,6 +16,7 @@
 #
 from collections import OrderedDict
 from copy import deepcopy
+from traceback import format_exc
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -978,8 +979,8 @@ def main():
         enhanced_input_model = enhance_input_model(input_model)
         heat_template = generate_heat_model(enhanced_input_model, virt_config)
         input_model = update_input_model(input_model, heat_template)
-    except Exception as e:
-        module.fail_json(msg="generate_heat_model.py: %s" % e)
+    except Exception:
+        module.fail_json(msg="generate_heat_model.py:\n%s" % format_exc())
     module.exit_json(rc=0, changed=False,
                      heat_template=heat_template,
                      input_model=input_model)

--- a/scripts/jenkins/ardana/ansible/roles/heat-generator/library/load_input_model.py
+++ b/scripts/jenkins/ardana/ansible/roles/heat-generator/library/load_input_model.py
@@ -17,6 +17,7 @@
 
 import os
 from collections import OrderedDict
+from traceback import format_exc
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -90,8 +91,8 @@ def main():
 
     try:
         input_model = load_input_model(input_model_path)
-    except Exception as e:
-        module.fail_json(msg="load_input_model.py: %s" % e)
+    except Exception:
+        module.fail_json(msg="load_input_model.py: %s" % format_exc())
     module.exit_json(rc=0, changed=False, input_model=input_model)
 
 


### PR DESCRIPTION
When an exception in the Ansible modules occur it is helpful for
debugging purposes to see the full traceback.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>