### PR TITLE
Make `bootstrap-crowbar` idempotent

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-crowbar.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-crowbar.yml
@@ -32,7 +32,7 @@
 
         # FIXME: remove everything but eth0 ifcfg files from base image
         - name: Remove unused ifcfg files
-          shell: rm /etc/sysconfig/network/ifcfg-eth[1-9]*
+          shell: rm --force --verbose /etc/sysconfig/network/ifcfg-eth[1-9]*
 
         # FIXME: remove when https://github.com/crowbar/crowbar/pull/2371 is
         # available in all crowbar versions


### PR DESCRIPTION
When the `bootstrap-crowbar.yml` playbook is ran multiple times the
removal of `ifcfg` files fails because they were removed already in
the first run. This change makes this task idempotent.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>