### PR TITLE
Make `bootstrap-crowbar-nodes` idempotent

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-crowbar-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-crowbar-nodes.yml
@@ -54,7 +54,7 @@
         # This is needed because crowbar_register fails if there are
         # ifcfg files configured for non-existing interfaces
         - name: Remove unused ifcfg files
-          shell: rm /etc/sysconfig/network/ifcfg-eth[1-9]*
+          shell: rm --force --verbose /etc/sysconfig/network/ifcfg-eth[1-9]*
 
       rescue:
         - include_role:


### PR DESCRIPTION
When the `bootstrap-crowbar-nodes.yml` playbook is run multiple times
the removal of `ifcfg` files fails because the files were removed
already in the first run. This change makes this task idempotent.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>