### PR TITLE
Remove ssh host key of admin FIP

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ssh_keys/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ssh_keys/tasks/main.yml
@@ -25,3 +25,17 @@
       {{ key }}
       {% endfor %}
       {% endfor %}
+
+- name: Create local SSH key on deployer
+  shell: ssh-keygen -t rsa -f "{{ ansible_env.HOME }}/.ssh/id_rsa" -N ""
+  delegate_to: localhost
+  args:
+    creates: "{{ ansible_env.HOME }}/.ssh/id_rsa"
+  when: local_ssh_key
+
+- name: Copy local SSH key to deployer
+  lineinfile:
+    path: "{{ ansible_env.HOME }}/.ssh/authorized_keys"
+    create: yes
+    line: "{{ lookup('file', ansible_env.HOME + '/.ssh/id_rsa.pub') }}"
+  when: local_ssh_key

--- a/scripts/jenkins/cloud/ansible/setup-ssh-access.yml
+++ b/scripts/jenkins/cloud/ansible/setup-ssh-access.yml
@@ -56,6 +56,14 @@
             name: "{{ cloud_env }}"
             ansible_host: "{{ is_physical_deploy | ternary(omit, admin_floating_ip) }}"
             ansible_password: "linux"
+
+        - name: Remove local ssh host key for admin floating IP
+          known_hosts:
+            name: "{{ admin_floating_ip }}"
+            state: absent
+          failed_when: False
+          when: not is_physical_deploy
+
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -24,6 +24,11 @@ os_project_name: 'cloud'
 # exists, it will be replaced.
 cloud_env: ''
 
+# If true, use a local ssh key for access to the deployer. This
+# setting is only useful if the cloud deployment is deployed manually
+# from an ephemeral machine, e.g. a docker container.
+local_ssh_key: false
+
 # If set to false, the cloud deployment steps will be skipped. This option can be used
 # if you only need to set up the infrastructure and configure the cloud media and
 # repositories, but skip the actual cloud deployment, e.g. for testing purposes.


### PR DESCRIPTION
If the generated Heat stack uses a floating IP that was previously
used, the deploying host might have an outdated ssh host key which
should be removed prior to any ssh access.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>