### PR TITLE
use `wait_for` instead of unreliable 'wait_for_connection`

### DIFF
--- a/scripts/jenkins/ardana/ansible/bootstrap-crowbar-nodes.yml
+++ b/scripts/jenkins/ardana/ansible/bootstrap-crowbar-nodes.yml
@@ -33,9 +33,12 @@
   tasks:
     - block:
         - name: Wait for cloud nodes to be accessible
-          wait_for_connection:
-            sleep: 10
-            timeout: 300
+          wait_for:
+            host: "{{ ansible_ssh_host }}"
+            port: 22
+            search_regex: OpenSSH
+            state: started
+            delay: 10
           register: _connection
 
         - name: Fail if one or more hosts are unreacheable

--- a/scripts/jenkins/ardana/manual/deploy-crowbar.sh
+++ b/scripts/jenkins/ardana/manual/deploy-crowbar.sh
@@ -20,7 +20,7 @@ source lib.sh
 
 validate_input
 setup_ansible_venv
-mitogen_disable
+mitogen_enable
 prepare_input_model
 prepare_infra
 


### PR DESCRIPTION
use `wait_for` instead of unreliable 'wait_for_connection` even for crowbar in 'bootstrap-crowbar-nodes'