### PR TITLE
create script to deploy ardana system without running site.yml

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_deploy/tasks/main.yml
@@ -90,6 +90,7 @@
   when:
     - item.when | default(True)
     - not (ansible_scratch_plays | default({})) is failed
+    - skip_running_site_yml is not defined
   loop_control:
     label: "{{ item.play }}"
 

--- a/scripts/jenkins/ardana/manual/deploy-ardana-without-site.sh
+++ b/scripts/jenkins/ardana/manual/deploy-ardana-without-site.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+source lib.sh
+
+validate_input
+setup_ansible_venv
+mitogen_enable
+prepare_input_model
+prepare_infra
+
+trap exit_msg EXIT
+
+build_test_packages
+bootstrap_clm
+deploy_ses_vcloud
+bootstrap_nodes
+deploy_ardana_but_dont_run_site_yml

--- a/scripts/jenkins/ardana/manual/lib.sh
+++ b/scripts/jenkins/ardana/manual/lib.sh
@@ -226,6 +226,13 @@ function deploy_cloud {
   fi
 }
 
+function deploy_ardana_but_dont_run_site_yml {
+  if $(get_from_input deploy_cloud); then
+    ansible_playbook deploy-cloud.yml -e "skip_running_site_yml=True"
+  fi
+}
+
+
 function update_cloud {
   if $(get_from_input deploy_cloud) && $(get_from_input update_after_deploy); then
     ansible_playbook ardana-update.yml -e cloudsource=$(get_from_input update_to_cloudsource)


### PR DESCRIPTION
For development it is very useful to have a system which is ready to run site.yml for the first time.