### PR TITLE
openstack-ardana: fix rocketchat announcement

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/set_announcement.yml
+++ b/scripts/jenkins/ardana/ansible/roles/rocketchat_notify/tasks/set_announcement.yml
@@ -28,7 +28,7 @@
 
 - name: Get channels list
   uri:
-    url: "{{ rc_url }}/api/v1/channels.list?count=100"
+    url: "{{ rc_url }}/api/v1/channels.list?count=0"
     validate_certs: no
     method: GET
     headers:


### PR DESCRIPTION
For getting the channel list there is a query limited to a number of 100
results. However some channels are missing in that resulting list, causing the
playbooks to fail.

This change removes that limit and instead get a list of all channels on
rocketchat.