### PR TITLE
openstack-ardana: increase initial root partition size

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/setup_root_partition/defaults/main.yml
@@ -35,4 +35,4 @@ vm_fdisk_start_field: 2
 # the size (in GB) to which the LVM root partition is resized
 # this needs to be less than 95% of the total available size, otherwise
 # the Ardana osconfig play will fail
-min_deployer_root_part_size: 24
+min_deployer_root_part_size: 34


### PR DESCRIPTION
Due to the increasing size of the SUSE/Cloud update channels, which are
rsynced into the deployer node, the actual root partition size is not
enough and is causing failures on some CI jobs [1, 2].

This change increase the root partition size from 24 GB to 34 GB.

1. https://ci.suse.de/blue/organizations/jenkins/cloud-ardana8-job-std-min-centos-x86_64/detail/cloud-ardana8-job-std-min-centos-x86_64/197/pipeline
2. https://ci.suse.de/blue/organizations/jenkins/cloud-ardana8-job-std-min-suse-x86_64/detail/cloud-ardana8-job-std-min-suse-x86_64/232/pipeline