### PR TITLE
Add upgradecloud9 cloudsource (SOC-9340)

### DIFF
--- a/hostscripts/clouddata/syncSLErepos
+++ b/hostscripts/clouddata/syncSLErepos
@@ -171,6 +171,7 @@ for version in 9 8 7 6; do
     done
 done
 
+rsync_and_unpack_iso ${ibs_source_nue}/Devel\:/Cloud\:/9\:/Upgrade/images/iso/SUSE-OPENSTACK-CLOUD-CROWBAR-9-x86_64-Media1.iso /srv/nfs/repos/x86_64/SUSE-OpenStack-Cloud-Crowbar-9-devel-upgrade
 rsync_with_create ${ibs_source_nue}/Devel:/Cloud:/8:/HOS5Migration/SLE_12_SP3/ /srv/nfs/repos/x86_64/SUSE-OpenStack-Cloud-8-devel-HOS5Migration/
 
 ##############

--- a/jenkins/ci.suse.de/cloud-mediacheck.yaml
+++ b/jenkins/ci.suse.de/cloud-mediacheck.yaml
@@ -21,6 +21,7 @@
             - Devel:Cloud:8/SLE_12_SP3/CROWBAR
             - Devel:Cloud:9/SLE_12_SP4/SOC
             - Devel:Cloud:9/SLE_12_SP4/CROWBAR
+            - Devel:Cloud:9:Upgrade/SLE_12_SP4/CROWBAR
             - SUSE:SLE-12-SP3:Update:Products:Cloud8/SLE_12_SP3/SOC
             - SUSE:SLE-12-SP3:Update:Products:Cloud8/SLE_12_SP3/HOS
             - SUSE:SLE-12-SP3:Update:Products:Cloud8/SLE_12_SP3/CROWBAR

--- a/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
+++ b/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
@@ -29,7 +29,7 @@ case $cloudsource in
             unset want_ldap
         fi
         ;;
-    M*|develcloud9|develcloud8|develcloud7|GM7|GM7+up|susecloud9)
+    M*|develcloud9|upgradecloud9|develcloud8|develcloud7|GM7|GM7+up|susecloud9)
         if [[ $mkcloudtarget =~ upgrade ]]; then
             echo "Unsetting want_ldap for upgrade jobs until hybrid backend is migrated to domain-specific backends"
             unset want_ldap

--- a/scripts/lib/mkcloud-onhost.sh
+++ b/scripts/lib/mkcloud-onhost.sh
@@ -149,6 +149,9 @@ function onhost_cacheclouddata
                 suffix="devel"
                 [ -n "$TESTHEAD" ] && suffix+="-staging"
             fi
+            if [[ $cloudsource =~ (upgradecloud) ]]; then
+                suffix="devel-upgrade"
+            fi
             echo "repos/$a/SUSE-OpenStack-Cloud-$cloudrepover-$suffix/***"
 
             # Now the various test images

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1260,6 +1260,7 @@ Mandatory
         develcloud7   : product from IBS Devel:Cloud:7
         develcloud8   : product from IBS Devel:Cloud:8
         develcloud9   : product from IBS Devel:Cloud:9
+        upgradecloud9 : product from IBS Devel:Cloud:9:Upgrade
         GM6           : SUSE Cloud Goldmaster 6 without updates
         GM7           : SUSE Cloud Goldmaster 7 without updates
         GM8           : SUSE Cloud Goldmaster 8 without updates
@@ -1509,7 +1510,7 @@ function sanity_checks
 
     if [ -z "$cloudsource" ] ; then
         echo "Please set the env variable:"
-        echo "export cloudsource=M?*|develcloud6|develcloud7|develcloud8|develcloud9|GM6|GM6+up|GM7|GM7+up|GM8|GM9|GM9+up"
+        echo "export cloudsource=M?*|develcloud6|develcloud7|develcloud8|develcloud9|upgradecloud9|GM6|GM6+up|GM7|GM7+up|GM8|GM9|GM9+up"
         exit 1
     fi
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -901,6 +901,12 @@ function onadmin_set_source_variables
             CLOUDISONAME="SUSE-OPENSTACK-CLOUD-CROWBAR-9-${arch}-Media1.iso"
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-Crowbar-9-devel"
         ;;
+        upgradecloud9)
+            CLOUDISOURL="$susedownload/ibs/Devel:/Cloud:/9:/Upgrade/images/iso"
+            [ -n "$TESTHEAD" ] && CLOUDISOURL="$susedownload/ibs/Devel:/Cloud:/9:/Upgrade/images/iso"
+            CLOUDISONAME="SUSE-OPENSTACK-CLOUD-CROWBAR-9-${arch}-Media1.iso"
+            CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-Crowbar-9-devel-upgrade"
+        ;;
         GM9|GM9+up)
             cs=$cloudsource
             [[ $cs =~ GM9 ]] && cs=GM


### PR DESCRIPTION
This adds the temporary Devel:Cloud:9:Upgrade project as a
cloudsource. This project is meant for quick turnaround and
parallelization on fixing the cloud-mkcloud9-job-upgrade-disruptive
CI job: one person can add quick and dirty patches to this
repository until the job is green while others can polish
these existing patches and get them upstream in parallel.