### PR TITLE
Retry 'Run stage 0 - prepare' few times

### DIFF
--- a/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
@@ -44,7 +44,9 @@
   command: "salt-run state.orch ceph.stage.prep"
   register: stage0
   changed_when: false
-  ignore_errors: yes
+  retries: 3
+  delay: 5
+  until: stage0.rc == 0
 
 - name: Show stage 0 (salt-run state.orch ceph.stage.prep) results
   debug:


### PR DESCRIPTION
This action often fails on the first run. Proper fix would of course
require knowing why the task fails and wait for appropriate condition
instead.