### PR TITLE
openstack-ses: make SES deployment more reliable

### DIFF
--- a/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
@@ -23,6 +23,9 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
+    owner: salt
+    group: salt
+    mode: 0644
   with_items:
     - src: "master_minion.sls.j2"
       dest:  "/srv/pillar/ceph/master_minion.sls"
@@ -40,13 +43,19 @@
     group: salt
     mode: 0644
 
+- name: Ensure deepsea minions are reacheable
+  command: "salt '{{ ses_deepsea_minions }}' test.ping --out=yaml"
+  register: deepsea_minions
+  changed_when: false
+  failed_when: not deepsea_minions.stdout | regex_search(ansible_hostname ~ ':\strue')
+  until: deepsea_minions is succeeded
+  retries: 10
+  delay: 1
+
 - name: Run stage 0 - prepare
   command: "salt-run state.orch ceph.stage.prep"
   register: stage0
   changed_when: false
-  retries: 3
-  delay: 5
-  until: stage0.rc == 0
 
 - name: Show stage 0 (salt-run state.orch ceph.stage.prep) results
   debug:
@@ -118,10 +127,9 @@
   command: "salt-run state.orch ceph.stage.iscsi"
   when:
     - stage4.stdout.find('lrbd has been enabled, and is dead') != -1  # Implement workaround of the cosmetic issue https://www.suse.com/support/kb/doc/?id=7018668
-    
+
 # For some reason sometimes the radosgw package is not installed
 - name: Ensure RADOS GW installed
   package:
     name: ceph-radosgw
     state: present
-

--- a/scripts/jenkins/ses/ansible/roles/ses/tasks/salt_setup.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/tasks/salt_setup.yml
@@ -41,10 +41,24 @@
 
 - meta: flush_handlers
 
-- name: "Wait for salt-minion to initialize"
-  pause:
-    seconds: 5
+- name: Ensure salt-minion initialized
+  command: "salt-key -L"
+  register: minion
+  changed_when: false
+  failed_when: ansible_hostname not in minion.stdout_lines
+  until: minion is succeeded
+  retries: 10
+  delay: 1
 
 - name: Accept salt keys
   command: "salt-key --accept-all -y"
   changed_when: false
+
+- name: Ensure salt-minion is up
+  command: "salt-run manage.up --out=yaml"
+  register: minion_up
+  changed_when: false
+  failed_when: ansible_hostname not in minion_up.stdout | from_yaml
+  until: minion_up is succeeded
+  retries: 10
+  delay: 1


### PR DESCRIPTION
This change:
  - Adds additional checks before proceeding to the salt-run calls,
making sure everything is ready before starting SES deployment.
  - Drop the deepsea config with correct owner/permissions.