### PR TITLE
Cast bare variable to `bool`

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/input_model_generator/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/input_model_generator/tasks/main.yml
@@ -28,7 +28,7 @@
   when: "item ~ '_template' in scenario"
 
 - include_tasks: get_qe_bm_info.yml
-  when: is_physical_deploy
+  when: is_physical_deploy | bool
 
 - name: Create directories
   file:


### PR DESCRIPTION
Using a bare variable for conditionals is deprecated starting with
Ansible 2.8 and will eventually be removed. This means that the string
'false' will not get evaluated as `false` anymore. To retain the old
behavior, add an explicit `bool` filter.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>