### PR TITLE
Update `delegate_to` for Ansible 2.8

### DIFF
--- a/scripts/jenkins/cloud/ansible/bootstrap-crowbar-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-crowbar-nodes.yml
@@ -62,7 +62,8 @@
       rescue:
         - include_role:
             name: rocketchat_notify
-          delegate_to: "{{ cloud_env }}"
+            apply:
+              delegate_to: "{{ cloud_env }}"
           vars:
             rc_action: "finished"
             rc_state: "Failed"

--- a/scripts/jenkins/cloud/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-vcloud-nodes.yml
@@ -162,7 +162,8 @@
       rescue:
         - include_role:
             name: rocketchat_notify
-          delegate_to: "{{ cloud_env }}"
+            apply:
+              delegate_to: "{{ cloud_env }}"
           vars:
             rc_action: "finished"
             rc_state: "Failed"

--- a/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
@@ -50,7 +50,8 @@
       rescue:
         - include_role:
             name: rocketchat_notify
-          delegate_to: "{{ cloud_env }}"
+            apply:
+              delegate_to: "{{ cloud_env }}"
           vars:
             rc_action: "finished"
             rc_state: "Failed"


### PR DESCRIPTION
The `delegate_to` does not apply to dynamically included roles and
since Ansible 2.8 this construct throws an error. Instead the `apply`
argument should be used to specify the delegate_to host. For details
see the discussion at [1].

[1] https://github.com/ansible/ansible/issues/35398

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>