### PR TITLE
openstack-ardana: apply process count overrides on cloud8 only

### DIFF
--- a/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/ardana/ansible/group_vars/virt_all.yml
@@ -18,10 +18,16 @@
 ses_cluster_id: "virt"
 ses_rgw_port: 8081
 
-ardana_extra_vars:
+ardana_common_extra_vars:
   nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"
   nova_cpu_mode: custom
   nova_cpu_model: Westmere
+  # When the mariadb is running on top of shared storage, decouple commit and
+  # flush operations, to account for its high latency and prevent performance
+  # issues
+  innodb_flush_log_at_trx_commit: "{{ ardana_dbmq_use_root_volume | ternary(1, 2) }}"
+
+ardana_process_count_overrides:
   keystone_wsgi_admin_process_count: 2
   keystone_wsgi_public_process_count: 6
   neutron_api_workers: 2
@@ -35,7 +41,5 @@ ardana_extra_vars:
   swift_worker_count: 2
   num_engine_worker_count: 2
   glance_worker_count: 2
-  # When the mariadb is running on top of shared storage, decouple commit and
-  # flush operations, to account for its high latency and prevent performance
-  # issues
-  innodb_flush_log_at_trx_commit: "{{ ardana_dbmq_use_root_volume | ternary(1, 2) }}"
+
+ardana_extra_vars: "{{ when_cloud8 | ternary(ardana_common_extra_vars | combine(ardana_process_count_overrides), ardana_common_extra_vars) }}"


### PR DESCRIPTION
For cloud 9 the process count logic was reworked on the product itself,
so we do not need to override it anymore (see: [1]).

1. https://gerrit.prv.suse.net/q/topic:%2522SCRD-8748_worker_counts%2522