### PR TITLE
Fix bashate errors

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((sh-mode
+  (sh-basic-offset . 4)))

--- a/scripts/jenkins/ardana/manual/lib.sh
+++ b/scripts/jenkins/ardana/manual/lib.sh
@@ -227,9 +227,9 @@ function deploy_cloud {
 }
 
 function deploy_ardana_but_dont_run_site_yml {
-  if $(get_from_input deploy_cloud); then
-    ansible_playbook deploy-cloud.yml -e "skip_running_site_yml=True"
-  fi
+    if $(get_from_input deploy_cloud); then
+        ansible_playbook deploy-cloud.yml -e "skip_running_site_yml=True"
+    fi
 }
 
 


### PR DESCRIPTION
PR #3447 (4b7b2b77bcce016ef9277b6642fcf9b0702d8eb2) was written
without PR #3452 (6b0c8c9f76ab3ca79b19ecb055a4ce5967ab79ac) and had
not been linted with bashate. This change fixes the linter issues and
adds a `.dir-locals.el` file so that emacs users use the correct
indentation.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>