### PR TITLE
cleanvm: Add openSUSE Leap 15.1 for Master and Stein

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -45,6 +45,7 @@
     image:
       - SLE_15
       - openSUSE-Leap-15.0
+      - openSUSE-Leap-15.1
     jobs:
       - 'openstack-cleanvm-{release}'
 
@@ -55,5 +56,6 @@
     image:
       - SLE_15
       - openSUSE-Leap-15.0
+      - openSUSE-Leap-15.1
     jobs:
       - 'openstack-cleanvm-{release}'


### PR DESCRIPTION
We want to test the latest openSUSE release so add it for the latest
OpenStack release (stable/stein) and the current development (master)