### PR TITLE
cloud-gating: Fix start time sanity check

### DIFF
--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             script: '''
               rfcdate="$( curl -sI $staging_url | grep 'Last-Modified: ' | head -n1 | cut -d' ' -f2- )"
               epoch=$(date +%s -d "$rfcdate")
-              if test "$epoch" -gt "1400000000"; then
+              if test "$epoch" -lt "1400000000"; then
                 echo "Last-Modified epoch is too low to be valid."
                 exit 1
               fi


### PR DESCRIPTION
The test was the wrong way around.

Follow up for https://github.com/SUSE-Cloud/automation/pull/3278