### PR TITLE
Fix incorrect type in dir locals file

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,4 +2,4 @@
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((sh-mode
-  (sh-basic-offset . 4)))
+  ((sh-basic-offset . 4))))


### PR DESCRIPTION
The argument should be a list.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>