### PR TITLE
openstack-prepare-staging: Support Stein and Train

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-prepare-staging.py
+++ b/jenkins/ci.opensuse.org/openstack-prepare-staging.py
@@ -148,7 +148,7 @@ def prepare(branch):
 
 def main():
     branch = os.environ['openstack_project']
-    if 'Rocky' == branch:
+    if branch in ('Rocky', 'Stein'):
         sys.exit(prepare(branch))
     else:
         print("%s not supported for argument openstack_project." % branch)


### PR DESCRIPTION
The ToTest mechanism needs to work for Stein (and in the future for
Train) as well so fix the check to make it working.
Otherwise, Cloud:OpenStack:Stein:ToTest is never updated.