### PR TITLE
openstack-ardana: Fix for retrying tempest failed tests

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/retry_failed.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/tasks/retry_failed.yml
@@ -1,21 +1,17 @@
 - block:
     - name: Generate filter with failed tests
       template:
-        src: "run_filter_retry.txt.j2"
-        dest: "/opt/stack/tempest/run_filters/{{ tempest_run_filter }}_retry_serial.txt.j2"
+        src: "run_filter_{{ item.filter }}.txt.j2"
+        dest: "/opt/stack/tempest/run_filters/{{ tempest_run_filter }}_{{ item .filter}}.txt.j2"
         owner: tempest
         group: tempest
         mode: 0644
       become: yes
-
-    - name: Create fake run filter to force running tests serially
-      copy:
-        content: "-.*"
-        dest: "/opt/stack/tempest/run_filters/{{ tempest_run_filter }}_retry.txt.j2"
-        owner: tempest
-        group: tempest
-        mode: 0644
-      become: yes
+      when: item.when | default(True)
+      loop:
+         - filter: "retry"
+         - filter: "retry_serial"
+           when: "{{ tempest_failed_tests.stdout_lines | length > 1 }}"
 
     - name: Save previous tempest run outputs
       copy:

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
@@ -1,6 +1,7 @@
 {% set regexp = '\[.*]$' %}
-{% set test = tempest_failed_tests.stdout_lines[0] %}
+{% for test in tempest_failed_tests.stdout_lines[1:] %}
 {% if test.startswith('setUpClass') %}
 {% set regexp = '.*\(|\)$' %}
 {% endif %}
 +{{ test | regex_replace(regexp, '') }}
+{% endfor %}


### PR DESCRIPTION
The run filter file needs to have at least one test or it will include
`The specified regex doesn't match with anything` into the subunit file,
resulting in a corrupt subunit output.