### PR TITLE
Use correct ca_certs path in signing section

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2150,6 +2150,9 @@ function enable_ssl_generic
         keystone)
             $p "$a['ssl']['ca_certs']" "'/etc/ssl/ca-bundle.pem'"
             $p "$a['api']['protocol']" "'https'"
+            if iscloudver 7minus ; then
+                $p "$a['signing']['ca_certs']" "'/etc/ssl/ca-bundle.pem'"
+            fi
         ;;
         *)
             $p "$a['api']['protocol']" "'https'"


### PR DESCRIPTION
In older versions where PKI token signing was used, signing section
was using the same cert/key paths as ssl but ca_certs attribute was not
updated.