### PR TITLE
socok8s: add ansible lint job

### DIFF
--- a/jenkins/ci.suse.de/cloud-socok8s.yaml
+++ b/jenkins/ci.suse.de/cloud-socok8s.yaml
@@ -6,3 +6,4 @@
     repo-credentials: c2350527-476a-45df-b406-84f028614682
     jobs:
       - '{name}-integration'
+      - '{name}-lint'

--- a/jenkins/ci.suse.de/templates/cloud-socok8s-ansible-lint.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-socok8s-ansible-lint.yaml
@@ -1,0 +1,20 @@
+- job-template:
+    name: '{name}-lint'
+    project-type: multibranch
+    periodic-folder-trigger: 5m
+    number-to-keep: 30
+    days-to-keep: 30
+    script-path: Jenkinsfile.lint
+    scm:
+      - github:
+          repo: '{repo-name}'
+          repo-owner: '{repo-owner}'
+          credentials-id: '{repo-credentials}'
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: current
+          submodule:
+            recursive: true
+          notification-context: continuous-integration/jenkins/lint
+          filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$


### PR DESCRIPTION
Adds a job for ansible linting the socok8s playbooks

Lint file is provided on https://github.com/SUSE-Cloud/socok8s/pull/331