### PR TITLE
openstack-ardana: Rerun failed tempest tests on gating jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -27,6 +27,8 @@
     concurrent: False
     version: '8'
     ardana_env: 'cloud-ardana-gate{version}-slot'
+    extra_params: |
+      tempest_retry_failed=True
     jobs:
         - '{cloud_gating_job}'
 

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -15,6 +15,8 @@
     concurrent: False
     version: '9'
     ardana_env: 'cloud-ardana-gate{version}-slot'
+    extra_params: |
+      tempest_retry_failed=True
     jobs:
         - '{cloud_gating_job}'
 

--- a/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
@@ -53,7 +53,7 @@
 
       - text:
           name: extra_params
-          default:
+          default: '{extra_params|}'
           description: >-
             This field may be used to define additional parameters, one per line, in the form:
 


### PR DESCRIPTION
This change enable reruning the failed tempest tests on the gating jobs
for cloud 8 and 9.

This is a temporary solution to unblock the gating jobs until running
tempest full gets more stable.