### PR TITLE
openstack-ardana: remove swift tests from gating 9 job

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -127,7 +127,7 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+      keystone,glance,cinder,neutron,nova,barbican,fwaas,\
       designate,heat,magnum,monasca"
     triggers: []
     jobs:
@@ -149,7 +149,7 @@
     ses_enabled: true
     ses_rgw_enabled: false
     tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+      keystone,glance,cinder,neutron,nova,barbican,fwaas,\
       designate,heat,magnum,monasca"
     triggers: []
     jobs:


### PR DESCRIPTION
Currently the tempest swift tests are very unreliable and is the main
reason for the failures of the gating 9 job.

This change remove the swift tests from the gating 9 job until further
investigation is done (tracked by SOC-9287).