### PR TITLE
Use git ref location that prevents overlap

### DIFF
--- a/jenkins/ci.suse.de/openstack-mkcloud-log-parser-test.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud-log-parser-test.yaml
@@ -118,9 +118,9 @@
                   pushd $automationrepo
                   ghremote=origin
                   git config --get-all remote.${ghremote}.fetch | grep -q pull || \
-                      git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
+                      git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}-pr/*"
                   git fetch $ghremote 2>&1 | grep -v '\[new ref\]'
-                  git checkout -t $ghremote/pr/$github_pr_id
+                  git checkout -t ${ghremote}-pr/$github_pr_id
                   echo "we merge to always test what will end up in master"
                   git merge master -m temp-merge-commit
                   # Show latest commit in log to see what's really tested.

--- a/scripts/github_pr/suse.cloud-specs.helper.sh
+++ b/scripts/github_pr/suse.cloud-specs.helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -xue
 
 #
 # small helper to run tox on a PR with github_pr
@@ -24,9 +24,9 @@ pushd "$pr_dir"
 ### copied from openstack-mkcloud job
 ghremote=origin
 git config --get-all remote.${ghremote}.fetch | grep -q pull || \
-    git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
+    git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}-pr/*"
 git fetch $ghremote 2>&1 | grep -v '\[new ref\]' || :
-git checkout -t $ghremote/pr/$pr_id
+git checkout -t $ghremote-pr/$pr_id
 git config user.email cloud-devel+jenkins@suse.de
 git config user.name "Jenkins User"
 echo "we merge to always test what will end up in master"

--- a/scripts/jenkins/ardana/pr-update.sh
+++ b/scripts/jenkins/ardana/pr-update.sh
@@ -19,7 +19,7 @@ if ! $ghpr --action is-latest-sha $ghpr_paras --pr $github_pr_id ; then
 fi
 $ghpr --action set-status $ghpr_paras --status "pending" --targeturl $BUILD_URL --message "Started PR gating"
 
-git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin-pr/*"
 git fetch origin $github_pr_sha
 git checkout -B ardana-ci FETCH_HEAD
 git clean  # remove files deleted from git

--- a/scripts/jenkins/mkcloud/openstack-mkcloud.prep.sh
+++ b/scripts/jenkins/mkcloud/openstack-mkcloud.prep.sh
@@ -21,9 +21,9 @@ if [[ "$github_pr_repo" = "SUSE-Cloud/automation" ]]; then
     pushd $automationrepo
     ghremote=origin
     git config --get-all remote.${ghremote}.fetch | grep -q pull || \
-        git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}/pr/*"
+        git config --add remote.${ghremote}.fetch "+refs/pull/*/head:refs/remotes/${ghremote}-pr/*"
     git fetch $ghremote 2>&1 | grep -v '\[new ref\]' || :
-    git checkout -t $ghremote/pr/$github_pr_id
+    git checkout -t ${ghremote}-pr/$github_pr_id
     git config user.email cloud-devel+jenkins@suse.de
     git config user.name "Jenkins User"
     echo "we merge to always test what will end up in master"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5777,10 +5777,10 @@ function onadmin_run_cct
         cd cct
         if [[ $want_cct_pr ]] ; then
             git config --get-all remote.origin.fetch | grep -q pull || \
-                git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
+                git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin-pr/*"
             safely git fetch origin
             # checkout the PR
-            safely git checkout -t origin/pr/$want_cct_pr
+            safely git checkout -t origin-pr/$want_cct_pr
             # merge the PR to always test what will end up in $checkout_branch
             safely git merge $checkout_branch -m temp-merge-commit
         fi


### PR DESCRIPTION
Someone created a branch named pr/282 which with the git fetch config
creates a path for the local remotes ref where the PR of that
number and the branch of that name overlap. This prevents fetching all
updates in the git repo.

```
cloud-specs$ git fetch origin
fatal: Cannot fetch both refs/heads/pr/282 and refs/pull/282/head to
 refs/remotes/origin/pr/282
```

Afterwards the cloud-specs CI job failed to checkout the PR to test as
it was not locally availabe and thus tested master instead.

Fix this by chosing a config where those don't overlap.

Also set error on exit to fail CI instead of silently passing.