### PR TITLE
socok8s: Change discover strategy for Pull request

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
@@ -11,9 +11,9 @@
           repo-owner: '{repo-owner}'
           credentials-id: '{repo-credentials}'
           branch-discovery: no-pr
-          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-strategy: current
           discover-pr-forks-trust: permission
-          discover-pr-origin: merge-current
+          discover-pr-origin: current
           submodule:
             recursive: true
           notification-context: continuous-integration/jenkins


### PR DESCRIPTION
To reduce the number of jobs that are triggered let's switch to
"current" strategy. By doing that we should prevent new jobs being
triggered for every PR when a change get's merged into master.