### PR TITLE
openstack-ardana/crowbar: remove unused volumes from heat template

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/defaults/main.yml
@@ -38,6 +38,14 @@ disabled_services: ""
 # in deployed clouds
 enable_extra_volume_groups: "{{ want_lvm }}"
 
+# Disable cinder LVM device group in Crowbar
+cinder_disk_enabled: "{{ cinder_lvm_enabled and cloud_product == 'ardana' }}"
+
+# Disable swiftpac device group in Crowbar
+swiftpac_disk_enabled: "{{ cloud_product == 'ardana' }}"
+
+swiftobj_disk_enabled: True
+
 enable_external_network_bridge: "{{ versioned_features.external_network_bridge.enabled }}"
 
 enable_designate_worker_producer: "{{ versioned_features.designate_worker_producer.enabled }}"

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/templates/input_model/data/disk_models.yml
@@ -207,9 +207,11 @@
 
 {%     if ns.service_component_groups | intersect(['SWPAC', 'SWOBJ', 'CORE']) %}
     device-groups:
+{%       set device_groups_idx = ns.drive_idx %}
 {%       for service_component_group in ns.service_component_groups %}
 {%         if service_component_group == 'SWPAC' %}
-{%           set ns.drive_idx = ns.drive_idx+1 %}
+{%           if swiftpac_disk_enabled | bool %}
+{%             set ns.drive_idx = ns.drive_idx+1 %}
 
       # Additional disk group defined for Swift
       # If available, you can add additional disks to the "devices" list.
@@ -223,8 +225,10 @@
             rings:
               - account
               - container
+{%           endif %}
 {%         elif service_component_group == 'SWOBJ' %}
-{%           set ns.drive_idx = ns.drive_idx+1 %}
+{%           if swiftobj_disk_enabled | bool %}
+{%             set ns.drive_idx = ns.drive_idx+1 %}
 
       # Additional disk group defined for Swift
       # If available, you can add additional disks to the "devices" list.
@@ -237,8 +241,9 @@
           attrs:
             rings:
               - object-0
+{%           endif %}
 {%         elif service_component_group == 'CORE' %}
-{%           if cinder_lvm_enabled | bool %}
+{%           if cinder_disk_enabled | bool %}
 {%             set ns.drive_idx = ns.drive_idx+1 %}
 
       - name: cinder-volume
@@ -249,6 +254,9 @@
 {%           endif %}
 {%         endif %}
 {%       endfor %}
+{%       if device_groups_idx == ns.drive_idx %}
+      []
+{%       endif %}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/entry-scale-kvm.yml
@@ -26,7 +26,7 @@ scenario:
     Multi-cluster scenario with all services enabled, {{ clm_model }} CLM node,
     {{ sles_computes }} SLES compute nodes and {{ rhel_computes }} RHEL compute nodes.
   audit_enabled: True
-  use_cinder_volume_disk: True
+  use_cinder_volume_disk: False
   use_glance_cache_disk: False
   availability_zones: "{{ availability_zones }}"
 

--- a/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/mid-scale-kvm.yml
+++ b/scripts/jenkins/ardana/ansible/roles/input_model_generator/vars/mid-scale-kvm.yml
@@ -33,7 +33,7 @@ scenario:
     agent nodes, {{ swift_nodes }} swift nodes, {{ lmm_nodes }} LMM nodes and with {{ sles_computes }} SLES compute nodes
     and {{ rhel_computes }} RHEL compute nodes.
   audit_enabled: False
-  use_cinder_volume_disk: True
+  use_cinder_volume_disk: False
   use_glance_cache_disk: False
   availability_zones: "{{ availability_zones }}"
   rack_networks_enabled: "{{ is_physical_deploy }}"


### PR DESCRIPTION
The generated heat stack for Crowbar as well as Ardana virtual cloud
environments includes a lot of volumes that are not actually being used:
  - the cinder volume used for the LVM back-end and those used for swift
  proxy-account-container are not used for Crowbar deployments
 - the cinder volume disk which is mounted by Ardana to `/var/lib/cinder`.
 This volume was included with the `entry-scale-kvm` and `mid-scale-kvm` scenarios,
 but using the root partition instead may actually bring better performance,
 so this change turns it off  
