### PR TITLE
manila: Fix tempest issues

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3662,6 +3662,8 @@ id-f5dfcc22-45fd-409f-954c-5bd500d7890b
 id-301f5a30-1c6f-4ea0-be1a-91fd28d44354
 id-bdbb5441-9204-419d-a225-b4fdbfb1a1a8
 id-6bba729b-3fb6-494b-9e1e-82bbd89a1045
+manila_tempest_tests.tests.scenario.test_share_basic_ops.TestShareBasicOpsNFS.test_read_write_two_vms # bsc#1137262
+manila_tempest_tests.tests.scenario.test_share_basic_ops.TestShareBasicOpsCIFS.test_read_write_two_vms # bsc#1137262
 EOF
     fi
 
@@ -4071,7 +4073,7 @@ function oncontroller_testsetup
 
     if ! openstack catalog show manila 2>&1 | grep -q "service manila not found" && \
         ! manila type-list | grep -q "[[:space:]]default[[:space:]]" ; then
-        manila type-create default false || complain 79 "manila type-create failed"
+        manila type-create default false --snapshot_support true || complain 79 "manila type-create failed"
     fi
 
     if iscloudver 7plus && \


### PR DESCRIPTION
The `read_write_two_vms` tests are known to fail because the share
doesn't cleanly unmount when it is shared to more than one vm[1], so
blacklist them. We also need to create the default share type with
snapshot support explicitly set, otherwise the snapshot tests will fail
with message "Snapshot cannot be created from share $id, because share
back end does not support it."

[1] https://bugzilla.suse.com/show_bug.cgi?id=1137262

This combined with https://review.opendev.org/662255 and https://review.opendev.org/664434 should fix the failing manila tests in the tempestfull job for cloud9.