### PR TITLE
openstack-ardana: configure CephFS backend for manila

### DIFF
--- a/scripts/jenkins/ardana/ansible/ardana-ses-manila.yml
+++ b/scripts/jenkins/ardana/ansible/ardana-ses-manila.yml
@@ -1,0 +1,122 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Configure CephFS backend for manila
+  hosts: "{{ ardana_env }}"
+  remote_user: ardana
+  gather_facts: no
+  vars:
+    task: "deploy"
+    ses_cluster_id: "{{ (ardana_env.startswith('pcloud') or ardana_env.startswith('qe')) | ternary('qe', 'virt') }}"
+    ses_cloud_config_path: "/tmp/ses_config"
+    ardana_openstack_path: "~/openstack/ardana/ansible"
+    ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
+    ardana_openstack_playbooks:
+      - "config-processor-run.yml -e encrypt='' -e rekey=''"
+      - "ready-deployment.yml"
+
+  tasks:
+    - block:
+        - name: Copy manila keyring to MNL-API hosts
+          shell:
+            ansible -m copy -a "src={{ ses_cloud_config_path }}/ceph.client.{{ ardana_env }}-manila.keyring \
+              dest=/etc/ceph/ owner=manila group=ceph" -b MNL-API
+          args:
+            chdir: "{{ ardana_scratch_path }}"
+
+        - name: Ensure manila client section on ceph.conf
+          shell:
+            ansible -m ini_file -a "dest=/etc/ceph/ceph.conf section=client.{{ ardana_env }}-manila \
+              option='{{ item.option }}' value={{ item.value }}" -b MNL-API
+          args:
+            chdir: "{{ ardana_scratch_path }}"
+          loop:
+            - option: "client mount uid"
+              value: 0
+            - option: "client mount gid"
+              value: 0
+            - option: "keyring"
+              value: "/etc/ceph/ceph.client.{{ ardana_env }}-manila.keyring"
+
+        - name: Add CephFS backend section to manila config
+          blockinfile:
+            path: "/var/lib/ardana/openstack/my_cloud/config/manila/manila.conf.j2"
+            block: |
+              [cephfsnative1]
+              driver_handles_share_servers = False
+              share_backend_name = CEPHFSNATIVE1
+              share_driver = manila.share.drivers.cephfs.cephfs_native.CephFSNativeDriver
+              cephfs_conf_path = /etc/ceph/ceph.conf
+              cephfs_protocol_helper_type = CEPHFS
+              cephfs_auth_id = {{ ardana_env }}-manila
+              cephfs_cluster_name = ceph
+              cephfs_enable_snapshots = False
+
+        - name: Enable CephFS backend in manila config
+          ini_file:
+            path: "{{ ardana_openstack_path }}/roles/_MNL-CMN/templates/manila.conf.j2"
+            section: "DEFAULT"
+            option: "{{ item.option }}"
+            value: "{{ item.value }}"
+          loop:
+            - option: "enabled_share_protocols"
+              value: "NFS,CIFS,CEPHFS"
+            - option: "enabled_share_backends"
+              value: "cephfsnative1"
+
+        - name: Commit changes
+          shell: |
+            git add -A
+            git commit -m 'Enabled CphFS backend for manila'
+          args:
+            chdir: "{{ ardana_openstack_path }}"
+
+        - name: Run playbooks from "{{ ardana_openstack_path }}"
+          command: "ansible-playbook -i hosts/localhost {{ item }}"
+          args:
+            chdir: "{{ ardana_openstack_path }}"
+          loop: "{{ ardana_openstack_playbooks }}"
+          register: ansible_openstack_plays
+          when: not (ansible_openstack_plays | default({})) is failed
+
+        - name: Reconfigure manila
+          command: "ansible-playbook {{ item }}"
+          args:
+            chdir: "{{ ardana_scratch_path }}"
+          loop:
+            - "manila-reconfigure.yml"
+          register: manila_plays
+          when: not (manila_plays | default({})) is failed
+      rescue:
+        - include_role:
+            name: rocketchat_notify
+          vars:
+            rc_action: "finished"
+            rc_state: "Failed"
+          when: rc_notify
+
+        - name: Stop if something failed
+          fail:
+            msg: "{{ task }} failed."
+
+  post_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "finished"
+        rc_state: "Success"
+      when: rc_notify

--- a/scripts/jenkins/ardana/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/ardana/ansible/deploy-cloud.yml
@@ -73,3 +73,6 @@
 
 - import_playbook: ardana-ses-rgw.yml
   when: ses_enabled and ses_rgw_enabled
+
+- import_playbook: ardana-ses-manila.yml
+  when: ses_enabled and 'manila' not in disabled_services | default('')

--- a/scripts/jenkins/ardana/ansible/roles/ses_cloud_integration/tasks/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_cloud_integration/tasks/main.yml
@@ -21,3 +21,6 @@
     state: directory
 
 - include_tasks: ses_configure_v{{ ardana_ses_integration_version }}.yml
+
+- include_tasks: ses_configure_manila.yml
+  when: "'manila' not in disabled_services | default('')"

--- a/scripts/jenkins/ardana/ansible/roles/ses_cloud_integration/tasks/ses_configure_manila.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_cloud_integration/tasks/ses_configure_manila.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2019 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,10 +15,8 @@
 #
 ---
 
-- include_tasks: delete_pools.yml
-
-- include_tasks: configure_ses.yml
-  when: ardana_ses_integration_version == 1
-
-- include_tasks: configure_manila.yml
-  when: "'manila' not in disabled_services | default('')"
+- name: Copy manila keyring file
+  copy:
+    dest: "{{ ses_cloud_config_path }}/ceph.client.{{ ardana_env }}-manila.keyring"
+    content: "{{ hostvars['ses-' + ses_cluster_id].manila_keyring.content | b64decode }}"
+    mode: 0644

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/defaults/main.yml
@@ -61,6 +61,15 @@ ses_openstack_keys:
     mode: "0600"
     acls: []
 
+ses_manila_key:
+  name: "client.{{ ardana_env }}-manila"
+  key: "$(ceph-authtool --gen-print-key)"
+  mon_cap: "allow r, allow command 'auth del', allow command 'auth caps', allow command 'auth get', allow command 'auth get-or-create'"
+  osd_cap: "allow rw"
+  mds_cap: "allow *"
+  mode: "0600"
+  acls: []
+
 ses_rgw_key:
   name: "client.rgw.ses-{{ ardana_env }}"
   key: "$(ceph-authtool --gen-print-key)"

--- a/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_manila.yml
+++ b/scripts/jenkins/ardana/ansible/roles/ses_configure/tasks/configure_manila.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2019 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,10 +15,16 @@
 #
 ---
 
-- include_tasks: delete_pools.yml
+- include_tasks: create_users.yml
+  vars:
+    ses_openstack_keys:
+      - "{{ ses_manila_key }}"
 
-- include_tasks: configure_ses.yml
-  when: ardana_ses_integration_version == 1
+- name: Ensure index export file on data pool
+  shell:
+    echo | rados -p cephfs_data put ganesha-export-index -
 
-- include_tasks: configure_manila.yml
-  when: "'manila' not in disabled_services | default('')"
+- name: Get manila keyring file contents
+  slurp:
+    src: "/etc/ceph/ceph.client.{{ ardana_env }}-manila.keyring"
+  register: manila_keyring


### PR DESCRIPTION
This change adds a playbook for configuring a CephFS native backend for manila.
This playbook is called by cloud-deploy.yml after the cloud is deployed
whenever SES and manila are enabled.

This enable us to run tempest tests for manila without prior manual
configuration.