### PR TITLE
openstack-ardana: update MU jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -161,7 +161,7 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana8-job-std-3cp-test-maintenance-updates-x86_64
+    name: cloud-ardana8-job-entry-scale-kvm-test-maintenance-updates-x86_64
     ardana_job: '{name}'
     disabled: false
     ardana_env: cloud-ardana-ci-slot
@@ -169,8 +169,8 @@
     updates_test_enabled: true
     update_after_deploy: true
     update_to_cloudsource: GM8+up
-    scenario_name: standard
-    clm_model: standalone
+    scenario_name: entry-scale-kvm
+    clm_model: integrated
     controllers: '3'
     sles_computes: '1'
     ses_enabled: true
@@ -189,7 +189,7 @@
     updates_test_enabled: false
     scenario_name: entry-scale-kvm
     tempest_filter_list: "\
-      smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
+      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
       designate,heat,ceilometer,magnum,freezer,monasca"
     qa_test_list: "iverify"
     triggers: []

--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -172,7 +172,7 @@
     scenario_name: entry-scale-kvm
     clm_model: integrated
     controllers: '3'
-    sles_computes: '1'
+    sles_computes: '2'
     ses_enabled: true
     ses_rgw_enabled: false
     triggers:
@@ -188,10 +188,14 @@
     cloudsource: GM8+up
     updates_test_enabled: false
     scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    ses_enabled: true
+    ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
       designate,heat,ceilometer,magnum,freezer,monasca"
-    qa_test_list: "iverify"
     triggers: []
     jobs:
         - '{ardana_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -189,6 +189,42 @@
         - '{ardana_job}'
 
 - project:
+    name: cloud-ardana9-job-entry-scale-kvm-test-maintenance-updates-x86_64
+    ardana_job: '{name}'
+    disabled: false
+    ardana_env: cloud-ardana-ci-slot
+    cloudsource: GM9+up
+    updates_test_enabled: true
+    update_after_deploy: true
+    update_to_cloudsource: GM9+up
+    scenario_name: entry-scale-kvm
+    clm_model: integrated
+    controllers: '3'
+    sles_computes: '1'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{ardana_job}'
+
+- project:
+    name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
+    ardana_job: '{name}'
+    disabled: false
+    reserve_env: false
+    cloudsource: GM9+up
+    updates_test_enabled: false
+    scenario_name: entry-scale-kvm
+    tempest_filter_list: "\
+      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+      designate,heat,magnum,monasca"
+    qa_test_list: "iverify"
+    triggers: []
+    jobs:
+        - '{ardana_job}'
+
+- project:
     name: cloud-ardana9-job-std-min-suse-x86_64
     ardana_job: '{name}'
     ardana_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -200,7 +200,7 @@
     scenario_name: entry-scale-kvm
     clm_model: integrated
     controllers: '3'
-    sles_computes: '1'
+    sles_computes: '2'
     ses_enabled: true
     ses_rgw_enabled: false
     triggers:
@@ -216,10 +216,14 @@
     cloudsource: GM9+up
     updates_test_enabled: false
     scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    sles_computes: '2'
+    ses_enabled: true
+    ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
       designate,heat,magnum,monasca"
-    qa_test_list: "iverify"
     triggers: []
     jobs:
         - '{ardana_job}'

--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -86,7 +86,8 @@
 
       - text:
           name: extra_params
-          default:
+          default: |
+            tempest_retry_failed=True
           description: >-
             This field may be used to define additional parameters, one per line, in the form:
 

--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -44,17 +44,14 @@
           description: >-
             Reserve the 'ardana_env' lockable resource throughout the execution of this job
 
-      - choice:
-          name: cloudsource
-          choices:
-            - 'GM8+up'
-            - 'hosGM8+up'
-          description: >-
-            The cloud repository (from provo-clouddata) to be used for testing.
-            This value can take the following form:
-
-               GM<X>+up (official GM plus Cloud-Updates)
-               hosGM<X>+up (official HOS GM plus Cloud-Updates)
+      - extended-choice:
+          name: cloudversion
+          type: multi-select
+          visible-items: 2
+          multi-select-delimiter: ','
+          default-value: '{cloudversion|}'
+          value: >-
+            SOC8,SOC9
 
       - validating-string:
           name: maint_updates

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.groovy
@@ -105,6 +105,33 @@ def generate_qa_tests_stages(qa_test_list) {
   }
 }
 
+def generate_mu_stages(cloudversion_list, deploy, update, body) {
+  def jobs = [:]
+  for (cv in cloudversion_list) {
+    if (deploy) {
+      jobs["${cv}-deploy"] = {
+        stage("Deploy: ${cv}") {
+          body(cv, false)
+        }
+      }
+    }
+    if (update) {
+      jobs["${cv}-update"] = {
+        stage("Update: ${cv}") {
+          body(cv, true)
+        }
+      }
+    }
+  }
+  return jobs
+}
+
+def get_mu_job_name(cloudversion) {
+ def jobs_map = [
+   "SOC": "cloud-ardana${cloudversion[-1]}-job-entry-scale-kvm-maintenance-update-x86_64"
+ ]
+ return jobs_map[cloudversion[0..-2]]
+}
 
 // Implements a simple closure that executes the supplied function (body) with
 // or without reserving a Lockable Resource identified by the 'resource_label'


### PR DESCRIPTION
For cloud 8:
- Change from standard 3cp model to entry-scale-kvm for the test updates
job.
- Adds lbaas to the list of tempest tests to run on the update job.

For cloud 9:
- Create maintenance update jobs

For both:
- Change the `cloud-maintenance-gating` job to be able to trigger jobs for
testing multiple cloud versions. For example, if a MU affects both cloud
8 and 9, this job can be triggered for testing both instead of needing
to trigger one job for cloud 8 and another for cloud 9.
- Replaced the `cloudsource` parameter with `cloudversion` which provide the options `SOC8/SOC9`
- Enable re-runing failed tempest tests, just as the gating job does.