### PR TITLE
Enable some tests in Ironic CI

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-agent-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-agent-template.yaml
@@ -21,7 +21,7 @@
             cloudsource=develcloud{version}
             storage_method=swift
             hacloud=1
-            mkcloudtarget=plain setupironicnodes
+            mkcloudtarget=plain setupironicnodes testsetup
             networkingplugin=openvswitch
             networkingmode=gre
             want_node_aliases=controller={nodenumber_controller},compute=1

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
@@ -21,7 +21,7 @@
             cloudsource=develcloud{version}
             storage_method=none
             hacloud=1
-            mkcloudtarget=plain setupironicnodes
+            mkcloudtarget=plain setupironicnodes testsetup
             networkingplugin=openvswitch
             networkingmode=gre
             want_node_aliases=controller={nodenumber_controller},compute=1


### PR DESCRIPTION
After recent extensions of Ironic environment setup, it should
be possible to start doing some real Ironic functional tests (not
just deployment testing).