### PR TITLE
openstack-ardana: set default project for heat_stack role

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
@@ -21,3 +21,4 @@ heat_stack_create_timeout: 900
 heat_stack_name: "openstack-ardana-{{ ardana_env }}"
 ses_stack_name: "openstack-ses-{{ ardana_env }}"
 monitor_stack_after_delete: True
+os_project_name: "cloud"


### PR DESCRIPTION
As the `heat_stack` role is also used in SES and it does not use the same inventory as ardana, it cannot get the default value for `os_project_name` which is defined on the ardana group vars.

Defining the `os_project_name` in the defaults values for the `heat_stack` role ensures that we have the default value available for anyone who uses the role.