### PR TITLE
openstack-cloud-heat: parameterized timeout

### DIFF
--- a/jenkins/ci.suse.de/cloud-heat.yaml
+++ b/jenkins/ci.suse.de/cloud-heat.yaml
@@ -2,7 +2,9 @@
 - project:
     name: openstack-cloud-heat
     os_cloud:
-      - engcloud
-      - susecloud
+      - engcloud:
+          heat_stack_timeout: '480'
+      - susecloud:
+          heat_stack_timeout: '900'
     jobs:
         - 'openstack-cloud-heat-{os_cloud}'

--- a/jenkins/ci.suse.de/pipelines/openstack-cloud-heat.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-cloud-heat.Jenkinsfile
@@ -53,7 +53,8 @@ pipeline {
           // OpenStack API only while actually deleting the stack
           ardana_lib.ansible_playbook('heat-stack', "-e heat_action=monitor")
           lock(resource: "$os_cloud-API") {
-            timeout(time: 10, unit: 'MINUTES', activity: true) {
+            // Use an activity timeout that is higher than the configured OpenStack heat API create/delete timeout
+            timeout(time: heat_stack_timeout.toInteger()+60, unit: 'SECONDS', activity: true) {
               ardana_lib.ansible_playbook('heat-stack', "-e heat_action=delete -e monitor_stack_after_delete=False")
             }
           }
@@ -71,7 +72,8 @@ pipeline {
           writeFile file: "$WORKSPACE/heat_template.yml", text: params.heat_template
 
           lock(resource: "$os_cloud-API") {
-            timeout(time: 20, unit: 'MINUTES', activity: true) {
+            // Use an activity timeout that is higher than the configured OpenStack heat API create/delete timeout
+            timeout(time: heat_stack_timeout.toInteger()+60, unit: 'SECONDS', activity: true) {
               ardana_lib.ansible_playbook('heat-stack', "-e heat_template_file=$WORKSPACE/heat_template.yml")
             }
           }

--- a/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
@@ -98,6 +98,12 @@
               engcloud  - the Provo engineering cloud (engcloud.prv.suse.net)
               susecloud - the Nuremberg SUSE cloud (cloud.suse.de)
 
+      - hidden:
+          name: heat_stack_timeout
+          default: '{heat_stack_timeout}'
+          description: >-
+            The timeout (seconds) configured for the OpenStack heat API create/delete operations.
+
       - text:
           name: extra_params
           default:

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/defaults/main.yml
@@ -17,7 +17,8 @@
 
 heat_action: "create"
 
-heat_stack_create_timeout: 900
+# The timeout used by heat for the create/delete stack operations
+heat_stack_timeout: 900
 heat_stack_name: "openstack-ardana-{{ ardana_env }}"
 ses_stack_name: "openstack-ses-{{ ardana_env }}"
 monitor_stack_after_delete: True

--- a/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/create.yml
+++ b/scripts/jenkins/ardana/ansible/roles/heat_stack/tasks/create.yml
@@ -23,5 +23,5 @@
     name: "{{ heat_stack_name }}"
     state: present
     template: "{{ heat_template_file }}"
-    timeout: "{{ heat_stack_create_timeout }}"
+    timeout: "{{ heat_stack_timeout }}"
   register: heat_stack_create


### PR DESCRIPTION
The timeout used by heat when creating/deleting a heat stack is
configurable. The OpenStack heat API call (and consequently
the wrapping ansible playbook) will fail and exit if the heat
stack create or delete operation exceeds this timeout value,
and will not print any output during this time.

The Jenkins pipeline also uses a second, inactivity timeout
value (based on output lines being added to the Jenkins log),
in case something else goes wrong. The Jenkins job inactivity timeout
needs to account for the heat stack timeout (i.e. the value must
a little higher).

All this logic is in reality based on a single parameter - the heat
stack timeout - but the implementation so far used two independent
values. To add to the complexity, the supported ECP and SUSE cloud
platforms differ in performance (the SUSE cloud takes roughly twice
as much time to create a heat stack).

This commit makes things easier to maintain, by adding a hidden
parameter to the openstack-cloud-heat jobs, which controls both
timeout values.