### PR TITLE
openstack-ses: Rerun stage 4 (services) after iscsi workaround

### DIFF
--- a/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/tasks/deepsea_setup.yml
@@ -126,12 +126,8 @@
     verbosity: 1
 
 - name: Run iscsi workaround
-  command: "salt-run state.orch ceph.stage.iscsi"
-  when:
-    - stage4.stdout.find('lrbd has been enabled, and is dead') != -1  # Implement workaround of the cosmetic issue https://www.suse.com/support/kb/doc/?id=7018668
-
-# For some reason sometimes the radosgw package is not installed
-- name: Ensure RADOS GW installed
-  package:
-    name: ceph-radosgw
-    state: present
+  command: "salt-run state.orch {{ item }}"
+  when: stage4.stdout.find('lrbd has been enabled, and is dead') != -1  # Implement workaround of the cosmetic issue https://www.suse.com/support/kb/doc/?id=7018668
+  loop:
+    - "ceph.stage.iscsi"
+    - "ceph.stage.services"


### PR DESCRIPTION
Running the iscsi stage is not enough as other ceph services (mds,
rgw, ...) are not setup. Running the stage 4 again make sure those services
are setup.