### PR TITLE
openstack-ardana: Fix tempest retry for tearDownClass failures

### DIFF
--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
@@ -1,6 +1,6 @@
 {% set regexp = '\[.*]$' %}
 {% set test = tempest_failed_tests.stdout_lines[0] %}
-{% if test.startswith('setUpClass') %}
+{% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
 {% set regexp = '.*\(|\)$' %}
 {% endif %}
 +{{ test | regex_replace(regexp, '') }}

--- a/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
+++ b/scripts/jenkins/ardana/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
@@ -1,6 +1,6 @@
 {% set regexp = '\[.*]$' %}
 {% for test in tempest_failed_tests.stdout_lines[1:] %}
-{% if test.startswith('setUpClass') %}
+{% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
 {% set regexp = '.*\(|\)$' %}
 {% endif %}
 +{{ test | regex_replace(regexp, '') }}


### PR DESCRIPTION
Parse and include tearDownClass failures into the list of tempest tests
to rerun.