### PR TITLE
openstack-ardana: run manila tempest tests on gating jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -134,7 +134,7 @@
     ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
-      designate,heat,ceilometer,magnum,freezer,monasca"
+      designate,heat,manila,ceilometer,magnum,freezer,monasca"
     triggers: []
     jobs:
         - '{ardana_job}'
@@ -155,7 +155,7 @@
     ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
-      designate,heat,ceilometer,magnum,freezer,monasca"
+      designate,heat,manila,ceilometer,magnum,freezer,monasca"
     triggers: []
     jobs:
         - '{ardana_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -128,7 +128,7 @@
     ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-      designate,heat,magnum,monasca"
+      designate,heat,manila,magnum,monasca"
     triggers: []
     jobs:
         - '{ardana_job}'
@@ -150,7 +150,7 @@
     ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-      designate,heat,magnum,monasca"
+      designate,heat,manila,magnum,monasca"
     triggers: []
     jobs:
         - '{ardana_job}'


### PR DESCRIPTION
This change adds manila to the list of tempest tests that are executed
on the gating job for both cloud 8 and 9.