### PR TITLE
openstack-crowbar: fix swift HA scenarios

### DIFF
--- a/scripts/scenarios/cloud7/cloud7-5nodes-default.yml
+++ b/scripts/scenarios/cloud7/cloud7-5nodes-default.yml
@@ -84,8 +84,8 @@ proposals:
       swift-ring-compute:
       - @@controller1@@
       swift-storage:
-      - @@controller1@@
-      - @@controller2@@
+      - @@compute-kvm1@@
+      - @@compute-kvm2@@
 - barclamp: glance
   attributes:
     default_store: swift

--- a/scripts/scenarios/cloud8/cloud8-5nodes-default.yml
+++ b/scripts/scenarios/cloud8/cloud8-5nodes-default.yml
@@ -83,8 +83,8 @@ proposals:
       swift-ring-compute:
       - @@controller1@@
       swift-storage:
-      - @@controller1@@
-      - @@controller2@@
+      - @@compute-kvm1@@
+      - @@compute-kvm2@@
 - barclamp: glance
   attributes:
     default_store: swift

--- a/scripts/scenarios/cloud9/cloud9-5nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-5nodes-default.yml
@@ -81,8 +81,8 @@ proposals:
       swift-ring-compute:
       - @@controller1@@
       swift-storage:
-      - @@controller1@@
-      - @@controller2@@
+      - @@compute-kvm1@@
+      - @@compute-kvm2@@
 - barclamp: glance
   attributes:
     default_store: swift

--- a/scripts/scenarios/cloud9/cloud9-5nodes-ses.yml
+++ b/scripts/scenarios/cloud9/cloud9-5nodes-ses.yml
@@ -81,8 +81,8 @@ proposals:
       swift-ring-compute:
       - @@controller1@@
       swift-storage:
-      - @@controller1@@
-      - @@controller2@@
+      - @@compute-kvm1@@
+      - @@compute-kvm2@@
 - barclamp: glance
   attributes:
     default_store: rbd


### PR DESCRIPTION
Fix the swift configuration in the the 5 nodes HA scenarios used
with Crowbar ECP deployments to be aligned to the `crowbar` input
model generator scenario, which currently only features a swift
volume on the compute nodes.

NOTE: currently, all HA ECP Crowbar jobs are failing because the
swift-object role is associated with the controller nodes, but the
input model generated from the `crowbar` scenario associates
the `SWOBJ` service components with the compute nodes.