### PR TITLE
openstack-ardana: make packages from extra-repos available to all nodes

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -153,7 +153,7 @@ pipeline {
                 string(name: 'git_automation_branch', value: "$git_automation_branch"),
                 text(name: 'extra_params', value: extra_params)
               ], false)
-              env.test_repository_url = "http://download.suse.de/ibs/Devel:/Cloud:/Testbuild:/ardana-ci-${slaveJob.getNumber()}/standard/Devel:Cloud:Testbuild:ardana-ci-${slaveJob.getNumber()}.repo"
+              env.test_repository_url = "http://download.suse.de/ibs/Devel:/Cloud:/Testbuild:/ardana-ci-${slaveJob.getNumber()}/standard"
               if (extra_repos == '') {
                 env.extra_repos = test_repository_url
               } else {

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -103,11 +103,14 @@
       - validating-string:
           name: extra_repos
           default: ''
-          regex: '((http(s)?:\/\/[^ ,]+\.repo)(,http(s)?:\/\/[^ ,]+\.repo)*)*'
+          regex: '((http(s)?:\/\/[^ ,]+)(,http(s)?:\/\/[^ ,]+)*)*'
           msg: The entered value failed validation
           description: >-
-            A comma separated list of repository urls (ending with .repo) to be
-            added on the deployer node
+            A comma separated list of repository urls to be added on the deployer node
+
+            NOTE: The packages from those repositories will be available to all cloud nodes
+            through a repository with a higher priority, meaning that those packages will be
+            installed even if there is a newer package available on other repositories.
 
       - string:
           name: git_automation_repo

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -364,11 +364,14 @@
       - validating-string:
           name: extra_repos
           default: ''
-          regex: '((http(s)?:\/\/[^ ,]+\.repo)(,http(s)?:\/\/[^ ,]+\.repo)*)*'
+          regex: '((http(s)?:\/\/[^ ,]+)(,http(s)?:\/\/[^ ,]+)*)*'
           msg: The entered value failed validation
           description: >-
-            A comma separated list of repository urls (ending with .repo) to be
-            added on the deployer node
+            A comma separated list of repository urls to be added on the deployer node
+
+            NOTE: The packages from those repositories will be available to all cloud nodes
+            through a repository with a higher priority, meaning that those packages will be
+            installed even if there is a newer package available on other repositories
 
       - bool:
           name: rc_notify

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
@@ -76,6 +76,18 @@
     - '-b -a "rpm --import /tmp/content.key"'
   when: "'staging' in cloudsource or 'devel' in cloudsource"
 
+- name: Ensure extra-repos repository on non-deployer nodes
+  command: |
+    ansible -m command -a "zypper ar -f -G -p 90 \
+        http://{{ '{{' }} hostvars[groups['ARD-SVC--first-member'].0].ansible_ssh_host {{ '}}' }}:79/{{ suse_release | replace('.', '-') | upper }}/{{ ansible_architecture }}/repos/extra-repos \
+        extra-repos creates=/etc/zypp/repos.d/extra-repos.repo" -b 'resources:!ARD-SVC--first-member:!*rhel*'
+  environment:
+    ANSIBLE_HOST_KEY_CHECKING: False
+    ANSIBLE_SSH_ARGS: '-o UserKnownHostsFile=/dev/null'
+  when:
+    - extra_repos is defined
+    - extra_repos != ''
+
 - include_tasks: setup_mu_repos.yml
   when:
     - not update_after_deploy

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/README.md
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/README.md
@@ -59,10 +59,12 @@ It is also possible to use the role to add extra zypper repositories from the
 URL by overriding the `extra_repos` variable, for example:
 
 ```sh
-extra_repos: "http://download.suse.de/ibs/.../extra-repo1.repo,http://download.suse.de/ibs/.../extra-repo2.repo"
+extra_repos: "http://download.suse.de/ibs/.../,http://download.suse.de/ibs/.../"
 ```
 
-Notice that for `extra_repos` you need the URL containing the `.repo` file.
+The packages from those repositories will be available to all cloud nodes
+through a new repository with a higher priority, meaning that those packages will be
+installed even if there is a newer package available on other repositories.
 
 ### Source Repositories
 

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/add_extra_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/add_extra_repos.yml
@@ -15,9 +15,38 @@
 #
 ---
 
-- name: Add extra repos
-  zypper_repository:
-    repo: "{{ item }}"
+- name: Download packages from extra repositories
+  command: |
+    wget --progress=dot:mega -r --directory-prefix {{ local_repos_base_dir }}/extra-repos \
+      -e robots=off  --no-check-certificate --no-parent --no-clobber --accept \
+       x86_64.rpm,noarch.rpm {{ item }}
+  args:
+    warn: false
   loop: "{{ extra_repos_list }}"
+  register: rpm_download_status
+  until: rpm_download_status is succeeded
+  retries: 5
+  delay: 5
+  notify:
+    - Refresh all repos
+
+- name: Ensure createrepo tool installed
+  zypper:
+    name: createrepo
+    disable_gpg_check: true
+
+- name: Create extra-repos repository
+  command: |
+    createrepo -o {{ local_repos_base_dir }}/extra-repos {{ local_repos_base_dir }}/extra-repos
+  args:
+    creates: "{{ local_repos_base_dir }}/extra-repos/repodata/repomd.xml"
+
+- name: Add extra-repos repository
+  zypper_repository:
+    name: "extra-repos"
+    priority: 90
+    repo: "{{ local_repos_base_dir }}/extra-repos"
+    disable_gpg_check: true
+    state: present
   notify:
     - Refresh all repos

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -57,11 +57,11 @@ update_to_cloudsource: ''
 maint_updates: ''
 
 # A comma separated list of repository urls to be added on the deployer/admin node.
-# For Ardana, each URL must be supplied in a form that includes the .repo file name.
-# For Crowbar, the .repo filename should be excluded.
-# WARNING: Ardana only installs the extra repositories on the deployer node (see
-# https://jira.suse.com/browse/SOC-7800), so they will not be available on the
-# non-deployer nodes.
+# WARNING: For ARDANA the packages from those repositories will be availabe to all cloud
+# nodes through a repository with a higher priority, meaning that those packages will be
+# installed even if there is a newer package available on other repositories.
+# For CROWBAR the repository has higher priority only on the deployer node, on the other
+# nodes it has the default priority.
 extra_repos: ''
 
 #============= Gerrit =============#


### PR DESCRIPTION
Instead of adding the extra repositories on the deployer node as a
zypper repository, create a new repository on the deployer and make
all RPMs from the extra repositories available to all cloud nodes by
setting up this repository on all nodes.

This new repository will be configure with higher priority, meaning that
all packages from the `extra_repos` will be installed even if there are
newer packages available on other repositories.

An easier way to do the same would be to use the PTF repository to provide
those packages, however we have decided to not use the PTF repository as we would be affecting the product if we create and set the priority of the PTF repository which is something done by ardana itself.

https://jira.suse.com/browse/SOC-7800