### PR TITLE
openstack-ardana: add option to update services serially

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/defaults/main.yml
@@ -20,6 +20,7 @@ update_method: "{{ (cloudsource | regex_search('devel|staging.*')) | ternary('up
 update_gpg_checks: true
 update_licenses_agree: true
 update_include_reboot_patches: true
+update_services_serial: False
 
 cloud_brand: "{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'SUSE-OpenStack-Cloud') }}"
 cloud_update_repo_name: "{{ cloud_brand }}-{{ sles_cloud_version[ansible_distribution_version] }}-Updates"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_nodes.yml
@@ -74,11 +74,6 @@
     - var: pending_system_reboot
       value: "{{ 'system reboot' in _ardana_update_status.stdout }}"
 
-- name: Run ardana-update playbook to update services on all nodes
-  command: |
-    ansible-playbook ardana-update.yml -e '{{ ardana_extra_vars|to_json }}'
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
+- name: Update Ardana/OpenStack services if needed
+  include_tasks: update_services_{{ update_services_serial | ternary('serial', 'parallel') }}.yml
   when: pending_service_update

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_services_parallel.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_services_parallel.yml
@@ -1,0 +1,24 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Run ardana-update playbook to update services on all nodes in parallel
+  command: |
+    ansible-playbook ardana-update.yml -e '{{ ardana_extra_vars|to_json }}'
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  environment:
+    SKIP_REPO_CHECKS: 1

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_services_serial.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_services_serial.yml
@@ -1,0 +1,26 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Run ardana-update playbook to update services on all nodes serially
+  command: |
+    ansible-playbook ardana-update.yml \
+      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  environment:
+    SKIP_REPO_CHECKS: 1
+  loop: "['ARD-SVC--first-member'] + {{ ardana_nodes.stdout_lines }}"


### PR DESCRIPTION
Although the documentation recommends running service updates serially,
for the CI we have been running service updates in parallel due to the
long time it takes to complete when running in serial (5h vs 9h).

However, during the testing of MUs for cloud 8, the update failed when
running in parallel (SOC-9524) and an option to run services update in
serial was needed.