### PR TITLE
pining down ansible to a know working version 

### DIFF
--- a/scripts/jenkins/cloud/manual/requirements.txt
+++ b/scripts/jenkins/cloud/manual/requirements.txt
@@ -1,4 +1,4 @@
-ansible
+ansible<2.8.0
 netaddr
 openstacksdk
 sh


### PR DESCRIPTION
there have been several defects found with ansible 2.8.0 that make the manual deployment break. 
For, example The "synchronize" module used by the setup_zypper_repos role
does not behave well when using "delegate_to". I tries to use sshpass instead of ssh key authentication.
This causes a failure.