### PR TITLE
Use system-wide python-libvirt for vbmc

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -837,7 +837,8 @@ function install_vbmc
     # virtualenv is also not (yet) available in standard repos
     virtualenv --version 2> /dev/null || \
         rpm -i http://download.suse.de/ibs/SUSE:/SLE-12-SP4:/Update:/Products:/Cloud9/standard/noarch/python-virtualenv-15.1.0-3.3.noarch.rpm
-    virtualenv $cloud-vbmc
+    # include global packages to avoid compiling libvirt bindings
+    virtualenv --system-site-packages $cloud-vbmc
     . $cloud-vbmc/bin/activate
     pip install virtualbmc
 }


### PR DESCRIPTION
As not all hosts have libvirt-devel, python-devel or even gcc
installed and all should have python-libvirt, let's use system-wide
python packages as part of the virtualenv created for vbmc.
This way we won't need to install gcc, devel packages and some other
compile-time dependencies when installing python-libvirt in virtualenv.