### PR TITLE
Remove obsoleted task

### DIFF
--- a/scripts/jenkins/cloud/ansible/bootstrap-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-crowbar.yml
@@ -34,14 +34,6 @@
         - name: Remove unused ifcfg files
           shell: rm --force --verbose /etc/sysconfig/network/ifcfg-eth[1-9]*
 
-        # FIXME: remove when https://github.com/crowbar/crowbar/pull/2371 is
-        # available in all crowbar versions
-        - name: Remove comments from authorized_keys file
-          lineinfile:
-            dest: "{{ ansible_env.HOME }}/.ssh/authorized_keys"
-            regexp: "^ *#"
-            state: absent
-
         # add MU repos
         - include_role:
             name: setup_zypper_repos


### PR DESCRIPTION
The task to remove comments in the authorized keys file breaks
the idempotency of [1]. Since https://github.com/crowbar/crowbar/pull/2371 [2] is merged for all Crowbar
versions, we can safely remove it now.

[1] https://github.com/SUSE-Cloud/automation/blob/master/scripts/jenkins/cloud/ansible/roles/ssh_keys/tasks/main.yml#L18
[2] https://github.com/crowbar/crowbar/pull/2371

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>