### PR TITLE
Give an option to tests different socok8s versions

### DIFF
--- a/jenkins/ci.suse.de/cloud-socok8s.yaml
+++ b/jenkins/ci.suse.de/cloud-socok8s.yaml
@@ -6,4 +6,27 @@
     repo-credentials: c2350527-476a-45df-b406-84f028614682
     jobs:
       - '{name}-integration'
-      - '{name}-nightly-airship-from-rpm'
+
+- project:
+    name: cloud-socok8s-master-nightly
+    triggers:
+      - timed: '@daily'
+    socok8s_source: master
+    jobs:
+      - '{name}-airship-from-rpm'
+
+- project:
+    name: cloud-socok8s-stable-nightly
+    triggers:
+      - timed: '@daily'
+    socok8s_source: stable_1
+    jobs:
+      - '{name}-airship-from-rpm'
+
+- project:
+    name: cloud-socok8s-stable-staging-nightly
+    triggers:
+      - timed: '@daily'
+    socok8s_source: stable_1_staging
+    jobs:
+      - '{name}-airship-from-rpm'

--- a/jenkins/ci.suse.de/pipelines/socok8s-airship-from-rpm.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/socok8s-airship-from-rpm.Jenkinsfile
@@ -47,6 +47,16 @@ pipeline {
                     sh 'echo ANSIBLE_STDOUT_CALLBACK="yaml" >> jenkins.env'
                     sh 'echo USER="root" >> jenkins.env'
 
+                    if (socok8s_source == 'stable_1') {
+                        su 'echo SOCOK8S_OBS_REPO_URL="https://download.opensuse.org/repositories/Cloud:/socok8s/openSUSE_Leap_15.0/" >> jenkins.env'
+                    }
+                    else if (socok8s_source == 'stable_1_staging') {
+                        su 'echo SOCOK8S_OBS_REPO_URL="https://download.opensuse.org/repositories/Cloud:/socok8s:/staging/openSUSE_Leap_15.0/" >> jenkins.env'
+                    }
+                    else {
+                        su 'echo SOCOK8S_OBS_REPO_URL="https://download.opensuse.org/repositories/Cloud:/socok8s:/master/openSUSE_Leap_15.0/" >> jenkins.env'
+                    }
+
                     // Start container
                     env.CONTAINER_ID = sh(
                         returnStdout: true,
@@ -69,7 +79,7 @@ pipeline {
                     // CA is required for accessing engcloud
                     in_container('zypper addrepo http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_15.0/ "SUSE CA"')
                     // Add socok8s repo
-                    in_container('zypper addrepo https://download.opensuse.org/repositories/Cloud:/socok8s/openSUSE_Leap_15.0/ "SUSE OpenStack Cloud on Kubernetes Preview"')
+                    in_container('zypper addrepo ${SOCOK8S_OBS_REPO_URL} "SUSE OpenStack Cloud on Kubernetes Preview"')
                     in_container('zypper --no-gpg-checks refresh')
                     in_container('zypper --no-gpg-checks install -yl ca-certificates-suse socok8s')
                 }

--- a/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
@@ -20,7 +20,7 @@
           filter-head-regex: ^(master|stable\-\d\.\d|PR\-\d+)$
 
 - job-template:
-    name: '{name}-nightly-airship-from-rpm'
+    name: '{name}-airship-from-rpm'
     project-type: pipeline
     concurrent: false
 
@@ -28,8 +28,7 @@
       numToKeep: -1
       daysToKeep: 14
 
-    triggers:
-      - timed: '@daily'
+    triggers: '{triggers}'
 
     parameters:
       - string:
@@ -43,6 +42,15 @@
           default: '{git_automation_branch|master}'
           description: >-
             The git automation branch
+
+      - choice:
+          name: socok8s_source
+          choices:
+            - master
+            - stable_1
+            - stable_1_staging
+          description: >-
+            The OBS repository to be used for testing.
 
     pipeline-scm:
       scm:


### PR DESCRIPTION
Expose a choice parameter to select which socok8s repo to use. This is
done so that we can also change the job logic depending on the tested
version of necessary.