### PR TITLE
openstack-ardana: remove manila tests from gate update jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -155,7 +155,7 @@
     ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
-      designate,heat,manila,ceilometer,magnum,freezer,monasca"
+      designate,heat,ceilometer,magnum,freezer,monasca"
     triggers: []
     jobs:
         - '{ardana_job}'

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -150,7 +150,7 @@
     ses_rgw_enabled: false
     tempest_filter_list: "\
       keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-      designate,heat,manila,magnum,monasca"
+      designate,heat,magnum,monasca"
     triggers: []
     jobs:
         - '{ardana_job}'


### PR DESCRIPTION
Some tempest manila tests are failing due to a known bug (SOC-9553),
this change remove manila from the tests ran on the gate update
job for cloud 8 and 9 until the issue is fixed.