### PR TITLE
Remove jtsync from the CI Jobs

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-repocheck.yaml
+++ b/jenkins/ci.opensuse.org/openstack-repocheck.yaml
@@ -65,8 +65,7 @@
           [ -z "$PROJECTSOURCE" ] && ( echo "Error: no PROJECTSOURCE defined." ; exit 1 )
 
           export automationrepo=~/github.com/SUSE-Cloud/automation
-          export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
-          
+
           # Workaround to get only the name of the job:
           # https://issues.jenkins-ci.org/browse/JENKINS-39189
           # When the JOB_BASE_NAME contains only in ex. "openstack-repocheck", this
@@ -74,17 +73,8 @@
           echo "$JOB_BASE_NAME"
           main_job_name=${JOB_NAME%%/*}
 
-          function jtsync_trap() {
-            $jtsync --ci opensuse --matrix ${main_job_name},${project},${BUILD_NUMBER} 1
-          }
-
-          if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
-            trap jtsync_trap EXIT ERR
-          fi
-
           DIST_NAME=$(echo $repository|cut -d "_" -f 1)
           DIST_VERSION=$(echo $repository|cut -d "_" -f 2-)
-
 
           OBS_TYPE=${PROJECTSOURCE%%/*}
           OBS_PROJECT=${PROJECTSOURCE##*/}
@@ -131,11 +121,4 @@
 
           test -e ~/repo || { echo "~/repo needs to have a copy of pre-generated .solv files from internal media" ; exit 55; }
           installcheck $ARCH --withobsoletes --exclude "-kmp-" tmp/repo/primary.xml.gz  --nocheck $EXTRA_NOCHECK ~/repo/${repository}-${ARCH}.solv
-          ret=$?
-
-          # only enable jtsync when build is not manually triggered
-          if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
-            trap - EXIT ERR
-            $jtsync --ci opensuse --matrix ${main_job_name},${project},${BUILD_NUMBER} $ret || :
-          fi
-          exit $ret
+          exit $?

--- a/jenkins/ci.suse.de/cloud-mediacheck.yaml
+++ b/jenkins/ci.suse.de/cloud-mediacheck.yaml
@@ -53,7 +53,6 @@
     builders:
       - shell: |
           export automationrepo=~/github.com/SUSE-Cloud/automation
-          export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
 
           # Workaround to get only the name of the job:
           # https://issues.jenkins-ci.org/browse/JENKINS-39189
@@ -70,14 +69,6 @@
           # fetch the latest automation updates
           ${automationrepo}/scripts/jenkins/update_automation
 
-          function jtsync_trap() {
-            $jtsync --ci suse --matrix ${main_job_name},${project},${BUILD_NUMBER} 1 || :
-          }
-
-          # only enable jtsync when build is not manually triggered
-          if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
-            trap jtsync_trap EXIT ERR
-          fi
           if [[ ! -d /mounts/dist ]] ; then
               zypper -n install git-core rsync make autofs nfs-client ypbind kernel-default -kernel-default-base curl wget libsolv-tools bsdtar
               echo -e 'ypserver 10.160.0.10\nypserver 10.160.0.1\nypserver 10.160.0.150' > /etc/yp.conf
@@ -135,13 +126,6 @@
           fi
 
           OBS_TYPE=IBS OBS_PROJECT=$OBS_PROJECT make -C cloud/scripts/release-mgmt/ mediacheck
-          RETVAL=$?
-
-          # only enable jtsync when build is not manually triggered
-          if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
-            trap - EXIT ERR
-            $jtsync --ci suse --matrix ${main_job_name},${project},${BUILD_NUMBER} $RETVAL || :
-          fi
     publishers:
       - workspace-cleanup:
           fail-build: false

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -354,8 +354,6 @@ pipeline {
       sh '''
         if [ -n "$github_pr" ] ; then
           automation-git/scripts/cloud/pr-success.sh
-        else
-          automation-git/scripts/jtsync/jtsync.rb --ci suse --job $JOB_NAME 0
         fi
       '''
     }
@@ -363,8 +361,6 @@ pipeline {
       sh '''
         if [ -n "$github_pr" ] ; then
           automation-git/scripts/cloud/pr-failure.sh
-        else
-          automation-git/scripts/jtsync/jtsync.rb --ci suse --job $JOB_NAME 1
         fi
       '''
     }

--- a/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
+++ b/scripts/jenkins/mkcloud/openstack-mkcloud.builder.sh
@@ -8,7 +8,6 @@ mkdir -p $artifacts_dir
 touch $artifacts_dir/.ignore
 export log_dir=$artifacts_dir/mkcloud_log
 
-jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
 export ghprrepo=~/github.com/openSUSE/github-pr
 export ghpr=${ghprrepo}/github_pr.rb
 
@@ -190,8 +189,6 @@ ret=${PIPESTATUS[0]}
 if [[ $ret != 0 ]] ; then
     if [[ $github_pr_sha ]] ; then
         mkcloudgating_trap
-    else
-        $jtsync --ci suse --job $JOB_NAME 1
     fi
     echo "mkcloud ret=$ret"
     exit $ret # check return code before tee
@@ -201,6 +198,4 @@ fi
 if [[ $github_pr_sha ]] ; then
     $ghpr --action set-status --debugratelimit $ghpr_paras --status "success" --targeturl $BUILD_URL --message "PR gating succeeded"
     trap "-" ERR
-else
-    $jtsync --ci suse --job $JOB_NAME 0
 fi

--- a/scripts/jenkins/track-upstream.sh
+++ b/scripts/jenkins/track-upstream.sh
@@ -10,7 +10,6 @@ zypper -n in osc obs-service-tar_scm obs-service-github_tarballs obs-service-rec
 [ -z "$PROJECTSOURCE" ] && ( echo "Error: no PROJECTSOURCE defined." ; exit 1 )
 
 export automationrepo=~/github.com/SUSE-Cloud/automation
-export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
 
 # Workaround to get only the name of the job:
 # https://issues.jenkins-ci.org/browse/JENKINS-39189
@@ -18,14 +17,6 @@ export jtsync=${automationrepo}/scripts/jtsync/jtsync.rb
 # workaround can be removed.
 echo "$JOB_BASE_NAME"
 main_job_name=${JOB_NAME%%/*}
-
-function jtsync_trap() {
-    $jtsync --ci opensuse --matrix ${main_job_name},${project},${BUILD_NUMBER} 1
-}
-
-if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
-    trap jtsync_trap EXIT ERR
-fi
 
 OBS_TYPE=${PROJECTSOURCE%%/*}
 OBS_PROJECT=${PROJECTSOURCE##*/}
@@ -89,11 +80,4 @@ if [ ${OBS_PROJECT} != "Cloud:OpenStack:Master" ] ; then
     grep -q "<linkinfo" .osc/_files || exit 2
 fi
 timeout 1h ~/github.com/SUSE-Cloud/automation/scripts/jenkins/track-upstream-and-package.pl
-ret=$?
-
-# only enable jtsync when build is not manually triggered
-if [[ ${ROOT_BUILD_CAUSE} != "MANUALTRIGGER" ]]; then
-    trap - EXIT ERR
-    $jtsync --ci opensuse --matrix ${main_job_name},${project},${BUILD_NUMBER} $ret || :
-fi
-exit $ret
+exit $?


### PR DESCRIPTION
We used jtsync to trigger notifications and set the CI status on
trello cards. This process is no longer followed and creates noise
and maintenance effort. Let's kill jtsync in order to safe this.