### PR TITLE
Travis Remove sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: bash
-sudo: required
 dist: xenial
 install:
   - make install


### PR DESCRIPTION
Since xenial sudo can be used by default. We don't have to call it out.