### PR TITLE
openstack-crowbar/ansible: python3 enablement

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-gerrit-events.yaml
@@ -57,14 +57,16 @@
 
           git clone $git_automation_repo --branch $git_automation_branch automation-git
 
+          source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
+
           if [[ -n $GERRIT_EVENT_TYPE ]]; then
               if [[ $GERRIT_EVENT_TYPE == 'change-merged' ]]; then
-                  automation-git/scripts/jenkins/cloud/gerrit/gerrit_handle_event.py ${GERRIT_CHANGE_NUMBER} merged
+                  run_python_script automation-git/scripts/jenkins/cloud/gerrit/gerrit_handle_event.py ${GERRIT_CHANGE_NUMBER} merged
               elif [[ $GERRIT_EVENT_TYPE == 'patchset-created' ]]; then
-                  automation-git/scripts/jenkins/cloud/gerrit/gerrit_handle_event.py ${GERRIT_CHANGE_NUMBER} updated
+                  run_python_script automation-git/scripts/jenkins/cloud/gerrit/gerrit_handle_event.py ${GERRIT_CHANGE_NUMBER} updated
               elif [[ $GERRIT_EVENT_TYPE == 'comment-added' ]]; then
-                  automation-git/scripts/jenkins/cloud/gerrit/gerrit_merge.py ${GERRIT_CHANGE_NUMBER}
+                  run_python_script automation-git/scripts/jenkins/cloud/gerrit/gerrit_merge.py ${GERRIT_CHANGE_NUMBER}
               fi
           else
-              automation-git/scripts/jenkins/cloud/gerrit/gerrit_merge.py ${GERRIT_CHANGE_NUMBER}
+              run_python_script automation-git/scripts/jenkins/cloud/gerrit/gerrit_merge.py ${GERRIT_CHANGE_NUMBER}
           fi

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
@@ -46,9 +46,10 @@ pipeline {
         sh('echo "zypper repository for test packages: http://download.suse.de/ibs/${homeproject//:/:\\/}:/ardana-ci-${BUILD_NUMBER}/standard/${homeproject}:ardana-ci-${BUILD_NUMBER}.repo"')
         timeout(time: 30, unit: 'MINUTES', activity: true) {
           sh('''
+            source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
             cd automation-git/scripts/jenkins/cloud/gerrit
             set -eux
-            python -u build_test_package.py --homeproject ${homeproject} --buildnumber ${BUILD_NUMBER} -c ${gerrit_change_ids//,/ -c }
+            run_python_script -u build_test_package.py --homeproject ${homeproject} --buildnumber ${BUILD_NUMBER} -c ${gerrit_change_ids//,/ -c }
           ''')
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -266,7 +266,8 @@ pipeline {
     always {
       script{
         sh('''
-          automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
+          source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
+          run_python_script automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
             --recursive \
             --filter 'Declarative: Post Actions' \
             --filter 'Setup workspace' > .artifacts/pipeline-report.txt || :

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -236,7 +236,8 @@ pipeline {
     always {
       script{
         sh('''
-          automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
+          source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
+          run_python_script automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
             --recursive \
             --filter 'Setup workspace' \
             --filter 'Declarative: Post Actions' \

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_setup/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_setup/tasks/main.yml
@@ -7,6 +7,7 @@
     exit ${PIPESTATUS[0]}
   args:
     executable: "/bin/bash"
+    chdir: "/root"
   delegate_to: "{{ cloud_env }}"
   register: _qa_crowbarsetup_result
   run_once: true

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -521,7 +521,7 @@ def enhance_input_model(input_model):
     for network_tag in itervalues(neutron_network_tags):
         for tag in network_tag['tags']:
             if isinstance(tag, dict):
-                tag = tag.values()[0]
+                tag = list(tag.values())[0]
             # The only relevant tag without a provider is the external
             # "bridge" network.
             # Assume a default 'external' physnet value for this network.

--- a/scripts/jenkins/cloud/jenkins-helper.sh
+++ b/scripts/jenkins/cloud/jenkins-helper.sh
@@ -28,3 +28,11 @@ function ansible_playbook {
     echo "Running: ansible-playbook ${@}"
     ansible-playbook "${@}"
 }
+
+
+# this wrapper will choose python3 over python2 when running a python script
+function run_python_script {
+    set +x
+    python_bin=$(command -v python3 || command -v python)
+    $python_bin "${@}"
+}

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -37,7 +37,7 @@ function is_defined {
 
 function setup_ansible_venv {
     if [ ! -d "$ANSIBLE_VENV" ]; then
-        virtualenv --python=python2.7 $ANSIBLE_VENV
+        virtualenv $ANSIBLE_VENV
         $ANSIBLE_VENV/bin/pip install --upgrade pip
         $ANSIBLE_VENV/bin/pip install -r $WORK_DIR/requirements.txt
     fi
@@ -105,6 +105,13 @@ function ansible_playbook_ses {
     fi
 }
 
+# this wrapper will choose python3 over python2 when running a python script
+function run_python_script {
+    set +x
+    python_bin=$(command -v python3 || command -v python)
+    $python_bin "${@}"
+}
+
 function is_physical_deploy {
     cloud_env=$(get_from_input cloud_env)
     [[ $cloud_env == qe* ]] || [[ $cloud_env == pcloud* ]]
@@ -166,7 +173,7 @@ function build_test_packages {
             source $ANSIBLE_VENV/bin/activate
             gerrit_change_ids=$(get_from_input gerrit_change_ids)
             GERRIT_VERIFY=0 PYTHONWARNINGS="ignore:Unverified HTTPS request" \
-                python -u build_test_package.py --buildnumber local \
+                run_python_script -u build_test_package.py --buildnumber local \
                 --homeproject $(get_from_input homeproject) -c ${gerrit_change_ids//,/ -c }
             popd
         fi


### PR DESCRIPTION
Enables the unified CI jobs and the manual cloud deployment toolchain
to use python3 preferentially if available when running python scripts
and ansible playbooks.

NOTE: this step is required to switch to using python3 in the Jenkins agents