### PR TITLE
Update Flake8 to the latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ suseinstall:
 	sudo zypper install perl-JSON-XS perl-libxml-perl perl-libwww-perl python-pip python3-pip libvirt-python python3-libvirt-python
 
 genericinstall:
-	sudo pip2 install -U 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder requests
-	sudo pip3 install -U 'pbr>=2.0.0,!=2.1.0' bashate 'flake8<3.0.0' flake8-import-order jenkins-job-builder requests
+	sudo pip2 install -U 'pbr>=2.0.0,!=2.1.0' bashate flake8 flake8-import-order jenkins-job-builder requests
+	sudo pip3 install -U 'pbr>=2.0.0,!=2.1.0' bashate flake8 flake8-import-order jenkins-job-builder requests
 	git clone https://github.com/SUSE-Cloud/roundup && \
 	cd roundup && \
 	./configure && \

--- a/hostscripts/rpm-packaging/createproject.py
+++ b/hostscripts/rpm-packaging/createproject.py
@@ -248,7 +248,7 @@ def create_project(worktree, project, linkproject):
     try:
         existing_pkgs = [x.strip() for x in
                          sh.osc('ls', '-e', project, _iter=True)]
-    except:
+    except Exception:
         existing_pkgs = []
 
     alive_pkgs = set()

--- a/scripts/iscsictl.py
+++ b/scripts/iscsictl.py
@@ -386,7 +386,7 @@ class Initiator(ISCSI):
         try:
             self.target_ssh.lio_node('--dellunacl', iqn, '1',
                                      initiator, '0')
-        except:
+        except Exception:
             pass
         finally:
             self.target_ssh.lio_node('--addlunacl', iqn, '1',

--- a/scripts/jenkins/cloud/gerrit/build_test_package.py
+++ b/scripts/jenkins/cloud/gerrit/build_test_package.py
@@ -24,8 +24,11 @@ except ImportError:
     import cElementTree as ET
 
 sys.path.append(os.path.dirname(__file__))
-from gerrit_settings import gerrit_project_map, obs_project_settings  # noqa: E402
-from gerrit import GERRIT_URL, GerritChange, GerritApiCaller  # noqa: E402
+
+from gerrit import GERRIT_URL, GerritApiCaller, GerritChange  # noqa: E402,I100
+
+from gerrit_settings import gerrit_project_map, \
+    obs_project_settings  # noqa: E402,I100
 
 
 @contextlib.contextmanager
@@ -211,7 +214,7 @@ class OBSProject(GerritApiCaller):
 
     @find_in_osc_file('obsinfo commit value')
     def _get_obsinfo_commit(self, obsinfo):
-        matches = re.findall('^commit: (\S+)$', obsinfo, re.MULTILINE)
+        matches = re.findall(r'^commit: (\S+)$', obsinfo, re.MULTILINE)
         if len(matches) != 1:
             return None
         return matches[0]

--- a/scripts/jenkins/cloud/gerrit/gerrit_handle_event.py
+++ b/scripts/jenkins/cloud/gerrit/gerrit_handle_event.py
@@ -5,8 +5,11 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(__file__))
+
 from gerrit import GerritChange, GerritChangeSet  # noqa: E402
+
 from gerrit_merge import gerrit_merge  # noqa: E402
+
 from gerrit_review import gerrit_review  # noqa: E402
 
 

--- a/scripts/jenkins/cloud/gerrit/gerrit_merge.py
+++ b/scripts/jenkins/cloud/gerrit/gerrit_merge.py
@@ -5,7 +5,9 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(__file__))
+
 from gerrit import GerritChange  # noqa: E402
+
 from gerrit_settings import gerrit_project_map  # noqa: E402
 
 

--- a/scripts/jenkins/cloud/gerrit/gerrit_review.py
+++ b/scripts/jenkins/cloud/gerrit/gerrit_review.py
@@ -5,7 +5,9 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(__file__))
+
 from gerrit import GerritChange  # noqa: E402
+
 from gerrit_settings import gerrit_project_map  # noqa: E402
 
 

--- a/scripts/jenkins/jenkins-job-pipeline-report.py
+++ b/scripts/jenkins/jenkins-job-pipeline-report.py
@@ -141,7 +141,7 @@ def generate_summary(server, job_name, build_number,
                         job_name, build_number, node['id'])
 
                     downstream_jobs = re.findall(
-                        "href='(/job/([\w-]+)/([\d]+)/)'",
+                        r"href='(/job/([\w-]+)/([\d]+)/)'",
                         log['text'])
                     if downstream_jobs:
                         d_job_name = downstream_jobs[0][1]

--- a/scripts/lib/libvirt/libvirt_setup.py
+++ b/scripts/lib/libvirt/libvirt_setup.py
@@ -371,10 +371,10 @@ def domain_cleanup(dom):
     print("undefining {0}".format(dom.name()))
     try:
         dom.undefineFlags(flags=libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
-    except:
+    except Exception:
         try:
             dom.undefine()
-        except:
+        except Exception:
             print("failed to undefine {0}".format(dom.name()))
 
 


### PR DESCRIPTION
3 years ago we pinned flake8 to a specific version due to compatibility
issues. This seems to be fixed so let's update to the latest version.