### PR TITLE
SES ceph conf with multiple nodes with spaces

### DIFF
--- a/scripts/jenkins/ses/ansible/roles/ses/tasks/openstack_config.yml
+++ b/scripts/jenkins/ses/ansible/roles/ses/tasks/openstack_config.yml
@@ -44,7 +44,7 @@
   when: item.1.rc != 0
 
 - name: Get ses conf options
-  shell: grep 'fsid\|mon_host\|mon_initial\|network' /etc/ceph/ceph.conf | awk '{ print $3}'
+  shell: grep 'fsid\|mon_host\|mon_initial\|network' /etc/ceph/ceph.conf | awk -F'=' '{ gsub(/ /,"", $2); print $2}'
   register: conf_options
 
 - name: Get ceph conf/key file contents


### PR DESCRIPTION
In CCP Tech preview, we noticed that /etc/ceph/ceph.conf can have
mon_host and mon_initial_members field values with spaces in-between
with comma as delimiter. This was noticed in SAP installation where
multiple nodes were used as part of SES cluster.

Current logic cannot handle following situation. So updating logic
to handle cases, where it can have spaces in between e.g.

mon_host = 192.168.89.120, 192.168.89.121, 192.168.89.122
,192.168.89.123,192.168.89.124

Output should be
192.168.89.120,192.168.89.121,192.168.89.122,192.168.89.123,192.168.89.124