### PR TITLE
Adds job/playbooks for creating new jenkins workers (SOC-4902)

### DIFF
--- a/jenkins/ci.suse.de/cloud-jenkins-worker.yaml
+++ b/jenkins/ci.suse.de/cloud-jenkins-worker.yaml
@@ -1,0 +1,132 @@
+- job:
+    name: cloud-jenkins-worker
+    project-type: pipeline
+    concurrent: true
+
+    logrotate:
+      numToKeep: 300
+      daysToKeep: 90
+
+    properties:
+      - authorization:
+          cloud:
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-delete
+            - job-discover
+            - job-read
+            - job-workspace
+            - run-delete
+            - run-update
+            - scm-tag
+          anonymous:
+            - job-read
+
+    parameters:
+      - validating-string:
+          name: worker_ids
+          default: ''
+          regex: '([A-Za-z0-9-_]+(,[A-Za-z0-9-_]+)*)*'
+          msg: >-
+            The entered value failed validation
+          description: >-
+            The jenkins worker identifier(s). This field should be set to a
+            value that will uniquely identify the jenkins worker instance.
+
+            Passing multiple values (comma separated) will create/setup multiple workers.
+
+      - choice:
+          name: os_cloud
+          choices:
+            - 'engcloud'
+            - 'susecloud'
+          description: >-
+            The target OpenStack cloud platform. Possible values are:
+
+              engcloud - the Provo engineering cloud (engcloud.prv.suse.net)
+              susecloud - the Nuremberg SUSE cloud (cloud.suse.de)
+
+      - hidden:
+          name: os_project_name
+          default: 'cloud-ci'
+          description: >-
+            The name of the OpenStack project that hosts the worker node
+            in the 'os_cloud' OpenStack cloud platform (leave empty to use the
+            default shared 'cloud' account).
+
+      - hidden:
+          name: jenkins_worker_key_name
+          default: "engcloud-cloud-ci"
+          description: >-
+            Keypair to be used on the worker instance
+
+      - hidden:
+          name: jenkins_worker_image
+          default: "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
+          description: >-
+            Image used to boot the worker instance
+
+      - hidden:
+          name: jenkins_worker_flavor
+          default: "jenkins-worker"
+          description: >-
+            Worker instance flavor
+
+      - string:
+          name: jenkins_worker_labels
+          default: ""
+          description: >-
+            A list of labels for this worker node
+
+      - string:
+          name: jenkins_workers_executors
+          default: "10"
+          description: >-
+            Number of workers configured for this node
+
+      - string:
+          name: jenkins_worker_ansible_version
+          default: "<2.8"
+          description: >-
+            Ansible version setup on the virtual environment
+
+            Leaving it empty will skip creating the virtual environment
+
+      - string:
+          name: git_automation_repo
+          default: https://github.com/SUSE-Cloud/automation.git
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: master
+          description: >-
+            The git automation branch
+
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters, one per line, in the form:
+
+              <parameter_name>=<parameter-value>
+
+            These parameters will be injected into the Jenkins job as environment variables that supplement
+            or override the other parameters configured for the Jenkins job.
+            This should not be used by default or regularly. It is meant to run job build customized in ways
+            not already supported by the job's parameters, such as testing automation git pull requests
+            with special configurations.
+
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${git_automation_repo}
+            branches:
+              - ${git_automation_branch}
+            browser: auto
+            wipe-workspace: false
+      script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
+      lightweight-checkout: false

--- a/jenkins/ci.suse.de/pipelines/cloud-jenkins-worker.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-jenkins-worker.Jenkinsfile
@@ -1,0 +1,72 @@
+/**
+ * The cloud-jenkins-worker Jenkins Pipeline
+ */
+
+pipeline {
+  options {
+    // skip the default checkout, because we want to use a custom path
+    skipDefaultCheckout()
+    timestamps()
+  }
+
+  agent {
+    node {
+      label 'cloud-ardana-ci'
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
+    }
+  }
+
+  stages {
+    stage('Setup workspace') {
+      steps {
+        script {
+          // Set this variable to be used by upstream builds
+          env.blue_ocean_buildurl = env.RUN_DISPLAY_URL
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${worker_ids}"
+
+          sh('''
+            git clone $git_automation_repo --branch $git_automation_branch automation-git
+
+            set +x
+            export ANSIBLE_FORCE_COLOR=true
+            cd $WORKSPACE/automation-git/scripts/jenkins/workers
+            source /opt/ansible/bin/activate
+            ansible-playbook load-job-params.yml
+          ''')
+        }
+      }
+    }
+
+    stage('Create/Get server(s)') {
+      steps {
+        script {
+          ansible_playbook('create-server')
+        }
+      }
+    }
+
+    stage('Bootstrap jenkins worker') {
+      steps {
+        script {
+          ansible_playbook('jenkins-worker')
+        }
+      }
+    }
+
+  }
+  post {
+    cleanup {
+      cleanWs()
+    }
+  }
+}
+
+def ansible_playbook(playbook, params='') {
+  sh("""
+    set +x
+    export ANSIBLE_FORCE_COLOR=true
+    cd $WORKSPACE/automation-git/scripts/jenkins/workers
+    source /opt/ansible/bin/activate
+    ansible-playbook """+playbook+""".yml -e @input.yml """+params
+  )
+}

--- a/scripts/jenkins/workers/ansible.cfg
+++ b/scripts/jenkins/workers/ansible.cfg
@@ -1,0 +1,58 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+[defaults]
+# For faster ansible - see: http://mitogen.readthedocs.io/en/latest/ansible.html
+# Recommended if running ansible on high-latency (eg. nue<->provo)
+#strategy_plugins = /opt/ansible/mitogen-0.2.2/ansible_mitogen/plugins/strategy
+#strategy = mitogen_linear
+
+# Fact caching
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = ansible_facts
+fact_caching_timeout = 86400
+
+# Optimize ansible
+pipelining = True
+poll_interval = 5
+
+# Disable retry files
+retry_files_enabled = False
+
+# Default inventory file
+inventory = inventory
+host_key_checking = False
+
+# Set color options
+nocolor = 0
+
+# SSH timeout
+timeout = 120
+
+# Enable tasks profiling
+callback_whitelist = profile_tasks, timer
+
+# Use the YAML callback plugin
+stdout_callback = yaml
+
+# Supress warning about empty inventory
+localhost_warning = False
+
+[ssh_connection]
+
+# Do not save host keys on SSH known_hosts
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null

--- a/scripts/jenkins/workers/create-server.yml
+++ b/scripts/jenkins/workers/create-server.yml
@@ -1,0 +1,67 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Create/get jenkins worker node
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Ensure worker instance exists on "{{ os_cloud }}/{{ os_project_name }}"
+      os_server:
+        cloud: "{{ cloud }}"
+        state: present
+        name: "{{ jenkins_worker_server }}"
+        image: "{{ jenkins_worker_image }}"
+        key_name: "{{ jenkins_worker_key_name }}"
+        flavor: "{{ jenkins_worker_flavor }}"
+        boot_from_volume: yes
+        volume_size: "{{ jenkins_worker_volume_size }}"
+        network: "{{ jenkins_worker_network }}"
+        security_groups: "{{ jenkins_worker_security_groups }}"
+      loop: "{{ jenkins_worker_id_list }}"
+
+    - name: Ensure floating IP on worker instance
+      os_floating_ip:
+        cloud: "{{ cloud }}"
+        server: "{{ jenkins_worker_server }}"
+        network: "{{ jenkins_worker_fip_network }}"
+        wait: yes
+      register: _worker_fip
+      loop: "{{ jenkins_worker_id_list }}"
+
+    - name: Wait for node to be accessible
+      wait_for:
+        host: "{{ item.floating_ip.floating_ip_address }}"
+        port: 22
+        search_regex: OpenSSH
+        state: started
+        delay: 10
+      loop: "{{ _worker_fip.results }}"
+      loop_control:
+        label: "{{ item.invocation.module_args.server }}: {{ item.floating_ip.floating_ip_address }}"
+
+    - name: Ensure nodes on ansible inventory file
+      blockinfile:
+        path: "inventory"
+        insertafter: "\\[jenkins_workers\\]"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK"
+        block: |
+          {% for server in _worker_fip.results %}
+          {{ server.invocation.module_args.server }}      ansible_host={{ server.floating_ip.floating_ip_address }}
+          {% endfor %}
+
+    - meta: refresh_inventory

--- a/scripts/jenkins/workers/group_vars/all.yml
+++ b/scripts/jenkins/workers/group_vars/all.yml
@@ -1,0 +1,18 @@
+---
+
+os_cloud: "engcloud"
+os_project_name: "cloud-ci"
+
+cloud:
+  cloud: "{{ os_cloud }}"
+  os_project_name: "{{ os_project_name }}"
+
+jenkins_worker_id_list: "{{ (worker_ids is defined and worker_ids | length > 0) | ternary(worker_ids.split(','), []) }}"
+jenkins_worker_server: "cloud-jenkins-worker_{{ item }}"
+jenkins_worker_image: "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
+jenkins_worker_key_name: ""
+jenkins_worker_flavor: "jenkins-worker"
+jenkins_worker_volume_size: 20
+jenkins_worker_network: "jenkins-worker_net"
+jenkins_worker_security_groups: "jenkins-worker"
+jenkins_worker_fip_network: "floating"

--- a/scripts/jenkins/workers/group_vars/jenkins_workers.yml
+++ b/scripts/jenkins/workers/group_vars/jenkins_workers.yml
@@ -1,0 +1,5 @@
+---
+
+ansible_python_interpreter: "/usr/bin/python3"
+ansible_user: "opensuse"
+ansible_become: yes

--- a/scripts/jenkins/workers/inventory
+++ b/scripts/jenkins/workers/inventory
@@ -1,0 +1,1 @@
+[jenkins_workers]

--- a/scripts/jenkins/workers/jenkins-worker.yml
+++ b/scripts/jenkins/workers/jenkins-worker.yml
@@ -1,0 +1,25 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Bootstrap jenkins worker node
+  hosts: jenkins_workers
+  become: yes
+  vars_files:
+    - "../cloud/ansible/group_vars/all/ssh_pub_keys.yml"
+
+  roles:
+    - jenkins_worker

--- a/scripts/jenkins/workers/load-job-params.yml
+++ b/scripts/jenkins/workers/load-job-params.yml
@@ -1,0 +1,49 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Build input file for playbooks
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    jjb_file: "../../../jenkins/ci.suse.de/{{ lookup('env', 'JOB_NAME') }}.yaml"
+    jjb: "{{ lookup('file', jjb_file) | from_yaml }}"
+    default_line: "{{ item.value.name }}: '{{ lookup('env', item.value.name) }}'"
+    bool_line: "{{ item.value.name }}: {{ lookup('env', item.value.name) }}"
+    jjb_type: "job"
+
+  tasks:
+    - name: Load ansible variables from ENV
+      lineinfile:
+        path: "./input.yml"
+        create: yes
+        line: "{{ (item.key == 'bool') | ternary(bool_line, default_line) }}"
+      with_dict: "{{ jjb.0[jjb_type].parameters }}"
+      when: item.value.name != 'extra_params' and lookup('env', item.value.name)
+      loop_control:
+        label: "{{ item.value.name }}"
+
+    - name: Load extra parameters
+      lineinfile:
+        path: "./input.yml"
+        create: yes
+        line: "{{ item.split('=')[0] }}: {{ lookup('env', item.split('=')[0]) }}"
+        regexp: "^{{ item.split('=')[0] }}: "
+      loop: "{{ lookup('env', 'extra_params').splitlines() }}"
+      when: lookup('env', 'extra_params') is defined and item.split('=')[0] != ''
+      loop_control:
+        label: "{{ item.split('=')[0] }}"

--- a/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
@@ -1,0 +1,100 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+jenkins_worker_zypp_repos:
+  - name: "SUSE-CA"
+    repo: "http://download.suse.de/ibs/SUSE:/CA/{{ ansible_distribution | replace(' ', '_') }}_{{ ansible_distribution_version }}"
+  - name: "Cloud-CI"
+    repo: "https://download.opensuse.org/repositories/Cloud:/CI/{{ ansible_distribution | replace(' ', '_') }}_{{ ansible_distribution_version }}"
+    import_keys: True
+  - name: "Tools"
+    repo: "https://download.opensuse.org/repositories/openSUSE:/Tools/{{ ansible_distribution | replace(' Leap', '') }}_{{ ansible_distribution_version }}"
+    import_keys: True
+
+jenkins_worker_zypp_requires:
+  - ca-certificates-suse
+  - gcc
+  - git-core
+  - jenkins-swarm-client
+  - ntp
+  - obs-service-download_files
+  - obs-service-format_spec_file
+  - obs-service-obs_scm
+  - obs-service-set_version
+  - osc
+  - python3-devel
+  - python3-gitlint
+  - python3-pygerrit2
+  - python3-python-jenkins
+  - python3-sh
+  - python3-virtualenv
+  - ruby2.5-rubygem-activesupport-5.2
+  - sshpass
+
+jenkins_worker_venv_path: "/opt/ansible"
+jenkins_worker_venv_requires:
+  - "ansible{{ jenkins_worker_ansible_version | default('') }}"
+  - "netaddr"
+  - "openstackclient"
+  - "openstacksdk"
+  - "sh"
+
+jenkins_worker_ntp_server: "ntp1.suse.de"
+
+jenkins_worker_labels: "disabled"
+jenkins_worker_master: "https://ci.suse.de/"
+jenkins_workers_executors: 10
+jenkins_worker_swarm_conf_file: "/etc/sysconfig/jenkins-swarm-client"
+jenkins_worker_swarm_config:
+  - line: 'LABELS="{{ jenkins_worker_labels }}"'
+    regexp: '^LABELS='
+  - line: 'PARAMS="-username {{ _swarm_username }} -password {{ _swarm_password }} -master {{ jenkins_worker_master }} -mode exclusive -executors {{ jenkins_workers_executors }} -name {{ ansible_hostname }} -description {{ os_cloud }}/{{ os_project_name }} -disableSslVerification -disableClientsUniqueId -fsroot /home/jenkins/workspace"'
+    regexp: '^PARAMS='
+  - line: 'JENKINS_USER="jenkins"'
+    regexp: '^JENKINS_USER='
+  - line: 'JENKINS_HOME="/home/jenkins"'
+    regexp: '^JENKINS_HOME='
+
+jenkins_worker_copy_files:
+  - path: "/home/jenkins/.ssh/id_rsa"
+    owner: "jenkins"
+    group: "users"
+    mode: "0600"
+  - path: "/home/jenkins/.netrc"
+    owner: "jenkins"
+    group: "users"
+    mode: "0600"
+  - path: "/home/jenkins/.config/openstack/"
+    owner: "jenkins"
+    group: "users"
+    mode: "0644"
+  - path: "/home/jenkins/.oscrc"
+    owner: "jenkins"
+    group: "users"
+    mode: "0600"
+  - path: "/etc/jenkinsapi.conf"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+
+jenkins_worker_authorized_users:
+  - dmueller
+  - esampson
+  - framalho
+  - fmccarthy
+  - rsalevsky
+  - snica

--- a/scripts/jenkins/workers/roles/jenkins_worker/handlers/main.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/handlers/main.yml
@@ -1,0 +1,28 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Restart ntp
+  service:
+    name: "ntpd"
+    enabled: yes
+    state: restarted
+
+- name: Restart jenkins swarm client
+  service:
+    name: "jenkins-swarm-client"
+    enabled: yes
+    state: restarted

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/authorized_keys.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/authorized_keys.yml
@@ -1,0 +1,34 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Copy public keys
+  blockinfile:
+    path: "/root/.ssh/authorized_keys"
+    create: yes
+    block: |
+      {% for user in ssh_pub_keys %}
+      {%   if user['name'] in jenkins_worker_authorized_users %}
+      {%     for key in user['keys'] %}
+      {{ key }}
+      {%     endfor %}
+      {%   endif %}
+      {% endfor %}
+
+- name: Drop motd
+  template:
+    src: motd.j2
+    dest: "/etc/motd"

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/configure_swarm_client.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/configure_swarm_client.yml
@@ -1,0 +1,50 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Configure NTP server
+  lineinfile:
+    path: "/etc/ntp.conf"
+    line: "server {{ jenkins_worker_ntp_server }}"
+  notify:
+    - Restart ntp
+
+- name: Create jenkins user
+  user:
+    name: "jenkins"
+    group: "users"
+    comment: "Jenkins Home"
+    shell: "/bin/bash"
+    createhome: yes
+    home: "/home/jenkins"
+
+- name: Load credentials from agent node
+  set_fact:
+      _swarm_{{ item }}: "{{ lookup('pipe', 'grep -Eo \"' ~ item ~ '\\s[a-z]+\" ' ~ jenkins_worker_swarm_conf_file ~ ' |  cut -d \" \" -f2') }}"
+  no_log: True
+  loop:
+    - "username"
+    - "password"
+
+- name: Configure jenkins swarm client
+  lineinfile:
+    path: "{{ jenkins_worker_swarm_conf_file }}"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  no_log: True
+  loop: "{{ jenkins_worker_swarm_config }}"
+  notify:
+    - Restart jenkins swarm client

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/copy_files.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/copy_files.yml
@@ -1,0 +1,33 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Ensure directories exists
+  file:
+    path: "{{ item.path | dirname }}"
+    state: directory
+  loop: "{{ jenkins_worker_copy_files }}"
+
+- name: Copy files to new agent node
+  copy:
+    src: "{{ item.path }}"
+    dest: "{{ item.path }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop: "{{ jenkins_worker_copy_files }}"
+  notify:
+    - Restart jenkins swarm client

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/install_packages.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/install_packages.yml
@@ -1,0 +1,20 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Ensure zypper requires installed
+  zypper:
+    name: "{{ jenkins_worker_zypp_requires }}"

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/main.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/main.yml
@@ -1,0 +1,26 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- include_tasks: update.yml
+- include_tasks: install_packages.yml
+- include_tasks: configure_swarm_client.yml
+- include_tasks: copy_files.yml
+- include_tasks: setup_venv.yml
+  when:
+    - jenkins_worker_ansible_version is defined
+    - jenkins_worker_ansible_version | length
+- include_tasks: authorized_keys.yml

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/setup_venv.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/setup_venv.yml
@@ -1,0 +1,22 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Setup virtual environment
+  pip:
+    name: "{{ jenkins_worker_venv_requires }}"
+    state: latest
+    virtualenv: "{{ jenkins_worker_venv_path }}"

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/update.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/update.yml
@@ -1,0 +1,40 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Add zypper repositories
+  zypper_repository:
+    name: "{{ item.name }}"
+    repo: "{{ item.repo }}"
+    auto_import_keys: "{{ item.import_keys | default(False) }}"
+  loop: "{{ jenkins_worker_zypp_repos }}"
+
+- name: Run zypper update
+  zypper:
+    name: "*"
+    state: latest
+
+- name: Check if reboot required
+  shell: |
+    LAST_KERNEL=$(ls -t /boot/vmlinuz-* | sed "s/\/boot\/vmlinuz-//g" | head -n1)
+    CURRENT_KERNEL=$(uname -r)
+    test $LAST_KERNEL = $CURRENT_KERNEL || echo True
+  register: reboot
+  changed_when: false
+
+- name: Reboot if necessary
+  reboot:
+  when: reboot.stdout == 'True'

--- a/scripts/jenkins/workers/roles/jenkins_worker/templates/motd.j2
+++ b/scripts/jenkins/workers/roles/jenkins_worker/templates/motd.j2
@@ -1,0 +1,13 @@
+{% if lookup('env', 'BUILD_URL') %}
+Built by: {{ lookup('env', 'BUILD_URL') }}
+{% endif %}
+------------------------------------------------------------------------------
+* This is one of the CI worker nodes for the Cloud Team!                     *
+* Please only connect on this node for last resort debugging.                *
+* Be careful in what you do on this environment, as it might break CI.       *
+*                                                                            *
+* WARNING                                                                    *
+* This secured system and your actions will be logged along                  *
+* with identifying information. Disconnect immediately if you are not an     *
+* authorized user of this system.                                            *
+------------------------------------------------------------------------------


### PR DESCRIPTION
The new cloud-jenkins-worker jenkins job can be used to create/maintain
new/existing jenkins workers which are connected to jenkins using the
jenkins-swarm-client.

The playbooks should be executed from an existing worker as it needs to
copy the credential files (available on the existing worker) to the new
nodes.

By default the mew worker(s) is/are created on the cloud-ci project using the
openSUSE-Leap15.1 image and should be ready to run any job from the
Cloud-CI.