### PR TITLE
gitlint: Allow trivial changes to be without reference (SOC-9559)

### DIFF
--- a/scripts/jenkins/gitlint.ini
+++ b/scripts/jenkins/gitlint.ini
@@ -15,6 +15,3 @@ line-length=80
 
 [body-min-length]
 min-length=5
-
-[author-valid-email]
-regex=[^@]+@suse.(com|de)

--- a/scripts/jenkins/gitlint.ini
+++ b/scripts/jenkins/gitlint.ini
@@ -8,7 +8,7 @@ line-length=80
 words=wip,WIP
 
 [title-match-regex]
-regex=^(?!SOC).*\(((bsc#|SOC-)[0-9]+(,\s)?)+\)$
+regex=^(?!SOC).*\((((bsc#|SOC-)[0-9]+(,\s)?)+|trivial|typo|noref)\)$
 
 [body-max-line-length]
 line-length=80


### PR DESCRIPTION
The author of a commit should make a conscious decision to either add a
reference or not. Adding trivial instead of bsc or SOC enables this.
This change prevents that adding a refernce is forgotten as the
syntax requires to think about it.

See #3509 for more details.