### PR TITLE
openstack-ardana-gerrit: fix python3 error

### DIFF
--- a/scripts/jenkins/cloud/gerrit/gerrit.py
+++ b/scripts/jenkins/cloud/gerrit/gerrit.py
@@ -146,7 +146,7 @@ class GerritChange(GerritApiCaller):
         if patchset:
             revisions = [
                 r_id
-                for r_id, r in self._change_object['revisions'].iteritems()
+                for r_id, r in self._change_object['revisions'].items()
                 if r['_number'] == int(patchset)]
             if len(revisions) != 1:
                 raise Exception(


### PR DESCRIPTION
Fixes a python3 error affecting the Gerrit CI, which is now running
python 3.