### PR TITLE
jenkins-workers: make reboot optional

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-jenkins-worker-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-jenkins-worker-template.yaml
@@ -77,6 +77,12 @@
 
             Leaving it empty will skip creating the virtual environment
 
+      - bool:
+          name: jenkins_worker_reboot
+          default: '{jenkins_worker_reboot|false}'
+          description: >-
+            Reboot the node if there is a pending kernel update
+
       - string:
           name: git_automation_repo
           default: '{git_automation_repo|https://github.com/SUSE-Cloud/automation.git}'

--- a/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
@@ -15,6 +15,7 @@
 #
 ---
 
+jenkins_worker_reboot: False
 jenkins_worker_zypp_repos:
   - name: "SUSE-CA"
     repo: "http://download.suse.de/ibs/SUSE:/CA/{{ ansible_distribution | replace(' ', '_') }}_{{ ansible_distribution_version }}"

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/update.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/update.yml
@@ -37,4 +37,6 @@
 
 - name: Reboot if necessary
   reboot:
-  when: reboot.stdout == 'True'
+  when:
+    - reboot.stdout == 'True'
+    - jenkins_worker_reboot


### PR DESCRIPTION
Reboot the node only if the `jenkins_worker_reboot` parameter is set to
true (defaults to false).