### PR TITLE
Configure git email for jenkins workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 
 filecheck:
 	! git ls-tree -r HEAD --name-only | \
-		egrep -v 'Makefile|sample-logs/.*\.txt$$' | \
+		egrep -v 'Makefile|gitconfig|sample-logs/.*\.txt$$' | \
 		xargs grep $$'\t'
 
 bashate:

--- a/scripts/jenkins/workers/roles/jenkins_worker/files/gitconfig
+++ b/scripts/jenkins/workers/roles/jenkins_worker/files/gitconfig
@@ -1,0 +1,3 @@
+[user]
+	name = SUSE Jenkins Gerrit
+	email = cloud-jenkins-gerrit-owner@suse.de

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/configure_git.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/configure_git.yml
@@ -1,0 +1,8 @@
+- name: Configure git for jenkins user
+  copy:
+    src: "gitconfig"
+    dest: "/home/jenkins/.gitconfig"
+    owner: "jenkins"
+    group: "users"
+    mode: "0644"
+

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/main.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/main.yml
@@ -24,3 +24,4 @@
     - jenkins_worker_ansible_version is defined
     - jenkins_worker_ansible_version | length
 - include_tasks: authorized_keys.yml
+- include_tasks: configure_git.yml


### PR DESCRIPTION
Otherwise git merge will fail with:
```
fatal: unable to auto-detect email address
(got 'jenkins@cloud-jenkins-worker-ci.(none)')
```