### PR TITLE
openstack-maintenance-gating: add crowbar deploy jobs (SOC-9599,SOC-9669)

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -7,22 +7,6 @@
       numToKeep: 500
       daysToKeep: 90
 
-    properties:
-      - authorization:
-          cloud:
-            - job-build
-            - job-cancel
-            - job-configure
-            - job-delete
-            - job-discover
-            - job-read
-            - job-workspace
-            - run-delete
-            - run-update
-            - scm-tag
-          anonymous:
-            - job-read
-
     parameters:
       - validating-string:
           name: cloud_env
@@ -47,11 +31,11 @@
       - extended-choice:
           name: cloudversion
           type: multi-select
-          visible-items: 2
+          visible-items: 5
           multi-select-delimiter: ','
           default-value: '{cloudversion|}'
           value: >-
-            SOC8,SOC9
+            SOC8,SOC9,SOCC7,SOCC8,SOCC9
 
       - validating-string:
           name: maint_updates
@@ -59,18 +43,6 @@
           regex: '([0-9]+(,[0-9]+)*)*'
           msg: The entered value failed validation
           description: List of maintenance update IDs separated by comma (eg. 7396,7487)
-
-      - bool:
-          name: deploy
-          default: true
-          description: >-
-            Start a job to deploy ardana with MU(s)
-
-      - bool:
-          name: deploy_and_update
-          default: true
-          description: >-
-            Start a job to deploy ardana then update with MU(s)
 
       - string:
           name: git_automation_repo
@@ -86,8 +58,7 @@
 
       - text:
           name: extra_params
-          default: |
-            tempest_retry_failed=True
+          default:
           description: >-
             This field may be used to define additional parameters, one per line, in the form:
 

--- a/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
@@ -1,0 +1,59 @@
+SOC8:
+  ardana8-deploy:
+    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM8+up
+      update_after_deploy: false
+      extra_params: |
+        tempest_retry_failed=True
+  ardana8-update:
+    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM8+up
+      update_after_deploy: true
+      extra_params: |
+        tempest_retry_failed=True
+        update_services_serial=True
+SOC9:
+  ardana9-deploy:
+    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM9+up
+      update_after_deploy: false
+      extra_params: |
+        tempest_retry_failed=True
+  ardana9-update:
+    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM9+up
+      update_after_deploy: true
+      extra_params: |
+        tempest_retry_failed=True
+        update_services_serial=True
+SOCC7:
+  crowbar7-deploy:
+    job_name: cloud-crowbar7-job-x86_64
+    job_params:
+      cloudsource: GM7+up
+  crowbar7-ha-deploy:
+    job_name: cloud-crowbar7-job-ha-x86_64
+    job_params:
+      cloudsource: GM7+up
+SOCC8:
+  crowbar8-deploy:
+    job_name: cloud-crowbar8-job-x86_64
+    job_params:
+      cloudsource: GM8+up
+  crowbar8-ha-deploy:
+    job_name: cloud-crowbar8-job-ha-x86_64
+    job_params:
+      cloudsource: GM8+up
+SOCC9:
+  crowbar9-deploy:
+    job_name: cloud-crowbar9-job-x86_64
+    job_params:
+      cloudsource: GM9+up
+  crowbar9-ha-deploy:
+    job_name: cloud-crowbar9-job-ha-x86_64
+    job_params:
+      cloudsource: GM9+up

--- a/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
@@ -32,9 +32,9 @@
             qa_crowbarsetup_cmd: onadmin_batch
 
         - include_role:
-            name: reboot_node
+            name: crowbar_setup
           vars:
-            reboot_target: cloud_nodes_crowbar
+            qa_crowbarsetup_cmd: onadmin_rebootcloud
           when:
             - not update_after_deploy
             - maint_updates_list | length


### PR DESCRIPTION
Add Crowbar jobs to the set of jobs executed for a maintenance
update.

This commit switches the MU gating job implementation to use
a configuration yaml file listing the jobs and the parameters
that need to be launched for each cloud version rather than
hard-coding them in the groovy library.

This PR also includes another couple of fixes required to get the Crowbar
MU gating job to pass: 
 - call onadmin_rebootcloud instead of relying on the reboot_node
  ansible role when testing maintenance updates. The onadmin_rebootcloud
  functionality from qa_crowbarsetup.sh has additional logic built
  into it which ensures that controller nodes are rebooted correctly
  when HA is enabled, whereas the reboot_node ansible role does not
 (included from #3529)
 - serializing the service update process for cloud nodes in Ardana
 deploy-and-update MU jobs