### PR TITLE
openstack-crowbar: use onadmin_rebootcloud for MU testing

### DIFF
--- a/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
@@ -32,9 +32,9 @@
             qa_crowbarsetup_cmd: onadmin_batch
 
         - include_role:
-            name: reboot_node
+            name: crowbar_setup
           vars:
-            reboot_target: cloud_nodes_crowbar
+            qa_crowbarsetup_cmd: onadmin_rebootcloud
           when:
             - not update_after_deploy
             - maint_updates_list | length


### PR DESCRIPTION
Call `onadmin_rebootcloud` instead of relying on the `reboot_node`
ansible role when testing maintenance updates. The `onadmin_rebootcloud`
functionality from `qa_crowbarsetup.sh` has additional logic built
into it which ensures that controller nodes are rebooted correctly
when HA is enabled, whereas the `reboot_node` ansible role does not.