### PR TITLE
rpm-packaging: Fix zuul layout

### DIFF
--- a/hostscripts/zuul/layout.yaml
+++ b/hostscripts/zuul/layout.yaml
@@ -33,13 +33,13 @@ pipelines:
 projects:
   - name: openstack/rpm-packaging
     rpm-packaging:
-      - openstack-rpm-packaging-sles12-Master
+      - openstack-rpm-packaging-sles15-Master
       - openstack-rpm-packaging-sles12-Newton
       - openstack-rpm-packaging-sles12-Ocata
       - openstack-rpm-packaging-sles12-Pike
       - openstack-rpm-packaging-sles12-Queens
       - openstack-rpm-packaging-sles12-Rocky
-      - openstack-rpm-packaging-sles12-Stein
+      - openstack-rpm-packaging-sles15-Stein
     post-rpm-packaging:
       - openstack-rpm-packaging-update-Master
       - openstack-rpm-packaging-update-Newton


### PR DESCRIPTION
Commit 3f1b9da50bc started to fix the used distro names for Master and
Stein but this commit was incomplete. Hopefully it works now.