### PR TITLE
openstack-crowbar: make reboot after deploy optional

### DIFF
--- a/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
@@ -36,8 +36,7 @@
           vars:
             qa_crowbarsetup_cmd: onadmin_rebootcloud
           when:
-            - not update_after_deploy
-            - maint_updates_list | length
+            - reboot_after_deploy
 
       rescue:
         - include_role:

--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -69,6 +69,8 @@ ipv6: False
 
 updates_test_enabled: False
 
+reboot_after_deploy: False
+
 update_after_deploy: False
 maintenance_updates_path:
   Cloud: "SUSE_Updates_{{ cloud_repo_path }}_{{ sles_cloud_version[ansible_distribution_version] }}_x86_64"


### PR DESCRIPTION
Make rebooting the cloud nodes after deploying the cloud
configurable via an ansible global variable, `reboot_after_deploy`,
set to False by default.