### PR TITLE
openstack-ardana: set default value for local_ssh_key

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ssh_keys/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ssh_keys/defaults/main.yml
@@ -1,0 +1,18 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+local_ssh_key: False

--- a/scripts/jenkins/cloud/ansible/roles/ssh_keys/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ssh_keys/tasks/main.yml
@@ -26,16 +26,16 @@
       {% endfor %}
       {% endfor %}
 
-- name: Create local SSH key on deployer
-  shell: ssh-keygen -t rsa -f "{{ ansible_env.HOME }}/.ssh/id_rsa" -N ""
-  delegate_to: localhost
-  args:
-    creates: "{{ ansible_env.HOME }}/.ssh/id_rsa"
-  when: local_ssh_key
+- block:
+    - name: Create local SSH key on deployer
+      shell: ssh-keygen -t rsa -f "{{ ansible_env.HOME }}/.ssh/id_rsa" -N ""
+      delegate_to: localhost
+      args:
+        creates: "{{ ansible_env.HOME }}/.ssh/id_rsa"
 
-- name: Copy local SSH key to deployer
-  lineinfile:
-    path: "{{ ansible_env.HOME }}/.ssh/authorized_keys"
-    create: yes
-    line: "{{ lookup('file', ansible_env.HOME + '/.ssh/id_rsa.pub') }}"
+    - name: Copy local SSH key to deployer
+      lineinfile:
+        path: "{{ ansible_env.HOME }}/.ssh/authorized_keys"
+        create: yes
+        line: "{{ lookup('file', ansible_env.HOME + '/.ssh/id_rsa.pub') }}"
   when: local_ssh_key


### PR DESCRIPTION
The ssh_keys role is failing as `local_ssh_key` is undefined. This change
sets a default value to `local_ssh_key` (false).