### PR TITLE
openstack-crowbar: fix tempest result collection

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/tempest_results/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/tempest_results/tasks/main.yml
@@ -32,13 +32,16 @@
 - name: Generate xml subunit results
   shell: "subunit2junitxml {{ tempest_results_subunit }} > {{ subunit_xml_results }}"
   changed_when: false
+  failed_when: false
 
 - name: Generate html subunit results
   shell: "subunit2html {{ tempest_results_subunit }} {{ subunit_html_results }}"
   changed_when: false
+  failed_when: false
 
 - name: Get results from subunit
   command: "subunit-stats {{ tempest_results_subunit }}"
+  failed_when: false
   register: _test_results
 
 - name: Process test results from subunit


### PR DESCRIPTION
When there are tempest failures, the scripts that generate the
xml and html output also return non-zero exit codes. This causes
the tempest playbook to fail for Crowbar before it publishes
results.