### PR TITLE
openstack-ses: FIP association depends on router interface

### DIFF
--- a/scripts/jenkins/ses/ansible/roles/heat_ses_template/templates/heat-template.yml.j2
+++ b/scripts/jenkins/ses/ansible/roles/heat_ses_template/templates/heat-template.yml.j2
@@ -97,6 +97,9 @@ resources:
 
   ses_floating_ip_assoc:
     type: OS::Neutron::FloatingIPAssociation
+{% if network is not defined or network|length == 0 %}
+    depends_on: ses_router_interface
+{% endif %}
     properties:
       floatingip_id: { get_resource: ses_floating_ip }
       port_id: { get_resource: ses_port }


### PR DESCRIPTION
Before associating the FIP to the server we need to make sure the
SES subnet is connected to the external router.