### PR TITLE
openstack-crowbar: don't set use_l3_ha unless required

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/input_model_generator/templates/barclamps/neutron.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/input_model_generator/templates/barclamps/neutron.yml.j2
@@ -21,8 +21,10 @@
       ml2_type_drivers_default_provider_network: {{ neutron_networkingmode }}
       ml2_type_drivers_default_tenant_network: {{ neutron_networkingmode }}
       use_lbaas: true
+{% if neutron_use_l3_ha %}
       l3_ha:
-        use_l3_ha: {{ neutron_use_l3_ha }}
+        use_l3_ha: true
+{% endif %}
       api:
         protocol: {{ api_protocol }}
 {% include 'barclamps/lib/ssl.yml.j2' %}


### PR DESCRIPTION
In the released crowbar cloud 7 and 9 neutron barclamp we
don't yet have the `l3_ha` option available. Excluding it
from the generated barclamp configuration to avoid errors
while deploying GM8+up and GM7+up.