### PR TITLE
qa_crowbarsetup.sh: setup magnum service in batch mode

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-6a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-6a.yaml
@@ -212,9 +212,7 @@
 
               timeout --signal=ALRM 240m bash -x -c "\
               source scripts/qa_crowbarsetup.sh ;    \
-              onadmin_runlist $commands;             \
-              get_novacontroller;                    \
-              oncontroller magnum_service_setup     "
+              onadmin_runlist $commands;             "
           EOF
           ret=$?
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -6002,6 +6002,10 @@ function onadmin_batch
                 ${scenario}
         safely crowbar batch --include manila --timeout 2400 build ${scenario}
     fi
+    if grep -q "barclamp: magnum" ${scenario}; then
+        get_novacontroller
+        safely oncontroller magnum_service_setup
+    fi
     return $?
 }
 


### PR DESCRIPTION
When deploying a crowbar batch scenario that includes magnum,
the service image and flavors also need to set up.
This is currently only done with the standard, non-batch way of
deploying Crowbar.