### PR TITLE
Add prepareupgraderepos step

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1145,6 +1145,13 @@ function cloudupgrade
     fi
 }
 
+function prepareupgraderepos
+{
+    export cloudsource=$upgrade_cloudsource
+    onadmin prepare_cloudupgrade_nodes_repos
+    onadmin prepare_cloudupgrade_admin_repos
+}
+
 function cct
 {
     onadmin run_cct "$@"
@@ -1595,7 +1602,7 @@ allcmds="$step_aliases _test_setuphost \
     setupcompute instnodes instcompute proposal testsetup rebootcrowbar \
     rebootcloud addupdaterepo runupdate testupdate \
     crowbarbackup crowbarrestore shutdowncloud restartcloud qa_test help \
-    rebootneutron cloudupgrade \
+    rebootneutron cloudupgrade prepareupgraderepos \
     setuplonelynodes crowbar_register createadminsnapshot \
     lonelynode_nfs_server setupironicnodes\
     restoreadminfromsnapshot createcloudsnapshot restorecloudfromsnapshot \


### PR DESCRIPTION
This is just a small feature for simplifying manual testing of upgrade.
In normal upgrade scenarios, repos need to be prepared and updated by the
user. Exposing the "prepare" functions already present in mkcloud enables
developers to use these instead of various hacks (e.g. local modifications
to mkcloud) that were done in the past.