### PR TITLE
openstack-ardana: remove duplicate definition of maintenance_updates_path

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/setup_mu_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/setup_mu_repos.yml
@@ -15,6 +15,10 @@
 #
 ---
 
+- name: Set cloud MU repo path based on product (HOS/SOC)
+  set_fact:
+    cloud_repo_path: "{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'OpenStack-Cloud') }}"
+
 - name: Generate maintenance update playbook
   template:
     src: "maint_updates.yml.j2"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/templates/maint_updates.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/templates/maint_updates.yml.j2
@@ -23,9 +23,7 @@
     sles_sp: {{ ansible_distribution_release }}
     cloud_release: {{ cloud_release }}
     maintenance_updates_server: {{ maintenance_updates_server }}
-    maintenance_updates_path:
-      Cloud: "SUSE_Updates_{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'OpenStack-Cloud') }}_{{ sles_cloud_version[ansible_distribution_version] }}_x86_64"
-      SLES: "SUSE_Updates_SLE-SERVER_{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}_x86_64"
+    maintenance_updates_path: {{ maintenance_updates_path }}
 {% raw %}
     deployer_ip: "{{ hostvars[groups['ARD-SVC--first-member'].0].ansible_ssh_host }}"
 


### PR DESCRIPTION
Add LTSS repository MU path. SLES12SP3 went(30.6.2019) to LTSS and therefore repository name changed. This patch makes conditional aware of the LTSS repos and is vital for installing MU repos.