### PR TITLE
iscsictl.py: fix SBD persistence issues (SOC-9821)

### DIFF
--- a/scripts/iscsictl.py
+++ b/scripts/iscsictl.py
@@ -319,10 +319,6 @@ class Target(ISCSI):
         self.ssh.lio_node('--disableauth', iqn, '1')
         self.ssh.lio_node('--enabletpg', iqn, '1')
 
-        # Persist configuration
-        print("Persisting configuration ...")
-        self.ssh.tcm_dump('--b=OVERWRITE')
-
         # Add in /etc/rc.d/boot.local
         if self.device.startswith('/dev/loop'):
             print("Adding loopback to boot.local ...")
@@ -391,7 +387,6 @@ class Initiator(ISCSI):
         finally:
             self.target_ssh.lio_node('--addlunacl', iqn, '1',
                                      initiator, '0', '0')
-            self.target_ssh.tcm_dump('--b=OVERWRITE')
 
         # Discovery and login
         print("Initiator discovery and login ...")

--- a/scripts/jenkins/cloud/ansible/install-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/install-crowbar.yml
@@ -59,9 +59,8 @@
           vars:
             reboot_target: deployer
           when:
+            - reboot_after_deploy
             - not update_after_deploy
-            - maint_updates_list | length
-
 
       rescue:
         - include_role:

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1771,6 +1771,8 @@ function onadmin_post_allocate
                     ssh $node "zypper --non-interactive install sbd; sbd -d $sbd_device create"
                 done
             done
+            # Restart the target service to persist the configuration
+            systemctl restart target.service
         fi
     fi
 }


### PR DESCRIPTION
Rebooting the admin node in an SBD enabled HA Crowbar setup had
issues with the shared iSCSI volume, because the iSCSI configuration
wasn't persisted on the admin node.

The `tcm_dump --b` parameter expects an value of 1 if the default
configuration is to be overwritten [1]. Our `iscsictl.py` script
was using an incorrect value of `OVERWRITE`, which had no effect.

However, supplying `tcm_dump --b=1` overwrites the `/etc/target/tcm_start.sh`
and `/etc/target/lio_start.sh` files [2], which the `ilo-utils` package
pre-installs with some useful commands such as loading required modules,
so we can't use that either.

As it turns out, the `target.service` unit already has support for
persisting the configuration [3]. All we have to do is restart the
service after completing the configuration.

[1] https://github.com/Datera/lio-utils/blob/d488da31b062bb374afdc8ae9afa2de7f044a3b6/tcm-py/tcm_dump.py#L320
[2] https://github.com/Datera/lio-utils/blob/d488da31b062bb374afdc8ae9afa2de7f044a3b6/tcm-py/tcm_dump.py#L298-L299
[3] https://build.suse.de/package/view_file/SUSE:SLE-12-SP3:Update/lio-utils/0030-target.service-Fixup-service-file.patch?expand=1