### PR TITLE
Add second interface for IPv6 (SOC-9828)

### DIFF
--- a/scripts/jenkins/cloud/ansible/generate-heat-template.yml
+++ b/scripts/jenkins/cloud/ansible/generate-heat-template.yml
@@ -20,7 +20,6 @@
   connection: local
   gather_facts: False
 
-
   tasks:
     - block:
         - include_role:

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
@@ -51,6 +51,10 @@ cp_prefix: cp1
 max_host_prefix_len: "{{ 33-(cp_prefix|length) }}"
 host_prefix: "{{ ('ardana-' ~ cloud_env)[:max_host_prefix_len|int-1] if cloud_env is defined else 'ardana' }}"
 
+# Whether to use a separate bootstrap network for communication in and
+# out of the deployment. This network is IPv4.
+bootstrap_network: False
+
 # First octets of the generated subnet prefixes for Ardana networks
 subnet_prefix:
   ipv4: 192.168

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
@@ -34,14 +34,14 @@
         - rabbitmq
 {%   endif %}
       component-endpoints:
-{%   if 'MANAGEMENT' in network_group['component_endpoints'] %}
+{%   if 'MANAGEMENT' in network_group['component_endpoints'] and not bootstrap_network %}
 
         #
         # Management
         #
-        # This is the network group that will be used to for
-        # management traffic within the cloud. It is used
-        # as a default by all component-endpoints.
+        # This is the network group that will be used for management
+        # traffic within the cloud. It is used as a default by all
+        # component-endpoints.
         - default
 
 {%   elif 'CLM' in network_group['component_endpoints'] %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/networks.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/networks.yml
@@ -18,9 +18,9 @@
     version: 2
 
   networks:
-
-{% set ns = namespace(net_id=gen_subnet_start) %}
+{% set ns = namespace(net_id=gen_subnet_start, bootstrap=false) %}
 {% for network_group in scenario['network_groups'] %}
+{%   set ns.bootstrap = network_group.name == 'BOOTSTRAP' %}
 {%   if network_group.rack_network|default(False) %}
 {%     for az in range(scenario.availability_zones) %}
     - name: {{ network_group.name|upper }}-NET-RACK{{ az + 1 }}
@@ -30,23 +30,24 @@
 {%     endfor %}
 {%   else %}
     - name: {{ network_group.name|upper }}-NET
-{%  if bm_info is defined %}
+{%     if bm_info is defined %}
 {{ bm_info.networks[network_group.name|replace('-', '_')|lower] | to_nice_yaml(indent=2) | indent(6, True) }}
-{%-  else -%}
-{%   if network_group['tagged_vlan']|default(True) %}
-      vlanid: {{ ns.net_id }}
-{%   endif %}
+{%-    else -%}
+{%       if network_group['tagged_vlan']|default(True) %}
+      vlanid: {{ ns.bootstrap | ternary(bootstrap_subnet, ns.net_id) }}
+{%       endif %}
       tagged-vlan: {{ network_group['tagged_vlan']|default('False')|lower }}
-{%     if ipv6 and ns.net_id != gen_subnet_start %}
+{%       if ipv6 and not ns.bootstrap %}
       cidr: {{ subnet_prefix.ipv6 }}:{{ ns.net_id }}::/64
       gateway-ip: {{ subnet_prefix.ipv6 }}:{{ ns.net_id }}::1
-{%     else  %}
-      cidr: {{ subnet_prefix.ipv4 }}.{{ ns.net_id }}.0/24
-      gateway-ip: {{ subnet_prefix.ipv4 }}.{{ ns.net_id }}.1
+{%       else  %}
+      cidr: {{ subnet_prefix.ipv4 }}.{{ ns.bootstrap | ternary(bootstrap_subnet, ns.net_id) }}.0/24
+      gateway-ip: {{ subnet_prefix.ipv4 }}.{{ ns.bootstrap | ternary(bootstrap_subnet, ns.net_id) }}.1
+{%       endif %}
 {%     endif %}
-{%   endif %}
       network-group: {{ network_group.name|upper }}
-
-{%   set ns.net_id = ns.net_id+1 %}
+{%     if not ns.bootstrap %}
+{%       set ns.net_id = ns.net_id+1 %}
+{%     endif %}
 {%   endif %}
 {% endfor %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/servers.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/servers.yml
@@ -14,16 +14,27 @@
 # under the License.
 #
 ---
-{% set ns = namespace(clm_net_id=0, server_idx=0) %}
+{% set ns = namespace(clm_net_id=0, server_idx=0, baremetal_netmask='255.255.255.0', baremetal_subnet=-1) %}
+{% for network_group in scenario['network_groups'] %}
+{%   if 'BOOTSTRAP' in network_group['component_endpoints'] %}
+{%     set ns.baremetal_subnet = bootstrap_subnet %}
+{%   endif %}
+{% endfor %}
 {% for network_group in scenario['network_groups'] %}
 {%   if 'CLM' in network_group['component_endpoints'] %}
 {%     set ns.clm_net_id = loop.index0+gen_subnet_start %}
+{%     if ns.baremetal_subnet < 0 %}
+{%       set ns.baremetal_subnet = ns.clm_net_id %}
+{%     endif %}
 {%   endif %}
 {% endfor %}
 {% if ns.clm_net_id == 0  %}
 {%   for network_group in scenario['network_groups'] %}
 {%     if 'MANAGEMENT' in network_group['component_endpoints'] %}
 {%       set ns.clm_net_id = loop.index0+gen_subnet_start %}
+{%       if ns.baremetal_subnet < 0 %}
+{%         set ns.baremetal_subnet = ns.clm_net_id %}
+{%       endif %}
 {%     endif %}
 {%   endfor  %}
 {% endif %}
@@ -31,17 +42,17 @@
     version: 2
 
   baremetal:
-    netmask: {{ bm_info.networks.bm_netmask if bm_info is defined else '255.255.255.0' }}
-    subnet: {{ subnet_prefix.ipv4 }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.0
+    netmask: {{ bm_info.networks.bm_netmask if bm_info is defined else ns.baremetal_netmask }}
+    subnet: {{ subnet_prefix.ipv4 }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.baremetal_subnet }}.0
 
   servers:
-{% for service_group in scenario['service_groups'] if service_group['member_count']|int %}
-{%   for idx in range(service_group['member_count']|int) %}
-{%     set server_id = "%s-%04d"|format(service_group.name, idx+1) %}
+{% for service_group in scenario['service_groups'] if service_group['member_count'] | int %}
+{%   for idx in range(service_group['member_count'] | int) %}
+{%     set server_id = "%s-%04d" | format(service_group.name, idx + 1) %}
     - id: {{ bm_info.servers[ns.server_idx].id if bm_info is defined else server_id }}
-      ip-addr: {{ subnet_prefix.ipv4 }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.clm_net_id }}.{{ bm_info.networks.bm_subnet_start + ns.server_idx if bm_info is defined else ns.server_idx + gen_ip_start }}
-      role: {{ service_group.name|upper }}-ROLE
-      server-group: RACK{{ (idx%3)+1 }}
+      ip-addr: {{ subnet_prefix.ipv4 }}.{{ bm_info.networks.bm_subnet if bm_info is defined else ns.baremetal_subnet }}.{{ bm_info.networks.bm_subnet_start + ns.server_idx if bm_info is defined else ns.server_idx + gen_ip_start }}
+      role: {{ service_group.name | upper }}-ROLE
+      server-group: RACK{{ (idx%3) + 1 }}
       nic-mapping: {{ bm_info.servers[ns.server_idx].nic_mapping if bm_info is defined else 'HEAT' }}
 {% if bm_info is defined and 'ilo_user' in bm_info.servers[ns.server_idx] %}
       ilo-user: {{ bm_info.servers[ns.server_idx].ilo_user }}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/ardana.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/ardana.yml
@@ -8,7 +8,12 @@ swiftpac_disk_enabled: True
 # Start value for the third octet for the generated subnet prefixes and also
 # start of generated VLAN IDs for Ardana networks
 gen_subnet_start: 100
+
 # Start value for the fourth octet for the generated server IP addresses
 gen_ip_start: 100
+
 # Gap to be left between the generated IP for the admin node and the rest of the nodes
 gen_ip_gap: 1
+
+# Bootstrap network subnet
+bootstrap_subnet: 50

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
@@ -10,7 +10,12 @@ swiftpac_disk_enabled: False
 # Start value for the third octet for the generated subnet prefixes and also
 # start of generated VLAN IDs for Ardana networks
 gen_subnet_start: 124
+
 # Start value for the fourth octet for the generated server IP addresses
 gen_ip_start: 10
+
 # Gap to be left between the generated IP for the admin node and the rest of the nodes
 gen_ip_gap: 71
+
+# Bootstrap network subnet
+bootstrap_subnet: 50

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/crowbar-single.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/crowbar-single.yml
@@ -15,7 +15,7 @@ interface_models:
       - swobj
       - swift
     network_interfaces:
-{% if ipv6 %}
+{% if bootstrap_network %}
       - network_groups:
           - BOOTSTRAP
 {% endif %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/crowbar-single.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/crowbar-single.yml
@@ -15,6 +15,10 @@ interface_models:
       - swobj
       - swift
     network_interfaces:
+{% if ipv6 %}
+      - network_groups:
+          - BOOTSTRAP
+{% endif %}
       - network_groups:
           - MANAGEMENT
           - PUBLIC

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
@@ -1,12 +1,15 @@
 ---
 
 network_groups:
-{% if ipv6 %}
+{% if bootstrap_network %}
   - name: BOOTSTRAP
     hostname_suffix: bootstrap
     tagged_vlan: false
     component_endpoints: []
+    routes:
+      - default
 {% endif %}
+
   - name: MANAGEMENT
     hostname_suffix: mgmt
     tagged_vlan: false
@@ -20,8 +23,10 @@ network_groups:
     hostname_suffix: public
     tagged_vlan: true
     component_endpoints: []
+{% if not bootstrap_network %}
     routes:
       - default
+{% endif %}
 
   - name: OS_SDN
     hostname_suffix: os_sdn

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
@@ -5,7 +5,8 @@ network_groups:
   - name: BOOTSTRAP
     hostname_suffix: bootstrap
     tagged_vlan: false
-    component_endpoints: []
+    component_endpoints:
+      - BOOTSTRAP
     routes:
       - default
 {% endif %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
@@ -1,6 +1,12 @@
 ---
 
 network_groups:
+{% if ipv6 %}
+  - name: BOOTSTRAP
+    hostname_suffix: bootstrap
+    tagged_vlan: false
+    component_endpoints: []
+{% endif %}
   - name: MANAGEMENT
     hostname_suffix: mgmt
     tagged_vlan: false

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -89,7 +89,7 @@ resources:
 {%       endfor %}
 {%     endif  %}
 {%   endif  %}
-{%   if ipv6 %}
+{%   if ipv6 and name != 'bootstrap' %}
       ip_version: 6
 {%     if network.is_conf or network.is_mgmt %}
       ipv6_ra_mode: dhcpv6-stateful

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -55,6 +55,7 @@ resources:
 {% for network_rec in heat_template.networks|dictsort %}
 {%   set network = network_rec[1] %}
 {%   set name = network.name|lower|replace('-','_')|regex_replace('_net$', '') %}
+{%   set enable_dhcp = network.is_conf or network.is_mgmt or name == 'management' %}
 
   # network: {{ network.name }}
   {{ name }}_network:
@@ -91,14 +92,14 @@ resources:
 {%   endif  %}
 {%   if ipv6 and name != 'bootstrap' %}
       ip_version: 6
-{%     if network.is_conf or network.is_mgmt %}
+{%     if enable_dhcp %}
       ipv6_ra_mode: dhcpv6-stateful
       ipv6_address_mode: dhcpv6-stateful
 {%     endif %}
 {%   else %}
       ip_version: 4
 {%   endif  %}
-      enable_dhcp: {{ network.is_conf or network.is_mgmt }}
+      enable_dhcp: {{ enable_dhcp }}
 {%   if network.gateway is defined %}
       gateway_ip: "{{ network.gateway }}"
 {%   endif   %}

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -189,9 +189,12 @@ enabled_services: ''
 # disabled_services: 'monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer|octavia'
 disabled_services: ''
 
+# Whether to use a separate bootstrap network for communication in and
+# out of the deployment. This network is IPv4.
+bootstrap_network: false
+
 # Use ipv6 networks in the cloud input model.
 ipv6: false
-
 
 #============= SES =============#
 # Configure SES backend for glance, cinder, cinder-backup and nova


### PR DESCRIPTION
Currently we cannot route IPv6 traffic in and out of the ECP. We will
need a second network interface on IPv4 for the IPv6 Heat template
jobs until this is fixed.

This change introduces this second network interface in the input
model templates.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>