### PR TITLE
crowbar-openstack: support updating a deployed cloud with MUs (SOC-8465)

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -217,6 +217,17 @@ pipeline {
       }
     }
 
+    stage('Update cloud') {
+      when {
+        expression { deploy_cloud == 'true' && update_after_deploy == 'true' }
+      }
+      steps {
+        script {
+          cloud_lib.ansible_playbook('crowbar-update')
+        }
+      }
+    }
+
     stage('Test cloud') {
       when {
         expression { deploy_cloud == 'true' && test_cloud == 'true' }

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -102,6 +102,24 @@
             Enable SLES/Cloud test update repos (the Cloud test update repos will
             be enabled only when cloudsource is GM based)
 
+      - bool:
+          name: update_after_deploy
+          default: '{update_after_deploy|false}'
+          description: >-
+            If true the Maintenance update repos will be added and updates applied after
+            cloud is deployed.
+
+            NOTE: Maintenance updates = 'maint_updates' option
+
+      - bool:
+          name: reboot_after_deploy
+          default: '{reboot_after_deploy|false}'
+          description: >-
+            If true then cloud will be rebooted after deployment. For example after
+            maintenance updates were installed.
+
+            NOTE: Currently works when 'update_after_deploy' is ticked.
+
       - validating-string:
           name: maint_updates
           default: ''

--- a/scripts/jenkins/cloud/ansible/_create-vcloud-inventory.yml
+++ b/scripts/jenkins/cloud/ansible/_create-vcloud-inventory.yml
@@ -17,6 +17,10 @@
         ansible_host: "{{ item.1 }}"
         ansible_password: "linux"
         group: "{{ item.0.group }}, cloud_virt_hosts"
+        ansible_ssh_common_args: >
+          -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o
+          StrictHostKeyChecking=no -W %h:%p -q root@{{ hostvars[cloud_env].ansible_host }}'
+          -o ControlPath='~/.ansible/cp/{{ cloud_env }}-%r@%h:%p'
       loop: "{{ virtual_hosts | subelements('ips') }}"
       loop_control:
         label: "{{ item.0.group }}{{ item.0.ips.index(item.1) + 1 }} - {{ item.1 }}"

--- a/scripts/jenkins/cloud/ansible/bootstrap-crowbar-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-crowbar-nodes.yml
@@ -25,10 +25,6 @@
   gather_facts: false
   vars:
     task: "deploy"
-    ansible_ssh_common_args: >
-      -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o
-      StrictHostKeyChecking=no -W %h:%p -q root@{{ hostvars[cloud_env].ansible_host }}'
-      -o ControlPath='~/.ansible/cp/{{ cloud_env }}-%r@%h:%p'
 
   tasks:
     - block:

--- a/scripts/jenkins/cloud/ansible/bootstrap-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-crowbar.yml
@@ -42,6 +42,12 @@
             - maint_updates_list | length
 
         - include_role:
+            name: crowbar_update
+          when:
+            - not update_after_deploy
+            - maint_updates_list | length
+
+        - include_role:
             name: frontail
 
       rescue:

--- a/scripts/jenkins/cloud/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-vcloud-nodes.yml
@@ -70,10 +70,6 @@
   gather_facts: false
   vars:
     task: "deploy"
-    ansible_ssh_common_args: >
-      -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o
-      StrictHostKeyChecking=no -W %h:%p -q root@{{ hostvars[cloud_env].ansible_host }}'
-      -o ControlPath='~/.ansible/cp/{{ cloud_env }}-%r@%h:%p'
 
   tasks:
     - block:

--- a/scripts/jenkins/cloud/ansible/crowbar-update.yml
+++ b/scripts/jenkins/cloud/ansible/crowbar-update.yml
@@ -1,0 +1,95 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- import_playbook: _create-vcloud-inventory.yml
+
+- name: Update cloud - crowbar
+  hosts: "{{ cloud_env }}"
+  remote_user: root
+  gather_facts: True
+  vars:
+    task: "update"
+
+  pre_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "started"
+        rc_state: "Started"
+      when: rc_notify
+
+  tasks:
+    - block:
+        # add MU repos
+        - include_role:
+            name: setup_zypper_repos
+          when:
+            - maint_updates_list | length
+
+        - include_role:
+            name: crowbar_update
+            apply:
+              delegate_to: "{{ target_host }}"
+          vars:
+            inventory_hostname: "{{ target_host }}"
+          loop: "{{ [cloud_env]+groups['cloud_virt_hosts'] }}"
+          loop_control:
+            loop_var: target_host
+
+        - include_role:
+            name: reboot_node
+          vars:
+            reboot_target: deployer
+          when:
+            - update_after_deploy
+            - reboot_after_deploy
+
+        - include_role:
+            name: crowbar_setup
+          vars:
+            qa_crowbarsetup_cmd: onadmin_rebootcloud
+          when:
+            - reboot_after_deploy
+            - update_after_deploy
+
+      rescue:
+        - include_role:
+            name: rocketchat_notify
+          vars:
+            rc_action: "finished"
+            rc_state: "Failed"
+          when: rc_notify
+
+        - name: Stop if something failed
+          fail:
+            msg: "{{ task }} failed."
+      always:
+        - include_role:
+            name: jenkins_artifacts
+          when: lookup("env", "WORKSPACE")
+          vars:
+            jenkins_artifacts_to_collect:
+              - src: "{{ qa_crowbarsetup_log }}"
+
+  post_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "finished"
+        rc_state: "Success"
+      when: rc_notify

--- a/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
@@ -45,6 +45,7 @@
             qa_crowbarsetup_cmd: onadmin_rebootcloud
           when:
             - reboot_after_deploy
+            - not update_after_deploy
 
       rescue:
         - include_role:

--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -56,6 +56,7 @@ local_repos_web_dir_prefix: "{{ (cloud_product == 'crowbar') | ternary('tftpboot
 local_repos_base_dir: "/srv/{{ local_repos_web_dir_prefix }}/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
 sles_cloud_version:
+  "12.2": 7
   "12.3": 8
   "12.4": 9
 

--- a/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
@@ -19,10 +19,6 @@
   gather_facts: True
   vars:
     task: "register"
-    ansible_ssh_common_args: >
-      -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o
-      StrictHostKeyChecking=no -W %h:%p -q root@{{ hostvars[cloud_env].ansible_host }}'
-      -o ControlPath='~/.ansible/cp/{{ cloud_env }}-%r@%h:%p'
 
   tasks:
     - block:

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_setup/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_setup/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Run 'qa_crowbarsetup.sh {{ qa_crowbarsetup_cmd }}' on the admin node
-  shell: |
+  shell: |-
     . {{ admin_scripts_path }}/qa_crowbarsetup.sh
     {{ qa_crowbarsetup_cmd }} 2>&1 | tee -a {{ qa_crowbarsetup_log }}
     exit ${PIPESTATUS[0]}

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_update/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_update/defaults/main.yml
@@ -23,4 +23,4 @@ update_include_reboot_patches: true
 
 deployer_repo_base_url: "http://{{ deployer_ip }}:8091/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
-cloud_repo_path: "OpenStack-Cloud-Crowbar"
+cloud_repo_path: "{{ (sles_cloud_version[ansible_distribution_version] == 7)| ternary ('OpenStack-Cloud', 'OpenStack-Cloud-Crowbar') }}"

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_update/tasks/add_mu_repos_crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_update/tasks/add_mu_repos_crowbar.yml
@@ -20,17 +20,16 @@
     url: "http://{{ maintenance_updates_server }}/ibs/SUSE:/Maintenance:/{{ item }}/"
     return_content: yes
   loop: "{{ maint_updates_list }}"
+  delegate_to: "{{ cloud_env }}"
   register: mu_url
 
 
-- name: Add MU zypper repositories - Crowbar on {{ ansible_host }}
+- name: Add MU zypper repositories - Crowbar on {{ inventory_hostname }}
   zypper_repository:
     name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
     repo: "{{ deployer_repo_base_url }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
     runrefresh: yes
     state: present
   loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
-  #  notify:
-  #  - Apply all available patches
   when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
 

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_update/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_update/tasks/main.yml
@@ -15,18 +15,9 @@
 #
 ---
 
-- name: Check if crowbar product line
-  fail:
-    msg: "the role is intended for crowbar only"
-  when: cloud_product != 'crowbar'
-
 - include_tasks: add_mu_repos_crowbar.yml
   when:
     - maint_updates_list | length
+    - inventory_hostname not in groups['deployer_virt']
 
-# TODO: maybe worth to do that in future - upgrading cloud"
-#- include_tasks: pre_cloudsource_update.yml
-#  when:
-#    - cloudsource is defined
-#    - cloudsource != ''
-
+- include_tasks: update_cloud.yml

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_update/tasks/update_cloud.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_update/tasks/update_cloud.yml
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#
 # (c) Copyright 2019 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,25 +12,16 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+#
+---
 
-set -e
+- name: Refresh repos on {{ inventory_hostname }}
+  zypper_repository:
+    repo: '*'
+    runrefresh: yes
 
-source lib.sh
-
-validate_input
-setup_ansible_venv
-mitogen_enable
-prepare_input_model
-prepare_infra
-
-trap exit_msg EXIT
-
-#build_test_packages
-bootstrap_crowbar
-deploy_ses_vcloud
-bootstrap_nodes
-install_crowbar
-register_crowbar_nodes
-deploy_cloud
-update_cloud
-run_crowbar_tests
+- name: Update packages on {{ inventory_hostname }}
+  zypper:
+    name: '*'
+    state: latest
+    type: "{{ update_method }}"

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -34,6 +34,9 @@ local_ssh_key: false
 # repositories, but skip the actual cloud deployment, e.g. for testing purposes.
 deploy_cloud: true
 
+# Reboot cloud after deploy. Primarly used to reboot cloud after installation of
+# Maintenance updates. For now it is valid for **CROWBAR** flavor only.
+reboot_after_deploy: true
 
 #============= Repositories =============#
 # The cloud repository (from provo-clouddata) to be used for testing. This value can take

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -251,7 +251,11 @@ function deploy_ardana_but_dont_run_site_yml {
 
 function update_cloud {
     if $(get_from_input deploy_cloud) && $(get_from_input update_after_deploy); then
-        ansible_playbook ardana-update.yml -e cloudsource=$(get_from_input update_to_cloudsource)
+        if [ "$(get_cloud_product)" == "crowbar" ]; then
+            ansible_playbook crowbar-update.yml -e cloudsource=$(get_from_input update_to_cloudsource)
+        elif $(get_from_input deploy_cloud); then
+            ansible_playbook ardana-update.yml -e cloudsource=$(get_from_input update_to_cloudsource)
+        fi
     fi
 }
 


### PR DESCRIPTION
Extends the crowbar ECP test automation with support to set up
maintenance updates and update a predeployed cloud.
Similar to Ardana, this is controlled by a `update_after_deploy`
parameter.