### PR TITLE
Create the local ssh key in the right directory

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ssh_keys/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ssh_keys/tasks/main.yml
@@ -27,15 +27,15 @@
       {% endfor %}
 
 - block:
-    - name: Create local SSH key on deployer
-      shell: ssh-keygen -t rsa -f "{{ ansible_env.HOME }}/.ssh/id_rsa" -N ""
+    - name: Create local SSH key
+      shell: ssh-keygen -t rsa -f "{{ lookup('env', 'HOME') }}/.ssh/id_rsa" -N ""
       delegate_to: localhost
       args:
-        creates: "{{ ansible_env.HOME }}/.ssh/id_rsa"
+        creates: "{{ lookup('env', 'HOME') }}/.ssh/id_rsa"
 
     - name: Copy local SSH key to deployer
       lineinfile:
         path: "{{ ansible_env.HOME }}/.ssh/authorized_keys"
         create: yes
-        line: "{{ lookup('file', ansible_env.HOME + '/.ssh/id_rsa.pub') }}"
+        line: "{{ lookup('file', lookup('env', 'HOME') + '/.ssh/id_rsa.pub') }}"
   when: local_ssh_key


### PR DESCRIPTION
The local ssh key needs to be added to the home directory of the user
running the Ansible playbook.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>