### PR TITLE
openstack-crowbar: enable SSL for magnum & sahara

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/input_model_generator/templates/barclamps/magnum.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/input_model_generator/templates/barclamps/magnum.yml.j2
@@ -1,5 +1,7 @@
   - barclamp: magnum
     attributes:
+      api:
+        protocol: {{ api_protocol }}
       trustee:
         domain_name: magnum
         domain_admin_name: magnum_domain_admin

--- a/scripts/jenkins/cloud/ansible/roles/input_model_generator/templates/barclamps/sahara.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/input_model_generator/templates/barclamps/sahara.yml.j2
@@ -1,5 +1,7 @@
   - barclamp: sahara
     attributes:
+      api:
+        protocol: {{ api_protocol }}
       plugins: 'vanilla,spark,cdh,ambari,fake'
 {% include 'barclamps/lib/deployment.yml.j2' %}
 


### PR DESCRIPTION
The barclamps generated for magnum and sahara do not include
setting the protocol to https when SSL is enabled.