### PR TITLE
jenkins: Rename cloud-ardana-maintenance-slot to cloud-maintenance-slot

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -10,7 +10,7 @@
     parameters:
       - validating-string:
           name: cloud_env
-          default: 'cloud-ardana-maintenance-slot'
+          default: 'cloud-maintenance-slot'
           regex: '[A-Za-z0-9-_]+'
           msg: >-
             Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).


### PR DESCRIPTION
The maintenance-slot is nowadys used for ardana and crowbar so let's
change the label to reflect this change.