### PR TITLE
 maintenance gating: add Crowbar update jobs to maintenance gating (SOC-9797,SOC-9798)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -181,26 +181,6 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
-    ardana_job: '{name}'
-    disabled: false
-    reserve_env: false
-    cloudsource: GM8+up
-    updates_test_enabled: false
-    scenario_name: entry-scale-kvm
-    clm_model: standalone
-    controllers: '3'
-    computes: '2'
-    ses_enabled: true
-    ses_rgw_enabled: false
-    tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
-      designate,heat,ceilometer,magnum,freezer,monasca"
-    triggers: []
-    jobs:
-        - '{ardana_job}'
-
-- project:
     name: cloud-ardana8-job-std-min-suse-x86_64
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -209,26 +209,6 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
-    ardana_job: '{name}'
-    disabled: false
-    reserve_env: false
-    cloudsource: GM9+up
-    updates_test_enabled: false
-    scenario_name: entry-scale-kvm
-    clm_model: standalone
-    controllers: '3'
-    computes: '2'
-    ses_enabled: true
-    ses_rgw_enabled: false
-    tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-      designate,heat,magnum,monasca"
-    triggers: []
-    jobs:
-        - '{ardana_job}'
-
-- project:
     name: cloud-ardana9-job-std-min-suse-x86_64
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -52,8 +52,9 @@
           default-value: ''
           value: >-
             ardana8-deploy,ardana8-update,ardana9-deploy,ardana9-update,
-            crowbar7-deploy,crowbar7-ha-deploy,crowbar8-deploy,crowbar8-ha-deploy,
-            crowbar9-deploy,crowbar9-ha-deploy
+            crowbar7-no-ha-deploy,crowbar7-ha-deploy,crowbar7-no-ha-update,crowbar7-ha-update,
+            crowbar8-no-ha-deploy,crowbar8-ha-deploy,crowbar8-no-ha-update,crowbar8-ha-update,
+            crowbar9-no-ha-deploy,crowbar9-ha-deploy,crowbar9-no-ha-update,crowbar9-ha-update
           description: >-
             Use this parameter to filter the list of jobs that are triggered to test the maintenance
             updates. This is useful e.g. when re-running only the subset of jobs that have failed

--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -95,5 +95,5 @@
               - ${git_automation_branch}
             browser: auto
             wipe-workspace: false
-      script-path: jenkins/ci.suse.de/pipelines/openstack-maintenance-gating.Jenkinsfile
+      script-path: jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
       lightweight-checkout: false

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -1,0 +1,117 @@
+
+- project:
+    name: cloud-ardana-job-mu-entry-scale-kvm-x86_64
+    reserve_env: false
+    updates_test_enabled: false
+    scenario_name: entry-scale-kvm
+    clm_model: standalone
+    controllers: '3'
+    computes: '2'
+    ses_enabled: true
+    ses_rgw_enabled: false
+    extra_params: |
+      tempest_retry_failed=True
+      update_services_serial=True
+    triggers: []
+    ardana_job:
+      - cloud-ardana8-job-mu-entry-scale-kvm-deploy-x86_64:
+          cloudsource: GM8+up
+          update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
+            designate,heat,ceilometer,magnum,freezer,monasca"
+      - cloud-ardana8-job-mu-entry-scale-kvm-update-x86_64:
+          cloudsource: GM8+up
+          update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
+            designate,heat,ceilometer,magnum,freezer,monasca"
+      - cloud-ardana9-job-mu-entry-scale-kvm-deploy-x86_64:
+          cloudsource: GM9+up
+          update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            designate,heat,magnum,monasca"
+      - cloud-ardana9-job-mu-entry-scale-kvm-update-x86_64:
+          cloudsource: GM9+up
+          update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            designate,heat,magnum,monasca"
+    jobs:
+        - '{ardana_job}'
+
+
+- project:
+    name: cloud-crowbar-job-mu-no-ha-x86_64
+    reserve_env: false
+    updates_test_enabled: false
+    scenario_name: standard
+    controllers: '1'
+    computes: '2'
+    triggers: []
+    crowbar_job:
+      - cloud-crowbar7-job-mu-no-ha-deploy-x86_64:
+          cloudsource: GM7+up
+          ses_enabled: false
+          update_after_deploy: false
+      - cloud-crowbar7-job-mu-no-ha-update-x86_64:
+          cloudsource: GM7+up
+          ses_enabled: false
+          update_after_deploy: true
+      - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
+          cloudsource: GM8+up
+          ses_enabled: false
+          update_after_deploy: false
+      - cloud-crowbar8-job-mu-no-ha-update-x86_64:
+          cloudsource: GM8+up
+          ses_enabled: false
+          update_after_deploy: true
+      - cloud-crowbar9-job-mu-no-ha-deploy-x86_64:
+          cloudsource: GM9+up
+          ses_enabled: true
+          update_after_deploy: false
+      - cloud-crowbar9-job-mu-no-ha-update-x86_64:
+          cloudsource: GM9+up
+          ses_enabled: true
+          update_after_deploy: true
+    jobs:
+        - '{crowbar_job}'
+
+
+- project:
+    name: cloud-crowbar-job-mu-ha-x86_64
+    reserve_env: false
+    updates_test_enabled: false
+    reboot_after_deploy: true
+    scenario_name: standard
+    controllers: '3'
+    computes: '2'
+    triggers: []
+    crowbar_job:
+      - cloud-crowbar7-job-mu-ha-deploy-x86_64:
+          cloudsource: GM7+up
+          ses_enabled: false
+          update_after_deploy: false
+      - cloud-crowbar7-job-mu-ha-update-x86_64:
+          cloudsource: GM7+up
+          ses_enabled: false
+          update_after_deploy: true
+      - cloud-crowbar8-job-mu-ha-deploy-x86_64:
+          cloudsource: GM8+up
+          ses_enabled: false
+          update_after_deploy: false
+      - cloud-crowbar8-job-mu-ha-update-x86_64:
+          cloudsource: GM8+up
+          ses_enabled: false
+          update_after_deploy: true
+      - cloud-crowbar9-job-mu-ha-deploy-x86_64:
+          cloudsource: GM9+up
+          ses_enabled: true
+          update_after_deploy: false
+      - cloud-crowbar9-job-mu-ha-update-x86_64:
+          cloudsource: GM9+up
+          ses_enabled: true
+          update_after_deploy: true
+    jobs:
+        - '{crowbar_job}'

--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating-config.yml
@@ -1,59 +1,53 @@
 SOC8:
   ardana8-deploy:
-    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM8+up
-      update_after_deploy: false
-      extra_params: |
-        tempest_retry_failed=True
+    job_name: cloud-ardana8-job-mu-entry-scale-kvm-deploy-x86_64
+    job_params: []
   ardana8-update:
-    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM8+up
-      update_after_deploy: true
-      extra_params: |
-        tempest_retry_failed=True
-        update_services_serial=True
+    job_name: cloud-ardana8-job-mu-entry-scale-kvm-update-x86_64
+    job_params: []
 SOC9:
   ardana9-deploy:
-    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM9+up
-      update_after_deploy: false
-      extra_params: |
-        tempest_retry_failed=True
+    job_name: cloud-ardana9-job-mu-entry-scale-kvm-deploy-x86_64
+    job_params: []
   ardana9-update:
-    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM9+up
-      update_after_deploy: true
-      extra_params: |
-        tempest_retry_failed=True
-        update_services_serial=True
+    job_name: cloud-ardana9-job-mu-entry-scale-kvm-update-x86_64
+    job_params: []
 SOCC7:
-  crowbar7-deploy:
-    job_name: cloud-crowbar7-job-x86_64
-    job_params:
-      cloudsource: GM7+up
+  crowbar7-no-ha-deploy:
+    job_name: cloud-crowbar7-job-mu-no-ha-deploy-x86_64
+    job_params: []
   crowbar7-ha-deploy:
-    job_name: cloud-crowbar7-job-ha-x86_64
-    job_params:
-      cloudsource: GM7+up
+    job_name: cloud-crowbar7-job-mu-ha-deploy-x86_64
+    job_params: []
+  crowbar7-no-ha-update:
+    job_name: cloud-crowbar7-job-mu-no-ha-update-x86_64
+    job_params: []
+  crowbar7-ha-update:
+    job_name: cloud-crowbar7-job-mu-ha-update-x86_64
+    job_params: []
 SOCC8:
-  crowbar8-deploy:
-    job_name: cloud-crowbar8-job-x86_64
-    job_params:
-      cloudsource: GM8+up
+  crowbar8-no-ha-deploy:
+    job_name: cloud-crowbar8-job-mu-no-ha-deploy-x86_64
+    job_params: []
   crowbar8-ha-deploy:
-    job_name: cloud-crowbar8-job-ha-x86_64
-    job_params:
-      cloudsource: GM8+up
+    job_name: cloud-crowbar8-job-mu-ha-deploy-x86_64
+    job_params: []
+  crowbar8-no-ha-update:
+    job_name: cloud-crowbar8-job-mu-no-ha-update-x86_64
+    job_params: []
+  crowbar8-ha-update:
+    job_name: cloud-crowbar8-job-mu-ha-update-x86_64
+    job_params: []
 SOCC9:
-  crowbar9-deploy:
-    job_name: cloud-crowbar9-job-x86_64
-    job_params:
-      cloudsource: GM9+up
+  crowbar9-no-ha-deploy:
+    job_name: cloud-crowbar9-job-mu-no-ha-deploy-x86_64
+    job_params: []
   crowbar9-ha-deploy:
-    job_name: cloud-crowbar9-job-ha-x86_64
-    job_params:
-      cloudsource: GM9+up
+    job_name: cloud-crowbar9-job-mu-ha-deploy-x86_64
+    job_params: []
+  crowbar9-no-ha-update:
+    job_name: cloud-crowbar9-job-mu-no-ha-update-x86_64
+    job_params: []
+  crowbar9-ha-update:
+    job_name: cloud-crowbar9-job-mu-ha-update-x86_64
+    job_params: []

--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating-config.yml
@@ -1,0 +1,59 @@
+SOC8:
+  ardana8-deploy:
+    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM8+up
+      update_after_deploy: false
+      extra_params: |
+        tempest_retry_failed=True
+  ardana8-update:
+    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM8+up
+      update_after_deploy: true
+      extra_params: |
+        tempest_retry_failed=True
+        update_services_serial=True
+SOC9:
+  ardana9-deploy:
+    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM9+up
+      update_after_deploy: false
+      extra_params: |
+        tempest_retry_failed=True
+  ardana9-update:
+    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
+    job_params:
+      cloudsource: GM9+up
+      update_after_deploy: true
+      extra_params: |
+        tempest_retry_failed=True
+        update_services_serial=True
+SOCC7:
+  crowbar7-deploy:
+    job_name: cloud-crowbar7-job-x86_64
+    job_params:
+      cloudsource: GM7+up
+  crowbar7-ha-deploy:
+    job_name: cloud-crowbar7-job-ha-x86_64
+    job_params:
+      cloudsource: GM7+up
+SOCC8:
+  crowbar8-deploy:
+    job_name: cloud-crowbar8-job-x86_64
+    job_params:
+      cloudsource: GM8+up
+  crowbar8-ha-deploy:
+    job_name: cloud-crowbar8-job-ha-x86_64
+    job_params:
+      cloudsource: GM8+up
+SOCC9:
+  crowbar9-deploy:
+    job_name: cloud-crowbar9-job-x86_64
+    job_params:
+      cloudsource: GM9+up
+  crowbar9-ha-deploy:
+    job_name: cloud-crowbar9-job-ha-x86_64
+    job_params:
+      cloudsource: GM9+up

--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
           parallel cloud_lib.generate_parallel_stages(
             cloudversion.split(','),
             job_filter.tokenize(','),
-            "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml") {
+            "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating-config.yml") {
             job_title, job_def ->
 
             // reserve a resource here for the integration job, to avoid


### PR DESCRIPTION
Adds the "deploy-and-update" Crowbar scenarios to the list of scenarios
used to test maintenance updates.

This PR also creates dedicated jobs for the various scenario used to test
maintenance updates, to have an individual build history for each scenario.  

NOTE: depends on #3553 