### PR TITLE
createproject: handle newer osc release

### DIFF
--- a/hostscripts/rpm-packaging/createproject.py
+++ b/hostscripts/rpm-packaging/createproject.py
@@ -228,7 +228,7 @@ def osc_commit_all(workdir, packagename):
         sh.osc('addremove')
         for o in sh.osc('service', 'localrun', 'source_validator'):
             if o.startswith('###ASK'):
-                sh.osc('rm', o.strip().split()[1])
+                sh.osc('rm', '--force', o.strip().split()[1])
         sh.osc('commit', '--noservice', '-n')
     finally:
         os.chdir(olddir)


### PR DESCRIPTION
With the newer osc release, osc rm on an empty file no longer
silently succeeds but it fails with:

  'openstack-nova-cells.service' has local modifications (use --force to remove this file)

So we need to use the force, Luke.