### PR TITLE
openstack-crowbar/ardana: prevent underscores in cloud_env

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
@@ -15,9 +15,9 @@
       - validating-string:
           name: cloud_env
           default: '{cloud_env|}'
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The Lockable Resource label representing the resource pool to used by this job.
 

--- a/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
@@ -36,7 +36,7 @@
           default: ''
           regex: '[A-Za-z0-9-_]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual environment identifier. This field should be set to a
             value that will uniquely identify the heat stack.

--- a/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
@@ -15,9 +15,9 @@
       - validating-string:
           name: cloud_env
           default: '{os_cloud}-ci-slot'
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -3,6 +3,8 @@
 # The cloud product to be deployed. Possible values are:
 # - crowbar
 # - ardana
+#
+# IMPORTANT: only alphanumeric and '-' characters must be used for this value
 cloud_product: 'ardana'
 
 #============= Cloud Platform ===========#


### PR DESCRIPTION
The `cloud_env` value is reflected into the hostnames set up
for the cloud nodes, so we must prevent underscore characters
from being part of it because they are not allowed to be part
of a hostname value [1].

[1] https://www.ietf.org/rfc/rfc952.txt - B. Lexical grammar