### PR TITLE
openstack-crowbar: support SOC7 maintenance updates (SOC-9887)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -24,6 +24,9 @@ include_maint_update: "{{ (task == 'deploy' and not update_after_deploy) or (tas
 
 # Media/repositories mapped by the cloudsource value
 cloudsource_repos:
+  stagingcloud7: "SUSE-OpenStack-Cloud-7-devel-staging"
+  develcloud7: "SUSE-OpenStack-Cloud-7-devel"
+  GM7: "SUSE-OpenStack-Cloud-7-Pool"
   stagingcloud8: "SUSE-OpenStack-Cloud-8-devel-staging"
   develcloud8: "SUSE-OpenStack-Cloud-8-devel"
   GM8: "SUSE-OpenStack-Cloud-8-Pool"
@@ -36,6 +39,12 @@ cloudsource_repos:
 cloud_brand: "{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'SUSE-OpenStack-Cloud') }}"
 
 repository_mnemonics:
+  cloud7:
+    SLES-Pool: "SLES12-SP2-Pool"
+    SLES-Updates: "SLES12-SP2-Updates"
+    SLES-Updates-test: "SLES12-SP2-Updates-test"
+    Cloud-Updates: "{{ cloud_brand }}-7-Updates"
+    Cloud-Updates-test: "SUSE-OpenStack-Cloud-7-Updates-test"
   cloud8:
     SLES-Pool: "SLES12-SP3-Pool"
     SLES-Updates: "SLES12-SP3-Updates"

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
@@ -28,7 +28,7 @@
 
 - name: Set cloud MU repo path based on product - Crowbar
   set_fact:
-    cloud_repo_path: "OpenStack-Cloud-Crowbar"
+    cloud_repo_path: "{{ (sles_cloud_version[ansible_distribution_version] == 7)| ternary ('OpenStack-Cloud', 'OpenStack-Cloud-Crowbar') }}"
   when: cloud_product == 'crowbar'
 
 - name: Check MU URL


### PR DESCRIPTION
Adds the missing definitions for Cloud 7 and SLES12_SP2 and
fixes `cloud_repo_path` in `setup_zypper_repos` to handle Crowbar
SOC7 maintenance updates.