### PR TITLE
iscsictl.py: setup loop device before target service start (SOC-9821)

### DIFF
--- a/scripts/iscsictl.py
+++ b/scripts/iscsictl.py
@@ -205,8 +205,8 @@ class ISCSI(object):
 
         # Only append the line if is not there
         for line in lines:
-            if not re.search('^%s$' % line, cfg, re.MULTILINE):
-                self.ssh.echo('-e', line, '>> %s' % fname)
+            if not re.search('^%s$' % re.escape(line), cfg, re.MULTILINE):
+                self.ssh.echo('-e', "'%s'" % line, '>> %s' % fname)
 
     def remove_cfg(self, fname, lines):
         """Remove lines in a configuration file."""
@@ -319,13 +319,14 @@ class Target(ISCSI):
         self.ssh.lio_node('--disableauth', iqn, '1')
         self.ssh.lio_node('--enabletpg', iqn, '1')
 
-        # Add in /etc/rc.d/boot.local
+        # Add in /etc/target/tcm_start.sh
         if self.device.startswith('/dev/loop'):
-            print("Adding loopback to boot.local ...")
+            print("Adding loopback to target service startup ...")
             lines = (
-                'losetup %s %s' % (self.device, self.path),
+                '[[ $(losetup -j %s) == "%s"* ]] || losetup %s %s' % (
+                    self.path, self.device, self.device, self.path),
             )
-            self.append_cfg('/etc/rc.d/boot.local', lines)
+            self.append_cfg('/etc/target/tcm_start.sh', lines)
 
         # Check if the device is exported
         print("Checking that the target is exported ...")


### PR DESCRIPTION
There is no clear execution order dependency between
`/etc/rc.d/boot.local` and the startup of the target service,
which leads to situations in which the target service starts
before the loop device has had a chance to be properly set up.

Moving the setup of the loop device to the target service startup
script ensures that the commands setting up the ISCSI device used
for SBD are executed in the correct order.