### PR TITLE
cloud-maintenance-gating: keep environments after job success

### DIFF
--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
                 reserve_env          : false,
                 maint_updates        : maint_updates,
                 rc_notify            : false,
-                cleanup              : "on success",
+                cleanup              : "never",
                 git_automation_repo  : git_automation_repo,
                 git_automation_branch: git_automation_branch
               ]


### PR DESCRIPTION
Keep the maintenance update gating cloud environments even after
a job successfully tests a maintenance update.