### PR TITLE
ironic: Use direct deploy interface only with Swift

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -864,8 +864,6 @@ function setup_ironic_test_env
 
     local host_admin_ip=${net_admin}${ip_sep}1
 
-    local deploy_interface=direct
-
     install_vbmc
 
     local i
@@ -889,7 +887,6 @@ function setup_ironic_test_env
         # create node in ironic
         onadmin create_ironic_node $cloud-node$i \
             $vcpus $ram_mb $ironicnode_hdd_size $(macfunc $i 1) \
-            $deploy_interface \
             $host_admin_ip $ipmi_port $ipmi_user $ipmi_password
     done
 

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4717,12 +4717,14 @@ function oncontroller_create_ironic_node
     local disk_gb=$4
     local mac=$5
 
-    local deploy_interface=$6
+    local ipmi_ip=$6
+    local ipmi_port=$7
+    local ipmi_user=$8
+    local ipmi_pass=$9
 
-    local ipmi_ip=$7
-    local ipmi_port=$8
-    local ipmi_user=$9
-    local ipmi_pass=${10}
+    # select best deploy interface based on proposalvars
+    local deploy_interface=iscsi
+    [[ $deployswift ]] && deploy_interface=direct
 
     # pick latest versions of kernel/ramdisk images
     local deploy_initrd_uuid=$(openstack image list -f value | grep ir-deploy-ramdisk | sort -V -k 2 | tail -n1 | awk '{print $1}')


### PR DESCRIPTION
Direct deploy interface is not available if Swift is not deployed.
For this cases, iscsi interface should be used.