### PR TITLE
follow switch to python3 of osc on trackupstream

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-prepare-staging.py
+++ b/jenkins/ci.opensuse.org/openstack-prepare-staging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 import os
 import re
 import sys


### PR DESCRIPTION
The osc package on the trackupstream Jenkins node for ci.opensuse.org
was switched to python3. Do the same in the script that imports osc
modules, to make it work again.