### PR TITLE
ironic: List nodes before delete

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4775,6 +4775,10 @@ function oncontroller_delete_ironic_node
         export OS_BAREMETAL_API_VERSION=latest
     fi
 
+    # List ironic nodes just before deleting for easier troubleshooting
+    echo "ironic nodes:"
+    openstack baremetal node list
+
     # Maintenance mode enables delete if node is in error state
     openstack baremetal node maintenance set "$1" || true
     openstack baremetal node delete "$1" || true


### PR DESCRIPTION
When something fails during ironic testing, test env teardown will
try to delete the nodes. Node list can contains some important info
so lets print it before starting the cleanup.