### PR TITLE
ironic: Deploy only one ironic node

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-agent-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-agent-template.yaml
@@ -28,7 +28,7 @@
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-ironic-agent-{arch}
             want_ironic=1
-            nodenumberironicnode=2
+            nodenumberironicnode=1
             want_monasca_proposal=0
             want_ceilometer_proposal=0
             want_aodh_proposal=0

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-ironic-template.yaml
@@ -28,7 +28,7 @@
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-ironic-{arch}
             want_ironic=1
-            nodenumberironicnode=2
+            nodenumberironicnode=1
             want_monasca_proposal=0
             want_ceilometer_proposal=0
             want_aodh_proposal=0


### PR DESCRIPTION
Ironic tests never use more than one node so it doesn't make much
sense to deploy two.