### PR TITLE
cloud-gating: configurable and dedicated jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -1,26 +1,4 @@
 - project:
-    name: cloud-8-gating-trigger
-    cloud_url_trigger_job: '{name}'
-    version: '8'
-    url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-devel-staging/media.1/build'
-    projects:
-      - project: 'cloud-{version}-gating'
-        block: false
-    jobs:
-        - '{cloud_url_trigger_job}'
-
-- project:
-    name: cloud-8-gating
-    cloud_gating_job: '{name}'
-    concurrent: False
-    version: '8'
-    cloud_env: 'cloud-gate{version}-slot'
-    extra_params: |
-      tempest_retry_failed=True
-    jobs:
-        - '{cloud_gating_job}'
-
-- project:
     name: cloud-ardana8-job-std-3cp-x86_64
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -1,26 +1,4 @@
 - project:
-    name: cloud-9-gating-trigger
-    cloud_url_trigger_job: '{name}'
-    version: '9'
-    url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-devel-staging/media.1/build'
-    projects:
-      - project: 'cloud-{version}-gating'
-        block: false
-    jobs:
-        - '{cloud_url_trigger_job}'
-
-- project:
-    name: cloud-9-gating
-    cloud_gating_job: '{name}'
-    concurrent: False
-    version: '9'
-    cloud_env: 'cloud-gate{version}-slot'
-    extra_params: |
-      tempest_retry_failed=True
-    jobs:
-        - '{cloud_gating_job}'
-
-- project:
     name: cloud-ardana9-job-std-3cp-x86_64
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -1,8 +1,33 @@
+- project:
+    name: cloud-gating-trigger
+    url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-devel-staging/media.1/build'
+    projects:
+      - project: 'cloud-{version}-gating'
+        block: false
+    cloud_url_trigger_job:
+      - cloud-8-gating-trigger:
+          version: 8
+      - cloud-9-gating-trigger:
+          version: 9
+    jobs:
+        - '{cloud_url_trigger_job}'
 
 - project:
-    name: cloud-ardana-job-mu-entry-scale-kvm-x86_64
+    name: cloud-gating
+    concurrent: False
+    cloud_env: 'cloud-gate{version}-slot'
+    cloud_gating_job:
+      - cloud-8-gating:
+          version: 8
+      - cloud-9-gating:
+          version: 9
+    jobs:
+        - '{cloud_gating_job}'
+
+- project:
+    name: cloud-ardana-job-gate-entry-scale-kvm-x86_64
     reserve_env: false
-    updates_test_enabled: false
+    updates_test_enabled: true
     scenario_name: entry-scale-kvm
     clm_model: standalone
     controllers: '3'
@@ -11,29 +36,31 @@
     ses_rgw_enabled: false
     extra_params: |
       tempest_retry_failed=True
-      update_services_serial=True
+      update_services_serial=False
     triggers: []
     ardana_job:
-      - cloud-ardana8-job-mu-entry-scale-kvm-deploy-x86_64:
-          cloudsource: GM8+up
+      - cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64:
+          cloudsource: stagingcloud8
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
             designate,heat,ceilometer,magnum,freezer,monasca"
-      - cloud-ardana8-job-mu-entry-scale-kvm-update-x86_64:
-          cloudsource: GM8+up
+      - cloud-ardana8-job-gate-entry-scale-kvm-update-x86_64:
+          cloudsource: develcloud8
+          update_cloudsource: stagingcloud8
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
             designate,heat,ceilometer,magnum,freezer,monasca"
-      - cloud-ardana9-job-mu-entry-scale-kvm-deploy-x86_64:
-          cloudsource: GM9+up
+      - cloud-ardana9-job-gate-entry-scale-kvm-deploy-x86_64:
+          cloudsource: stagingcloud9
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
             designate,heat,magnum,monasca"
-      - cloud-ardana9-job-mu-entry-scale-kvm-update-x86_64:
-          cloudsource: GM9+up
+      - cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64:
+          cloudsource: develcloud9
+          update_cloudsource: stagingcloud9
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
@@ -43,45 +70,33 @@
 
 
 - project:
-    name: cloud-crowbar-job-mu-no-ha-x86_64
+    name: cloud-crowbar-job-gate-no-ha-x86_64
     reserve_env: false
-    updates_test_enabled: false
+    updates_test_enabled: true
     reboot_after_deploy: true
     scenario_name: standard
     controllers: '1'
     computes: '2'
     triggers: []
     crowbar_job:
-      - cloud-crowbar7-job-mu-no-ha-deploy-x86_64:
-          cloudsource: GM7+up
+      - cloud-crowbar7-job-gate-no-ha-deploy-x86_64:
+          cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-      - cloud-crowbar7-job-mu-no-ha-update-x86_64:
-          cloudsource: GM7+up
-          ses_enabled: false
-          update_after_deploy: true
-      - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
-          cloudsource: GM8+up
+      - cloud-crowbar8-job-gate-no-ha-deploy-x86_64:
+          cloudsource: stagingcloud8
           ses_enabled: false
           update_after_deploy: false
-      - cloud-crowbar8-job-mu-no-ha-update-x86_64:
-          cloudsource: GM8+up
-          ses_enabled: false
-          update_after_deploy: true
-      - cloud-crowbar9-job-mu-no-ha-deploy-x86_64:
-          cloudsource: GM9+up
+      - cloud-crowbar9-job-gate-no-ha-deploy-x86_64:
+          cloudsource: stagingcloud9
           ses_enabled: true
           update_after_deploy: false
-      - cloud-crowbar9-job-mu-no-ha-update-x86_64:
-          cloudsource: GM9+up
-          ses_enabled: true
-          update_after_deploy: true
     jobs:
         - '{crowbar_job}'
 
 
 - project:
-    name: cloud-crowbar-job-mu-ha-x86_64
+    name: cloud-crowbar-job-gate-ha-x86_64
     reserve_env: false
     updates_test_enabled: false
     reboot_after_deploy: true
@@ -90,29 +105,17 @@
     computes: '2'
     triggers: []
     crowbar_job:
-      - cloud-crowbar7-job-mu-ha-deploy-x86_64:
-          cloudsource: GM7+up
+      - cloud-crowbar7-job-gate-ha-deploy-x86_64:
+          cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-      - cloud-crowbar7-job-mu-ha-update-x86_64:
-          cloudsource: GM7+up
-          ses_enabled: false
-          update_after_deploy: true
-      - cloud-crowbar8-job-mu-ha-deploy-x86_64:
-          cloudsource: GM8+up
+      - cloud-crowbar8-job-gate-ha-deploy-x86_64:
+          cloudsource: stagingcloud8
           ses_enabled: false
           update_after_deploy: false
-      - cloud-crowbar8-job-mu-ha-update-x86_64:
-          cloudsource: GM8+up
-          ses_enabled: false
-          update_after_deploy: true
-      - cloud-crowbar9-job-mu-ha-deploy-x86_64:
-          cloudsource: GM9+up
+      - cloud-crowbar9-job-gate-ha-deploy-x86_64:
+          cloudsource: stagingcloud9
           ses_enabled: true
           update_after_deploy: false
-      - cloud-crowbar9-job-mu-ha-update-x86_64:
-          cloudsource: GM9+up
-          ses_enabled: true
-          update_after_deploy: true
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
@@ -1,59 +1,38 @@
 SOC8:
   ardana8-deploy:
-    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM8+up
-      update_after_deploy: false
-      extra_params: |
-        tempest_retry_failed=True
+    job_name: cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64
+    job_params: []
   ardana8-update:
-    job_name: cloud-ardana8-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM8+up
-      update_after_deploy: true
-      extra_params: |
-        tempest_retry_failed=True
-        update_services_serial=True
+    job_name: cloud-ardana8-job-gate-entry-scale-kvm-update-x86_64
+    job_params: []
 SOC9:
   ardana9-deploy:
-    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM9+up
-      update_after_deploy: false
-      extra_params: |
-        tempest_retry_failed=True
+    job_name: cloud-ardana9-job-gate-entry-scale-kvm-deploy-x86_64
+    job_params: []
   ardana9-update:
-    job_name: cloud-ardana9-job-entry-scale-kvm-maintenance-update-x86_64
-    job_params:
-      cloudsource: GM9+up
-      update_after_deploy: true
-      extra_params: |
-        tempest_retry_failed=True
-        update_services_serial=True
-SOCC7:
-  crowbar7-deploy:
-    job_name: cloud-crowbar7-job-x86_64
-    job_params:
-      cloudsource: GM7+up
-  crowbar7-ha-deploy:
-    job_name: cloud-crowbar7-job-ha-x86_64
-    job_params:
-      cloudsource: GM7+up
-SOCC8:
-  crowbar8-deploy:
-    job_name: cloud-crowbar8-job-x86_64
-    job_params:
-      cloudsource: GM8+up
-  crowbar8-ha-deploy:
-    job_name: cloud-crowbar8-job-ha-x86_64
-    job_params:
-      cloudsource: GM8+up
-SOCC9:
-  crowbar9-deploy:
-    job_name: cloud-crowbar9-job-x86_64
-    job_params:
-      cloudsource: GM9+up
-  crowbar9-ha-deploy:
-    job_name: cloud-crowbar9-job-ha-x86_64
-    job_params:
-      cloudsource: GM9+up
+    job_name: cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64
+    job_params: []
+#
+# NOTE: to be enabled when Crowbar ECP gating jobs will replace mkcloud gating jobs
+#
+#SOCC7:
+#  crowbar7-no-ha-deploy:
+#    job_name: cloud-crowbar7-job-gate-no-ha-deploy-x86_64
+#    job_params: []
+#  crowbar7-ha-deploy:
+#    job_name: cloud-crowbar7-job-gate-ha-deploy-x86_64
+#    job_params: []
+#SOCC8:
+#  crowbar8-no-ha-deploy:
+#    job_name: cloud-crowbar8-job-gate-no-ha-deploy-x86_64
+#    job_params: []
+#  crowbar8-ha-deploy:
+#    job_name: cloud-crowbar8-job-gate-ha-deploy-x86_64
+#    job_params: []
+#SOCC9:
+#  crowbar9-no-ha-deploy:
+#    job_name: cloud-crowbar9-job-gate-no-ha-deploy-x86_64
+#    job_params: []
+#  crowbar9-ha-deploy:
+#    job_name: cloud-crowbar9-job-gate-ha-deploy-x86_64
+#    job_params: []

--- a/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
@@ -8,9 +8,6 @@
       numToKeep: -1
       daysToKeep: 30
 
-    triggers:
-      - timed: 'H H */2 * *'
-
     parameters:
       - validating-string:
           name: cloud_env
@@ -20,18 +17,6 @@
             Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The Lockable Resource label representing the resource pool to used by this job.
-
-      - bool:
-          name: deploy
-          default: '{deploy|true}'
-          description: >-
-            Run Ardana deploy validation step
-
-      - bool:
-          name: deploy_and_update
-          default: '{deploy_and_update|true}'
-          description: >-
-            Run Ardana deploy and update validation step
 
       - string:
           name: git_automation_repo


### PR DESCRIPTION
Align the cloud (staging) gating job to the cloud maintenance
update gating job by doing the following:

 - use dedicated Jenkins jobs that preserve the build history
 independently from other builds, along with a distinct naming
 scheme identifying the jobs as being used by gating
 - use a yaml configuration file to list the sub-jobs that are
 triggered by the gating job