### PR TITLE
cloud-update-ci: use string instead of integers for version

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -6,9 +6,9 @@
         block: false
     cloud_url_trigger_job:
       - cloud-8-gating-trigger:
-          version: 8
+          version: '8'
       - cloud-9-gating-trigger:
-          version: 9
+          version: '9'
     jobs:
         - '{cloud_url_trigger_job}'
 
@@ -18,9 +18,9 @@
     cloud_env: 'cloud-gate{version}-slot'
     cloud_gating_job:
       - cloud-8-gating:
-          version: 8
+          version: '8'
       - cloud-9-gating:
-          version: 9
+          version: '9'
     jobs:
         - '{cloud_gating_job}'
 


### PR DESCRIPTION
Some older versions of JJB don't handle JJB template parameter
integer values properly. Using string values instead helps to
avoid problems.