### PR TITLE
Updating socok8s integration job to use tempest run option

### DIFF
--- a/jenkins/ci.suse.de/cloud-socok8s.yaml
+++ b/jenkins/ci.suse.de/cloud-socok8s.yaml
@@ -5,5 +5,13 @@
     # the credentialId for opensusegithubapi
     repo-credentials: c2350527-476a-45df-b406-84f028614682
     jobs:
-      - '{name}-integration'
+      - '{name}-integration-{tempest}':
+          tempest: 'without-tempest'
+          # tempest: 'with-tempest'
+          run_tempest: false
+          tempest_test_type: smoke
       - '{name}-nightly-airship-from-rpm'
+      - '{name}-daily-airship-integration':
+          run_tempest: true
+          tempest_test_type: all
+

--- a/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
@@ -1,10 +1,32 @@
 - job-template:
-    name: '{name}-integration'
+    name: '{name}-integration-{tempest}'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30
     days-to-keep: 30
     script-path: Jenkinsfile.integration
+    parameters:
+      - choice:
+          name: deployment
+          choices:
+            - 'airship'
+            - 'osh'
+          default: 'airship'
+          description: >-
+            Which deployment mechanism?
+      - bool:
+          name: run_tempest
+          default: '{run_tempest|true}'
+          description: >-
+            Run tempest tests?
+      - choice:
+          name: tempest_test_type
+          choices:
+            - 'all'
+            - 'smoke'
+          default: 'all'
+          description: >-
+            Run all or smoke tempest tests?
     scm:
       - github:
           repo: '{repo-name}'
@@ -57,3 +79,55 @@
       # git-scm module with an environment variable (for some odd jenkins
       # reason).
       lightweight-checkout: false
+
+- job-template:
+    name: '{name}-daily-airship-integration'
+    project-type: pipeline
+    concurrent: false
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 14
+
+    triggers:
+      - timed: '@daily'
+
+    parameters:
+      - choice:
+          name: deployment
+          choices:
+            - 'airship'
+            - 'osh'
+          default: 'airship'
+          description: >-
+            Which deployment mechanism?
+      - bool:
+          name: run_tempest
+          default: '{run_tempest|true}'
+          description: >-
+            Run tempest tests?
+      - choice:
+          name: tempest_test_type
+          choices:
+            - 'all'
+            - 'smoke'
+          default: 'all'
+          description: >-
+            Run all or smoke tempest tests?
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/SUSE-Cloud/socok8s.git
+            repo-owner: '{repo-owner}'
+            credentials-id: '{repo-credentials}'
+            branches:
+              - master
+            browser: auto
+            wipe-workspace: false
+            submodule:
+              recursive: true
+            notification-context: daily-integration/jenkins
+      script-path: Jenkinsfile.integration
+      lightweight-checkout: false
+


### PR DESCRIPTION
Updating existing integration job so that it can run with and
without tempest execution at its end. Tempest run currently takes
a while to complete depending on if its smoke (< 1hr) or full (2-3 hrs)
test execution. So running the whole deployment and then tempest execution
will take a while to finish.
We can run job without tempest more frequently and periodically can run
full deployment + tempest at different interval.

May be need to run tempest only when related changes are made. Need to
investigate this further as currently jenkins file in socok8s has
related logic.

This change depends on https://github.com/SUSE-Cloud/socok8s/pull/644

Depends-On: #fe7657d813cb485a93a26ae3f99353842522db1a