### PR TITLE
openstack-crowbar: handle admin node reboot in SOC7 (SOC-9887)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/reboot_node/tasks/reboot_deployer.yml
+++ b/scripts/jenkins/cloud/ansible/roles/reboot_node/tasks/reboot_deployer.yml
@@ -35,12 +35,6 @@
     msg: "Uptime more then 2 minutes - it looks like node didn't reboot"
   when: _hostuptime.stdout|int > 120
 
-- name: Find cloud product
-  shell: "zypper pd | grep -m 1 'OpenStack Cloud' | cut -d'|' -f4"
-  args:
-    warn: False
-  register: _cloud_product
-
 - name: Check crowbar webui (http status)
   uri:
     url: http://127.0.0.1:3000/
@@ -49,4 +43,4 @@
   delay: 9
   register: _uri_output
   until: "(_uri_output.status == 200)"
-  when: "'Crowbar' in _cloud_product.stdout"
+  when: cloud_product == 'crowbar'


### PR DESCRIPTION
The cloud_reboot ansible code also includes a task that waits
until the crowbar service is coming back up after reboot.
It wasn't running for SOC7 deployments because the zypper
repository is named differently (i.e. doesn't have `Crowbar`
in its name).

This commit is switching to using the `cloud_product` ansible
variable to correct this issue.

NOTE: this fixes issues with the SOC7 Crowbar ECP reboot
(e.g. [this](https://ci.suse.de/blue/organizations/jenkins/cloud-crowbar7-job-mu-ha-update-x86_64/detail/cloud-crowbar7-job-mu-ha-update-x86_64/8/pipeline/) build)