### PR TITLE
cloud-gating: re-add extra_params support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,6 @@ matrix:
     - name: "Validate Jenkins (jjb)"
       language: python
       install:
-        - pip install jenkins-job-builder
+        - pip install 'jenkins-job-builder!=3.0.0'
       script:
         - make jjb_test

--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -75,7 +75,8 @@ pipeline {
                 rc_notify            : false,
                 cleanup              : "never",
                 git_automation_repo  : git_automation_repo,
-                git_automation_branch: git_automation_branch
+                git_automation_branch: git_automation_branch,
+                extra_params         : extra_params
               ]
               // override default parameters with those loaded from config file
               job_params.putAll(job_def.job_params)

--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
@@ -71,7 +71,8 @@ pipeline {
                 rc_notify            : false,
                 cleanup              : "never",
                 git_automation_repo  : git_automation_repo,
-                git_automation_branch: git_automation_branch
+                git_automation_branch: git_automation_branch,
+                extra_params         : extra_params
               ]
               // override default parameters with those loaded from config file
               job_params.putAll(job_def.job_params)


### PR DESCRIPTION
Re-add the ability to pass parameters value overrides through
the `extra_params` parameter in the `cloud-8|9-gating` and
`cloud-maintenance-gating` jobs.
This ability was removed when these jobs were migrated to use
a yaml configuration file listing the jobs they must trigger.