### PR TITLE
openstack-crowbar: do not handle extra_repos via bootstrap-crowbar.yml (SOC-9296)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/main.yml
@@ -31,7 +31,9 @@
     - maint_updates_list | length
 
 - include_tasks: add_extra_repos.yml
-  when: extra_repos_list | length
+  when:
+    - extra_repos_list | length
+    - cloud_product == 'ardana'
 
 - include_tasks: set_motd.yml
   when: task == 'deploy'


### PR DESCRIPTION
Crowbar deployment leaves handling `extra_repos` on qa_crowbar_setup.sh in `addupdaterepo` step.
Reference failed ci job:
https://ci.suse.de/blue/organizations/jenkins/cloud-crowbar7-job-mu-ha-deploy-x86_64/detail/cloud-crowbar7-job-mu-ha-deploy-x86_64/18/pipeline#step-71-log-279

from manual run with the fix:
```
host-192-168-124-10:~ # zypper se -s | grep crowbar-openstack
i  | crowbar-openstack                                 | package     | 4.0+git.1562759922.43761a6ac-0           | noarch | cloud-ptf               
v  | crowbar-openstack                                 | package     | 5.0+git.1559335140.62bb4c014-4.25.1      | noarch | cloudmaintup            
v  | crowbar-openstack                                 | package     | 5.0+git.1554709170.195ba0e26-4.22.2      | noarch | cloudmaintup            
v  | crowbar-openstack                                 | package     | 5.0+git.1550668971.0719acd6c-4.19.1      | noarch | cloudmaintup       

```