### PR TITLE
openstack-ardana: update tempest correctly (SOC-9296)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_services_serial.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_services_serial.yml
@@ -23,4 +23,4 @@
     chdir: "{{ ardana_scratch_path }}"
   environment:
     SKIP_REPO_CHECKS: 1
-  loop: "['ARD-SVC--first-member'] + {{ ardana_nodes.stdout_lines }}"
+  loop: "['ARD-SVC--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"


### PR DESCRIPTION
The test automation scripts that implement the maintenance update
workflow for Ardana run the `ardana-deploy.yml` playbook serially
on every node, starting with the deployer. It does this by using
the `--limit` ansible parameter to limit the host where that
playbook runs. However, tempest is special, because it also creates
virtual ansible hosts which it then uses as a target for some of
the ansible tasks that update tempest configuration.

For that reason, we need to include those virtual hosts when we
run the `ardana-update.yml` playbook limited to the deployer node,
otherwise the tempest configuration doesn't get updated.