### PR TITLE
crowbar: Increase sync_mark timeout multiplier for cloud 9 (SOC-10009)

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -36,6 +36,7 @@
     controllers: '3'
     computes: '2'
     ses_enabled: true
+    sync_mark_timeout_multiplier: '2.0'
     triggers:
      - timed: 'H H * * *'
     jobs:

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -340,6 +340,15 @@
           description: >-
             Re-run failed tempest test cases.
 
+      - validating-string:
+          name: sync_mark_timeout_multiplier
+          default: '{sync_mark_timeout_multiplier|1.0}'
+          regex: '[+-]?([0-9]*[.])[0-9]+'
+          msg: The entered value failed validation - requires a floating point value
+          description: >-
+            Set the crowbar sync_mark_timeout multiplier. Can be used to increase/decrease
+            the crowbar sync mark timeout.
+
       - hidden:
           name: cloud_product
           default: 'crowbar'

--- a/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
@@ -9,6 +9,7 @@ cloud_fqdn: "{{ cloud_env }}.prv.suse.net"
 
 mkcloud_config_file: "{{ workspace_path }}/mkcloud.config"
 crowbar_batch_file: "{{ workspace_path }}/scenario.yml"
+sync_mark_timeout_multiplier: "1.0"
 
 ssl_enabled: true
 

--- a/scripts/jenkins/cloud/ansible/install-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/install-crowbar.yml
@@ -53,6 +53,27 @@
           loop_control:
             loop_var: command
 
+        - block:
+            - name: Get sync_mark json from data bag
+              command: "knife data bag show crowbar-config sync_mark -F json"
+              register: _sync_mark_json
+
+            - name: Update timeout_multiplier value to {{ sync_mark_timeout_multiplier }}
+              set_fact:
+                _sync_mark_updated: "{{ _sync_mark_json.stdout | from_json | combine(
+                  { 'timeout_multiplier': sync_mark_timeout_multiplier }) }}"
+
+            - name: Generate json with updated sync_mark
+              copy:
+                content: "{{ _sync_mark_updated | to_json }}"
+                dest: "/tmp/crowbar_sync_mark.json"
+
+            - name: Insert json with updated sync_mark timeout_multiplier on data bag
+              command: "knife data bag from file crowbar-config /tmp/crowbar_sync_mark.json"
+              register: _data_bag_update_result
+              changed_when: _data_bag_update_result.rc == 0
+          when: sync_mark_timeout_multiplier != "1.0"
+
         # reboot node after crowbar install
         - include_role:
             name: reboot_node


### PR DESCRIPTION
The cloud-crowbar9-job-ha-x86_64 job has been occasionally failing due
to timeouts. This change increase the timeout multiplier for the cloud 9
jobs  as a way to avoid those issues.