### PR TITLE
crowbar: add tempest tests on MU jobs for cloud 9 (SOC-9298)

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -72,10 +72,16 @@
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            heat,magnum,manila"
       - cloud-crowbar9-job-mu-no-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            heat,magnum,manila"
     jobs:
         - '{crowbar_job}'
 
@@ -110,9 +116,15 @@
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            heat,magnum,manila"
       - cloud-crowbar9-job-mu-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            heat,magnum,manila"
     jobs:
         - '{crowbar_job}'


### PR DESCRIPTION
For the crowbar cloud 9 maintenance update gating jobs run tempest for
validating the deployment.