### PR TITLE
Report known jenkins job failures to its Jira card

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -364,6 +364,9 @@ pipeline {
           automation-git/scripts/cloud/pr-failure.sh
         fi
       '''
+      script {
+        cloud_lib.track_failure()
+      }
     }
     cleanup {
       cleanWs()

--- a/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy
@@ -217,4 +217,18 @@ def run_with_reserved_env(reserve, resource_label, default_resource, body) {
   }
 }
 
+def track_failure() {
+  ansible_playbook('report-job-failure')
+
+  def jiraIssuesFilePath = "${WORKSPACE}/.artifacts/triggered_issues.txt"
+  def jiraUrlList = []
+  if (fileExists(jiraIssuesFilePath)) {
+    def jiraIssues = readFile jiraIssuesFilePath
+    for (issue in jiraIssues.split("\n")) {
+      jiraUrlList = jiraUrlList + "<a href='https://jira.suse.com/browse/${issue}'>${issue}</a>"
+    }
+    currentBuild.description = "Jira issue(s): " + jiraUrlList.join(", ")
+  }
+}
+
 return this

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -335,6 +335,11 @@ pipeline {
         }
       }
     }
+    failure {
+      script {
+        cloud_lib.track_failure()
+      }
+    }
     cleanup {
       cleanWs()
     }

--- a/scripts/jenkins/cloud/ansible/report-job-failure.yml
+++ b/scripts/jenkins/cloud/ansible/report-job-failure.yml
@@ -1,0 +1,23 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Report known failures to Jira
+  hosts: "localhost"
+  gather_facts: no
+
+  roles:
+    - jira_issue_report

--- a/scripts/jenkins/cloud/ansible/roles/jira_issue_report/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/jira_issue_report/defaults/main.yml
@@ -1,0 +1,19 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+jenkins_build_url: "{{ lookup('ENV', 'BUILD_URL') }}"
+jira_known_issues_url: "https://etherpad.nue.suse.com/p/cloud-jira-issue-report"

--- a/scripts/jenkins/cloud/ansible/roles/jira_issue_report/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/jira_issue_report/tasks/main.yml
@@ -1,0 +1,47 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Get build log and known issues
+  set_fact:
+    _build_log: "{{ lookup('url', jenkins_build_url ~ '/consoleText').split(',') }}"
+    jira_known_issues: "{{ lookup('url', jira_known_issues_url ~ '/export/txt', split_lines=False) | from_yaml }}"
+
+- name: Comment on jira card
+  jira:
+    uri: "https://jira.suse.com"
+    username: "{{ lookup('pipe', 'grep -A2 jira ~/.netrc | grep login | cut -d\" \" -f4') }}"
+    password: "{{ lookup('pipe', 'grep -A2 jira ~/.netrc | grep password | cut -d\" \" -f4') }}"
+    issue: "{{ item.issue }}"
+    operation: "comment"
+    comment: |
+      The following build failure matches an error message associated to this issue:
+        - {{ jenkins_build_url }}
+
+      Source: {{ jira_known_issues_url }}
+  register: _triggered_issues
+  when: _build_log | select('match', item.regexp) | list
+  loop: "{{ jira_known_issues }}"
+
+- name: Save known triggered issues
+  lineinfile:
+    line: "{{ item.item.issue }}"
+    dest: "{{ jenkins_artifacts_dir }}/triggered_issues.txt"
+    create: yes
+  when:  not 'skipped' in item
+  loop: "{{ _triggered_issues.results }}"
+  loop_control:
+    label: "{{ item.item.issue }}"


### PR DESCRIPTION
Keeping track of the known issues related to failures on the cloud
jenkins jobs is kinda hard (nowadays there are many jenkins jobs
crowbar/ardana/7/8/9, sometimes it is not easy to reproduce the
issue and we think the issue was fixed, there is already a ticket opened
for the issue and another one is created...).

This change makes keeping track of those failures easier by
automatically commenting on the existing jira card whenever a know issue
happens. It also edit the job description with the link of the known
jira cards related to job failure (if there is any).