### PR TITLE
openstack-ardana: do not rerun teardown failed tempest tests

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
@@ -1,6 +1,8 @@
 {% set regexp = '\[.*]$' %}
 {% set test = tempest_failed_tests.stdout_lines[0] %}
-{% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
-{% set regexp = '.*\(|\)$' %}
-{% endif %}
+{% if not test.startswith('tearDownClass') %}
+{%   if test.startswith('setUpClass')%}
+{%     set regexp = '.*\(|\)$' %}
+{%   endif %}
 +{{ test | regex_replace(regexp, '') }}
+{% endif %}

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
@@ -1,7 +1,9 @@
 {% set regexp = '\[.*]$' %}
 {% for test in tempest_failed_tests.stdout_lines[1:] %}
-{% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
-{% set regexp = '.*\(|\)$' %}
-{% endif %}
+{%   if not test.startswith('tearDownClass') %}
+{%     if test.startswith('setUpClass') %}
+{%       set regexp = '.*\(|\)$' %}
+{%     endif %}
 +{{ test | regex_replace(regexp, '') }}
+{%   endif %}
 {% endfor %}


### PR DESCRIPTION
Re-running teardown failed tests causes it to re-run all set of tests
part of the teardown class.