### PR TITLE
cloud-gate: fix deploy-and-update Ardana gating jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -44,10 +44,10 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
-            designate,heat,ceilometer,magnum,freezer,monasca"
+            designate,heat,manila,ceilometer,magnum,freezer,monasca"
       - cloud-ardana8-job-gate-entry-scale-kvm-update-x86_64:
           cloudsource: develcloud8
-          update_cloudsource: stagingcloud8
+          update_to_cloudsource: stagingcloud8
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
@@ -57,10 +57,10 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            designate,heat,magnum,monasca"
+            designate,heat,manila,magnum,monasca"
       - cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64:
           cloudsource: develcloud9
-          update_cloudsource: stagingcloud9
+          update_to_cloudsource: stagingcloud9
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\


### PR DESCRIPTION
The `update_to_cloudsource` parameter was not set for these jobs,
which means the staging media was not installed and no updates
were actually performed.

This commit also re-adds manila to the Ardana deploy gating jobs.