### PR TITLE
cloud-gating: better handling for extra_params

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -34,9 +34,8 @@
     computes: '2'
     ses_enabled: true
     ses_rgw_enabled: false
-    extra_params: |
-      tempest_retry_failed=True
-      update_services_serial=False
+    tempest_retry_failed: true
+    update_services_serial: false
     triggers: []
     ardana_job:
       - cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64:

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -9,9 +9,8 @@
     computes: '2'
     ses_enabled: true
     ses_rgw_enabled: false
-    extra_params: |
-      tempest_retry_failed=True
-      update_services_serial=True
+    tempest_retry_failed: true
+    update_services_serial: true
     triggers: []
     ardana_job:
       - cloud-ardana8-job-mu-entry-scale-kvm-deploy-x86_64:

--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -75,11 +75,15 @@ pipeline {
                 rc_notify            : false,
                 cleanup              : "never",
                 git_automation_repo  : git_automation_repo,
-                git_automation_branch: git_automation_branch,
-                extra_params         : extra_params
+                git_automation_branch: git_automation_branch
               ]
               // override default parameters with those loaded from config file
               job_params.putAll(job_def.job_params)
+              // combine together extra_params from this job with those loaded from config file
+              combined_extra_params = [extra_params, job_def.job_params.extra_params?: ""].join('\n').trim()
+              if (!combined_extra_params.isEmpty()) {
+                 job_params.extra_params = combined_extra_params
+              }
               cloud_lib.trigger_build(job_def.job_name, cloud_lib.convert_to_build_params(job_params))
             }
           }

--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
@@ -76,11 +76,15 @@ pipeline {
                 rc_notify            : false,
                 cleanup              : "never",
                 git_automation_repo  : git_automation_repo,
-                git_automation_branch: git_automation_branch,
-                extra_params         : extra_params
+                git_automation_branch: git_automation_branch
               ]
               // override default parameters with those loaded from config file
               job_params.putAll(job_def.job_params)
+              // combine together extra_params from this job with those loaded from config file
+              combined_extra_params = [extra_params, job_def.job_params.extra_params?: ""].join('\n').trim()
+              if (!combined_extra_params.isEmpty()) {
+                 job_params.extra_params = combined_extra_params
+              }
               cloud_lib.trigger_build(job_def.job_name, cloud_lib.convert_to_build_params(job_params))
             }
           }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -470,6 +470,18 @@
             with special configurations.
 
       - hidden:
+          name: update_services_serial
+          default: '{update_services_serial|false}'
+          description: >-
+            Update services one node at a time instead of updating them on all nodes in parallel.
+
+      - hidden:
+          name: tempest_retry_failed
+          default: '{tempest_retry_failed|false}'
+          description: >-
+            Re-run failed tempest test cases.
+
+      - hidden:
           name: cloud_product
           default: 'ardana'
           description: >-

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -335,6 +335,12 @@
             with special configurations.
 
       - hidden:
+          name: tempest_retry_failed
+          default: '{tempest_retry_failed|false}'
+          description: >-
+            Re-run failed tempest test cases.
+
+      - hidden:
           name: cloud_product
           default: 'crowbar'
           description: >-


### PR DESCRIPTION
This commit attempts to improve the way `extra_params` are
handled in the gating jobs (both staging and maintenance),
by doing the following:
  - avoid setting `extra_params` in downstream jobs, because
  those will be overwritten if `extra_params` are set in the
  gating jobs. Instead, use hidden parameters to avoid cluttering
  the jobs unnecessarily
  - combine the `extra_params` set in the gating jobs with those
  loaded from the job yaml configuration file and, if the result
  is not empty, use that when triggering downstream jobs