### PR TITLE
cloud-gating: fix JJB failures with older JJB

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -34,8 +34,8 @@
     computes: '2'
     ses_enabled: true
     ses_rgw_enabled: false
-    tempest_retry_failed: true
-    update_services_serial: false
+    tempest_retry_failed: 'true'
+    update_services_serial: 'false'
     triggers: []
     ardana_job:
       - cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64:

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -9,8 +9,8 @@
     computes: '2'
     ses_enabled: true
     ses_rgw_enabled: false
-    tempest_retry_failed: true
-    update_services_serial: true
+    tempest_retry_failed: 'true'
+    update_services_serial: 'true'
     triggers: []
     ardana_job:
       - cloud-ardana8-job-mu-entry-scale-kvm-deploy-x86_64:


### PR DESCRIPTION
Use string values instead of boolean with hidden parameters,
because some older JJB versions don't know how handle that.