### PR TITLE
openstack-crowbar/ardana: allow periodic jobs to use lockable resources

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
             fi
           ''')
           cloud_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy"
-          cloud_lib.load_os_params_from_resource(cloud_env)
+          cloud_lib.load_os_params_from_resource(cloud_env, reserve_env.toBoolean())
           cloud_lib.load_extra_params_as_vars(extra_params)
           cloud_lib.ansible_playbook('load-job-params',
                                       "-e jjb_type=job-template -e jjb_file=$WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml"

--- a/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy
@@ -23,9 +23,10 @@ def load_extra_params_as_vars(extra_params) {
 // 1. the 'cloud-ci' OpenStack project (supplied via `os_project_name`) is reserved
 //    and may only be used with 'cloud_env' values that correspond to CI Lockable Resource
 //    slots
-// 2. CI Lockable Resource slots may not be used directly by manually triggered jobs.
+// 2. CI Lockable Resource slots may not be used directly by manually triggered jobs
+//    without reserving the resource
 //
-def load_os_params_from_resource(cloud_env) {
+def load_os_params_from_resource(cloud_env, is_reserved=false) {
   def is_lockable_resource = false
   if (cloud_env.startsWith("engcloud-ci-slot")) {
     env.os_cloud = "engcloud"
@@ -43,7 +44,7 @@ Please adjust your 'cloud_env' or 'os_project_name' parameter values to avoid th
     error(errMsg)
   }
 
-  if (is_lockable_resource && currentBuild.upstreamBuilds.isEmpty()) {
+  if (is_lockable_resource && !is_reserved && currentBuild.upstreamBuilds.isEmpty()) {
     def errMsg = """The '${cloud_env}' cloud environment name may not be used with manually triggered jobs.
 Please adjust your 'cloud_env' parameter value to avoid this error, or use the parent job instead."""
     echo errMsg

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
             fi
           ''')
           cloud_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy"
-          cloud_lib.load_os_params_from_resource(cloud_env)
+          cloud_lib.load_os_params_from_resource(cloud_env, reserve_env.toBoolean())
           cloud_lib.load_extra_params_as_vars(extra_params)
           cloud_lib.ansible_playbook('load-job-params',
                                       "-e jjb_type=job-template -e jjb_file=$WORKSPACE/automation-git/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml"


### PR DESCRIPTION
The Jenkins pipeline check recently implemented to prevent manually
triggered jobs from using environments regulated through lockable
resource slots doesn't take into account periodic jobs, which
have no upstream job and still reserve a lockable resource.