### PR TITLE
openstack-ardana/crowbar: minimize virtual storage requirements

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
@@ -34,11 +34,12 @@ disabled_services: ""
 # all applicable barclamps will be deployed.
 enabled_services: ""
 
-# Disable extra volume groups in the generated disk models when LVM is
-# disabled in the base image, since these have no effect anyway as long as
-# `skip_disk_config` is also used to skip LVM disk configuration
-# in deployed clouds
-enable_extra_volume_groups: "{{ want_lvm }}"
+# Disable extra volume groups in the disk models generated for the virtual
+# cloud deployments, otherwise they will be implemented as Ceph volumes,
+# which have a latency higher than the ephemeral disk used for the root
+# partition, which is implemented using the local storage available on the
+# underlying OpenStack compute node.
+enable_extra_volume_groups: False
 
 swiftobj_disk_enabled: True
 

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/disk_models.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/disk_models.yml
@@ -107,7 +107,7 @@
 
 {%         endif %}
 
-{%       elif service_component_group == 'COMPUTE' and not cinder_lvm_enabled %}
+{%       elif service_component_group == 'COMPUTE' and cinder_lvm_enabled %}
 {%         set ns.drive_idx = ns.drive_idx+1 %}
 
       - name: vg-comp

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/defaults/main.yml
@@ -18,6 +18,7 @@
 heat_resource_name_prefix: "{{ cloud_env }}-cloud"
 rhel_distro_id: "rhel{{ rhel_os_version }}-x86_64"
 rhel_image: "centos{{ rhel_os_version }}"
+disk_size: 2
 
 # Versioned virtualized configuration artifacts
 virt_artifacts:
@@ -29,7 +30,6 @@ virt_artifacts:
     clm_flavor: cloud-ardana-job-compute
     controller_flavor: cloud-ardana-job-controller
     compute_flavor: cloud-ardana-job-compute
-    disk_size: 20
   cloud8:
     sles_distro_id: sles12sp3-x86_64
     rhel_distro_id: "{{ rhel_distro_id }}"
@@ -38,7 +38,6 @@ virt_artifacts:
     clm_flavor: cloud-ardana-job-compute
     controller_flavor: cloud-ardana-job-controller
     compute_flavor: cloud-ardana-job-compute
-    disk_size: 20
   cloud9:
     sles_distro_id: sles12sp4-x86_64
     rhel_distro_id: "{{ rhel_distro_id }}"
@@ -47,7 +46,6 @@ virt_artifacts:
     clm_flavor: cloud-ardana-job-compute
     controller_flavor: cloud-ardana-job-controller
     compute_flavor: cloud-ardana-job-compute
-    disk_size: 20
 
 # Exhaustive list of service components required by the CLM node.
 # When service components that are not in this list are hosted
@@ -83,7 +81,7 @@ virt_config:
   compute_flavor: '{{ compute_flavor|default(virt_artifacts[cloud_release].compute_flavor) }}'
   sles_image: '{{ sles_image|default(virt_artifacts[cloud_release].sles_image) }}'
   rhel_image: '{{ rhel_image|default(virt_artifacts[cloud_release].rhel_image) }}'
-  disk_size: '{{ disk_size|default(virt_artifacts[cloud_release].disk_size) }}'
+  disk_size: '{{ disk_size }}'
   flavors: '{{ flavors|default([]) }}'
   images: '{{ images|default([]) }}'
   disks: '{{ disks|default([]) }}'


### PR DESCRIPTION
Minimize the amount of virtual storage required by the CLM and
Crowbar virtual deployments by making the following changes to
the cloud generator and heat generator components:
 - move all CLM services to the root partition by default instead
 of using dedicated volumes for database/rabbitmq, LMM, cinder and
 glance. This should also add to the overall performance of the
 deployed cloud, e.g. because LMM services will no longer use
 a volume implemented using the Ceph back-end, which has a higher
 latency then the root partition, which uses the ephemeral volume
 located on the underlying OpenStack compute node.
 - reduce the default size of the remaining Ceph volumes from 20 GB to
 2 GB. The only remaining service that still uses Ceph volumes is
 Swift, which doesn't really need 20 GB of storage space, especially
 since SES is used as the preferred storage back-end for deployed
 cloud environments. NOTE: this means that Swift will still
 use Ceph volumes in the underlying infrastructure, with all
 the consequences related to performance that come with it.

This PR reduces the current CI Ceph storage requirements from 4 TB down
to 250 GB (reported to the current number of 21 Lockable Resource slots).
The _expected_ resource requirements are documented [here](https://confluence.suse.com/pages/viewpage.action?spaceKey=SOC&title=Cloud+CI+Resource+Usage)