### PR TITLE
openstack-crowbar: increase sync_mark_timeout_multiplier to 1.5 globally (SOC-10009)

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -36,7 +36,6 @@
     controllers: '3'
     computes: '2'
     ses_enabled: true
-    sync_mark_timeout_multiplier: '2.0'
     triggers:
      - timed: 'H H * * *'
     jobs:

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -342,7 +342,7 @@
 
       - validating-string:
           name: sync_mark_timeout_multiplier
-          default: '{sync_mark_timeout_multiplier|1.0}'
+          default: '{sync_mark_timeout_multiplier|1.5}'
           regex: '[+-]?([0-9]*[.])[0-9]+'
           msg: The entered value failed validation - requires a floating point value
           description: >-

--- a/scripts/jenkins/cloud/ansible/install-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/install-crowbar.yml
@@ -53,6 +53,10 @@
           loop_control:
             loop_var: command
 
+        - name: Check if sync mark timeout_multiplier feature is present
+          command: "knife data bag show crowbar-config -F json"
+          register: _crowbar_config_json
+
         - block:
             - name: Get sync_mark json from data bag
               command: "knife data bag show crowbar-config sync_mark -F json"
@@ -72,7 +76,9 @@
               command: "knife data bag from file crowbar-config /tmp/crowbar_sync_mark.json"
               register: _data_bag_update_result
               changed_when: _data_bag_update_result.rc == 0
-          when: sync_mark_timeout_multiplier != "1.0"
+          when:
+            - sync_mark_timeout_multiplier != "1.0"
+            - "'sync_mark' in (_crowbar_config_json.stdout | from_json)"
 
         # reboot node after crowbar install
         - include_role:

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -217,3 +217,12 @@ qa_test_list: ''
 #============= Rocketchat =============#
 # Notify RocketChat when deployment starts/finishes.
 rc_notify: false
+
+
+#============= Extra =============#
+# Set the Crowbar sync_mark_timeout multiplier. Can be used to increase/decrease
+# the crowbar sync mark timeout globally. This parameter is useful when sync
+# mark timeout failures occur frequently while deploying Crowbar. The default
+# 1.5 value has been proven experimentally to work best with virtual Crowbar
+# deployments.
+sync_mark_timeout_multiplier: 1.5


### PR DESCRIPTION
Recent ECP HA Crowbar builds failing due to pacemaker sync mark
issues have confirmed that the problem is generalized to all
Crowbar versions. The issues occur because one or more virtual
controller nodes are slower due to environmental issues, such as
running on a crowded ECP compute node.

Increasing the sync mark timeout multiplier to 2.0 only for Crowbar
version 9 jobs yielded good results. This commit promotes the 1.5
value as the default timeout multiplier value used with all Crowbar
jobs.

The sync mark multiplier feature hasn't yet been officially released
for Crowbar cloud 7 and 8, therefore setting `sync_mark_timeout_multiplier`
to a value other than the default 1.0 will fail when testing maintenance
updates for SLES12_SP2 and SLES12_SP3.

This PR also introduces a check to auto-detect if the
sync_mark_timeout_multiplier feature is present, to avoid running
into such failures.