### PR TITLE
cloud-maintenance-gating: implement additional checks

### DIFF
--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
       failFast false
       steps {
         script {
-          parallel cloud_lib.generate_parallel_stages(
+          def parallelJobMap = cloud_lib.generate_parallel_stages(
             ["SOC" + version, "SOCC" + version],
             [],
             "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml") {
@@ -87,6 +87,15 @@ pipeline {
               cloud_lib.trigger_build(job_def.job_name, cloud_lib.convert_to_build_params(job_params))
             }
           }
+
+          if (parallelJobMap.isEmpty()) {
+            def errorMsg = "ERROR: No jobs found that matched the SOC${version} and SOCC${version} cloud versions."
+            echo errorMsg
+            error(errorMsg)
+          }
+
+          parallel parallelJobMap
+
         }
       }
     }


### PR DESCRIPTION
Implement additional checks in the maintenance and staging gating
job:
  - always check that there's at least one downstream job found
  in the job configuration that corresponds to the affected cloud
  version(s), to avoid validating the staging media or maintenance
  update without actually running any tests
  - address the use-case when a maintenance update has already
  been released