### PR TITLE
[UNTESTED] fix devstack local.conf tweaks to tempest and neutron

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -213,10 +213,10 @@ USE_PYTHON3=$USE_PYTHON3
 PYTHON3_VERSION=$PYTHON3_VERSION
 $DEVSTACK_EXTRA_CONFIG
 
-[[test-config|$$TEMPEST_CONFIG]]
+[[test-config|\$TEMPEST_CONFIG]]
 [compute]
 min_compute_nodes = 1
-[[post-config|$$NEUTRON_CONF]]
+[[post-config|\$NEUTRON_CONF]]
 [DEFAULT]
 global_physnet_mtu = 1450
 EOF


### PR DESCRIPTION
[Not tested yet but since this has been broken for ever and is low risk and trivial I think we could merge anyway.]

The `local.conf` tweaks to tempest and neutron used by `qa_devstack.sh` never worked, because the wrong kind of escaping was used.  `$$` expanded to whatever pid number the code happened to be running under, resulting in `local.conf` containing something like

    [[test-config|9471TEMPEST_CONFIG]]
    [compute]
    min_compute_nodes = 1

    [[post-config|9471NEUTRON_CONF]]
    [DEFAULT]
    global_physnet_mtu = 1450

This was because the heredoc was done as `<<EOF` therefore subject to normal shell double-quotes interpolation.  However this interpolation is required in order for the

    SERVICE_IP_VERSION=$SVC_IP_VERSION

line in `local.conf` to expand correctly.

So instead escape the `$` correctly with backslash.