### PR TITLE
openstack-crowbar/ardana: Increase openstack.integrate call timeout

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ses_cloud_integration/tasks/ses_configure_v2.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ses_cloud_integration/tasks/ses_configure_v2.yml
@@ -30,6 +30,7 @@
   uri:
     url: "http://{{ hostvars['ses-' ~ ses_cluster_id].ansible_host }}:8000/"
     method: POST
+    timeout: 60
     headers:
       X-Auth-Token: "{{ _salt_token.json.return.0.token }}"
     body:


### PR DESCRIPTION
The cloud deployments are occasionally failing due to a timeout during
the openstack.integrate call. The default timeout is 30 seconds, however
sometimes the task takes around 40 seconds to conclude. This change
increases the timeout to 60 seconds to be on the safe side.