### PR TITLE
Revert "openstack-ardana: do not rerun teardown failed tempest tests"

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
@@ -1,8 +1,6 @@
 {% set regexp = '\[.*]$' %}
 {% set test = tempest_failed_tests.stdout_lines[0] %}
-{% if not test.startswith('tearDownClass') %}
-{%   if test.startswith('setUpClass')%}
-{%     set regexp = '.*\(|\)$' %}
-{%   endif %}
-+{{ test | regex_replace(regexp, '') }}
+{% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
+{% set regexp = '.*\(|\)$' %}
 {% endif %}
++{{ test | regex_replace(regexp, '') }}

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
@@ -1,9 +1,7 @@
 {% set regexp = '\[.*]$' %}
 {% for test in tempest_failed_tests.stdout_lines[1:] %}
-{%   if not test.startswith('tearDownClass') %}
-{%     if test.startswith('setUpClass') %}
-{%       set regexp = '.*\(|\)$' %}
-{%     endif %}
+{% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
+{% set regexp = '.*\(|\)$' %}
+{% endif %}
 +{{ test | regex_replace(regexp, '') }}
-{%   endif %}
 {% endfor %}


### PR DESCRIPTION
Reverting this change as if we do not re-run the teardown failures it will report as the test as failed anyways. Better give it another chance just like we do for the other cases.