### PR TITLE
openstack-crowbar: increase simple horizon test timeout (SOC-10011)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4839,7 +4839,7 @@ function onadmin_testsetup
     get_horizon
     echo "openstack horizon server:  $horizonserver"
     echo "openstack horizon service: $horizonservice"
-    curl -L -m 120 -s -S -k http://$horizonservice | \
+    curl -L -m 180 -s -S -k http://$horizonservice | \
         grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" \
     || complain 101 "simple horizon test failed"
 


### PR DESCRIPTION
With SSL enabled it requires a bit more time to resolve the horizon
page. This change adds 1 minute to the current timeout (2 minutes).