### PR TITLE
Add socok8s-trackupstream job

### DIFF
--- a/jenkins/ci.opensuse.org/socok8s-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/socok8s-trackupstream.yaml
@@ -1,0 +1,33 @@
+- job:
+    name: 'socok8s-trackupstream'
+    project-type: matrix
+
+    triggers:
+      - timed: 'H 1 * * *'
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 15
+
+    axes:
+      - axis:
+          type: user-defined
+          name: project
+          values:
+            - Cloud:socok8s:master
+      - axis:
+          type: user-defined
+          name: component
+          values:
+            - socok8s
+      - axis:
+          type: slave
+          name: slave
+          values:
+            - cloud-trackupstream
+    execution-strategy:
+      sequential: true
+    builders:
+      - update-automation
+      - shell: |
+          ~/github.com/SUSE-Cloud/automation/scripts/jenkins/track-upstream.sh

--- a/scripts/jenkins/track-upstream.sh
+++ b/scripts/jenkins/track-upstream.sh
@@ -37,6 +37,9 @@ case $OBS_TYPE in
             Cloud:OpenStack:Master)
                 OSC_BUILD_DIST=SLE_15
                 ;;
+            Cloud:socok8s:master)
+                OSC_BUILD_DIST=SLE_15_SP1
+                ;;
             *)
                 echo "Support missing"
                 exit 1


### PR DESCRIPTION
Similar to openstack-trackupstream and cloud-trackupstream, a new job
called soco-trackupstream is added.
This job will periodically update the Cloud:socok8s:master/socok8s RPM
package from the git source defined in the _service file.
This is needed to get an updated ISO with the latest socok8s code on a
daily base.