### PR TITLE
cloud-generator: restrict generated pacemaker barclamps

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/README.md
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/README.md
@@ -411,7 +411,8 @@ service group
 
 , the following Crowbar batch scenario elements:
 
-* one pacemaker proposal for each _cluster_ _service group_ that has more than one node member
+* one pacemaker proposal for each _cluster_ _service group_ that has more than one node member and
+is associated with at least one barclamp role that can be clustered
 * the deployment part of each barclamp proposal, based on the _service component groups_ in each _service group_
 
 , and the following Crowbar `mkcloud.confg` variables:

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/lib/common.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/lib/common.yml.j2
@@ -67,9 +67,11 @@
 {%           set _updated_roles = deployment[role] | default({}) %}
 {%           set _ = _updated_roles.update({service_group.name: service_group}) %}
 {%           set _ = deployment.update({role: _updated_roles}) %}
+{%           if role not in non_clustered_roles %}
+{%             set _ = ns.enabled_service_groups.update({service_group.name: True}) %}
+{%           endif %}
 {%         endfor %}
 {%         set _ = ns.deployments.update({barclamp: deployment}) %}
-{%         set _ = ns.enabled_service_groups.update({service_group.name: True}) %}
 {%       endif %}
 {%     endfor %}
 {%   endfor %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/scenario.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/scenario.yml.j2
@@ -10,7 +10,8 @@ proposals:
 {#
 
    Generate the pacemaker barclamps, based on the clusters service groups
-   configured in the scenario.
+   configured in the scenario, but only if the cluster is associated with
+   at least one barclamp role that can be clustered.
 
 #}
 {% for service_group in scenario.service_groups if service_group.type == 'cluster' and service_group.member_count|int > 1 and enabled_clusters[service_group.name] %}


### PR DESCRIPTION
Restrict generating pacemaker barclamps for clusters that are
associated with at least one barclamp role that can be clustered.

This fixes the mid-scale-kvm scenario, which was generating an
additional pacemaker barclamp for the swift-storage nodes.