### PR TITLE
openstack-crowbar: log simple horizon test curl output (SOC-10011)

### DIFF
--- a/scripts/jenkins/cloud/ansible/run-crowbar-tests.yml
+++ b/scripts/jenkins/cloud/ansible/run-crowbar-tests.yml
@@ -56,6 +56,7 @@
               - src: "{{ tempest_results_subunit }}"
               - src: "{{ subunit_xml_results }}"
               - src: "{{ subunit_html_results }}"
+              - src: "~/simple_horizon.log"
           when: lookup("env", "WORKSPACE")
 
   post_tasks:

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -931,6 +931,7 @@ function testsetup
     [[ $want_ironic = 1 ]] && teardown_ironic_test_env
 
     $scp root@$(wrap_ip $adminip):tempest*.log "$artifacts_dir/"
+    $scp root@$(wrap_ip $adminip):simple_horizon.log "$artifacts_dir/"
 
     # Register the cloud in Rally and import the results
     if [[ $rally_server && -f $artifacts_dir/tempest.subunit.log ]] ; then

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4839,7 +4839,7 @@ function onadmin_testsetup
     get_horizon
     echo "openstack horizon server:  $horizonserver"
     echo "openstack horizon service: $horizonservice"
-    curl -L -m 180 -s -S -k http://$horizonservice | \
+    curl -L -m 180 -s -S -k http://$horizonservice | tee simple_horizon.log | \
         grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" \
     || complain 101 "simple horizon test failed"
 


### PR DESCRIPTION
The simple horizon test occasionally fails and there is no way to debug
it without knowing what the curl is returning.