### PR TITLE
openstack-ardana: Increase rpc response timeout on virtual deployments (SOC-9285)

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
@@ -22,6 +22,7 @@ ardana_common_extra_vars:
   nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"
   nova_cpu_mode: custom
   nova_cpu_model: Westmere
+  nova_rpc_response_timeout: 90
   # When the mariadb is running on top of shared storage, decouple commit and
   # flush operations, to account for its high latency and prevent performance
   # issues


### PR DESCRIPTION
Due to the limitations of virtual deployments some operations takes
logger to be processed resulting in erros such as `MessagingTimeout:
Timed out waiting for a reply to message ID
2ecfb7e8756f41d99920052fd768bd88` which is ocasionally making some tests
fail.

This change increases the rpc response timeout of the nova service from
60 seconds to 90 seconds. This change is expected to fix numeral tests
failures related to octavia.