### PR TITLE
openstack-crowbar: run tempest on cloud 9 gating jobs (SOC-10029)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -73,6 +73,7 @@
     reserve_env: false
     updates_test_enabled: true
     reboot_after_deploy: true
+    tempest_retry_failed: 'true'
     scenario_name: standard
     controllers: '1'
     computes: '2'
@@ -90,6 +91,13 @@
           cloudsource: stagingcloud9
           ses_enabled: true
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            heat,magnum,manila"
+          # Delete when adding to the cloud 9 gating job
+          cloud_env: cloud-crowbar-test-slot
+          triggers:
+           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'
 
@@ -97,8 +105,9 @@
 - project:
     name: cloud-crowbar-job-gate-ha-x86_64
     reserve_env: false
-    updates_test_enabled: false
+    updates_test_enabled: true
     reboot_after_deploy: true
+    tempest_retry_failed: 'true'
     scenario_name: standard
     controllers: '3'
     computes: '2'
@@ -116,6 +125,13 @@
           cloudsource: stagingcloud9
           ses_enabled: true
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            heat,magnum,manila"
+          # Delete when adding to the cloud 9 gating job
+          cloud_env: cloud-crowbar-test-slot
+          triggers:
+           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'
 
@@ -125,7 +141,7 @@
     reserve_env: false
     updates_test_enabled: true
     reboot_after_deploy: true
-    tempest_retry_failed: true
+    tempest_retry_failed: 'true'
     neutron_networkingplugin: linuxbridge
     crowbar_networkingmode: team
     scenario_name: standard
@@ -145,5 +161,12 @@
           cloudsource: stagingcloud9
           ses_enabled: true
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
+            heat,magnum,manila"
+          # Delete when adding to the cloud 9 gating job
+          cloud_env: cloud-crowbar-test-slot
+          triggers:
+           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
@@ -53,7 +53,7 @@
   shell: knife node list | tr -d ' '
   register: _register_tmp
   # The more nodes we have, the longer this will take
-  retries: "{{ 4 * ( groups['cloud_virt_hosts'] | length ) }}"
+  retries: "{{ 6 * ( groups['cloud_virt_hosts'] | length ) }}"
   until: _register_tmp.rc == 0 and crowbar_node_name in _register_tmp.stdout_lines
   delay: 10
 
@@ -62,6 +62,6 @@
   shell: "knife node show -a state {{ crowbar_node_name }} | awk '{ print $2 }'"
   register: _register_tmp
   # The more nodes we have, the longer this will take
-  retries: "{{ 4 * ( groups['cloud_virt_hosts'] | length ) }}"
+  retries: "{{ 6 * ( groups['cloud_virt_hosts'] | length ) }}"
   until: _register_tmp.rc == 0 and _register_tmp.stdout == 'ready'
   delay: 10


### PR DESCRIPTION
This change enable running tempest with all filters available on the
cloud 9 gating jobs.

This change also configures the jobs to build on daily basis to evaluate
its stability before adding those jobs to the gating job. 

This change also increase the number of retries on checking the crowbar register operation. It seems like it was not enough as some jobs had failed because of it.