### PR TITLE
Cloud 9: Unified gating job (SOC-10029)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -94,11 +94,6 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
             heat,magnum,manila"
-          # Delete when adding to the cloud 9 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'
 
@@ -129,11 +124,6 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
             heat,magnum,manila"
-          # Delete when adding to the cloud 9 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'
 
@@ -166,10 +156,5 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
             heat,magnum,manila"
-          # Delete when adding to the cloud 9 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
@@ -12,6 +12,17 @@ SOC9:
   ardana9-update:
     job_name: cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64
     job_params: []
+SOCC9:
+  crowbar9-no-ha-deploy:
+    job_name: cloud-crowbar9-job-gate-no-ha-deploy-x86_64
+    job_params: []
+  crowbar9-ha-deploy:
+    job_name: cloud-crowbar9-job-gate-ha-deploy-x86_64
+    job_params: []
+  crowbar9-linuxbridge-deploy:
+    job_name: cloud-crowbar9-job-gate-linuxbridge-deploy-x86_64
+    job_params: []
+
 #
 # NOTE: to be enabled when Crowbar ECP gating jobs will replace mkcloud gating jobs
 #
@@ -34,14 +45,4 @@ SOC9:
 #    job_params: []
 #  crowbar8-linuxbridge-deploy:
 #    job_name: cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64
-#    job_params: []
-#SOCC9:
-#  crowbar9-no-ha-deploy:
-#    job_name: cloud-crowbar9-job-gate-no-ha-deploy-x86_64
-#    job_params: []
-#  crowbar9-ha-deploy:
-#    job_name: cloud-crowbar9-job-gate-ha-deploy-x86_64
-#    job_params: []
-#  crowbar9-linuxbridge-deploy:
-#    job_name: cloud-crowbar9-job-gate-linuxbridge-deploy-x86_64
 #    job_params: []


### PR DESCRIPTION
This change adds the three crowbar gating jobs (ha, no-ha, linuxbridge)
to the `cloud-9-gating` job, meaning that for the cloud 9 gating we will
have a unique job that triggers the ardana and crowbar gating jobs.

**ps**: after merging this change, besides running the update job, the `cloud-crowbar-test-slot` slots needs to be renamed to `cloud-gate9-slot`