### PR TITLE
openstack-ardana: Set monasca tuning config to small (SOC-10145)

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
@@ -23,6 +23,7 @@ ardana_common_extra_vars:
   nova_cpu_mode: custom
   nova_cpu_model: Westmere
   nova_rpc_response_timeout: 90
+  monasca_tuning_selector_override: small
   # When the mariadb is running on top of shared storage, decouple commit and
   # flush operations, to account for its high latency and prevent performance
   # issues


### PR DESCRIPTION
The monasca role chooses the tuning setting based on how much memory the
system has, meaning that for virtual deployments it is using the `demo`
setting [1]. However `monasca-thresh` is occasionally hanging during
start/stop and there is a suspicion that his happens due to the lack of
memory allocated to it.

This change override the monasca tuning parameter to use the `small`
setting. This will enable storm to use more memory (from 64 to 128 MB)
and probably fixes SOC-10145. Previous tests were made and SOC-10145 was
not reproducible when using the `small` setting (3 deployments).

1. http://git.suse.provo.cloud/cgit/ardana/monasca-ansible/tree/roles/monasca-variables/vars/configuration.yml#n48