### PR TITLE
openstack-crowbar: reserve slots for cloud9 gate jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -96,6 +96,7 @@
             heat,magnum,manila"
           # Delete when adding to the cloud 9 gating job
           cloud_env: cloud-crowbar-test-slot
+          reserve_env: true
           triggers:
            - timed: 'H H * * *'
     jobs:
@@ -130,6 +131,7 @@
             heat,magnum,manila"
           # Delete when adding to the cloud 9 gating job
           cloud_env: cloud-crowbar-test-slot
+          reserve_env: true
           triggers:
            - timed: 'H H * * *'
     jobs:
@@ -166,6 +168,7 @@
             heat,magnum,manila"
           # Delete when adding to the cloud 9 gating job
           cloud_env: cloud-crowbar-test-slot
+          reserve_env: true
           triggers:
            - timed: 'H H * * *'
     jobs:


### PR DESCRIPTION
The slots needs to be reserved or the jobs will not use the proper slot.