### PR TITLE
openstack-crowbar: fix networking mode

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/entry-scale-kvm-mml.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/entry-scale-kvm-mml.yml
@@ -21,5 +21,5 @@ scenario:
 
   service_template: mml-core
   network_template: "{{ (cloud_product == 'ardana') | ternary('compact', 'crowbar') }}"
-  interface_template: "{{ (cloud_product == 'ardana') | ternary('mml-core', 'crowbar') }}"
+  interface_template: "{{ (cloud_product == 'ardana') | ternary('mml-core', 'crowbar-' ~ crowbar_networkingmode) }}"
 

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/entry-scale-kvm.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/entry-scale-kvm.yml
@@ -32,4 +32,4 @@ scenario:
 
   service_template: standard
   network_template: "{{ (cloud_product == 'ardana') | ternary('compact', 'crowbar') }}"
-  interface_template: "{{ (cloud_product == 'ardana') | ternary('compact', 'crowbar') }}"
+  interface_template: "{{ (cloud_product == 'ardana') | ternary('compact', 'crowbar-' ~ crowbar_networkingmode) }}"

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/mid-scale-kvm.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/mid-scale-kvm.yml
@@ -40,4 +40,4 @@ scenario:
 
   service_template: full-spread
   network_template: "{{ (cloud_product == 'ardana') | ternary('full-spread', 'crowbar') }}"
-  interface_template: "{{ (cloud_product == 'ardana') | ternary('full-spread', 'crowbar') }}"
+  interface_template: "{{ (cloud_product == 'ardana') | ternary('full-spread', 'crowbar-' ~ crowbar_networkingmode) }}"

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/std-lmm.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/std-lmm.yml
@@ -35,4 +35,4 @@ scenario:
 
   service_template: std-lmm
   network_template: "{{ (cloud_product == 'ardana') | ternary('standard', 'crowbar') }}"
-  interface_template: "{{ (cloud_product == 'ardana') | ternary('standard', 'crowbar') }}"
+  interface_template: "{{ (cloud_product == 'ardana') | ternary('standard', 'crowbar-' ~ crowbar_networkingmode) }}"

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/std-split.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/std-split.yml
@@ -36,4 +36,4 @@ scenario:
 
   service_template: split
   network_template: "{{ (cloud_product == 'ardana') | ternary('standard', 'crowbar') }}"
-  interface_template: "{{ (cloud_product == 'ardana') | ternary('standard', 'crowbar') }}"
+  interface_template: "{{ (cloud_product == 'ardana') | ternary('standard', 'crowbar-' ~ crowbar_networkingmode) }}"


### PR DESCRIPTION
Extend the Crowbar networking mode support to other cloud generator
scenarios (previously only supported by the standard scenario)