### PR TITLE
heat-generator: tag servers (SOC-10184)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -289,6 +289,17 @@ resources:
 {% endif %}
       image: {{ server.image }}
       flavor: {{ server.flavor }}
+      tags:
+{%   if server.is_admin %}
+        - soc-admin-node
+{%   elif server.is_controller %}
+        - soc-controller-node
+{%   elif server.is_compute %}
+        - soc-compute-node
+          # Also tag compute node VMs to indicate that nested virtualization
+          # is actively used (SOC-10184)
+        - uses-nested-virt
+{%   endif  %}
       networks:
 {%   for port_name, port in server_ns.ports %}
           # port: {{ port.name }}


### PR DESCRIPTION
As a workaround for SOC-10184, use a `uses-nested-virt`
tag to label compute node VMs, indicating that compute nodes
should not be live-migrated because this operation breaks
nested virtualization.

This tag should be used by the underlying engineering cloud
maintenance scripts to determine if a VM can be live-migrated.