### PR TITLE
openstack-crowbar: Fix tempest_results role

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/tempest_results/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/tempest_results/tasks/main.yml
@@ -39,4 +39,6 @@
 - name: Fail if any tempest test has failed
   fail:
     msg: "{{ tempest_test_results.failed }} tests failed."
-  when: tempest_test_results.failed | int > 0
+  when:
+    - tempest_test_results is defined
+    - tempest_test_results.failed | int > 0


### PR DESCRIPTION
If the Test Cloud step fails before running tempest the job fails with
undefined variable error when trying to get the tempest results. This
change fixes that by adding a condition to only check for tempest
results when the variable is defined which means that tempest did run.