### PR TITLE
mkcloud: fix timeout waiting for admin node reboot

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1116,7 +1116,7 @@ function crowbarupgrade_5plus
         onadmin upgrade_admin_backup
         onadmin upgrade_admin_repocheck
         onadmin upgrade_admin_server
-        wait_for 400 3 "! nc -w 1 -z $adminip 22" 'crowbar to go down after upgrade'
+        wait_for 100 12 "! nc -w 10 -z $adminip 22" 'crowbar to go down after upgrade'
         wait_for_crowbar_ssh
         onadmin check_admin_server_upgraded
         # use crowbar-init to bootstrap crowbar (only for 6-7 upgrade)


### PR DESCRIPTION
This commit increases the netcat timeout when waiting for the
SSH daemon on the admin node to vanish. This mechanism is used
to detect whether the Crowbar admin node has already gone down
for reboot. Under adverse circumstances (slow mkcloud host,
bad timing), an update of the openssh package could trigger
the previous timeout of 1s early (way before the reboot), thus
leaving the cloud in an inconsistent state.