### PR TITLE
openstack-crowbar: collect supportconfig files on failure (SOC-8460)

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar.yaml
@@ -8,5 +8,6 @@
     reserve_env: false
     cleanup: never
     ses_enabled: false
+    collect_supportconfig: false
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -355,6 +355,10 @@ pipeline {
     failure {
       script {
         cloud_lib.track_failure()
+        if (collect_supportconfig == 'true') {
+          cloud_lib.ansible_playbook('collect-supportconfig')
+          archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+        }
       }
     }
     cleanup {

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -373,6 +373,12 @@
           description: >-
             Cloud product (ardana or crowbar)
 
+      - hidden:
+          name: collect_supportconfig
+          default: '{collect_supportconfig|true}'
+          description: >-
+            Collect supportconfig files when the job fails
+
     pipeline-scm:
       scm:
         - git:

--- a/scripts/jenkins/cloud/ansible/collect-supportconfig.yml
+++ b/scripts/jenkins/cloud/ansible/collect-supportconfig.yml
@@ -1,0 +1,38 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- import_playbook: _create-vcloud-inventory.yml
+
+- name: Bootstrap crowbar cloud nodes
+  hosts: "{{ cloud_env }}, cloud_virt_hosts"
+  remote_user: root
+  gather_facts: true
+
+  tasks:
+
+    - include_role:
+        name: supportconfig
+        # Required to make supportconfig_filepath accessible to jenkins_artifacts
+        public: yes
+
+    - include_role:
+        name: jenkins_artifacts
+      when: lookup("env", "WORKSPACE")
+      vars:
+        jenkins_artifacts_to_collect:
+          - src: "{{ supportconfig_filepath }}"

--- a/scripts/jenkins/cloud/ansible/roles/supportconfig/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/supportconfig/defaults/main.yml
@@ -1,0 +1,24 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+supportconfig_pkgs:
+  - bzip2
+  - supportutils
+  - supportutils-plugin-suse-openstack-cloud
+
+supportconfig_filename: "{{ cloud_env }}-{{ (inventory_hostname in groups['deployer_virt']) | ternary('admin', inventory_hostname) }}"
+supportconfig_filepath: "/var/log/nts_{{ supportconfig_filename }}.tbz"

--- a/scripts/jenkins/cloud/ansible/roles/supportconfig/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/supportconfig/tasks/main.yml
@@ -1,0 +1,30 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- name: Install requirements for supportconfig
+  zypper:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ supportconfig_pkgs }}"
+
+- name: Generate supportconfig
+  shell: |
+    supportconfig -B {{ supportconfig_filename }}
+  args:
+    creates: "{{ supportconfig_filepath }}"
+  failed_when: false


### PR DESCRIPTION
Implement an ansible playbook and role to generate and collect
supportconfig files from all cloud nodes.
Collect supportconfig files as Jenkins artifacts by default in all
periodic and gating Crowbar jobs in case of failure.