### PR TITLE
Remove cloud-maintenance RC notifications

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -113,8 +113,6 @@ rc_channels:
   qe202: "cloud-qe-hlm202"
   qe2023: "cloud-qe-hlm2023par"
   qescale: "cloud-qe-scale"
-  engcloud-ci-slot16: "cloud-maintenance"
-  engcloud-ci-slot17: "cloud-maintenance"
   engcloud-ci-slot18: "cloud-ci-monitoring"
   engcloud-ci-slot19: "cloud-ci-monitoring"
   engcloud-ci-slot20: "cloud-ci-monitoring"


### PR DESCRIPTION
We closed the cloud-maintenance RC channel some time ago. Let's remove
the RC notifications.