### PR TITLE
Add collect supportconfig to ardana (SOC-8460)

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana.yaml
@@ -8,5 +8,6 @@
     reserve_env: false
     tempest_filter_list: ''
     cleanup: never
+    collect_supportconfig: false
     jobs:
         - '{ardana_job}'

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -366,6 +366,10 @@ pipeline {
       '''
       script {
         cloud_lib.track_failure()
+        if (collect_supportconfig == 'true') {
+          cloud_lib.ansible_playbook('collect-supportconfig')
+          archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+        }
       }
     }
     cleanup {

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -487,6 +487,12 @@
           description: >-
             Cloud product (ardana or crowbar)
 
+      - hidden:
+          name: collect_supportconfig
+          default: '{collect_supportconfig|true}'
+          description: >-
+            Collect supportconfig files when the job fails
+
     pipeline-scm:
       scm:
         - git:

--- a/scripts/jenkins/cloud/ansible/bootstrap-vcloud-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-vcloud-nodes.yml
@@ -137,6 +137,9 @@
             group: ardana
             mode: 0600
 
+        - include_role:
+            name: ssh_keys
+
         - name: Enable skip_disk_config on non-deployer nodes
           file:
             state: "{{ item.state }}"


### PR DESCRIPTION
Collect supportconfig files as Jenkins artifacts by default in all
periodic and gating Ardana jobs in case of failure.

This also requires setting up passwordless SSH access for the root
account on the Ardana cloud nodes. This is needed by the SSH jump-host
feature used to collect supportconfig files.