### PR TITLE
openstack-crowbar: handle partial supportconfig (SOC-8460)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/supportconfig/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/supportconfig/tasks/main.yml
@@ -21,6 +21,7 @@
     name: "{{ item }}"
     state: present
   loop: "{{ supportconfig_pkgs }}"
+  failed_when: false
 
 - name: Generate supportconfig
   shell: |


### PR DESCRIPTION
Sometimes the deployment may fail before the cloud nodes are
registered, so the repositories aren't properly set up. In that
case, the supportconfig collection logic only needs to collect
supportconfig files from the admin node.