### PR TITLE
Increase debug output for OpenStack components

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -31,6 +31,12 @@
           description: >-
             Reserve the 'cloud_env' lockable resource throughout the execution of this job.
 
+      - bool:
+          name: debug
+          default: '{debug|false}'
+          description: >-
+            Debug 'qa_crowbarsetup.sh' and OpenStack services, i.e. add a lot of verbose output.
+
       - choice:
           name: os_cloud
           choices:

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -2,8 +2,13 @@
 {% include 'barclamps/lib/common.yml.j2' %}
 {% set deployments = ns.deployments %}
 
+{% if debug %}
+export debug_qa_crowbarsetup=1
+export debug_openstack=1
+{% else %}
 # export debug_qa_crowbarsetup=0
 # export debug_openstack=0
+{% endif %}
 
 # export drbdnode_mac_vol=
 export cloud={{ cloud_env }}


### PR DESCRIPTION
When a CI job fails it helps if the logs contain debug level
information. This change enables debug for OpenStack components with
Crowbar.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>