### PR TITLE
openstack-crowbar: upgrade test automation and periodic job (SOC-10314)

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -42,6 +42,24 @@
         - '{crowbar_job}'
 
 - project:
+    name: cloud-crowbar9-job-upgrade-x86_64
+    crowbar_job: '{name}'
+    cloudsource: stagingcloud8
+    upgrade_cloudsource: stagingcloud9
+    cloud_env: cloud-crowbar-ci-slot
+    scenario_name: std-lmm
+    controllers: '1'
+    computes: '1'
+    ses_enabled: false
+    enabled_services: database,rabbitmq,keystone,swift,monasca,glance,cinder,neutron,nova,horizon
+    extra_params: |
+      ssl_enabled=false
+    triggers:
+     - timed: 'H H * * *'
+    jobs:
+        - '{crowbar_job}'
+
+- project:
     name: cloud-crowbar9-job-image-update
     cloud_image_update_job: '{name}'
     os_cloud:

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -145,6 +145,24 @@
             NOTE: use this parameter only if you want to use a generated input model. To use an existing input model instead,
             leave this field empty and use the 'model' parameter instead.
 
+      - choice:
+          name: upgrade_cloudsource
+          choices:
+            - '{upgrade_cloudsource|}'
+            - stagingcloud8
+            - develcloud8
+            - GM8+up
+            - stagingcloud9
+            - develcloud9
+            - GM9+up
+          description: >-
+            The cloud repository to be used for a cloud upgrade.
+            This value can take the following form:
+
+               stagingcloud<X> (Devel:Cloud:X:Staging)
+               develcloud<X> (Devel:Cloud:X)
+               GM<X>+up (official GM plus Cloud-Updates)
+
       - extended-choice:
           name: enabled_services
           type: multi-select

--- a/scripts/jenkins/cloud/ansible/crowbar-upgrade.yml
+++ b/scripts/jenkins/cloud/ansible/crowbar-upgrade.yml
@@ -1,0 +1,84 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- name: Upgrade cloud - crowbar
+  hosts: "{{ cloud_env }}"
+  remote_user: root
+  gather_facts: True
+  vars:
+    extra_upgrade_vars:
+      upgrade_progress_file: "/var/lib/crowbar/upgrade/{{ cloud_release_number }}-to-{{ (cloud_release_number | int) + 1 }}-progress.yml"
+      UPDATEREPOS_UPGRADE: "{{ (upgrade_repos | length > 0) | ternary(upgrade_repos.split(',') | join('+'), '') }}"
+      cloudsource: "{{ upgrade_cloudsource }}"
+      want_nodesupgrade: 1
+  tasks:
+    - block:
+        - include_role:
+            name: crowbar_setup
+          vars:
+            qa_crowbarsetup_cmd: "{{ upgrade_step.command }}"
+            override_vars: "{{ extra_upgrade_vars|combine(upgrade_step.vars|default({})) }}"
+            override_vars_reason: upgrade
+          loop:
+            - command: onadmin_prepare_cloudupgrade_nodes_repos
+            - command: onadmin_zypper_patch_all
+              vars:
+                cloudsource: "{{ cloudsource }}"
+            - command: onadmin_upgrade_prechecks
+              vars:
+                cloudsource: "{{ cloudsource }}"
+            - command: onadmin_allow_vendor_change_at_nodes
+              vars:
+                cloudsource: "{{ cloudsource }}"
+              enabled: "{{ 'devel' in cloudsource or 'staging' in cloudsource or 'devel' in upgrade_cloudsource or 'staging' in upgrade_cloudsource }}"
+            - command: onadmin_prepare_crowbar_upgrade
+            - command: onadmin_prepare_cloudupgrade_admin_repos
+            - command: onadmin_addupdaterepo upgrade
+              enabled: "{{ extra_upgrade_vars.UPDATEREPOS_UPGRADE != '' }}"
+            - command: onadmin_upgrade_admin_backup
+            - command: onadmin_upgrade_admin_repocheck
+            - command: onadmin_upgrade_admin_server
+          loop_control:
+            loop_var: upgrade_step
+          when: upgrade_step.enabled | default(True)
+
+        - include_role:
+            name: reboot_node
+          vars:
+            reboot_target: deployer
+            reboot_in_progress: True
+
+        - include_role:
+            name: crowbar_setup
+          vars:
+            qa_crowbarsetup_cmd: "{{ upgrade_step.command }}"
+          loop:
+            - command: onadmin_check_admin_server_upgraded
+            - command: onadmin_wait_for_crowbar_api
+            - command: onadmin_crowbar_nodeupgrade
+          loop_control:
+            loop_var: upgrade_step
+          when: upgrade_step.enabled | default(True)
+
+      always:
+        - include_role:
+            name: jenkins_artifacts
+          when: lookup("env", "WORKSPACE")
+          vars:
+            jenkins_artifacts_to_collect:
+              - src: "{{ qa_crowbarsetup_log }}"

--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -18,6 +18,8 @@ cloud_env: localhost
 
 cloudsource: stagingcloud9
 
+upgrade_cloudsource: ""
+
 # cloud product can be ardana or crowbar
 cloud_product: "ardana"
 
@@ -26,7 +28,8 @@ cloud_admin_user:
   crowbar: root
 
 # The cloud release is encoded in the cloudsource value
-cloud_release: "cloud{{ cloudsource | regex_search('\\d') }}"
+cloud_release_number: "{{ cloudsource | regex_search('\\d') }}"
+cloud_release: "cloud{{ cloud_release_number }}"
 cloud_git_branch:
   cloud8: "stable/pike"
   cloud9: "master"

--- a/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
@@ -24,3 +24,5 @@ ssl_cert_required: false
 ssl_certfile: /etc/cloud/ssl/certs/signing_cert.pem
 ssl_keyfile: /etc/cloud/private/signing_key.pem
 ssl_ca_certs: /etc/ssl/ca-bundle.pem
+
+upgrade_repos: ''

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -30,6 +30,7 @@ export cloudsource=develcloud{{ cloudsource[-1] }}
 export TESTHEAD=1
 {% else %}
 export cloudsource={{ cloudsource }}
+export TESTHEAD=
 {% endif %}
 
 # export mkclouddriver=
@@ -66,10 +67,10 @@ export crowbar_networkingmode={{ crowbar_networkingmode }}
 # export cinder_netapp_login=
 # export cinder_netapp_password=
 
-{% if extra_repos is defined and extra_repos | length > 0 != '' %}
+{% if extra_repos is defined and extra_repos | length > 0 %}
 export UPDATEREPOS={{ extra_repos.split(',') | join('+') }}
 {% endif %}
-# export UPDATEREPOS_UPGRADE=
+
 # export UPDATEREPOS_EXTRA=
 # export NOINSTALLCLOUDPATTERN=
 

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_setup/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_setup/tasks/main.yml
@@ -1,5 +1,27 @@
 ---
 
+- name: Add override env vars to mkcloud.config
+  blockinfile:
+    path: "{{ admin_mkcloud_config_file }}"
+    marker: "# {mark} {{ override_vars_reason|default('') }} environment variable overrides "
+    block: |
+      {% for var_name, var_value in override_vars.items() %}
+      {%   if var_name == 'cloudsource' %}
+      {%     if var_value.startswith("stagingcloud") %}
+      export cloudsource=develcloud{{ var_value[-1] }}
+      export TESTHEAD=1
+      {%     else %}
+      export cloudsource={{ var_value }}
+      export TESTHEAD=
+      {%     endif %}
+      {%   else %}
+      export {{ var_name }}={{ var_value }}
+      {%   endif %}
+      {% endfor %}
+  delegate_to: "{{ cloud_env }}"
+  run_once: true
+  when: override_vars is defined
+
 - name: Run 'qa_crowbarsetup.sh {{ qa_crowbarsetup_cmd }}' on the admin node
   shell: |-
     . {{ admin_scripts_path }}/qa_crowbarsetup.sh
@@ -11,4 +33,3 @@
   delegate_to: "{{ cloud_env }}"
   register: _qa_crowbarsetup_result
   run_once: true
-

--- a/scripts/jenkins/cloud/ansible/roles/reboot_node/tasks/reboot_deployer.yml
+++ b/scripts/jenkins/cloud/ansible/roles/reboot_node/tasks/reboot_deployer.yml
@@ -21,10 +21,20 @@
   poll: 0
   failed_when: false
   become: yes
+  when: not reboot_in_progress | default(False)
 
-- name: Wait for node after reboot
+- name: Wait node to go down
+  wait_for:
+    host: "{{ hostvars[cloud_env].ansible_host }}"
+    port: 22
+    search_regex: OpenSSH
+    state: stopped
+    sleep: 12
+    timeout: 1200
+  delegate_to: localhost
+
+- name: Wait for node to come back up
   wait_for_connection:
-    delay: 5
 
 - name: Get host uptime
   shell: cut -d " " -f 1 /proc/uptime

--- a/scripts/jenkins/cloud/manual/deploy-crowbar.sh
+++ b/scripts/jenkins/cloud/manual/deploy-crowbar.sh
@@ -34,4 +34,5 @@ install_crowbar
 register_crowbar_nodes
 deploy_cloud
 update_cloud
+upgrade_cloud
 run_crowbar_tests

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -63,6 +63,11 @@ update_after_deploy: false
 # This opention takes the same values as cloudsource.
 update_to_cloudsource: ''
 
+# Only valid if update_after_deploy is true. The cloud repository to be used for
+# upgrade (Crowbar only).
+# This option takes the same values as cloudsource.
+upgrade_cloudsource: ''
+
 # List of maintenance update IDs separated by comma (eg. 7396,7487)
 maint_updates: ''
 

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -259,6 +259,14 @@ function update_cloud {
     fi
 }
 
+function upgrade_cloud {
+    if $(get_from_input deploy_cloud) && [[ -n $(get_from_input upgrade_cloudsource) ]]; then
+        if [ "$(get_cloud_product)" == "crowbar" ]; then
+            ansible_playbook crowbar-upgrade.yml
+        fi
+    fi
+}
+
 function run_tempest {
     if $(is_defined tempest_filter_list); then
         tempest_filter_list=($(echo "$(get_from_input tempest_filter_list)" | tr ',' '\n'))


### PR DESCRIPTION
Extend the unified Cloud test automation toolchain to allow testing
cloud upgrade use cases:
 - implement a new ansible playbook, `crowbar-upgrade.yml`, that
 executes the same steps as the `mkcloud` `cloudupgrade` function,
 by invoking the corresponding `qa_crowbarsetup.sh` steps
 - add an `upgrade_cloudsource` ansible variable that can be used
 to specify the target cloud source to be used for an upgrade
 - the additional `upgrade_repos` and `want_nodesupgrade` variables
 can be used to specify custom upgrade repositories (i.e. the
 UPDATEREPOS_UPGRADE `qa_crowbarsetup.sh` variable) and to control
 whether cloud nodes are also upgraded or not

This PR also creates [a periodic job](https://ci.suse.de/view/Cloud/view/Cloud%209%20Crowbar/job/cloud-crowbar9-job-upgrade-x86_64/) running a cloud 8 to 9 upgrade scenario
using a 2-node environment with monasca enabled, a minimal list
of openstack services and SSL disabled. This job will be updated as the
upgrade effort advances to cover more services.