### PR TITLE
Configure server and agents to run centralized (SOC-9144)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - include_tasks: reconfigure_neutron.yml
   vars:
-    extra_vars: "-e router_distributed=False"
+    extra_vars: "-e router_distributed=False -e enable_distributed_routing=False"
   when: tempest_run_filter in ['vpnaas', 'fwaas']
 
 - include_tasks: import_octavia_image.yml

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
@@ -22,11 +22,6 @@
   args:
     chdir: "{{ ardana_scratch_path }}"
 
-# FIXME: workaround for SCRD-9144
-- name: Wait a while to give neutron agents time to recover
-  pause:
-    minutes: 5
-
 - name: Run neutron-status
   shell: |
     ansible-playbook neutron-status.yml


### PR DESCRIPTION

When the neutron server is configured with distributed routing disabled
the agents must also be explicitly configure to run with distributed
routing disable.

Recent changes to neutron OpenStack make it unnecessary to wait for
neutron agent to recover.