### PR TITLE
Increased Crowbar webui timeouts after reboot - "SCRD-10174"

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/reboot_node/tasks/reboot_deployer.yml
+++ b/scripts/jenkins/cloud/ansible/roles/reboot_node/tasks/reboot_deployer.yml
@@ -39,8 +39,8 @@
   uri:
     url: http://127.0.0.1:3000/
     status_code: 200
-  retries: 3
-  delay: 9
+  retries: 10
+  delay: 30
   register: _uri_output
   until: "(_uri_output.status == 200)"
   when: cloud_product == 'crowbar'


### PR DESCRIPTION
After reboot the crowbar UI takes less minutes to be available so we
have to increase it.