### PR TITLE
openstack-crowbar/ardana: prevent underscores in cloud_env (continued)

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -11,9 +11,9 @@
       - validating-string:
           name: cloud_env
           default: 'cloud-maintenance-slot'
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -34,9 +34,9 @@
       - validating-string:
           name: cloud_env
           default: ''
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -34,9 +34,9 @@
       - validating-string:
           name: cloud_env
           default: ''
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -34,9 +34,9 @@
       - validating-string:
           name: cloud_env
           default: ''
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -13,9 +13,9 @@
       - validating-string:
           name: cloud_env
           default: ''
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -15,9 +15,9 @@
       - validating-string:
           name: cloud_env
           default: '{cloud_env|}'
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -14,9 +14,9 @@
       - validating-string:
           name: cloud_env
           default: '{cloud_env|}'
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -14,9 +14,9 @@
       - validating-string:
           name: cloud_env
           default: '{cloud_env|}'
-          regex: '[A-Za-z0-9-_]+'
+          regex: '[A-Za-z0-9-]+'
           msg: >-
-            Empty or malformed value (only alphanumeric, '-' and '_' characters are allowed).
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
           description: >-
             The virtual or hardware environment identifier. This field should either
             be set to one of the values associated with the known hardware environments


### PR DESCRIPTION
The `cloud_env` value is reflected into the hostnames set up
for the cloud nodes, so we must prevent underscore characters
from being part of it because they are not allowed to be part
of a hostname value [1].

This commit is a followup to 88b233b9e0856d1f1238dddf312fca7ffc7c9797,
which didn't cover all the jobs.

[1] https://www.ietf.org/rfc/rfc952.txt - B. Lexical grammar