### PR TITLE
Drop uneeded option and job for socok8s (SOC-10120)

### DIFF
--- a/jenkins/ci.suse.de/cloud-socok8s.yaml
+++ b/jenkins/ci.suse.de/cloud-socok8s.yaml
@@ -5,13 +5,6 @@
     # the credentialId for opensusegithubapi
     repo-credentials: c2350527-476a-45df-b406-84f028614682
     jobs:
-      - '{name}-integration-{tempest}':
-          tempest: 'without-tempest'
-          # tempest: 'with-tempest'
-          run_tempest: false
-          tempest_test_type: smoke
       - '{name}-nightly-airship-from-rpm'
       - '{name}-daily-airship-integration':
-          run_tempest: true
           tempest_test_type: all
-

--- a/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
@@ -1,47 +1,4 @@
 - job-template:
-    name: '{name}-integration-{tempest}'
-    project-type: multibranch
-    periodic-folder-trigger: 5m
-    number-to-keep: 30
-    days-to-keep: 30
-    script-path: Jenkinsfile.integration
-    parameters:
-      - choice:
-          name: deployment
-          choices:
-            - 'airship'
-            - 'osh'
-          default: 'airship'
-          description: >-
-            Which deployment mechanism?
-      - bool:
-          name: run_tempest
-          default: '{run_tempest|true}'
-          description: >-
-            Run tempest tests?
-      - choice:
-          name: tempest_test_type
-          choices:
-            - 'all'
-            - 'smoke'
-          default: 'all'
-          description: >-
-            Run all or smoke tempest tests?
-    scm:
-      - github:
-          repo: '{repo-name}'
-          repo-owner: '{repo-owner}'
-          credentials-id: '{repo-credentials}'
-          branch-discovery: no-pr
-          discover-pr-forks-strategy: current
-          discover-pr-forks-trust: permission
-          discover-pr-origin: current
-          submodule:
-            recursive: true
-          notification-context: continuous-integration/jenkins
-          filter-head-regex: ^(master|stable\-\d\.\d|PR\-\d+)$
-
-- job-template:
     name: '{name}-nightly-airship-from-rpm'
     project-type: pipeline
     concurrent: false
@@ -101,11 +58,6 @@
           default: 'airship'
           description: >-
             Which deployment mechanism?
-      - bool:
-          name: run_tempest
-          default: '{run_tempest|true}'
-          description: >-
-            Run tempest tests?
       - choice:
           name: tempest_test_type
           choices:


### PR DESCRIPTION
Drops the run_tempest option as its no longer optional to run
tempest.
As a side effect, drop also the smoke tempest job as all PRs and
master are now running tempest+smoke tests and we already have a
daily job for testing the full tempest suite