### PR TITLE
Add tempest filters to cloud 8 crowbar jobs (SOC-9799)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -87,6 +87,9 @@
           cloudsource: stagingcloud8
           ses_enabled: false
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,lbaas,heat,magnum,manila"
       - cloud-crowbar9-job-gate-no-ha-deploy-x86_64:
           cloudsource: stagingcloud9
           ses_enabled: true
@@ -122,6 +125,9 @@
           cloudsource: stagingcloud8
           ses_enabled: false
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,lbaas,heat,magnum,manila"
       - cloud-crowbar9-job-gate-ha-deploy-x86_64:
           cloudsource: stagingcloud9
           ses_enabled: true
@@ -159,6 +165,9 @@
           cloudsource: stagingcloud8
           ses_enabled: false
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,lbaas,heat,magnum,manila"
       - cloud-crowbar9-job-gate-linuxbridge-deploy-x86_64:
           cloudsource: stagingcloud9
           ses_enabled: true

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -50,8 +50,8 @@
           multi-select-delimiter: ','
           default-value: ''
           value: >-
-            smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
-            lbaas,heat,magnum,manila
+            smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
+            trove,aodh,lbaas,heat,magnum,manila
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -278,8 +278,8 @@
           multi-select-delimiter: ','
           default-value: '{tempest_filter_list|}'
           value: >-
-            smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
-            lbaas,heat,magnum,manila
+            smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
+            trove,aodh,lbaas,heat,magnum,manila
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.


### PR DESCRIPTION
For SOC8 jobs we need run tempest tests for ceilometer,aodh and trove and those filter options currently not available in  CI job setup.