### PR TITLE
 openstack-crowbar: add cloud-7-gating job (SOC-10029)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -5,6 +5,8 @@
       - project: 'cloud-{version}-gating'
         block: false
     cloud_url_trigger_job:
+      - cloud-7-gating-trigger:
+          version: '7'
       - cloud-8-gating-trigger:
           version: '8'
       - cloud-9-gating-trigger:
@@ -17,6 +19,9 @@
     concurrent: False
     cloud_env: 'cloud-gate{version}-slot'
     cloud_gating_job:
+      - cloud-7-gating:
+          version: '7'
+          skip_submit_project: 'true'
       - cloud-8-gating:
           version: '8'
       - cloud-9-gating:

--- a/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
@@ -12,19 +12,19 @@ SOC9:
   ardana9-update:
     job_name: cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64
     job_params: []
+SOCC7:
+  crowbar7-no-ha-deploy:
+    job_name: cloud-crowbar7-job-gate-no-ha-deploy-x86_64
+    job_params: []
+  crowbar7-ha-deploy:
+    job_name: cloud-crowbar7-job-gate-ha-deploy-x86_64
+    job_params: []
+  crowbar7-linuxbridge-deploy:
+    job_name: cloud-crowbar7-job-gate-linuxbridge-deploy-x86_64
+    job_params: []
 #
 # NOTE: to be enabled when Crowbar ECP gating jobs will replace mkcloud gating jobs
 #
-#SOCC7:
-#  crowbar7-no-ha-deploy:
-#    job_name: cloud-crowbar7-job-gate-no-ha-deploy-x86_64
-#    job_params: []
-#  crowbar7-ha-deploy:
-#    job_name: cloud-crowbar7-job-gate-ha-deploy-x86_64
-#    job_params: []
-#  crowbar7-linuxbridge-deploy:
-#    job_name: cloud-crowbar7-job-gate-linuxbridge-deploy-x86_64
-#    job_params: []
 #SOCC8:
 #  crowbar8-no-ha-deploy:
 #    job_name: cloud-crowbar8-job-gate-no-ha-deploy-x86_64

--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -101,6 +101,9 @@ pipeline {
     }
 
     stage('Submit project') {
+      when {
+        expression { skip_submit_project == 'false' }
+      }
       steps {
         script{
           cloud_lib.trigger_build("openstack-submit-project", [

--- a/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
@@ -34,7 +34,13 @@
           name: version
           default: '{version}'
           description: >-
-            Cloud version number (8, 9 etc.)
+            Cloud version number (7, 8, 9 etc.)
+
+      - hidden:
+          name: skip_submit_project
+          default: '{skip_submit_project|false}'
+          description:
+            Set to true to skip the submit project step
 
       - text:
           name: extra_params

--- a/scripts/jenkins/cloud/ansible/run-crowbar-tests.yml
+++ b/scripts/jenkins/cloud/ansible/run-crowbar-tests.yml
@@ -45,6 +45,8 @@
 
         - include_role:
             name: tempest_results
+            apply:
+              ignore_errors: yes
 
         - include_role:
             name: jenkins_artifacts


### PR DESCRIPTION
This change adds the cloud-7-gating and its trigger jobs.

For now skip the submit project step until we are sure of the coverage
and stability of its downstream jobs compared to the mkcloud7 gate jobs.

For skipping the submit project step this change also adds a hidden parameter on the cloud-X-gating jobs that can be set to optionally skip the submit project step.