### PR TITLE
openstack-crowbar: correct update procedure

### DIFF
--- a/scripts/jenkins/cloud/ansible/crowbar-update.yml
+++ b/scripts/jenkins/cloud/ansible/crowbar-update.yml
@@ -47,17 +47,9 @@
               delegate_to: "{{ target_host }}"
           vars:
             inventory_hostname: "{{ target_host }}"
-          loop: "{{ [cloud_env]+groups['cloud_virt_hosts'] }}"
+          loop: "{{ groups['cloud_virt_hosts'] }}"
           loop_control:
             loop_var: target_host
-
-        - include_role:
-            name: reboot_node
-          vars:
-            reboot_target: deployer
-          when:
-            - update_after_deploy
-            - reboot_after_deploy
 
         - include_role:
             name: crowbar_setup
@@ -65,7 +57,25 @@
             qa_crowbarsetup_cmd: onadmin_rebootcloud
           when:
             - reboot_after_deploy
-            - update_after_deploy
+
+        - include_role:
+            name: crowbar_update
+            apply:
+              delegate_to: "{{ cloud_env }}"
+          vars:
+            inventory_hostname: "{{ cloud_env }}"
+
+        - include_role:
+            name: reboot_node
+          vars:
+            reboot_target: deployer
+          when:
+            - reboot_after_deploy
+
+        - include_role:
+            name: crowbar_setup
+          vars:
+            qa_crowbarsetup_cmd: "crowbar batch export | crowbar batch --timeout 2400 build"
 
       rescue:
         - include_role:


### PR DESCRIPTION
The automated process used to install Crowbar maintenance
updates on a pre-deployed cloud is currently broken, because
it incorrectly combines two workflows that should be tested
separately: one workflow to patch cloud nodes (no crowbar
changes) and another workflow to update crowbar LCM packages.

The current process can be described as follows:
 - on every node, in sequence, starting with the admin node:
   - add the maintenance update repositories
   - run zypper patch
 - reboot the admin node
 - reboot the other nodes, in sequence, starting with
 controller nodes (using 'crowbarctl node reboot')

The part that is incorrect is applying the crowbar LCM updates
and then rebooting the cloud nodes without re-applying the barclamp
configuration first. After reboot, a cloud node will apply the
new chef configuration individually from the other nodes, which
can lead to inconsistencies and failures when there are barclamp
schema updates. This is also incorrect for another reason: it
doesn't verify that non-LCM package updates preserve backwards
compatibility (i.e. OpenStack and SLE package updates must be
backwards-compatible with the LCM functionality).

This commit changes moves installing LCM updates at the end of the
automated process:
 - on every node, except the admin node, in sequence:
   - add the maintenance update repositories
   - run zypper patch
 - reboot the cloud nodes (i.e. non-admin nodes), in sequence,
 starting with controller nodes (using 'crowbarctl node reboot')
 - on the admin node:
   - add the maintenance update repositories
   - run zypper patch
   - reboot the admin node
   - re-apply all the barclamps (e.g. by using crowbar batch
   export/apply)

The new procedure tests the workflow that patches cloud nodes
in the first stage, then the workflow that installs Crowbar
LCM updates in the second stage.