### PR TITLE
cloud-gating/maintenance-gating: cleanup on success

### DIFF
--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                 cloud_env            : reserved_env,
                 reserve_env          : false,
                 rc_notify            : false,
-                cleanup              : "never",
+                cleanup              : "on success",
                 git_automation_repo  : git_automation_repo,
                 git_automation_branch: git_automation_branch
               ]

--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
                 reserve_env          : false,
                 maint_updates        : maint_updates,
                 rc_notify            : false,
-                cleanup              : "never",
+                cleanup              : "on success",
                 git_automation_repo  : git_automation_repo,
                 git_automation_branch: git_automation_branch
               ]


### PR DESCRIPTION
Switch to cleaning up environments if jobs are successful.

NOTE: doing this should reduce the amount of ECP environments
running when jobs are passing and during low CI load periods.