### PR TITLE
revert osc release process (SOC-10025)

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-prepare-staging.py
+++ b/jenkins/ci.opensuse.org/openstack-prepare-staging.py
@@ -149,7 +149,7 @@ def prepare(branch):
 
 def main():
     branch = os.environ['openstack_project']
-    if branch in ('Rocky', 'Stein'):
+    if branch in ('disabled'):
         sys.exit(prepare(branch))
     else:
         print("%s not supported for argument openstack_project." % branch)

--- a/jenkins/ci.opensuse.org/openstack-submit.yaml
+++ b/jenkins/ci.opensuse.org/openstack-submit.yaml
@@ -50,7 +50,7 @@
             ;;
           esac
 
-          if [[ "$COS" =~ (Rocky|Stein) ]]; then
+          if [[ "$COS" =~ (disabled) ]]; then
               # TODO replace this once the osc here is new enough to have
               # https://github.com/openSUSE/osc/commit/fb80026651c47d262dbff33136ae5306ff83aff3
               $OSC api -m POST "/source/${COST}?cmd=release&nodelay=1"

--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -152,7 +152,7 @@ case "$cloudsource" in
         osrelease=${osrelease^}
         $zypper ar -G -f $cloudopenstackmirror/$osrelease/$REPO/ cloud
         if test -n "$OSHEAD" ; then
-            if [[ "$osrelease" =~ (Rocky|Stein) ]]; then
+            if [[ "$osrelease" =~ (disabled) ]]; then
                 $zypper ar -G -f $cloudopenstackmirror/$osrelease:/ToTest/$REPO/ cloudhead
             else
                 $zypper ar -G -f $cloudopenstackmirror/$osrelease:/Staging/$REPO/ cloudhead


### PR DESCRIPTION
This makes Rocky and Stein use the old process again.

OBS regularly causes conflicts that it could resolve automatically.
While each of these is a case where in the old process we would accept a
version of a package that was changed after testing started, we decided
to revert for now and revist later towards a more long term solution to
our staging needs.