### PR TITLE
upgrade: Fix Cloud9 prechecks

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -15,6 +15,8 @@
     magnumoptions: --regex '^magnum_tempest_plugin.tests.api'
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: mysql
+    want_monasca_proposal: 1
+    want_aodh_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
@@ -41,6 +43,8 @@
     storage_method_ha: swift
     database_engine: mysql
     want_all_ssl: 1
+    want_monasca_proposal: 1
+    want_aodh_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -25,6 +25,8 @@
             mkcloudtarget=plain_with_upgrade testsetup
             want_nodesupgrade=1
             want_database_sql_engine={database_engine}
+            want_monasca_proposal={want_monasca_proposal|0}
+            want_aodh_proposal={want_aodh_proposal|1}
             controller_node_memory=7864320
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-disruptive-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
@@ -33,6 +33,8 @@
             want_trove_proposal=0
             want_barbican_proposal=0
             want_sahara_proposal=0
+            want_monasca_proposal={want_monasca_proposal|0}
+            want_aodh_proposal={want_aodh_proposal|1}
             mkcloudtarget=instonly setuplonelynodes lonelynode_nfs_server proposal testpreupgrade addupdaterepo runupdate cloudupgrade testpostupgrade testsetup
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
@@ -29,6 +29,8 @@
             want_trove_proposal=0
             want_barbican_proposal=0
             want_sahara_proposal=0
+            want_monasca_proposal={want_monasca_proposal|0}
+            want_aodh_proposal={want_aodh_proposal|1}
             want_database_sql_engine={database_engine}
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}


### PR DESCRIPTION
Aodh and Monasca deployments are checked in upgrade prechecks for Cloud8-9
upgrade. These need to be adjusted to match the required state for prechecks
to pass.