### PR TITLE
Revert "Configure neutron server and agents to run centralized routing (SOC-9144)"

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
@@ -22,6 +22,11 @@
   args:
     chdir: "{{ ardana_scratch_path }}"
 
+# FIXME: workaround for SCRD-9144
+- name: Wait a while to give neutron agents time to recover
+  pause:
+    minutes: 5
+
 - name: Run neutron-status
   shell: |
     ansible-playbook neutron-status.yml


### PR DESCRIPTION
In cloud 8 Ardana, the neutron OVS agent on compute nodes still takes
a long time to restart. Re-adding the workaround to keep gating jobs
from failing.

This partially reverts commit ccdd3700f0aaae9b4d08b132485a09c55427f9a8.