### PR TITLE
qa_openstack: Add openstackupstreammaster as new cloud source

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -142,6 +142,17 @@ fi
 zypper rr cloudhead || :
 
 case "$cloudsource" in
+    openstackupstreammaster)
+        $zypper ar -G -f $cloudopenstackmirror/Upstream:/Master/standard/ upstreamcloud || :
+        $zypper mr --priority 1 upstreamcloud
+
+        $zypper ar -G -f $cloudopenstackmirror/Upstream:/Master:/Fixme/$REPO/ upstreamcloud-fixme || :
+        $zypper mr --priority 1 upstreamcloud-fixme
+
+        $zypper ar -G -f $cloudopenstackmirror/Master/$REPO/ cloud || :
+        $zypper mr --priority 22 cloud
+    ;;
+
     openstackmaster)
         $zypper ar -G -f $cloudopenstackmirror/Master/$REPO/ cloud || :
         # no staging for master


### PR DESCRIPTION
This can be used to test against Cloud:OpenStack:Upstream:Master .

Note: There are still problems from time to time when both (COM and
COUM) have the same packages with the same versions available.
But this is a starting point to test the current COUM state.