### PR TITLE
openstack-crowbar: fix crowbar_tempest rerun for SOCC8 (SOC-9799)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/tasks/retry_failed.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/tasks/retry_failed.yml
@@ -27,9 +27,11 @@
 - name: Rerun failed tests
   shell: |
     set -o pipefail
-    testdriver=testr
-    [ -f ".stestr.conf" ] && testdriver=stestr
-    $testdriver run --serial --failing | tee {{ tempest_results_log }}
+    if [ -f ".stestr.conf" ]; then
+      stestr run --serial --failing | tee {{ tempest_results_log }}
+    else
+      testr run --failing --subunit | subunit-trace | tee {{ tempest_results_log }}
+    fi
   args:
     chdir: "{{ tempest_work_dir }}"
   changed_when: false


### PR DESCRIPTION
SOCC8 uses testr instead of stestr (SOCC9) which has a different syntax
and output format. This change updates the command to rerun the failed tests accordingly.