### PR TITLE
Revert "designate: create desginate pools when designate pools is pre…

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4143,10 +4143,6 @@ function oncontroller_testsetup
         fi
     fi
 
-    # this file is created by the designate barclamp
-    designate_pools="/etc/desigate/pools.crowbar.yaml"
-    [[ -e $designate_pools ]] && designate-manage pool update --file $designate_pools
-
     # Run Tempest Smoketests if configured to do so
     tempestret=0
     if [[ $want_tempest = 1 ]]; then


### PR DESCRIPTION
…sent" (SOC-9636)

This moved into the designate barclamp. in order to ensure that the
code in the barclamp works, we need to test the code rather than
letting the CI workaround it.

This reverts commit 7973b74ecbaa12544a608f4a14f80158219f5e5b.