### PR TITLE
Fix deployer unreachable when running setup-ssh playbook

### DIFF
--- a/scripts/jenkins/cloud/ansible/setup-ssh-access.yml
+++ b/scripts/jenkins/cloud/ansible/setup-ssh-access.yml
@@ -89,11 +89,12 @@
     - block:
         - name: Wait for deployer to be accessible
           wait_for:
-            host: "{{ ansible_ssh_host }}"
+            host: "{{ hostvars[cloud_env].ansible_host }}"
             port: 22
             search_regex: OpenSSH
             state: started
             delay: 10
+          delegate_to: localhost
 
         - name: Gather facts
           setup:


### PR DESCRIPTION
The wait for deployer task should be executed from the localhost
targeting the deployer node, not on the deployer host itself.

This should fix occasional failures (when the deployer does not boot fast enough) such as in: https://ci.suse.de/blue/organizations/jenkins/openstack-crowbar/detail/openstack-crowbar/321/pipeline