### PR TITLE
Enable barbican barclamp on cloud 9 upgrade jobs (SOC-10477)

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -17,6 +17,7 @@
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: mysql
     want_monasca_proposal: 1
+    want_barbican_proposal: 1
     want_aodh_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
@@ -45,6 +46,7 @@
     database_engine: mysql
     want_all_ssl: 1
     want_monasca_proposal: 1
+    want_barbican_proposal: 1
     want_aodh_proposal: 0
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -27,6 +27,7 @@
             want_database_sql_engine={database_engine}
             want_monasca_proposal={want_monasca_proposal|0}
             want_aodh_proposal={want_aodh_proposal|1}
+            want_barbican_proposal={want_barbican_proposal|0}
             controller_node_memory={controller_node_memory|7864320}
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-disruptive-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-mariadb-template.yaml
@@ -31,7 +31,7 @@
             want_ping_running_instances=1
             want_clustered_rabbitmq=1
             want_trove_proposal=0
-            want_barbican_proposal=0
+            want_barbican_proposal={want_barbican_proposal|0}
             want_sahara_proposal=0
             want_monasca_proposal={want_monasca_proposal|0}
             want_aodh_proposal={want_aodh_proposal|1}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-nondisruptive-ha-without-nodes-upgrade-template.yaml
@@ -27,7 +27,7 @@
             mkcloudtarget=plain_with_upgrade
             want_nodesupgrade=
             want_trove_proposal=0
-            want_barbican_proposal=0
+            want_barbican_proposal={want_barbican_proposal|0}
             want_sahara_proposal=0
             want_monasca_proposal={want_monasca_proposal|0}
             want_aodh_proposal={want_aodh_proposal|1}


### PR DESCRIPTION
Currently there are 3 cloud 9 upgrade jobs:

```
cloud-mkcloud9-job-upgrade-disruptive-x86_64
cloud-mkcloud9-job-upgrade-nondisruptive-ha-mariadb-x86_64
cloud-mkcloud9-job-upgrade-nondisruptive-ha-without-nodes-upgrade-x86_64
```

This change update those job templates by adding/parameterizing the
`want_barbican_proposal` parameter and setting it to `1` on the jobs
definition. This should enable the barbican barclamp for those 3 cloud 9 upgrade jobs.