### PR TITLE
qa_openstack: Do not force install quickstart and tempest-test

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -225,7 +225,7 @@ fi
 
 # start with patterns
 $zypper -n install -t pattern cloud_controller cloud_compute cloud_network
-$zypper -n install --force openstack-quickstart openstack-tempest-test
+$zypper -n install openstack-quickstart openstack-tempest-test
 
 # for debugging, use some files if available after installing
 # the openstack-quickstart package


### PR DESCRIPTION
When calling

zypper --non-interactive -n install --force openstack-quickstart \
    openstack-tempest-test

the installation fails when both packages are in different
repositories. The failure is:

Forcing installation of 'openstack-quickstart-2019.2' from repository 'cloud'.
Package 'openstack-tempest-test' not found.

But openstack-tempest-test is provided by openstack-tempest from the
upstreamcloud repository.

The installation works fine if the "--force" option is not used.

Note: Filled also a zypper bug for it:
https://github.com/openSUSE/zypper/issues/289