### PR TITLE
upgrade: Increase controller memory for upgrade

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -11,6 +11,7 @@
     version: 9
     previous_version: 8
     arch: x86_64
+    controller_node_memory: 12582912
     tempestoptions: --smoke
     magnumoptions: --regex '^magnum_tempest_plugin.tests.api'
     label: openstack-mkcloud-SLE12-x86_64

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-upgrade-disruptive-template.yaml
@@ -27,6 +27,6 @@
             want_database_sql_engine={database_engine}
             want_monasca_proposal={want_monasca_proposal|0}
             want_aodh_proposal={want_aodh_proposal|1}
-            controller_node_memory=7864320
+            controller_node_memory={controller_node_memory|7864320}
             label={label}
             job_name=cloud-mkcloud{version}-job-upgrade-disruptive-{arch}


### PR DESCRIPTION
It was increased/changed to 7.5GB for Cloud6-7 upgrade where the default
was 6GB but for Cloud7+ the default is 12GB so this "increase" was actually
decreasing the limit.
This change adjusts this to the default 12GB from mkcloud for Cloud8-9 jobs.