### PR TITLE
Enable retry failed tempest tests on MU jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -49,6 +49,7 @@
     scenario_name: standard
     controllers: '1'
     computes: '2'
+    tempest_retry_failed: 'true'
     triggers: []
     crowbar_job:
       - cloud-crowbar7-job-mu-no-ha-deploy-x86_64:
@@ -93,6 +94,7 @@
     scenario_name: standard
     controllers: '3'
     computes: '2'
+    tempest_retry_failed: 'true'
     triggers: []
     crowbar_job:
       - cloud-crowbar7-job-mu-ha-deploy-x86_64:


### PR DESCRIPTION
In the same way as ardana, this change enable the automation to retry
tempest tests that failed for the crowbar MU jobs.