### PR TITLE
Allow to only run the crowbar trigger for one PR

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-pr-trigger.yaml
@@ -21,7 +21,7 @@
             - all
           description: |
               normal: trigger unseen PRs
-              rebuild: trigger unseend and pending PRs
+              rebuild: trigger unseen and pending PRs
               forcerebuild: trigger unseen, pending and failed PRs
               all: trigger rebuild for all open PRs (even if status is successful)
       - choice:
@@ -39,8 +39,8 @@
       - timed: 'H/10 * * * *'
 
     logrotate:
-      numToKeep: 300
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 8
 
     wrappers:
       - timeout:

--- a/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar-testbuild-pr-trigger.yaml
@@ -3,6 +3,15 @@
     node: cloud-trigger
 
     parameters:
+      - string:
+          name: prurl
+          default:
+          description: |
+            Only process this one PR with mode "all", irrespective of the below
+            mode selection.
+            Example:
+            https://github.com/SUSE-Cloud/automation/pull/0/commits/0000
+
       - choice:
           name: mode
           choices:
@@ -32,8 +41,14 @@
       - timed: 'H/10 * * * *'
 
     logrotate:
-      numToKeep: 48
-      daysToKeep: -1
+      numToKeep: -1
+      daysToKeep: 8
+
+    wrappers:
+      - timeout:
+          fail: true
+          timeout: 120
+      - timestamps
 
     builders:
       - shell: |
@@ -76,6 +91,11 @@
               repos="--only --org ${repositories%/*} --repo ${repositories##*/}"
               ;;
           esac
+
+          if [ $prurl ]; then
+            buildmode=all
+            repos="$repos --this $prurl"
+          fi
 
           # timeout should be less than the interval (currently 10m)
           timeout 500 ${ghpr} -a trigger-prs $repos --mode "$buildmode" --debugfilterchain --debugratelimit --config ${automationrepo}/scripts/github_pr/github_pr_crowbar.yaml


### PR DESCRIPTION
This was already supported in the automation trigger.
So make those two jobs more similar.

And extend the amount of runs we keep, so we have a chance to check on
failures.