### PR TITLE
openstack-crowbar: archive artifacts even if testsetup fails

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar-tests.Jenkinsfile
@@ -59,8 +59,14 @@ pipeline {
           // This step does the following on the non-admin nodes:
           //  - runs tempest (smoke) and other tests on the deployed cloud
           cloud_lib.ansible_playbook('run-crowbar-tests')
-          archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
-          junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+            junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+          }
         }
       }
     }

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -241,13 +241,19 @@ pipeline {
           // This step does the following on the non-admin nodes:
           //  - runs tempest and other tests on the deployed cloud
           cloud_lib.ansible_playbook('run-crowbar-tests')
-          archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
-          junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+        }
+      }
+      post {
+        always {
+          script {
+            archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
+            junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+          }
         }
       }
     }
 
-    stage ('Prepare tempest tests') {
+    stage('Prepare tempest tests') {
       when {
         expression { tempest_filter_list != '' }
       }
@@ -263,7 +269,7 @@ pipeline {
 
   post {
     always {
-      script{
+      script {
         sh('''
           source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
           run_python_script automation-git/scripts/jenkins/jenkins-job-pipeline-report.py \
@@ -275,7 +281,7 @@ pipeline {
         ''')
         archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
       }
-      script{
+      script {
         if (env.DEPLOYER_IP != null) {
           if (cloud_type == "virtual") {
             if (cleanup == "always" ||


### PR DESCRIPTION
If running testsetup fails the step execution is interrupted
consequently skipping the the archiveArtifacts call.

This change moves the arthieveArtifacts call to a post/always step
making sure that it will be called even in the case of an error.