### PR TITLE
openstack-crowbar: use bigger disks for swift if SES is disabled (SOC-10590)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/defaults/main.yml
@@ -18,7 +18,8 @@
 heat_resource_name_prefix: "{{ cloud_env }}-cloud"
 rhel_distro_id: "rhel{{ rhel_os_version }}-x86_64"
 rhel_image: "centos{{ rhel_os_version }}"
-disk_size: 2
+# If SES is disabled, we need a greater disk size for swift
+disk_size: "{{ ses_enabled | ternary(2, 3) }}"
 
 # Versioned virtualized configuration artifacts
 virt_artifacts:


### PR DESCRIPTION
Running full tempest when Swift is used as a Glance store runs
into a few failures if the default value of 2 GB is used for
its disk size. Using a greater value when SES is disabled will
fix this.