### PR TITLE
Pass the non-default deployment value to the osh job

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-socok8s-integration.yaml
@@ -91,9 +91,8 @@
       - choice:
           name: deployment
           choices:
-            - 'airship'
             - 'osh'
-          default: 'osh'
+            - 'airship'
           description: >-
             Which deployment mechanism?
       - choice:


### PR DESCRIPTION
I was surprised to see that the osh job started automatically with the `airship` option although I've set different default for that. Maybe this could help?