### PR TITLE
openstack-crowbar/ardana: move lbaas tempest to the end

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -99,46 +99,6 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana8-job-entry-scale-kvm-x86_64
-    ardana_job: '{name}'
-    cloud_env: cloud-ardana-ci-slot
-    cloudsource: stagingcloud8
-    scenario_name: entry-scale-kvm
-    clm_model: standalone
-    controllers: '3'
-    computes: '2'
-    rhel_computes: '0'
-    ses_enabled: true
-    ses_rgw_enabled: false
-    tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
-      designate,heat,manila,ceilometer,magnum,freezer,monasca"
-    triggers: []
-    jobs:
-        - '{ardana_job}'
-
-- project:
-    name: cloud-ardana8-job-entry-scale-kvm-update-x86_64
-    ardana_job: '{name}'
-    cloud_env: cloud-ardana-ci-slot
-    cloudsource: develcloud8
-    update_after_deploy: true
-    update_to_cloudsource: stagingcloud8
-    scenario_name: entry-scale-kvm
-    clm_model: standalone
-    controllers: '3'
-    computes: '2'
-    rhel_computes: '0'
-    ses_enabled: true
-    ses_rgw_enabled: false
-    tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
-      designate,heat,ceilometer,magnum,freezer,monasca"
-    triggers: []
-    jobs:
-        - '{ardana_job}'
-
-- project:
     name: cloud-ardana8-job-entry-scale-kvm-test-maintenance-updates-x86_64
     ardana_job: '{name}'
     disabled: false

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -93,47 +93,6 @@
         - '{ardana_job}'
 
 - project:
-    name: cloud-ardana9-job-entry-scale-kvm-x86_64
-    ardana_job: '{name}'
-    cloud_env: cloud-ardana-ci-slot
-    cloudsource: stagingcloud9
-    scenario_name: entry-scale-kvm
-    clm_model: standalone
-    controllers: '3'
-    computes: '2'
-    rhel_computes: '0'
-    ses_enabled: true
-    ses_rgw_enabled: false
-    tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-      designate,heat,manila,magnum,monasca"
-    triggers: []
-    jobs:
-        - '{ardana_job}'
-
-
-- project:
-    name: cloud-ardana9-job-entry-scale-kvm-update-x86_64
-    ardana_job: '{name}'
-    cloud_env: cloud-ardana-ci-slot
-    cloudsource: develcloud9
-    update_after_deploy: true
-    update_to_cloudsource: stagingcloud9
-    scenario_name: entry-scale-kvm
-    clm_model: standalone
-    controllers: '3'
-    computes: '2'
-    rhel_computes: '0'
-    ses_enabled: true
-    ses_rgw_enabled: false
-    tempest_filter_list: "\
-      keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-      designate,heat,magnum,monasca"
-    triggers: []
-    jobs:
-        - '{ardana_job}'
-
-- project:
     name: cloud-ardana9-job-std-min-ipv6-x86_64
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot

--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -47,28 +47,28 @@
           cloudsource: stagingcloud8
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
-            designate,heat,manila,ceilometer,magnum,freezer,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
+            designate,heat,manila,ceilometer,magnum,freezer,monasca,lbaas"
       - cloud-ardana8-job-gate-entry-scale-kvm-update-x86_64:
           cloudsource: develcloud8
           update_to_cloudsource: stagingcloud8
           update_after_deploy: true
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
-            designate,heat,ceilometer,magnum,freezer,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
+            designate,heat,ceilometer,magnum,freezer,monasca,lbaas"
       - cloud-ardana9-job-gate-entry-scale-kvm-deploy-x86_64:
           cloudsource: stagingcloud9
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            designate,heat,manila,magnum,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            designate,heat,manila,magnum,monasca,lbaas"
       - cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64:
           cloudsource: develcloud9
           update_to_cloudsource: stagingcloud9
           update_after_deploy: true
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            designate,heat,magnum,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            designate,heat,magnum,monasca,lbaas"
     jobs:
         - '{ardana_job}'
 
@@ -94,7 +94,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,lbaas,heat,magnum,manila"
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
           # Delete when adding to the cloud 8 gating job
           cloud_env: cloud-crowbar-test-slot
           reserve_env: true
@@ -105,8 +105,8 @@
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            heat,magnum,manila"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
           # Delete when adding to the cloud 9 gating job
           cloud_env: cloud-crowbar-test-slot
           reserve_env: true
@@ -137,7 +137,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,lbaas,heat,magnum,manila"
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
           # Delete when adding to the cloud 8 gating job
           cloud_env: cloud-crowbar-test-slot
           reserve_env: true
@@ -148,8 +148,8 @@
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            heat,magnum,manila"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
           # Delete when adding to the cloud 9 gating job
           cloud_env: cloud-crowbar-test-slot
           reserve_env: true
@@ -182,7 +182,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,lbaas,heat,magnum,manila"
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
           # Delete when adding to the cloud 8 gating job
           cloud_env: cloud-crowbar-test-slot
           reserve_env: true
@@ -193,8 +193,8 @@
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            heat,magnum,manila"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
           # Delete when adding to the cloud 9 gating job
           cloud_env: cloud-crowbar-test-slot
           reserve_env: true

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -17,26 +17,26 @@
           cloudsource: GM8+up
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
-            designate,heat,manila,ceilometer,magnum,freezer,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
+            designate,heat,manila,ceilometer,magnum,freezer,monasca,lbaas"
       - cloud-ardana8-job-mu-entry-scale-kvm-update-x86_64:
           cloudsource: GM8+up
           update_after_deploy: true
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,lbaas,\
-            designate,heat,ceilometer,magnum,freezer,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
+            designate,heat,ceilometer,magnum,freezer,monasca,lbaas"
       - cloud-ardana9-job-mu-entry-scale-kvm-deploy-x86_64:
           cloudsource: GM9+up
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            designate,heat,manila,magnum,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            designate,heat,manila,magnum,monasca,lbaas"
       - cloud-ardana9-job-mu-entry-scale-kvm-update-x86_64:
           cloudsource: GM9+up
           update_after_deploy: true
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            designate,heat,magnum,monasca"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            designate,heat,magnum,monasca,lbaas"
     jobs:
         - '{ardana_job}'
 
@@ -73,15 +73,15 @@
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            heat,magnum,manila"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-no-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            heat,magnum,manila"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
     jobs:
         - '{crowbar_job}'
 
@@ -118,14 +118,14 @@
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            heat,magnum,manila"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,lbaas,\
-            heat,magnum,manila"
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -68,8 +68,8 @@
           multi-select-delimiter: ','
           default-value: ''
           value: >-
-            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,
-            fwaas,vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca
+            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
+            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -107,8 +107,8 @@
           multi-select-delimiter: ','
           default-value: ''
           value: >-
-            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,
-            fwaas,vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca
+            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
+            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -51,7 +51,7 @@
           default-value: ''
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,lbaas,heat,magnum,manila
+            trove,aodh,heat,magnum,manila,lbaas
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -334,8 +334,8 @@
           multi-select-delimiter: ','
           default-value: '{tempest_filter_list|ci}'
           value: >-
-            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,lbaas,
-            fwaas,vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca
+            ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
+            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -279,7 +279,7 @@
           default-value: '{tempest_filter_list|}'
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,lbaas,heat,magnum,manila
+            trove,aodh,heat,magnum,manila,lbaas
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.


### PR DESCRIPTION
Move the LBaaS tempest test cases to the end of the list of
tempest test filters, to avoid having left over LBaaS resources
impacting other tempest test cases.

This PR also removes a few jobs running full tempest that aren't
used anymore.