### PR TITLE
Fix the run_tempest function in lib.sh

### DIFF
--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -261,9 +261,14 @@ function update_cloud {
 
 function run_tempest {
     if $(is_defined tempest_filter_list); then
+        if [ "$(get_cloud_product)" == "crowbar" ]; then
+            playbook_name=run-tempest-crowbar
+        else
+            playbook_name=run-tempest-ardana
+        fi
         tempest_filter_list=($(echo "$(get_from_input tempest_filter_list)" | tr ',' '\n'))
         for filter in "${tempest_filter_list[@]}"; do
-            ansible_playbook run-tempest.yml -e tempest_run_filter=$filter
+            ansible_playbook ${playbook_name}.yml -e tempest_run_filter=$filter
         done
     fi
 }


### PR DESCRIPTION
Update the manual/lib.sh run_tempest function to reflect the recent
change that replaced the run-tempest.yml playbook with LCM flavour
specific versions run-tempest-ardana.yml and run-tempest-crowbar.yml.