### PR TITLE
openstack-crowbar: send tempest results to OS-Health

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/send_to_os_health/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/send_to_os_health/defaults/main.yml
@@ -26,5 +26,6 @@ os_health_cloud_build: "{{ cloud_media_build_version['stdout'] | default('Not-av
 os_service_name: "{{ test_name.split('_')[0] }}"
 os_health_requires_state: "present"
 os_health_requires:
+  - "python-virtualenv"
   - "gcc"
   - "python-devel"

--- a/scripts/jenkins/cloud/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
+++ b/scripts/jenkins/cloud/ansible/roles/send_to_os_health/tasks/os_health_requires.yml
@@ -22,8 +22,9 @@
     repo: "http://{{ clouddata_server }}/repos/x86_64/{{ item.name }}/"
     runrefresh: yes
     priority: 9999
+    auto_import_keys: yes
     state: "{{ os_health_requires_state }}"
-  loop: "{{ sles_sdk_repos }}"
+  loop: "{{ sles_sdk_repos + (extra_requires_repo | default([])) }}"
   when: item.enabled | default(true)
   become: yes
 

--- a/scripts/jenkins/cloud/ansible/roles/send_to_os_health/vars/tempest.yml
+++ b/scripts/jenkins/cloud/ansible/roles/send_to_os_health/vars/tempest.yml
@@ -26,3 +26,4 @@ os_health_metadata:
   - "build_name:{{ os_health_build_name }}"
   - "openstack_service:{{ tempest_run_filter }}"
   - "build_version:{{ os_health_cloud_build }}"
+  - "job:{{ lookup('env', 'JOB_NAME') }}"

--- a/scripts/jenkins/cloud/ansible/run-tempest-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/run-tempest-crowbar.yml
@@ -65,6 +65,13 @@
               - src: "{{ subunit_html_results }}"
           when: lookup("env", "WORKSPACE")
 
+        - include_role:
+            name: send_to_os_health
+          vars:
+            extra_requires_repo:
+              - name: "leap/42.3/oss/suse"
+            test_results_subunit: "{{ tempest_results_subunit }}"
+
   post_tasks:
       - include_role:
           name: rocketchat_notify


### PR DESCRIPTION
Send results from tempest tests executed on Crowbar deployments
to OpenStack-Health.

This change also adds a new metadata to the tests (job) which can be used to group test results based on the job name (e.g. for cloud-gating8/9)