### PR TITLE
Add workaround for known issue on simple horizon test (SOC-10011)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4850,7 +4850,12 @@ function onadmin_testsetup
     get_horizon
     echo "openstack horizon server:  $horizonserver"
     echo "openstack horizon service: $horizonservice"
-    curl -L -m 130 -s -S -k http://$horizonservice | tee simple_horizon.log | \
+    # Remove when SOC-10011 is fixed
+    retry=0
+    if iscloudver 9plus; then
+        retry=3
+    fi
+    curl -L -m 130 -s -S -k --retry $retry http://$horizonservice | tee simple_horizon.log | \
         grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" \
         || complain 101 "simple horizon test failed"
 


### PR DESCRIPTION
This change adds a workaround for SOC-10011. This commit should be
reverted once SOC-10011 is fixed.