### PR TITLE
upgrade:update scenario-8a deploy more compute nodes

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -71,22 +71,15 @@
             - vlan
             - gre
 
-      - choice:
+      - string:
           name: tempest
           default: smoke
           description: Optional, specify what tempest test(s) to run, e.g. smoke, smoke|full or smoke|defcore
-          choices:
-            - smoke
-            - full
 
-      - choice:
+      - string:
           name: ssl_type
           default: no-ssl
           description: "Mandatory, set the SSL configuration for the cloud, available options: no-ssl, ssl-insecure, ssl"
-          choices:
-            - no-ssl
-            - ssl-insecure
-            - ssl
 
       - string:
           name: cloud_version
@@ -131,11 +124,10 @@
           name: want_ipmi
           default: "1"
 
-      - choice:
+      - string:
           name: commands
           default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
           description: All the steps that needs to be completed to have cloud installed:When deploying with SSL add "install_ca_certificates" before "batch" command
-          choices:
             - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
             - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases install_ca_certificates batch
 
@@ -207,14 +199,14 @@
               root@$admin:scenario.yml
           ret=0
 
-          #Copy CA files
+          #copy CA files
           if [[ $ssl_type = "ssl" ]]; then
              ssh root@crowbar$hw_number "mkdir ssl-certs"
              scp -r /home/jenkins/ssl-certs/qa$hw_number root@crowbar$hw_number:/root/ssl-certs/
           fi
 
           ssh root@$admin "
-          # Update certificate file paths
+          # update certificate file paths
           if [[ $ssl_type = "ssl" ]]; then
              sed -i -e "s,##certfile##,/etc/cloud/ssl/qa$hw_number/qa$hw_number.cloud.suse.de.crt," scenario.yml
              sed -i -e "s,##keyfile##,/etc/cloud/ssl/qa$hw_number/qa$hw_number.cloud.suse.de.pem," scenario.yml

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-8a.yaml
@@ -125,8 +125,10 @@
 
       - string:
           name: commands
-          default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases
-          description: All the steps that needs to be completed to have cloud installed
+          default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
+          description: All the steps that needs to be completed to have cloud installed:When deploying with SSL add "install_ca_certificates" before "batch" command
+            - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
+            - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases install_ca_certificates batch
 
       - string:
           name: want_test_updates
@@ -181,9 +183,21 @@
           scp ~/github.com/$repo_owner/automation/scripts/scenarios/cloud$cloud_version/qa/$ssl_type/$scenario_file \
               root@$admin:scenario.yml
 
+          #copy CA files
+          if [[ $ssl_type = "ssl" ]]; then
+             ssh root@crowbar$hw_number "mkdir ssl-certs"
+             scp -r /home/jenkins/ssl-certs/qa$hw_number root@crowbar$hw_number:/root/ssl-certs/
+          fi
+
           ret=0
 
           ssh root@$admin "
+          # update certificate file paths
+          if [[ $ssl_type = "ssl" ]]; then
+             sed -i -e "s,##certfile##,/etc/cloud/ssl/qa$hw_number/qa$hw_number.cloud.suse.de.crt," scenario.yml
+             sed -i -e "s,##keyfile##,/etc/cloud/ssl/qa$hw_number/qa$hw_number.cloud.suse.de.pem," scenario.yml
+             sed -i -e "s,##cafile##,/etc/cloud/ssl/qa$hw_number/SUSE_CA_suse.de.chain.crt," scenario.yml
+          fi
           export cloud=$cloud ;
           export hw_number=$hw_number ;
           export UPDATEREPOS=$UPDATEREPOS ;
@@ -194,7 +208,7 @@
           export hacloud=$hacloud ;
           export clusterconfig=$clusterconfig ;
           export shared_storage_ip=$shared_storage_ip
-          export want_node_aliases=controller=3,compute-kvm=1,storage-swift=2,monasca-server=1 ;
+          export want_node_aliases=controller=3,compute-kvm=2,storage-swift=1,monasca-server=1 ;
           export networkingplugin=$networkingplugin ;
           export networkingmode=$networkingmode ;
           export want_swift=1 ;

--- a/scripts/scenarios/cloud8/qa/ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud8/qa/ssl/qa-scenario-8a.yaml
@@ -38,6 +38,13 @@ proposals:
       - "@@controller3@@"
 
 - barclamp: database
+  attributes:
+    mysql:
+      ssl:
+        enabled: true
+        certfile: ##certfile##
+        keyfile: ##keyfile##
+        ca_certs: ##cafile##
   deployment:
     elements:
       database-server:
@@ -45,6 +52,11 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    ssl:
+      enabled: true
+      certfile: ##certfile##
+      keyfile: ##keyfile##
+      client_ca_certs: ##cafile##
     client:
       enable_notifications: true
   deployment:
@@ -54,6 +66,12 @@ proposals:
 
 - barclamp: keystone
   attributes:
+    ssl:
+      certfile: ##certfile##
+      keyfile: ##keyfile##
+      ca_certs: ##cafile##
+    api:
+     protocol: https
   deployment:
     elements:
       keystone-server:
@@ -62,6 +80,9 @@ proposals:
 - barclamp: swift
   attributes:
     replicas: 2
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
     cluster_hash: 181d283256
     keystone_delay_auth_decision: true
     allow_versions: true
@@ -87,6 +108,10 @@ proposals:
 
 - barclamp: glance
   attributes:
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
     default_store: swift
   deployment:
     elements:
@@ -101,6 +126,12 @@ proposals:
       nfs:
         nfs_shares: ##cinder-storage-shares##
         nfs_snapshot: true
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       cinder-controller:
@@ -117,6 +148,12 @@ proposals:
     num_vlans: 99
     ml2_type_drivers_default_provider_network: ##networkingmode##
     ml2_type_drivers_default_tenant_network: ##networkingmode##
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
+    api:
+      protocol: https
   deployment:
     elements:
       neutron-server:
@@ -131,6 +168,14 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    ssl:
+      enabled: true
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
+    novnc:
+      ssl:
+        enabled: true
     metadata:
       vendordata:
         json: '{"custom-key": "custom-value"}'
@@ -149,13 +194,24 @@ proposals:
 
 - barclamp: horizon
   attributes:
-  deployment:
+    apache:
+      ssl: true
+      ssl_crt_file: ##certfile##
+      ssl_key_file: ##keyfile##
+      ssl_crt_chain_file: ##cafile##
+  deployment:      
     elements:
       horizon-server:
       - cluster:services
 
 - barclamp: heat
   attributes:
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       heat-server:
@@ -163,6 +219,12 @@ proposals:
 
 - barclamp: ceilometer
   attributes:
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       ceilometer-agent:
@@ -181,6 +243,12 @@ proposals:
 
 - barclamp: monasca
   attributes:
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       monasca-master:

--- a/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/no-ssl/qa-scenario-8a.yaml
@@ -38,13 +38,6 @@ proposals:
       - "@@controller3@@"
 
 - barclamp: database
-  attributes:
-    ha:
-      storage:
-        shared:
-          device: ##shared_nfs_for_database##
-          fstype: nfs
-          options: nfsvers=3
   deployment:
     elements:
       database-server:
@@ -52,12 +45,6 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
-    ha:
-      storage:
-        shared:
-          device: ##shared_nfs_for_rabbitmq##
-          fstype: nfs
-          options: nfsvers=3
     client:
       enable_notifications: true
   deployment:
@@ -95,8 +82,8 @@ proposals:
       swift-ring-compute:
       - "@@controller1@@"
       swift-storage:
-      - "@@storage-swift1@@"
-      - "@@storage-swift2@@"
+      - "@@storage-swift@@"
+      - "@@compute-kvm1@@"
 
 - barclamp: glance
   attributes:
@@ -141,6 +128,7 @@ proposals:
   attributes:
     itxt_instance: ''
     use_migration: true
+    vnc_keymap: de
     kvm:
       ksm_enabled: true
     metadata:
@@ -154,7 +142,8 @@ proposals:
       - cluster:services
       nova-compute-hyperv: []
       nova-compute-kvm:
-      - "@@compute-kvm@@"
+      - "@@compute-kvm1@@"
+      - "@@compute-kvm2@@"
       nova-compute-qemu: []
       nova-compute-xen: []
 
@@ -172,42 +161,48 @@ proposals:
       heat-server:
       - cluster:services
 
-- barclamp: monasca
-  attributes:
-  deployment:
-    elements:
-      monasca-server:
-      - "@@monasca-server@@"
-      monasca-log-agent:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
-      - "@@compute-kvm@@"
-      - "@@storage-swift1@@"
-      - "@@storage-swift2@@"
-      - "@@monasca-server@@"
-      monasca-agent:
-      - "@@controller1@@"
-      - "@@controller2@@"
-      - "@@controller3@@"
-      - "@@compute-kvm@@"
-      - "@@storage-swift1@@"
-      - "@@storage-swift2@@"
-      - "@@monasca-server@@"
-
 - barclamp: ceilometer
   attributes:
   deployment:
     elements:
       ceilometer-agent:
-      - "@@compute-kvm@@"
+      - "@@compute-kvm1@@"
+      - "@@compute-kvm2@@"
       - "@@monasca-server@@"
       ceilometer-agent-hyperv: []
       ceilometer-central:
       - cluster:services
       ceilometer-server:
       - cluster:services
-      ceilometer-swift-proxy-middleware: []
+      ceilometer-swift-proxy-middleware:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+
+- barclamp: monasca
+  attributes:
+  deployment:
+    elements:
+      monasca-master:
+      - "@@crowbar@@"
+      monasca-server:
+      - "@@monasca-server@@"
+      monasca-log-agent:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+      - "@@compute-kvm1@@"
+      - "@@compute-kvm2@@"
+      - "@@storage-swift@@"
+      - "@@monasca-server@@"
+      monasca-agent:
+      - "@@controller1@@"
+      - "@@controller2@@"
+      - "@@controller3@@"
+      - "@@compute-kvm1@@"
+      - "@@compute-kvm2@@"
+      - "@@storage-swift@@"
+      - "@@monasca-server@@"
 
 - barclamp: tempest
   attributes:

--- a/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl/qa-scenario-1a.yaml
@@ -38,6 +38,12 @@ proposals:
       - "@@controller3@@"
 - barclamp: database
   attributes:
+    mysql:
+      ssl:
+        enabled: true
+        certfile: ##certfile##
+        keyfile: ##keyfile##
+        ca_certs: ##cafile##    
   deployment:
     elements:
       database-server:

--- a/scripts/scenarios/cloud9/qa/ssl/qa-scenario-8a.yaml
+++ b/scripts/scenarios/cloud9/qa/ssl/qa-scenario-8a.yaml
@@ -38,6 +38,13 @@ proposals:
       - "@@controller3@@"
 
 - barclamp: database
+  attributes:
+    mysql:
+      ssl:
+        enabled: true
+        certfile: ##certfile##
+        keyfile: ##keyfile##
+        ca_certs: ##cafile##
   deployment:
     elements:
       database-server:
@@ -45,6 +52,11 @@ proposals:
 
 - barclamp: rabbitmq
   attributes:
+    ssl:
+      enabled: true
+      certfile: ##certfile##
+      keyfile: ##keyfile##
+      client_ca_certs: ##cafile##
     client:
       enable_notifications: true
   deployment:
@@ -54,6 +66,12 @@ proposals:
 
 - barclamp: keystone
   attributes:
+    ssl:
+      certfile: ##certfile##
+      keyfile: ##keyfile##
+      ca_certs: ##cafile##
+    api:
+     protocol: https
   deployment:
     elements:
       keystone-server:
@@ -62,6 +80,9 @@ proposals:
 - barclamp: swift
   attributes:
     replicas: 2
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
     cluster_hash: 181d283256
     keystone_delay_auth_decision: true
     allow_versions: true
@@ -87,6 +108,10 @@ proposals:
 
 - barclamp: glance
   attributes:
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
     default_store: swift
   deployment:
     elements:
@@ -101,6 +126,12 @@ proposals:
       nfs:
         nfs_shares: ##cinder-storage-shares##
         nfs_snapshot: true
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       cinder-controller:
@@ -117,6 +148,12 @@ proposals:
     num_vlans: 99
     ml2_type_drivers_default_provider_network: ##networkingmode##
     ml2_type_drivers_default_tenant_network: ##networkingmode##
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
+    api:
+      protocol: https
   deployment:
     elements:
       neutron-server:
@@ -131,6 +168,14 @@ proposals:
     vnc_keymap: de
     kvm:
       ksm_enabled: true
+    ssl:
+      enabled: true
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
+    novnc:
+      ssl:
+        enabled: true
     metadata:
       vendordata:
         json: '{"custom-key": "custom-value"}'
@@ -149,13 +194,24 @@ proposals:
 
 - barclamp: horizon
   attributes:
-  deployment:
+    apache:
+      ssl: true
+      ssl_crt_file: ##certfile##
+      ssl_key_file: ##keyfile##
+      ssl_crt_chain_file: ##cafile##
+  deployment:      
     elements:
       horizon-server:
       - cluster:services
 
 - barclamp: heat
   attributes:
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       heat-server:
@@ -163,6 +219,12 @@ proposals:
 
 - barclamp: ceilometer
   attributes:
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       ceilometer-agent:
@@ -181,6 +243,12 @@ proposals:
 
 - barclamp: monasca
   attributes:
+    api:
+      protocol: https
+    ssl:
+      certfile: ##certfile##
+      keyfile:  ##keyfile##
+      ca_certs: ##cafile##
   deployment:
     elements:
       monasca-master:


### PR DESCRIPTION
To run non-disruptive upgrade we need deploy more than 1 compute
node updated scenario for SOC8 and SOC9
ssl enabled scenario-8a added for SOC8/SOC9
Update job parameter commands/tempest/ssl_type to string type (more flexible for jobs updates)