### PR TITLE
openstack-crowbar: don't check knife node state (SOC-10530)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
@@ -56,12 +56,3 @@
   retries: "{{ 6 * ( groups['cloud_virt_hosts'] | length ) }}"
   until: _register_tmp.rc == 0 and crowbar_node_name in _register_tmp.stdout_lines
   delay: 10
-
-- name: Check that node is ready
-  delegate_to: "{{ cloud_env }}"
-  shell: "knife node show -a state {{ crowbar_node_name }} | awk '{ print $2 }'"
-  register: _register_tmp
-  # The more nodes we have, the longer this will take
-  retries: "{{ 6 * ( groups['cloud_virt_hosts'] | length ) }}"
-  until: _register_tmp.rc == 0 and _register_tmp.stdout == 'ready'
-  delay: 10


### PR DESCRIPTION
The knife tool sometimes doesn't show the correct state for one of
the newly registered nodes until chef-client runs on the admin node.
Since this information isn't reliable and also redundant, because
of other ansible and qa_crowbarsetup.sh coded checks looking at the
node state, this change removes this check from the test automation.