### PR TITLE
Revert "Add workaround for known issue on simple horizon test (SOC-10011)"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4850,12 +4850,7 @@ function onadmin_testsetup
     get_horizon
     echo "openstack horizon server:  $horizonserver"
     echo "openstack horizon service: $horizonservice"
-    # Remove when SOC-10011 is fixed
-    retry=0
-    if iscloudver 9plus; then
-        retry=3
-    fi
-    curl -L -m 130 -s -S -k --retry $retry http://$horizonservice | tee simple_horizon.log | \
+    curl -L -m 130 -s -S -k http://$horizonservice | tee simple_horizon.log | \
         grep -q -e csrfmiddlewaretoken -e "<title>302 Found</title>" \
         || complain 101 "simple horizon test failed"
 


### PR DESCRIPTION
This reverts commit 7cb71032598daf2cc7ce8cc125922748736f529d.

Merge only when SOC-10011 is fixed.