### PR TITLE
mkcloud: install bzip2 required for supportconfig

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -238,6 +238,7 @@ function onhost_supportconfig
                 timeout 300 scp $node:/var/log/\*tbz /var/log/
             )&
             done
+            zypper --non-interactive install bzip2
             timeout 600 supportconfig | wc &
             wait
         '


### PR DESCRIPTION
The bzip2 package is missing on the admin node, causing empty
supportconfig files to be collected by failing jobs.