### PR TITLE
mkcloud: Multiple NICs for lonely nodes (SOC-10493)

### DIFF
--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -444,14 +444,18 @@ function libvirt_do_setuplonelynodes()
 {
     local i
     for i in $(nodes ids lonely) ; do
-        local mac=$(macfunc $i)
+        local macaddress=$(macfunc $i)
+        local mac_params=""
+        for nicnumber in $(seq 1 $nics) ; do
+            mac_params+=" --macaddress $(macfunc $i $nicnumber)";
+        done
         local lonely_node
         lonely_node=$cloud-node$i
         safely ${scripts_lib_dir}/libvirt/compute-config $cloud $i \
-               --macaddress $mac \
+               $mac_params \
                --cephvolumenumber "$cephvolumenumber" \
                --drbdserial "$drbdvolume" \
-               --computenodememory $compute_node_memory\
+               --computenodememory $lonelynode_memory\
                --controllernodememory $controller_node_memory \
                --libvirttype $libvirt_type \
                --vcpus $vcpus \

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -98,6 +98,7 @@ needcvol=1
 iscloudver 7plus && : ${controller_node_memory:=12582912}
 : ${controller_node_memory:=6291456}
 : ${compute_node_memory:=2621440}
+: ${lonelynode_memory:=2621440}
 [[ "$libvirt_type" = "hyperv" ]] && \
     compute_node_memory=$(max $compute_node_memory ${hyperv_node_memory:-3000000})
 [[ "$libvirt_type" = "xen" ]] && \
@@ -1348,6 +1349,8 @@ Optional
         Set the memory in KB assigned to controller nodes
     compute_node_memory (default 2097152)
         Set the memory in KB assigned to compute nodes
+    lonelynode_memory (defeault 2097152)
+        Set the memory in KB assigned to lonely nodes
     drbd_hdd_size  (default 0, or 15 if hacloud is set)
         Set the size in GB of the DRBD data disks attached to the
         nodes in the cluster hosting the database and rabbitmq.


### PR DESCRIPTION
This changes adds support for multiple network interfaces for lonely
nodes. The logic is identical to the logic for controller and compute
nodes. In addition, this change introduces a setting,
`lonelynode_memory`, to specify the memory assigned for a lonely node.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>