### PR TITLE
Setup public net on admin node (SOC-10658)

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -413,6 +413,10 @@ function setupadmin
         done
         $sudo iptables -w -I FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss $mss
     fi
+
+    if [[ $want_designate_proposal = 1 ]]; then
+        setuppublicnet
+    fi
 }
 
 function wait_for_node_shutdown


### PR DESCRIPTION
When want_designate_proposal=1, we need DNS servers to listen on
public network interface. For this, we need to setup public
network on the admin node in such case.