### PR TITLE
Upgrade recover prechecks

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -59,6 +59,46 @@
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-mariadb-{arch}'
         - 'cloud-mkcloud{version}-job-upgrade-nondisruptive-ha-without-nodes-upgrade-{arch}'
 - project:
+    name: cloud-mkcloud9-retryprechecks-x86_64
+    disabled: false
+    version: 9
+    previous_version: 8
+    arch: x86_64
+    controller_node_memory: 12582912
+    tempestoptions: --smoke
+    magnumoptions: --regex '^magnum_tempest_plugin.tests.api'
+    label: openstack-mkcloud-SLE12-x86_64
+    database_engine: mysql
+    want_monasca_proposal: 0
+    want_barbican_proposal: 1
+    fix_failed_prechecks: 1
+    want_aodh_proposal: 1
+    want_trove_proposal: 1
+    want_ceilometer_proposal: 1
+    jobs:
+        - 'cloud-mkcloud{version}-job-upgrade-retryprechecks-disruptive-{arch}'
+- project:
+    name: cloud-mkcloud9-retryprechecks-ha-x86_64
+    disabled: false
+    version: 9
+    previous_version: 8
+    arch: x86_64
+    nodenumber: 5
+    nodenumber_controller: 3
+    tempestoptions: --smoke
+    label: openstack-mkcloud-ha-x86_64
+    storage_method_ha: swift
+    database_engine: mysql
+    want_all_ssl: 1
+    want_monasca_proposal: 0
+    want_barbican_proposal: 1
+    fix_failed_prechecks: 1
+    want_aodh_proposal: 1
+    want_trove_proposal: 1
+    want_ceilometer_proposal: 1
+    jobs:
+        - 'cloud-mkcloud{version}-job-upgrade-retryprechecks-nondisruptive-ha-mariadb-{arch}'
+- project:
     name: cloud-mkcloud9-tempestfull-x86_64
     disabled: false
     version: 9

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -106,6 +106,7 @@ iscloudver 7plus && : ${controller_node_memory:=12582912}
 : ${adminnode_hdd_size:=15}
 [[ "$upgrade_cloudsource" ]] && \
     adminnode_hdd_size=$(max $adminnode_hdd_size 20)
+: ${fix_failed_prechecks:=0}
 : ${controller_hdd_size:=20}
 : ${computenode_hdd_size:=20}
 : ${cephvolume_hdd_size:=21}
@@ -365,6 +366,7 @@ function sshrun
         export bmc_user=$bmc_user;
         export bmc_password=$bmc_password;
         export upgrade_progress_file=$upgrade_progress_file;
+        export fix_failed_prechecks=$fix_failed_prechecks;
 EOF
     # setting these variables within mkcloud does not make them part of the env, so we need to export them
     export nodenumber nodenumberlonelynode nodenumberironicnode clusterconfig ironicnetmask


### PR DESCRIPTION
This pull request adds two things:

1) The `fix_failed_prechecks` environment variable for `mkcloud`. If set to `1`, `mkcloud` will attempt to recover from failed prechecks by deleting the offending barclamps, just like a customer would have to do it.

2) Two additional upgrade jobs for deliberately failing and recovering from failed prechecks that use this mechanism. Only two, because I omitted the `without-nodes-upgrade` job - the precheck show stoppers only affect the controllers anyway.

Note: this is currently only implemented for the Cloud 8 to Cloud 9 upgrade.