### PR TITLE
Removes 5 min wait time when restarting openvswitch-agent (SOC-9144)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/reconfigure_neutron.yml
@@ -22,10 +22,6 @@
   args:
     chdir: "{{ ardana_scratch_path }}"
 
-# FIXME: workaround for SCRD-9144
-- name: Wait a while to give neutron agents time to recover
-  pause:
-    minutes: 5
 
 - name: Run neutron-status
   shell: |


### PR DESCRIPTION
With the merge of https://build.opensuse.org/request/show/731343 the problem is expected to be aliviated.