### PR TITLE
Permit neutron service disablement

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/control_plane.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/control_plane.yml
@@ -25,18 +25,28 @@
         - AZ1
         - AZ2
         - AZ3
+{% set ns = namespace(config_data=[]) %}
+{% for config_service in ['designate', 'neutron', 'octavia'] %}
+{%   if not config_service in disabled_services %}
+{%     set ns.config_data = ns.config_data+[(config_service ~ '-CONFIG-CP1') | upper] %}
+{%   endif %}
+{% endfor %}
       configuration-data:
-        - DESIGNATE-CONFIG-CP1
-        - OCTAVIA-CONFIG-CP1
-        - NEUTRON-CONFIG-CP1
+{% if ns.config_data %}
+{%   for config_data in ns.config_data|unique|sort %}
+        - {{ config_data }}
+{%   endfor %}
+{% else %}
+        []
+{% endif %}
+
       common-service-components:
 {% set common_service_components = service_component_groups.COMMON | reject('match', disabled_services|ternary(disabled_services, '^$')) | list %}
 {% for service_component in common_service_components|unique|sort %}
         - {{ service_component }}
 {% endfor %}
-
+{% set sgt = namespace(header_printed=[]) %}
 {% for service_group_type in ['cluster', 'resource'] %}
-      {{ service_group_type }}s:
 {%   for service_group in scenario['service_groups'] if service_group.type == service_group_type and service_group['member_count']|int %}
 {%     set ns = namespace(service_components=[], service_component_groups=[]) %}
 {%     set ns.service_component_groups = service_group['service_components'] | reject('match', disabled_services|ternary(disabled_services, '^$')) | list %}
@@ -51,6 +61,11 @@
 {%     if ns.service_components %}
 {%       if 'ntp-server' not in ns.service_components %}
 {%         set ns.service_components = ns.service_components+['ntp-client'] %}
+{%       endif %}
+{%       if service_group_type not in sgt.header_printed %}
+
+      {{ service_group_type }}s:
+{%           set sgt.header_printed = sgt.header_printed + [service_group_type] %}
 {%       endif %}
 
         - name: {{ service_group.name }}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
@@ -68,7 +68,8 @@
         - swift-account
         - swift-object
         - swift-rsync
-{%   elif 'EXTERNAL-API' in network_group.component_endpoints %}
+{%   elif 'EXTERNAL-API' in network_group.component_endpoints and
+          not 'designate' in disabled_services %}
         - {{ designate_backend }}-ext
 {%   else %}
         []
@@ -80,7 +81,8 @@
 {%       set _ = ns.routes.append('OCTAVIA-MGMT-NET') %}
 {%       set _ = ns.routes.append('ILO') %}
 {%     else %}
-{%       for neutron_ng in scenario.network_groups if 'NEUTRON-VLAN' in neutron_ng.component_endpoints %}
+{%       for neutron_ng in scenario.network_groups if 'NEUTRON-VLAN' in neutron_ng.component_endpoints and
+                                                      not 'neutron' in disabled_services %}
 {%         set _ = ns.routes.append('NEUTRON-%s-VLAN-NET'|format(neutron_ng.name|upper)) %}
 {%       endfor  %}
 {%     endif %}
@@ -185,9 +187,10 @@
 {%   else %}
         []
 {%   endif %}
-{%   if 'NEUTRON-EXT' in network_group['component_endpoints'] or
-        'NEUTRON-VLAN' in network_group['component_endpoints'] or
-        'NEUTRON-VXLAN' in network_group['component_endpoints'] %}
+{%   if ( 'NEUTRON-EXT' in network_group['component_endpoints'] or
+          'NEUTRON-VLAN' in network_group['component_endpoints'] or
+          'NEUTRON-VXLAN' in network_group['component_endpoints'] ) and
+          'neutron' not in disabled_services %}
       tags:
 {%     if 'NEUTRON-EXT' in network_group['component_endpoints'] %}
         #

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -281,6 +281,8 @@ def map_list_attrs(element, element_schema):
     schema_sub_elements = element_schema.get('elements', {})
     for sub_element_name, sub_element_schema in schema_sub_elements.items():
         input_model_subelements = element.get(sub_element_name, {})
+        if element.get(sub_element_name, None) is None:
+            continue
         convert_element_list_to_map(
             element, sub_element_name,
             sub_element_schema.get('key', 'name'))
@@ -374,6 +376,8 @@ def map_foreign_keys(root_element, element_name,
                     element_key)
 
     for sub_element_name, sub_element_schema in schema_sub_elements.items():
+        if element.get(sub_element_name, None) is None:
+            continue
         for input_model_element in element[sub_element_name].values():
             map_foreign_keys(
                 root_element, sub_element_name,
@@ -392,6 +396,8 @@ def prune_input_model(element, element_schema):
     """
     schema_sub_elements = element_schema.get('elements', {})
     for sub_element_name, sub_element_schema in schema_sub_elements.items():
+        if element.get(sub_element_name, None) is None:
+            continue
         if sub_element_schema.get('prune'):
             element[sub_element_name] = dict(filter(
                 lambda el_rec: el_rec[1].get('is-referenced'),
@@ -497,6 +503,8 @@ def enhance_input_model(input_model):
         # balancers, which we have to transform into object references
         # explicitly here
         for cp in input_model['control-planes'].values():
+            if cp.get('load-balancers', None) is None:
+                continue
             link_elements_by_foreign_key_list(
                 network_group, 'load-balancers',
                 cp['load-balancers'],

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -44,6 +44,11 @@ function setup_ansible_venv {
 }
 
 function mitogen_enable {
+    if [[ "${NO_MITOGEN:+true}" == "true" ]]; then
+        mitogen_disable
+        return 0
+    fi
+
     if [ ! -d "mitogen" ]; then
         wget -qO- $MITOGEN_URL | tar -xz
         mv mitogen-* mitogen
@@ -300,6 +305,8 @@ function validate_input {
     if ! is_defined cloud_env; then
         echo "ERROR: cloud_env must be defined - please check all variables on input.yml"
         return 1
+    elif [[ "${NO_CONFIRM:+true}" == "true" ]]; then
+        return 0
     else
         echo "
 *****************************************************************************************


### PR DESCRIPTION
Enable neutron service disablement (SOC-9780)
=============================================
    
One of the goals of the SOC/CLM 8 to 9 upgrade tooling was to enable
testing of minimal deployments, such as a keystone+horizon only single
controller node setup.
    
However defining an extry-scale-kvm or standard scenario cloud without
neutron would fail throwing exceptions in the heat model generator
due to attempting to dereference an item with a value of None as either
a dictionary or a list; adding guard checks to skip such elements when
converting lists to dictionaries avoids the exceptions.
    
The reason that the exceptions were occurring was due to the fact that
if you specified compute nodes in your model, but disabled all of the
service components running on them, you ended up with compute nodes
without empty service component lists, which caused the control plane
templating to generate 'resources:' entry with no content, meaning a
value of None. This also leads to the ardana-configuration-processor
report errors for the input model. This can be avoided by only emitting
the service_group_type header line if there are actually nodes in the
associated group.
    
Additionally if you disable the designate, neutron, or octavia services
we still emitted references to the configuration data objects, which
leads to the configuration processor reporting warnings for unused refs
that can be avoided by making the config_data item entries conditional
on the service not being disabled when rendering the control_plane.yml.
    
Similarly when rendering the network_groups.yml, only generate the
designate, NEUTRON VLAN or Neutron physnet elements if the associated
service is not disabled.


Enable environment variable overrides.
======================================
    
Add support for using the NO_CONFIRM and NO_MITOGEN environment variables
to disable the interactive confirmation of input paramaters and whether
mitogen is configured/enabled.
    
The disablement of the interactive confirmation makes it easier to run
testing scenarios using the command line tooling from scripts.
    
Being able to disable mitogen configuration/enablement without needing
to edit the standard scripts is helpful when debugging issues that may
potentially be related to the manual tooling's use of mitogen which is
not used by the Jenkins CI tooling due to issues seen in the past.
