### PR TITLE
Add Train and remove Master from trackupstream

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -18,7 +18,7 @@
             - Cloud:OpenStack:Queens:Staging
             - Cloud:OpenStack:Rocky:Staging
             - Cloud:OpenStack:Stein:Staging
-            - Cloud:OpenStack:Master
+            - Cloud:OpenStack:Train:Staging
       - axis:
           type: user-defined
           name: component
@@ -93,7 +93,7 @@
             - cloud-trackupstream
     execution-strategy:
       combination-filter: |
-        ! ( [ "Cloud:OpenStack:Master" ].contains(project) &&
+        ! ( [ "Cloud:OpenStack:Train:Staging" ].contains(project) &&
             [
             "openstack-horizon-plugin-monasca-ui",
             "openstack-monasca-agent",
@@ -122,19 +122,19 @@
               "openstack-trove",
               "openstack-horizon-plugin-trove-ui",
             ].contains(component) ||
-            [ "Cloud:OpenStack:Master" ].contains(project) &&
+            [ "Cloud:OpenStack:Train:Staging" ].contains(project) &&
             [
               "openstack-horizon-plugin-neutron-fwaas-ui",
               "openstack-horizon-plugin-neutron-vpnaas-ui",
               "openstack-neutron-vsphere",
             ].contains(component) ||
-            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Pike:Staging" ].contains(project) &&
+            [ "Cloud:OpenStack:Train:Staging", "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Pike:Staging" ].contains(project) &&
             [
               "openstack-horizon-plugin-murano-ui",
               "openstack-gnocchi",
               "openstack-monasca-transform"
             ].contains(component) ||
-            [ "Cloud:OpenStack:Master", "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging" ].contains(project) &&
+            [ "Cloud:OpenStack:Train:Staging", "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging" ].contains(project) &&
             [
               "openstack-horizon-plugin-freezer-ui",
               "openstack-nova-virt-zvm"

--- a/scripts/jenkins/track-upstream.sh
+++ b/scripts/jenkins/track-upstream.sh
@@ -31,10 +31,7 @@ case $OBS_TYPE in
             Cloud:OpenStack:Rocky*)
                 OSC_BUILD_DIST=SLE_12_SP4
                 ;;
-            Cloud:OpenStack:Stein*)
-                OSC_BUILD_DIST=SLE_15
-                ;;
-            Cloud:OpenStack:Master)
+            Cloud:OpenStack:Stein*|Cloud:OpenStack:Train*)
                 OSC_BUILD_DIST=SLE_15
                 ;;
             Cloud:socok8s:master)


### PR DESCRIPTION
Since all of the service packages are now maintained in rpm-packaging
and updated in Cloud:OpenStack:Upstream:Master with the
openstack-rpm-packaging-update-Master job, we don't need to run
trackupstream for Cloud:OpenStack:Master, and in fact we can't any more
because those packages don't contain _service files. However, very soon
we will need to start running trackupstream for the Train branch, so
this change just s/Master/Train:Staging/ since all the conditions that
apply to the current master branch will also apply to stable/train. The
Train part of the trackupstream matrix won't work until the
Cloud:OpenStack:Train:Staging project is created in OBS.