### PR TITLE
Setup Pool & Updates tags for Devel and Staging repos (SOC-9780)

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -55,8 +55,6 @@ rc_notify: False
 rc_notify_start: True
 
 suse_release: "suse-{{ ansible_distribution_version }}"
-local_repos_web_dir_prefix: "{{ (cloud_product == 'crowbar') | ternary('tftpboot', 'www') }}"
-local_repos_base_dir: "/srv/{{ local_repos_web_dir_prefix }}/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
 sles_cloud_version:
   "12.2": 7

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/pre_cloudsource_update.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/pre_cloudsource_update.yml
@@ -27,27 +27,6 @@
     - '-b -a "rpm --import /tmp/content.key"'
   when: "'staging' in cloudsource or 'devel' in cloudsource"
 
-# This is needed to trick ardana repo check that the repository is a Cloud-Updates
-# repo.
-- name: Add cloud update tag to repomd when cloudsource is not a update repo
-  lineinfile:
-    path: "/srv/www/suse-{{ ansible_distribution_version }}/x86_64/repos/{{ cloud_update_repo_name }}/suse/repodata/repomd.xml"
-    insertafter: "<tags>"
-    line: "    <repo>obsrepository://build.suse.de/SUSE:Updates:{{ cloud_brand | replace('SUSE-', '') }}:{{ cloud_release[-1] }}:x86_64/update</repo>"
-  when: "'+up' not in cloudsource"
-  become: yes
-
-- name: Remove and add back Cloud update repo on all nodes to prevent repomd error
-  command: |
-    ansible -b -m zypper_repository -a "name={{ cloud_update_repo_name }}
-      repo={{ deployer_repo_base_url }}/{{ cloud_update_repo_name }} state={{ item }}"
-      'resources:!*rhel*:!ARD-SVC--first-member'
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  loop:
-    - "absent"
-    - "present"
-
 # Updating to another cloudsource may change the package vendor (SUSE LLC, obs)
 # disabling vendor stickiness allows the ardana update playbook to include those
 # packages on the update

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -15,6 +15,8 @@
 #
 ---
 
+setup_distribution_minor_version: "{{ ansible_distribution_version.split('.')[1] }}"
+
 clouddata_server: "provo-clouddata.cloud.suse.de"
 repos_url: "http://{{ clouddata_server }}/repos/{{ ansible_architecture }}"
 is_milestone: "{{ cloudsource is match('cloud\\d(M\\d|RC\\d|GMC)') }}"
@@ -37,6 +39,8 @@ cloudsource_repos:
   GM9: "SUSE-OpenStack-Cloud-9-Pool"
 
 cloud_brand: "{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'SUSE-OpenStack-Cloud') }}"
+cloud_pool_tag: "SLE-{{ ansible_distribution_major_version }}-SP{{ setup_distribution_minor_version }}:Update:Products:Cloud{{ cloud_release_number }}/{{ cloud_brand | lower }}/{{ cloud_release_number }}/POOL/{{ ansible_architecture }}"
+cloud_updates_tag: "Updates:{{ cloud_brand | replace('SUSE-', '') }}:{{ cloud_release_number }}:{{ ansible_architecture }}/update"
 
 repository_mnemonics:
   cloud7:
@@ -79,6 +83,9 @@ repos_to_sync: "{{ repos_to_add | difference(repos_to_mount) }}"
 extra_repos_list: "{{ extra_repos.split(',') if extra_repos is defined and extra_repos | length > 0 else [] }}"
 cloudsource_repo: "{{ (task == 'update' and cloudsource is defined and cloudsource != '') | ternary('Updates', 'Pool') }}"
 zypper_repo_name: "{{ item | regex_replace('devel.*', cloudsource_repo) }}"
+
+local_repos_web_dir_prefix: "{{ (cloud_product == 'crowbar') | ternary('tftpboot', 'www') }}"
+local_repos_base_dir: "/srv/{{ local_repos_web_dir_prefix }}/{{ suse_release }}/{{ ansible_architecture }}/repos"
 
 #media_versions
 ardana_media_version_src_file: "{{ local_repos_base_dir }}/{{ base_repos.0 | regex_replace('devel.*', 'Pool') }}/media.1/build"

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_sles_cloud_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_sles_cloud_repos.yml
@@ -15,9 +15,16 @@
 #
 ---
 
+# If this task is included more than once as part of a single ansible-playbook
+# top-level command, the subsequent runs will inherit the list created/updated
+# by the earlier runs, which isn't always desirable.
+- name: Initialise repos_to_add as an empty list
+  set_fact:
+    repos_to_add: []
+
 - name: Gather repos to add
   set_fact:
-    repos_to_add: "{{ repos_to_add | default([]) + item.repo }}"
+    repos_to_add: "{{ repos_to_add + item.repo }}"
   when: "item.enabled | default(True)"
   loop:
     - repo: "{{ base_repos }}"
@@ -50,6 +57,24 @@
   retries: 5
   until: sync_result.rc != 24
   delay: 300
+
+- name: Add Pool tag to relevant rsync'd repos
+  lineinfile:
+    path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}/suse/repodata/repomd.xml"
+    insertafter: "<tags>"
+    line: "    <repo>obsproduct://build.suse.de/SUSE:{{ cloud_pool_tag }}</repo>"
+  loop: "{{ repos_to_sync }}"
+  when:
+    - item.endswith('-devel') or item.endswith('-devel-staging')
+
+- name: Add Updates tag to relevant rsync'd repos
+  lineinfile:
+    path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}/suse/repodata/repomd.xml"
+    insertafter: "<tags>"
+    line: "    <repo>obsrepository://build.suse.de/SUSE:{{ cloud_updates_tag }}</repo>"
+  loop: "{{ repos_to_sync }}"
+  when:
+    - item.endswith('-devel') or item.endswith('-devel-staging')
 
 - name: Mount repos that are not frequently updated
   mount:


### PR DESCRIPTION
After rsync'ing the Devel or Staging repos to the deployer, setup the
appropriate Pool & Updates tags so that any update or upgrade actions
can use them without having to disable repos checks, and eliminates
the need to remove and re-add these repo after adding the Updates tag
during the update workflow.
    
Ensure that the repos_to_add list is reset to an empty list at the
top of the setup_sles_cloud_repos.yml task list as otherwise, if the
task list is included multiple times in a playbook run, subsequent
inclusions will inherit the value from the previous run which may not
be desirable if used as part of setting up a new cloudsource during
upgrade.
    
Move some facts used exclusively in the setup_zypper_repos role to be
managed in that role's defaults/main.yml, rather than as part of the
group_vars/all hierarchy.
