### PR TITLE
Enhance zypper repo management (SOC-9780)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -15,7 +15,27 @@
 #
 ---
 
-setup_distribution_minor_version: "{{ ansible_distribution_version.split('.')[1] }}"
+#
+# zypper repo management
+#
+zypper_repo_enabled: yes
+zypper_repo_state: "present"
+# set to true to delete repo backing content from the system;
+# only valid if enabled==no and state==absent
+zypper_repo_delete: false
+
+setup_cloud_info:
+  cloud9:
+    sles_version: 12.4
+  cloud8:
+    sles_version: 12.3
+  cloud7:
+    sles_version: 12.2
+
+setup_sles_version: "{{ setup_cloud_info[cloud_release].sles_version }}"
+setup_sles_major_version: "{{ setup_sles_version.split('.')[0] }}"
+setup_sles_minor_version: "{{ setup_sles_version.split('.')[1] }}"
+setup_suse_release: "suse-{{ setup_sles_version }}"
 
 clouddata_server: "provo-clouddata.cloud.suse.de"
 repos_url: "http://{{ clouddata_server }}/repos/{{ ansible_architecture }}"
@@ -39,7 +59,7 @@ cloudsource_repos:
   GM9: "SUSE-OpenStack-Cloud-9-Pool"
 
 cloud_brand: "{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'SUSE-OpenStack-Cloud') }}"
-cloud_pool_tag: "SLE-{{ ansible_distribution_major_version }}-SP{{ setup_distribution_minor_version }}:Update:Products:Cloud{{ cloud_release_number }}/{{ cloud_brand | lower }}/{{ cloud_release_number }}/POOL/{{ ansible_architecture }}"
+cloud_pool_tag: "SLE-{{ setup_sles_major_version }}-SP{{ setup_sles_minor_version }}:Update:Products:Cloud{{ cloud_release_number }}/{{ cloud_brand | lower }}/{{ cloud_release_number }}/POOL/{{ ansible_architecture }}"
 cloud_updates_tag: "Updates:{{ cloud_brand | replace('SUSE-', '') }}:{{ cloud_release_number }}:{{ ansible_architecture }}/update"
 
 repository_mnemonics:
@@ -93,15 +113,15 @@ sles_test_repos_enabled: "{{ updates_test_enabled and ((task == 'deploy' and not
 cloud_test_repos_enabled: "{{ updates_test_enabled and 'GM' in cloudsource and ((task == 'deploy' and not update_after_deploy) or (task == 'update')) }}"
 
 repos_to_mount_regexp: "{{ sles_ltss_enabled[cloud_release] | ternary('.*-Pool$|.*SP\\d-Updates$', '.*-Pool$') }}"
-repos_to_mount: "{{ repos_to_add | select('search', repos_to_mount_regexp) | list }}"
-repos_to_sync: "{{ repos_to_add | difference(repos_to_mount) }}"
+repos_to_mount: "{{ repos_to_manage | select('search', repos_to_mount_regexp) | list }}"
+repos_to_sync: "{{ repos_to_manage | difference(repos_to_mount) }}"
 
 extra_repos_list: "{{ extra_repos.split(',') if extra_repos is defined and extra_repos | length > 0 else [] }}"
 cloudsource_repo: "{{ (task == 'update' and cloudsource is defined and cloudsource != '') | ternary('Updates', 'Pool') }}"
 zypper_repo_name: "{{ item | regex_replace('devel.*', cloudsource_repo) }}"
 
 local_repos_web_dir_prefix: "{{ (cloud_product == 'crowbar') | ternary('tftpboot', 'www') }}"
-local_repos_base_dir: "/srv/{{ local_repos_web_dir_prefix }}/{{ suse_release }}/{{ ansible_architecture }}/repos"
+local_repos_base_dir: "/srv/{{ local_repos_web_dir_prefix }}/{{ setup_suse_release }}/{{ ansible_architecture }}/repos"
 
 #media_versions
 ardana_media_version_src_file: "{{ local_repos_base_dir }}/{{ base_repos.0 | regex_replace('devel.*', 'Pool') }}/media.1/build"

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/add_extra_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/add_extra_repos.yml
@@ -39,10 +39,11 @@
   args:
     creates: "{{ local_repos_base_dir }}/extra-repos/repodata/repomd.xml"
 
-- name: Add extra-repos repository
+- name: Manage extra-repos repository
   zypper_repository:
     name: "extra-repos"
     priority: 90
     repo: "{{ local_repos_base_dir }}/extra-repos"
     disable_gpg_check: true
-    state: present
+    enabled: "{{ zypper_repo_enabled }}"
+    state: "{{ zypper_repo_state }}"

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/check_settings.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/check_settings.yml
@@ -1,0 +1,45 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Fail if zypper repo enabled or state values not valid
+  fail:
+    msg: |
+      Valid values for zypper_repo_enabled and zypper_repo_state are
+        zypper_repo_enabled = [yes | no | true | false]
+        zypper_repo_state = [present | absent]
+  when:
+     # unquoted yes/no possibly converted to boolean values
+     - (zypper_repo_enabled not in ["yes", "no", true, false]) or
+       (zypper_repo_state not in ["present", "absent"])
+
+- name: Fail if zypper_repo_state preconditions not met
+  fail:
+    msg: |
+      zypper_repo_enabled should not be 'yes' when zypper_repo_state is
+      'absent'.
+  when:
+     - zypper_repo_enabled in ["yes", true]
+     - zypper_repo_state == "absent"
+
+- name: Fail if zypper_repo_delete preconditions not met
+  fail:
+    msg: |
+      zypper_repo_delete should not be true unless zypper_repo_state is
+      'absent' and zypper_repo_enabled is 'no'.
+  when:
+    - zypper_repo_delete | bool
+    - (zypper_repo_state != "absent") or (zypper_repo_enabled in ["yes", true])

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/main.yml
@@ -15,6 +15,9 @@
 #
 ---
 
+- name: Verify zypper repo state, enabled & delete settings
+  include_tasks: check_settings.yml
+
 - name: Gather variables when milestone cloudsousrce
   include_vars: "milestone.yml"
   when: is_milestone
@@ -30,7 +33,14 @@
     - include_maint_update
     - maint_updates_list | length
 
-- include_tasks: add_extra_repos.yml
+- block:
+    - include_tasks: add_extra_repos.yml
+      when:
+        - zypper_repo_state == "present"
+
+    - include_tasks: remove_extra_repos.yml
+      when:
+        - zypper_repo_state == "absent"
   when:
     - extra_repos_list | length
     - cloud_product == 'ardana'

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/remove_extra_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/remove_extra_repos.yml
@@ -1,0 +1,30 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Manage extra-repos repository
+  zypper_repository:
+    name: "extra-repos"
+    state: "{{ zypper_repo_state }}"
+  notify:
+    - Refresh all repos
+
+- name: Delete extra-repos repository contents
+  file:
+    name: "{{ local_repos_base_dir }}/extra-repos"
+    state: absent
+  when:
+    - zypper_repo_delete | bool

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_maint_update_repos.yml
@@ -42,44 +42,81 @@
   delay: 5
   until: mu_url is succeeded
 
-- name: Ensure MU directories exists
-  file:
-    state: directory
-    path: "{{ local_repos_base_dir }}/{{ item }}"
-  loop: "{{ maint_updates_list }}"
+# Download MU repo contents and add/enabled/disable MU repos
+- block:
+    - name: Ensure MU directories exist
+      file:
+        state: directory
+        path: "{{ local_repos_base_dir }}/{{ item }}"
+      loop: "{{ maint_updates_list }}"
 
-# This tasks is responsible for finding to which product the MUs are targeted for.
-# This is done by combining the MU IDs with the MU paths (for Cloud and SLES)
-# and for each combination it checks if the Cloud or SLES MU path is present on
-# the MU page content which registered in the mu_url variable.
-- name: Rsync MU repositories
-  synchronize:
-    mode: pull
-    src: "rsync://{{ maintenance_updates_server }}:/repos/SUSE:/Maintenance:/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}"
-    dest: "{{ local_repos_base_dir }}/{{ item.0 }}/"
-    rsync_opts:
-      - "--sparse"
-      - "--hard-links"
-      - "--fuzzy"
-      - "--delete-delay"
-  delegate_to: "{{ inventory_hostname }}"
-  when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
-  loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
-  register: mu_sync_result
-  retries: 5
-  until: mu_sync_result.rc != 24
-  delay: 300
+    # This tasks is responsible for finding to which product the MUs are targeted for.
+    # This is done by combining the MU IDs with the MU paths (for Cloud and SLES)
+    # and for each combination it checks if the Cloud or SLES MU path is present on
+    # the MU page content which registered in the mu_url variable.
+    - name: Rsync MU repositories
+      synchronize:
+        mode: pull
+        src: "rsync://{{ maintenance_updates_server }}:/repos/SUSE:/Maintenance:/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}"
+        dest: "{{ local_repos_base_dir }}/{{ item.0 }}/"
+        rsync_opts:
+          - "--sparse"
+          - "--hard-links"
+          - "--fuzzy"
+          - "--delete-delay"
+      delegate_to: "{{ inventory_hostname }}"
+      when:
+        - "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+        - zypper_repo_state == "present"
+      loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+      register: mu_sync_result
+      retries: 5
+      until: mu_sync_result.rc != 24
+      delay: 300
 
-- name: Add MU zypper repositories
-  zypper_repository:
-    name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
-    repo: "{{ local_repos_base_dir }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
-    runrefresh: yes
-    state: present
-  when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
-  loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
-  register: add_mu_repos_output
+    - name: Manage MU zypper repositories
+      zypper_repository:
+        name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
+        repo: "{{ local_repos_base_dir }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
+        runrefresh: yes
+        enabled: "{{ zypper_repo_enabled }}"
+        state: "{{ zypper_repo_state }}"
+      when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+      loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+      register: manage_mu_repos_output
 
-- fail:
-    msg: No repositories added
-  when: not add_mu_repos_output.changed
+    # TODO(fergal): This check is not idempotent safe - if we run the play multiple times, on
+    # subsequent runs no new repos will be registered so manage_mu_repos_output will not be
+    # registering as changed; instead we should be checking that there are MU repos registered
+    # after the previous step has completed.
+    - fail:
+        msg: No repositories added
+      when:
+        - not (manage_mu_repos_output is changed)
+        - mu_sync_result is changed
+        - zypper_repo_state == "present"
+        - zypper_repo_enabled in ["yes", true]
+
+  when:
+    - zypper_repo_state == "present"
+
+# Remove MU repo definitions and delete MU repo contents if specified
+- block:
+    - name: Remove MU zypper repos
+      zypper_repository:
+        name: "{{ item.1 }}-Maint-Update-{{ item.0 }}"
+        state: "{{ zypper_repo_state }}"
+      when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+      loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+
+    - name: Delete MU zypper repo contents
+      file:
+        path: "{{ local_repos_base_dir }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/"
+        state: absent
+      when:
+        - "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+        - zypper_repo_delete | bool
+      loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+
+  when:
+    - zypper_repo_state == "absent"

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_repo_from_iso.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_repo_from_iso.yml
@@ -15,19 +15,43 @@
 #
 ---
 
-- name: Download media "{{ media[cloud_release].name }}"
-  get_url:
-   url: "{{ media[cloud_release].url }}/{{ media[cloud_release].iso }}"
-   dest: "{{ media[cloud_release].dest }}"
-   mode: 0440
-  register: download_media
-  until: download_media is succeeded
-  retries: 5
-  delay: 3
+# Download ISO and add/enable/disable repo based on ISO
+- block:
+    - name: Download media "{{ media[cloud_release].name }}"
+      get_url:
+       url: "{{ media[cloud_release].url }}/{{ media[cloud_release].iso }}"
+       dest: "{{ media[cloud_release].dest }}"
+       mode: 0440
+      register: download_media
+      until: download_media is succeeded
+      retries: 5
+      delay: 3
 
-- name: Add media as zypper repository
-  zypper_repository:
-    name: "{{ media[cloud_release].name }}"
-    repo: "iso:///?iso={{ media[cloud_release].iso }}&url=dir:{{ media[cloud_release].dest }}"
-    auto_import_keys: yes
-    runrefresh: yes
+    - name: Manage media as zypper repository
+      zypper_repository:
+        name: "{{ media[cloud_release].name }}"
+        repo: "iso:///?iso={{ media[cloud_release].iso }}&url=dir:{{ media[cloud_release].dest }}"
+        auto_import_keys: yes
+        runrefresh: yes
+        state: "{{ zypper_repo_state }}"
+        enabled: "{{ zypper_repo_enabled }}"
+
+  when:
+    - zypper_repo_state == "present"
+
+# Remove ISO based repo definition and ISO if specified
+- block:
+    - name: Remove media as zypper repository
+      zypper_repository:
+        name: "{{ media[cloud_release].name }}"
+        state: "{{ zypper_repo_state }}"
+
+    - name: Delete media "{{ media[cloud_release].name }}"
+      file:
+        name: "{{ media[cloud_release].dest }}"
+        state: absent
+      when:
+        - zypper_repo_delete | bool
+
+  when:
+    - zypper_repo_state == "absent"

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_sles_cloud_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/setup_sles_cloud_repos.yml
@@ -18,13 +18,13 @@
 # If this task is included more than once as part of a single ansible-playbook
 # top-level command, the subsequent runs will inherit the list created/updated
 # by the earlier runs, which isn't always desirable.
-- name: Initialise repos_to_add as an empty list
+- name: Initialise repos_to_manage as an empty list
   set_fact:
-    repos_to_add: []
+    repos_to_manage: []
 
-- name: Gather repos to add
+- name: Gather repos to be managed
   set_fact:
-    repos_to_add: "{{ repos_to_add + item.repo }}"
+    repos_to_manage: "{{ repos_to_manage + item.repo }}"
   when: "item.enabled | default(True)"
   loop:
     - repo: "{{ base_repos }}"
@@ -39,59 +39,91 @@
     - repo: "{{ sles_ltss_test_repos }}"
       enabled: "{{ sles_ltss_enabled[cloud_release] and sles_test_repos_enabled }}"
 
-- name: Ensure repo directory exists
+- name: Setup managed zypper hierarchy
+  block:
+    - name: Ensure repo directory exists
+      file:
+        state: directory
+        path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}"
+      loop: "{{ repos_to_manage }}"
+
+    - name: Rsync repos that are frequently updated
+      synchronize:
+        mode: pull
+        src: "rsync://{{ clouddata_server }}/cloud/repos/{{ ansible_architecture }}/{{ item }}/"
+        dest: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}"
+        rsync_opts:
+          - "--sparse"
+          - "--hard-links"
+          - "--fuzzy"
+          - "--delete-delay"
+      delegate_to: "{{ inventory_hostname }}"
+      loop: "{{ repos_to_sync }}"
+      register: sync_result
+      retries: 5
+      until: sync_result.rc != 24
+      delay: 300
+      when:
+
+    - name: Add Pool tag to relevant rsync'd repos
+      lineinfile:
+        path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}/suse/repodata/repomd.xml"
+        insertafter: "<tags>"
+        line: "    <repo>obsproduct://build.suse.de/SUSE:{{ cloud_pool_tag }}</repo>"
+      loop: "{{ repos_to_sync }}"
+      when:
+        - item.endswith('-devel') or item.endswith('-devel-staging')
+
+    - name: Add Updates tag to relevant rsync'd repos
+      lineinfile:
+        path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}/suse/repodata/repomd.xml"
+        insertafter: "<tags>"
+        line: "    <repo>obsrepository://build.suse.de/SUSE:{{ cloud_updates_tag }}</repo>"
+      loop: "{{ repos_to_sync }}"
+      when:
+        - item.endswith('-devel') or item.endswith('-devel-staging')
+
+  when:
+    - zypper_repo_state == "present"
+
+- name: Remove zypper repo definitions
+  zypper_repository:
+    name: "{{ zypper_repo_name }}"
+    state: "{{ zypper_repo_state }}"
+  loop: "{{ repos_to_manage }}"
+  when:
+    # can only be absent if not enabled
+    - zypper_repo_state == "absent"
+
+- name: Delete zypper repo contents
   file:
-    state: directory
     path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}"
-  loop: "{{ repos_to_add }}"
-
-- name: Rsync repos that are frequently updated
-  synchronize:
-    mode: pull
-    src: "rsync://{{ clouddata_server }}/cloud/repos/{{ ansible_architecture }}/{{ item }}/"
-    dest: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}"
-    rsync_opts:
-      - "--sparse"
-      - "--hard-links"
-      - "--fuzzy"
-      - "--delete-delay"
-  delegate_to: "{{ inventory_hostname }}"
-  loop: "{{ repos_to_sync }}"
-  register: sync_result
-  retries: 5
-  until: sync_result.rc != 24
-  delay: 300
-
-- name: Add Pool tag to relevant rsync'd repos
-  lineinfile:
-    path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}/suse/repodata/repomd.xml"
-    insertafter: "<tags>"
-    line: "    <repo>obsproduct://build.suse.de/SUSE:{{ cloud_pool_tag }}</repo>"
+    state: absent
   loop: "{{ repos_to_sync }}"
   when:
-    - item.endswith('-devel') or item.endswith('-devel-staging')
+    # can only be true if state is absent and not enabled
+    - zypper_repo_delete | bool
 
-- name: Add Updates tag to relevant rsync'd repos
-  lineinfile:
-    path: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}/suse/repodata/repomd.xml"
-    insertafter: "<tags>"
-    line: "    <repo>obsrepository://build.suse.de/SUSE:{{ cloud_updates_tag }}</repo>"
-  loop: "{{ repos_to_sync }}"
-  when:
-    - item.endswith('-devel') or item.endswith('-devel-staging')
-
-- name: Mount repos that are not frequently updated
+# This will remove the NFS mount only after the repo is no longer in use
+# and delete is requested, or ensure it is mounted before attempting to
+# add it below.
+- name: Manage NFS mounting of repos that are not frequently updated
   mount:
     src: "{{ clouddata_server }}:/srv/nfs/repos/{{ ansible_architecture }}/{{ item }}"
     path: "{{ local_repos_base_dir }}/{{ item }}"
     opts: ro,nosuid,rsize=8192,wsize=8192,hard,intr,nolock,x-systemd.automount,noauto
     fstype: nfs
-    state: mounted
+    state: "{{ (zypper_repo_state == 'absent' and (zypper_repo_delete | bool)) | ternary('absent', 'mounted') }}"
   loop: "{{ repos_to_mount }}"
 
-- name: Add zypper repos
+# This will add a repo, possible in a disabled state, or disable an
+# existing repo, if it already present.
+- name: Manage zypper repos
   zypper_repository:
     name: "{{ zypper_repo_name }}"
     repo: "{{ local_repos_base_dir }}/{{ zypper_repo_name }}"
-    state: present
-  loop: "{{ repos_to_add }}"
+    enabled: "{{ zypper_repo_enabled }}"
+    state: "{{ zypper_repo_state }}"
+  loop: "{{ repos_to_manage }}"
+  when:
+    - zypper_repo_state == "present"

--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/templates/motd.j2
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/templates/motd.j2
@@ -5,7 +5,7 @@ Built by: {{ lookup('env', 'BUILD_URL') }}
 Media build version: {{ media_build_version }}
 Configured repositories:
 {% if cloud_product == 'ardana'%}
-{%   for repo in repos_to_add | sort %}
+{%   for repo in repos_to_manage | sort %}
   - {{ repo }}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Add support to the setup_zypper_repos role to allow it to completely
manage the lifecycle of repos, rather than just simply add them to
the system. This permits playbooks to:
  * add repos in a disabled state
  * disabled already defined repos
  * remove defined repos
  * delete the on-disk contents of downloaded repos or unmount NFS
    imported repos

Three new settings have been introduced that are used to manage the
state of zypper repos:
  * zypper_repo_enabled:
    - yes/no value indicates if repos are enabled or disabled
  * zypper_repo_state:
    - present/absent indicates if repos are added/remove
    - only valid if zypper_repo_enabled == no
  * zypper_repo_delete:
    - boolean indicating if repo on-disk contents or persistent NFS
      mount should be removed.
    - only valid if zypper_repo_state == absent

This will be useful to the Ardana/CLM upgrade process which will need
to dist-upgrade the deployer node from SP3/Cloud8 to SP4/Cloud9.

Renamed repos_to_add to repos_to_manage as a better logical fix for the
evolved usage of the fact.
