### PR TITLE
gating: Enable Cloud 7 gating submitproject

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -21,7 +21,6 @@
     cloud_gating_job:
       - cloud-7-gating:
           version: '7'
-          skip_submit_project: 'true'
       - cloud-8-gating:
           version: '8'
       - cloud-9-gating:


### PR DESCRIPTION
The Cloud 7 Gating in the ECP works the same way as the legacy Gating.
Therefore we can enable the submitproject job for this as well.