### PR TITLE
Created unified gating jobs (SOC-10029, SOC-10398)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -94,11 +94,6 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
             fwaas,trove,aodh,heat,magnum,manila,lbaas"
-          # Delete when adding to the cloud 8 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
       - cloud-crowbar9-job-gate-no-ha-deploy-x86_64:
           cloudsource: stagingcloud9
           ses_enabled: true
@@ -106,11 +101,6 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             heat,magnum,manila,lbaas"
-          # Delete when adding to the cloud 9 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'
 
@@ -137,11 +127,6 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
             fwaas,trove,aodh,heat,magnum,manila,lbaas"
-          # Delete when adding to the cloud 8 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
       - cloud-crowbar9-job-gate-ha-deploy-x86_64:
           cloudsource: stagingcloud9
           ses_enabled: true
@@ -149,11 +134,6 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             heat,magnum,manila,lbaas"
-          # Delete when adding to the cloud 9 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'
 
@@ -182,11 +162,6 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
             fwaas,trove,aodh,heat,magnum,manila,lbaas"
-          # Delete when adding to the cloud 8 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
       - cloud-crowbar9-job-gate-linuxbridge-deploy-x86_64:
           cloudsource: stagingcloud9
           ses_enabled: true
@@ -194,10 +169,5 @@
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             heat,magnum,manila,lbaas"
-          # Delete when adding to the cloud 9 gating job
-          cloud_env: cloud-crowbar-test-slot
-          reserve_env: true
-          triggers:
-           - timed: 'H H * * *'
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
@@ -5,12 +5,30 @@ SOC8:
   ardana8-update:
     job_name: cloud-ardana8-job-gate-entry-scale-kvm-update-x86_64
     job_params: []
+  crowbar8-no-ha-deploy:
+    job_name: cloud-crowbar8-job-gate-no-ha-deploy-x86_64
+    job_params: []
+  crowbar8-ha-deploy:
+    job_name: cloud-crowbar8-job-gate-ha-deploy-x86_64
+    job_params: []
+  crowbar8-linuxbridge-deploy:
+    job_name: cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64
+    job_params: []
 SOC9:
   ardana9-deploy:
     job_name: cloud-ardana9-job-gate-entry-scale-kvm-deploy-x86_64
     job_params: []
   ardana9-update:
     job_name: cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64
+    job_params: []
+  crowbar9-no-ha-deploy:
+    job_name: cloud-crowbar9-job-gate-no-ha-deploy-x86_64
+    job_params: []
+  crowbar9-ha-deploy:
+    job_name: cloud-crowbar9-job-gate-ha-deploy-x86_64
+    job_params: []
+  crowbar9-linuxbridge-deploy:
+    job_name: cloud-crowbar9-job-gate-linuxbridge-deploy-x86_64
     job_params: []
 SOCC7:
   crowbar7-no-ha-deploy:
@@ -22,26 +40,5 @@ SOCC7:
   crowbar7-linuxbridge-deploy:
     job_name: cloud-crowbar7-job-gate-linuxbridge-deploy-x86_64
     job_params: []
-#
-# NOTE: to be enabled when Crowbar ECP gating jobs will replace mkcloud gating jobs
-#
-#SOCC8:
-#  crowbar8-no-ha-deploy:
-#    job_name: cloud-crowbar8-job-gate-no-ha-deploy-x86_64
-#    job_params: []
-#  crowbar8-ha-deploy:
-#    job_name: cloud-crowbar8-job-gate-ha-deploy-x86_64
-#    job_params: []
-#  crowbar8-linuxbridge-deploy:
-#    job_name: cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64
-#    job_params: []
-#SOCC9:
-#  crowbar9-no-ha-deploy:
-#    job_name: cloud-crowbar9-job-gate-no-ha-deploy-x86_64
-#    job_params: []
-#  crowbar9-ha-deploy:
-#    job_name: cloud-crowbar9-job-gate-ha-deploy-x86_64
-#    job_params: []
-#  crowbar9-linuxbridge-deploy:
-#    job_name: cloud-crowbar9-job-gate-linuxbridge-deploy-x86_64
-#    job_params: []
+
+

--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -110,8 +110,10 @@ pipeline {
             string(name: 'project', value: "Devel:Cloud:${version}"),
             string(name: 'starttime', value: "${starttime}"),
             string(name: 'subproject', value: "Staging"),
-            string(name: 'package_whitelist', value: "ardana venv"),
-            string(name: 'package_blacklist', value: "crowbar")
+            // for unified gated we want everything white listed
+            // and nothing black listed.
+            string(name: 'package_whitelist', value: ""),
+            string(name: 'package_blacklist', value: "")
           ])
         }
       }


### PR DESCRIPTION
This should functially move all gating to the ECP based CI.
Changes:
1: enable Staging to Dev propigation for Cloud 8, 9 through ECP gate jobs
2: add crowbar jobs to cloud-{8,9}-gating
3: remove crowbar blacklist and ardana white list from ECP

Based code in: jenkins/ci.suse.de/openstack-submit-project.yaml

ISO modified time at the start time of the cloud-{8,9}-gating jobs that control
which packages will be promoted and since that will be the same
for crowbar and ardana, things should be as correct as they are now.
Possible more so, since the current code allows to venv rpms to trail
the RPMs in the ISOs.