### PR TITLE
dns: Drop the admin node after initial deployment (SOC-10636)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2463,7 +2463,7 @@ function custom_configuration
         ;;
         dns)
             [ "$want_multidnstest" = 1 ] || return 0
-            local cmachines=$(get_all_suse_nodes | head -n 3)
+            local cmachines=$(get_all_suse_nodes | head -n 3 | tail -n 2)
             local dnsnodes=`echo \"$cmachines\" | sed 's/ /", "/g'`
             proposal_set_value dns default "['attributes']['dns']['records']['multi-dns']" "{}"
             [[ $want_designate_proposal = 1 ]] && proposal_set_value dns default "['attributes']['dns']['enable_designate']" true


### PR DESCRIPTION
As it stands, the DNS barclamp is applied with only the admin node in
the dns-server role. As the first part of the proposal step, it adds the
first two nodes (for a total of 3 nodes) so we get multi-master DNS.
Filter out the lead node, which should drop the admin node from the
role.