### PR TITLE
Implement initial Ardana upgrade workflow (SOC-9780)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ screenlog*
 scripts/jenkins/cloud/manual/ansible-venv
 scripts/jenkins/cloud/manual/mitogen
 scripts/jenkins/cloud/ansible/ansible_facts
+scripts/jenkins/cloud/ansible/ardana-bm-info
 scripts/jenkins/cloud/ansible/*-virt-config.yml
 scripts/jenkins/cloud/ansible/input_model
 scripts/jenkins/cloud/ansible/heat-stack-*.yml

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -103,8 +103,8 @@
           name: update_after_deploy
           default: '{update_after_deploy|false}'
           description: >-
-            Run ardana update after the cloud is deployed. If true the MU's will
-            be applied only after the cloud is deployed.
+            Run ardana update or upgrade after the cloud is deployed. If true the MU's
+            will be applied only after the cloud is deployed.
             If `updates_test_enabled` is true, the test updates will be
             applied post-deployment only if the cloudsource is GM based.
 
@@ -126,6 +126,25 @@
           description: >-
             Only valid if update_after_deploy is true. The cloud repository
             (from provo-clouddata) to be used to update.
+
+      - choice:
+          name: upgrade_cloudsource
+          choices:
+            - '{upgrade_cloudsource|}'
+            - stagingcloud8
+            - develcloud8
+            - GM8
+            - GM8+up
+            - hosdevelcloud8
+            - hosGM8
+            - hosGM8+up
+            - stagingcloud9
+            - develcloud9
+            - GM9
+            - GM9+up
+          description: >-
+            Only valid if update_after_deploy is true. The cloud repository
+            (from provo-clouddata) to be used for upgrade.
 
       - validating-string:
           name: maint_updates

--- a/scripts/jenkins/cloud/ansible/ardana-disable-repos.yml
+++ b/scripts/jenkins/cloud/ansible/ardana-disable-repos.yml
@@ -1,0 +1,64 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- name: Disable/remove {{ cloudsource }} SLE/SOC repos on deployer
+  hosts: "{{ cloud_env }}"
+  remote_user: ardana
+  gather_facts: True
+  vars:
+    task: "disable-repos"
+
+  pre_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "started"
+        rc_state: "Started"
+      when: rc_notify
+
+  tasks:
+    - block:
+        - include_role:
+            name: setup_zypper_repos
+          vars:
+            ansible_become: yes
+            zypper_repo_enabled: no
+            zypper_repo_state: absent
+      rescue:
+        - include_role:
+            name: rocketchat_notify
+          vars:
+            rc_action: "finished"
+            rc_state: "Failed"
+          when: rc_notify
+
+        - name: Stop if something failed
+          fail:
+            msg: "{{ task }} failed."
+      always:
+        - include_role:
+            name: jenkins_artifacts
+          when: lookup("env", "WORKSPACE")
+
+  post_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "finished"
+        rc_state: "Success"
+      when: rc_notify

--- a/scripts/jenkins/cloud/ansible/ardana-reboot.yml
+++ b/scripts/jenkins/cloud/ansible/ardana-reboot.yml
@@ -1,0 +1,61 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- name: Reboot Ardana Cloud
+  hosts: "{{ cloud_env }}"
+  remote_user: ardana
+  gather_facts: True
+  vars:
+    task: "reboot"
+
+  pre_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "started"
+        rc_state: "Started"
+      when: rc_notify
+
+  tasks:
+    - block:
+        - name: Reboot nodes
+          include_role:
+            name: ardana_reboot
+      rescue:
+        - include_role:
+            name: rocketchat_notify
+          vars:
+            rc_action: "finished"
+            rc_state: "Failed"
+          when: rc_notify
+
+        - name: Stop if something failed
+          fail:
+            msg: "{{ task }} failed."
+      always:
+        - include_role:
+            name: jenkins_artifacts
+          when: lookup("env", "WORKSPACE")
+
+  post_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "finished"
+        rc_state: "Success"
+      when: rc_notify

--- a/scripts/jenkins/cloud/ansible/ardana-upgrade.yml
+++ b/scripts/jenkins/cloud/ansible/ardana-upgrade.yml
@@ -1,0 +1,87 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- name: Upgrade ardana
+  hosts: "{{ cloud_env }}"
+  remote_user: ardana
+  gather_facts: True
+  vars:
+    task: "upgrade"
+
+  pre_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "started"
+        rc_state: "Started"
+      when: rc_notify
+
+  tasks:
+    - block:
+        # Ensure SLE 12 SP4 ISO is downloaded and ready for cobbler-deploy
+        - include_role:
+            name: bootstrap_ardana
+            tasks_from: download_cobbler_requires.yml
+
+        # The appropriate PTF repo will be automatically created/added when
+        # ardana-init is run as part of the ardana_upgrade role.
+        - name: Remove any PTF repo associated with a previous cloudsource
+          become: yes
+          zypper_repository:
+            name: PTF
+            state: absent
+
+        - include_role:
+            name: setup_zypper_repos
+          vars:
+            ansible_become: yes
+
+        - include_role:
+            name: ardana_upgrade
+
+        - include_role:
+            name: setup_amphora_image
+
+        - name: Reboot nodes
+          include_role:
+            name: ardana_reboot
+          when: pending_system_reboot
+
+      rescue:
+        - include_role:
+            name: rocketchat_notify
+          vars:
+            rc_action: "finished"
+            rc_state: "Failed"
+          when: rc_notify
+
+        - name: Stop if something failed
+          fail:
+            msg: "{{ task }} failed."
+      always:
+        - include_role:
+            name: jenkins_artifacts
+          when: lookup("env", "WORKSPACE")
+
+  post_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "finished"
+        rc_state: "Success"
+      when: rc_notify

--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -22,6 +22,11 @@ debug: False
 
 upgrade_cloudsource: ""
 
+# The upgrade release is encoded in the upgrade_cloudsource value
+upgrade_release_number: "{{ upgrade_cloudsource | regex_search('\\d') }}"
+upgrade_release: "{{ (upgrade_release_number | length) |
+                     ternary('cloud' ~ upgrade_release_number, '') }}"
+
 # cloud product can be ardana or crowbar
 cloud_product: "ardana"
 

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
@@ -82,8 +82,8 @@
 - name: Ensure extra-repos repository on non-deployer nodes
   command: |
     ansible -m command -a "zypper ar -f -G -p 90 \
-        http://{{ '{{' }} hostvars[groups['ARD-SVC--first-member'].0].ansible_ssh_host {{ '}}' }}:79/{{ suse_release | replace('.', '-') | upper }}/{{ ansible_architecture }}/repos/extra-repos \
-        extra-repos creates=/etc/zypp/repos.d/extra-repos.repo" -b 'resources:!ARD-SVC--first-member:!*rhel*'
+        http://{{ '{{' }} hostvars[groups['OPS-LM--first-member'].0].ansible_ssh_host {{ '}}' }}:79/{{ suse_release | replace('.', '-') | upper }}/{{ ansible_architecture }}/repos/extra-repos \
+        extra-repos creates=/etc/zypp/repos.d/extra-repos.repo" -b 'resources:!OPS-LM--first-member:!*rhel*'
   environment:
     ANSIBLE_HOST_KEY_CHECKING: False
     ANSIBLE_SSH_ARGS: '-o UserKnownHostsFile=/dev/null'

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/templates/maint_updates.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/templates/maint_updates.yml.j2
@@ -27,7 +27,7 @@
       Cloud: "SUSE_Updates_{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'OpenStack-Cloud') }}_{{ sles_cloud_version[ansible_distribution_version] }}_x86_64"
       SLES: "SUSE_Updates_SLE-SERVER_{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}_x86_64"
 {% raw %}
-    deployer_ip: "{{ hostvars[groups['ARD-SVC--first-member'].0].ansible_ssh_host }}"
+    deployer_ip: "{{ hostvars[groups['OPS-LM--first-member'].0].ansible_ssh_host }}"
 
   tasks:
     - name: Check MU URL

--- a/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/main.yml
@@ -15,17 +15,43 @@
 #
 ---
 
-- name: Get list of non-deployer nodes
-  shell: |
-    deployer=`grep -A 1 ARD-SVC--first-member hosts/verb_hosts | tail -1`
-    for line in $(awk '/resources/' RS= hosts/verb_hosts); do
-      if [[ $deployer != *$line* ]]; then
-        echo $line
-      fi
-    done
+- name: Get deployer node
+  command: |
+    ansible 'OPS-LM--first-member' --list-hosts
   args:
     chdir: "{{ ardana_scratch_path }}"
-  register: ardana_nodes
+  register: ardana_deployer_result
+  changed_when: False
+
+- name: Get list of non-deployer non-compute i.e. controller nodes
+  command: |
+    ansible 'resources:!OPS-LM--first-member:!NOV-CMP' --list-hosts
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  register: ardana_controllers_result
+  changed_when: False
+
+- name: Get list of non-deployer compute nodes
+  command: |
+    ansible 'resources:!OPS-LM--first-member:&NOV-CMP' --list-hosts
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  register: ardana_computes_result
+  changed_when: False
+
+- name: Set node variables
+  set_fact:
+    ardana_deployer: "{{ ardana_deployer_result.stdout | trim }}"
+    ardana_controllers: "{{ ardana_controllers_result.stdout_lines | map('trim') | list }}"
+    ardana_computes: "{{ ardana_computes_result.stdout_lines | map('trim') | list }}"
+
+- debug:
+    var: "{{ item }}"
+    verbosity: 1
+  with_items:
+    - ardana_deployer
+    - ardana_controllers
+    - ardana_computes
 
 - include_tasks: reboot_nodes.yml
 

--- a/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/reboot_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/reboot_nodes.yml
@@ -28,13 +28,22 @@
 
 - name: Run post-reboot playbook on deployer
   command: |
-    ansible-playbook _ardana-post-reboot.yml --limit ARD-SVC--first-member  -e '{{ ardana_extra_vars|to_json }}'
+    ansible-playbook _ardana-post-reboot.yml --limit {{ ardana_deployer }}  -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
 
-- name: Reboot non-deployer nodes serially
+- name: Reboot non-deployer controller nodes serially, if any
   command: |
     ansible-playbook ardana-reboot.yml --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
-  loop: "{{ ardana_nodes.stdout_lines }}"
+  loop: "{{ ardana_controllers }}"
+  when: (ardana_controllers | count) > 0
+
+- name: Reboot compute nodes serially, if any
+  command: |
+    ansible-playbook ardana-reboot.yml --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  loop: "{{ ardana_computes }}"
+  when: (ardana_computes | count) > 0

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/main.yml
@@ -16,13 +16,8 @@
 ---
 
 - name: Get list of non-deployer nodes
-  shell: |
-    deployer=`grep -A 1 ARD-SVC--first-member hosts/verb_hosts | tail -1`
-    for line in $(awk '/resources/' RS= hosts/verb_hosts); do
-      if [[ $deployer != *$line* ]]; then
-        echo $line
-      fi
-    done
+  command: |
+    ansible 'resources:!OPS-LM--first-member' --list-hosts
   args:
     chdir: "{{ ardana_scratch_path }}"
   register: ardana_nodes

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/update_nodes.yml
@@ -25,7 +25,7 @@
 - name: Run ardana-update-pkgs playbook for deployer
   shell: |
     ansible-playbook ardana-update-pkgs.yml \
-      -l ARD-SVC--first-member -e \
+      -l OPS-LM--first-member -e \
       "zypper_update_method={{ update_method }}
        zypper_update_gpg_checks={{ update_gpg_checks }}
        zypper_update_licenses_agree={{ update_gpg_checks }}

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/defaults/main.yml
@@ -16,11 +16,6 @@
 ---
 
 deployer_ip: "{{ '{{' }} hostvars[groups['OPS-LM--first-member'].0].ansible_ssh_host {{ '}}' }}"
-update_method: "{{ (cloudsource | regex_search('devel|staging.*')) | ternary('update', 'patch') }}"
-update_gpg_checks: true
-update_licenses_agree: true
-update_include_reboot_patches: true
-update_services_serial: False
 
 cloud_brand: "{{ cloudsource.startswith('hos') | ternary('HPE-Helion-OpenStack', 'SUSE-OpenStack-Cloud') }}"
 cloud_update_repo_name: "{{ cloud_brand }}-{{ sles_cloud_version[ansible_distribution_version] }}-Updates"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/files/cloud9-input-model-upgrade
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/files/cloud9-input-model-upgrade
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Runs in the deployer.
+#
+
+set -eux
+set -o pipefail
+
+pushd "${HOME}/openstack/my_cloud/definition"
+
+deprecated_svc_comps=(
+    freezer-agent
+    freezer-api
+    glance-registry
+    heat-api-cloudwatch
+    neutron-lbaasv2-agent
+    nova-console-auth
+)
+
+for dsc in "${deprecated_svc_comps[@]}"
+do
+    found_files=( $(grep -rIl '^[[:space:]]*-[[:space:]]*'"${dsc}"'[[:space:]]*$' . || true) )
+
+    # continue to next iteration if no matching files found
+    (( ${#found_files[@]} > 0 )) || continue
+
+    echo "*** Fixing '${dsc}' references in ${found_files[@]}"
+    sed -i -e 's/\(^[[:space:]]*\)\(-[[:space:]]*'"${dsc}"'[[:space:]]*\)$/\1#\2/' \
+        "${found_files[@]}"
+done
+
+
+git add -A
+git commit --allow-empty -m "Cloud9 Upgrade - apply mandated changes to input model"
+
+# vim:shiftwidth=4:tabstop=4:expandtab

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/_upgrade-clm.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/_upgrade-clm.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -20,6 +20,18 @@
   environment:
     ARDANA_INIT_AUTO: 1
 
+- name: Copy up input model upgrade script
+  copy:
+    src: "{{ cloud_release }}-input-model-upgrade"
+    dest: "~/cloud-input-model-upgrade"
+    mode: 0755
+  register: ansible_copy_input_model_upgrade
+
+- name: Run input model upgrade script
+  shell: >-
+    ~/cloud-input-model-upgrade
+  register: ansible_input_model_upgrade
+
 - name: Run playbooks from "{{ ardana_openstack_path }}"
   command: |
     ansible-playbook -i hosts/localhost {{ item.play }}
@@ -30,6 +42,8 @@
   when:
     - item.when | default(True)
     - not (ansible_openstack_plays | default({})) is failed
+
+- include_tasks: update_status.yml
 
 - name: Clear pending CLM update status
   command: |

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/add_mu_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/add_mu_repos.yml
@@ -1,0 +1,34 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Add MU zypper repo(s) on all ardana nodes
+  command: |
+    ansible -b -m zypper_repository -a "name={{ item.1 }}-Maint-Update-{{ item.0 }}
+      repo={{ deployer_repo_base_url }}/{{ item.0 }}/{{ maintenance_updates_path[item.1] }}/
+      state=present" 'resources:!*rhel*'
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+  loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+
+- name: Update motd with MU updates
+  lineinfile:
+    path: /etc/motd
+    line: "  - {{ item.1 }}-Maint-Update-{{ item.0 }}"
+  when: "maintenance_updates_path[item.1] in mu_url.results | selectattr('item', 'equalto', item.0) | map(attribute='content') | join(' ')"
+  loop: "{{ maint_updates_list | product(maintenance_updates_path) | list }}"
+  become: yes

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/main.yml
@@ -1,0 +1,34 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+# Currently we set cloudsource==upgrade cloudsource when calling this role
+- name: Sanity test
+  fail:
+    msg: |
+      When calling the ardana-upgrade.yml playbook please specify the
+      target upgrade_cloudsource as the value for cloudsource using
+      a command line extra varsm, e.g.
+        % ansible-playbook ardana-upgrade.yml -e @input.yml \\
+            -e cloudsource={{ upgrade_cloudsource }}
+  when:
+    - cloudsource != upgrade_cloudsource
+
+- include_tasks: pre_cloudsource_upgrade.yml
+  when:
+    - when_staging_or_devel | bool
+
+- include_tasks: upgrade_nodes.yml

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/pre_cloudsource_upgrade.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/pre_cloudsource_upgrade.yml
@@ -1,0 +1,46 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Import Devel:Cloud:X key on all nodes when cloudsource is staging or devel
+  shell: "ansible {{ item }} resources"
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  environment:
+    ANSIBLE_HOST_KEY_CHECKING: False
+    ANSIBLE_SSH_ARGS: '-o UserKnownHostsFile=/dev/null'
+  loop:
+    - '-m copy -a "src=`find /srv/www/*/x86_64/repos/*Cloud* -name content.key` dest=/tmp/"'
+    - '-b -a "rpm --import /tmp/content.key"'
+  when: when_staging_or_devel | bool
+
+# Upgrading to another cloudsource may change the package vendor (SUSE LLC, obs)
+# disabling vendor stickiness allows the ardana update playbook to include those
+# packages on the upgrade
+- name: Disable zypper vendor stickiness on all nodes
+  command: |
+    ansible -b -m lineinfile -a "dest=/etc/zypp/zypp.conf
+      regexp='^solver.allowVendorChange' line='solver.allowVendorChange = true'"
+      'resources:!*rhel*'
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+
+- name: Update motd with upgrade cloudsource
+  lineinfile:
+    path: /etc/motd
+    line: "System upgraded to {{ cloudsource }} on {{ ansible_date_time.date }}"
+    insertafter: "^Media"
+  become: yes

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/update_status.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/update_status.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2019 SUSE LLC
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,12 +15,13 @@
 #
 ---
 
-- name: Run ardana-update playbook to update services on all nodes serially
-  command: |
-    ansible-playbook ardana-update.yml \
-      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
+- name: Get update status
+  shell: |
+    ansible-playbook ardana-update-status.yml \
+      -e update_status_brief=true | grep "Pending update actions"
   args:
     chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
-  loop: "['OPS-LM--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"
+  register: _ardana_update_status
+
+- debug:
+    var: _ardana_update_status

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/upgrade_deployer.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/upgrade_deployer.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2019 SUSE LLC
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,12 +15,16 @@
 #
 ---
 
-- name: Run ardana-update playbook to update services on all nodes serially
-  command: |
-    ansible-playbook ardana-update.yml \
-      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
-  loop: "['OPS-LM--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"
+- name: Run zypper dist-upgrade on deployer
+  become: yes
+  zypper:
+    name: '*'
+    state: dist-upgrade
+    extra_args: '--auto-agree-with-licenses'
+  register: _deployer_zypper_dist_upgrade
+
+- name: Upgrade CLM services
+  include_tasks: _upgrade-clm.yml
+  when: _deployer_zypper_dist_upgrade is changed
+
+- include_tasks: update_status.yml

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/upgrade_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/upgrade_nodes.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2019 SUSE LLC
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,12 +15,17 @@
 #
 ---
 
-- name: Run ardana-update playbook to update services on all nodes serially
-  command: |
-    ansible-playbook ardana-update.yml \
-      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
+- name: Upgrade deployer
+  include_tasks: upgrade_deployer.yml
+
+- name: Run ardana-upgrade playbook for all nodes
+  command: >
+    ansible-playbook ardana-upgrade.yml
   args:
     chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
-  loop: "['OPS-LM--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"
+
+- include_tasks: update_status.yml
+
+- name: Indicate that a system reboot is needed
+  set_fact:
+    pending_system_reboot: true

--- a/scripts/jenkins/cloud/ansible/roles/bootstrap_ardana/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/bootstrap_ardana/defaults/main.yml
@@ -33,7 +33,7 @@ cobbler_requires:
     download_when: "{{ cloud_release == 'cloud8' and (is_physical_deploy or pxe_boot_enabled) }}"
   - name: "sles12sp4.iso"
     url: "http://{{ sles_media_server }}/install/SLE-12-SP4-Server-GM/SLE-12-SP4-Server-DVD-x86_64-GM-DVD1.iso"
-    download_when: "{{ cloud_release == 'cloud9' and (is_physical_deploy or pxe_boot_enabled) }}"
+    download_when: "{{ ((cloud_release == 'cloud9') or (upgrade_release == 'cloud9')) and (is_physical_deploy or pxe_boot_enabled) }}"
   - name: "rhel7.iso"
     url: "http://10.84.144.252/compute_iso/{{ rhel_iso[rhel_os] }}"
     download_when: "{{ rhel_enabled }}"

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/service/full-spread.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/service/full-spread.yml
@@ -37,7 +37,7 @@ service_groups:
   - name: clm
     type: cluster
     prefix: clm
-    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-minimal"
     member_count: '{{ (clm_model == "standalone") | ternary(1, 0) }}'
     service_components:
       - CLM
@@ -53,14 +53,14 @@ service_groups:
   - name: lmm
     type: cluster
     prefix: lmm
-    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-controller"
     member_count: '{{ lmm_nodes|default(3) }}'
     service_components:
       - LMM
   - name: dbmq
     type: cluster
     prefix: dbmq
-    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-minimal"
+    heat_flavor_id: "{{ vcloud_flavor_name_prefix }}-compute"
     member_count: '{{ dbmq_nodes|default(3) }}'
     service_components:
       - DBMQ

--- a/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/disable-repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/disable-repos.yml
@@ -1,0 +1,70 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+# Announcement
+rc_announcement_started: "Disable Repos in PROGRESS: {{ _announcement_full }}"
+rc_announcement_finished: "{{ 'READY FOR TESTING: ' if rc_state == 'Success' else 'Disable Repos FAILED: ' }} {{ _announcement_full }}"
+
+_announcement_full: "{{ _announcement_data + _announcement_mu if _mu_available else _announcement_data }}"
+
+_announcement_data: "{{ cloudsource }} - {{ rc_im_name }}{{ _announcement_ses }}"
+_announcement_mu: "{{ ' - MU: ' + maint_updates if maint_updates is defined else '' }}"
+
+_announcement_ses: "{{ ses_enabled | ternary('-SES', '') }}"
+
+# Chat message
+rc_msg_fields_started: "{{ _msg_fields_started + _msg_field_mu }}"
+rc_msg_fields_finished: "{{ _msg_fields_finished + _msg_field_mu }}"
+
+_msg_ses_enabled: "{{ ses_enabled | ternary('Yes', 'No') }}"
+_msg_fields_started:
+  - title: Started by
+    value: "{{ jenkins_build_url_msg }}"
+    short: False
+  - title: Ardana log stream
+    value: "{{ ansible_log_stream_msg if cloud_env in groups['all'] else 'NA' }}"
+    short: False
+  - title: Deployer
+    value: "{{ hostvars[cloud_env].ansible_host if cloud_env in groups['all'] else 'NA' }}"
+    short: True
+  - title: Disabling cloudsource
+    value: "{{ cloudsource }}"
+    short: True
+
+_msg_fields_finished:
+  - title: Built by
+    value: "{{ jenkins_build_url_msg }}"
+    short: False
+  - title: Log
+    value: "{{ ansible_log_url_msg if jenkins_build_url else 'Not available' }}"
+    short: False
+  - title: Deployer
+    value: "{{ hostvars[cloud_env].ansible_host if cloud_env in groups['all'] else 'NA' }}"
+    short: True
+  - title: Disabled cloudsource
+    value: "{{ cloudsource }}"
+    short: True
+  - title: Status
+    value: "{{ rc_state }}"
+    short: True
+
+_field_mu:
+  - title: MU
+    value: "{{ maint_updates | default('') }}"
+    short: True
+_mu_available: "{{ maint_updates is defined and maint_updates | length > 0 }}"
+_msg_field_mu: "{{ _mu_available | ternary(_field_mu, []) }}"

--- a/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/reboot.yml
+++ b/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/reboot.yml
@@ -1,0 +1,55 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+# Announcement
+rc_announcement_started: "Reboot in PROGRESS"
+rc_announcement_finished: "{{ _announcement_success if rc_state == 'Success' else _announcement_failed }}"
+
+_announcement_success: "{{ _announcement_data | regex_replace('^Reboot FAILED', 'READY FOR TESTING') if rc_previous_announcement.content is defined else 'NA' }}"
+_announcement_failed: "{{ _announcement_data | regex_replace('^READY FOR TESTING', 'Reboot FAILED') if rc_previous_announcement.content is defined else 'NA' }}"
+
+_previous_announcement: "{{ rc_previous_announcement.content | b64decode }}"
+_announcement_data: "{{ _previous_announcement }}"
+
+# Chat message
+rc_msg_fields_started: "{{ _msg_fields_started }}"
+rc_msg_fields_finished: "{{ _msg_fields_finished }}"
+
+_msg_fields_started:
+  - title: Started by
+    value: "{{ jenkins_build_url_msg }}"
+    short: False
+  - title: Ardana log stream
+    value: "{{ ansible_log_stream_msg }}"
+    short: False
+  - title: Deployer
+    value: "{{ hostvars[cloud_env].ansible_host }}"
+    short: True
+
+_msg_fields_finished:
+  - title: Built by
+    value: "{{ jenkins_build_url_msg }}"
+    short: False
+  - title: Log
+    value: "{{ ansible_log_url_msg if jenkins_build_url else 'Not available' }}"
+    short: False
+  - title: Deployer
+    value: "{{ hostvars[cloud_env].ansible_host }}"
+    short: True
+  - title: Status
+    value: "{{ rc_state }}"
+    short: True

--- a/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/upgrade.yml
+++ b/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/upgrade.yml
@@ -1,0 +1,73 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+# Announcement
+rc_announcement_started: "Upgrade in PROGRESS {{ _announcement_mu }}"
+rc_announcement_finished: "{{ _announcement_success if rc_state == 'Success' else _announcement_failed }}"
+
+_announcement_success: "{{ _announcement_data | regex_replace('^Upgrade FAILED', 'READY FOR TESTING') if rc_previous_announcement.content is defined else 'NA' }}"
+_announcement_failed: "{{ _announcement_data | regex_replace('^READY FOR TESTING', 'Upgrade FAILED') if rc_previous_announcement.content is defined else 'NA' }}"
+
+_previous_announcement: "{{ rc_previous_announcement.content | b64decode }}"
+_announcement_cloudsource: "{{ _previous_announcement | regex_replace('READY FOR TESTING: [^ ]* ', 'READY FOR TESTING: ' ~ cloudsource ~ ' ') if cloudsource not in _previous_announcement else _previous_announcement }}"
+_announcement_data: "{{ _announcement_cloudsource | regex_replace('.- MU.*', _announcement_mu) if 'MU' in _announcement_cloudsource else _announcement_cloudsource + _announcement_mu }}"
+
+_announcement_mu: "{{ ' - MU: ' + maint_updates if maint_updates is defined else '' }}"
+
+# Chat message
+rc_msg_fields_started: "{{ _msg_fields_started + _msg_field_mu }}"
+rc_msg_fields_finished: "{{ _msg_fields_finished + _msg_field_mu }}"
+
+_msg_fields_started:
+  - title: Started by
+    value: "{{ jenkins_build_url_msg }}"
+    short: False
+  - title: Ardana log stream
+    value: "{{ ansible_log_stream_msg }}"
+    short: False
+  - title: Deployer
+    value: "{{ hostvars[cloud_env].ansible_host }}"
+    short: True
+  - title: Upgrading to cloudsource
+    value: "{{ cloudsource }}"
+    short: True
+
+_msg_fields_finished:
+  - title: Built by
+    value: "{{ jenkins_build_url_msg }}"
+    short: False
+  - title: Log
+    value: "{{ ansible_log_url_msg if jenkins_build_url else 'Not available' }}"
+    short: False
+  - title: Deployer
+    value: "{{ hostvars[cloud_env].ansible_host }}"
+    short: True
+  - title: Upgraded to cloudsource
+    value: "{{ cloudsource }}"
+    short: True
+  - title: Status
+    value: "{{ rc_state }}"
+    short: True
+
+_field_mu:
+  - title: MU
+    value: "{{ maint_updates | default('') }}"
+    short: True
+
+_mu_available: "{{ maint_updates is defined and maint_updates | length > 0 }}"
+
+_msg_field_mu: "{{ _mu_available | ternary(_field_mu, []) }}"

--- a/scripts/jenkins/cloud/manual/deploy-ardana.sh
+++ b/scripts/jenkins/cloud/manual/deploy-ardana.sh
@@ -32,5 +32,6 @@ deploy_ses_vcloud
 bootstrap_nodes
 deploy_cloud
 update_cloud
+upgrade_cloud
 run_tempest
 run_qa_tests

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -66,7 +66,7 @@ update_after_deploy: false
 update_to_cloudsource: ''
 
 # Only valid if update_after_deploy is true. The cloud repository to be used for
-# upgrade (Crowbar only).
+# upgrade.
 # This option takes the same values as cloudsource.
 upgrade_cloudsource: ''
 

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -328,9 +328,12 @@ function update_cloud {
 }
 
 function upgrade_cloud {
-    if $(get_from_input deploy_cloud) && $(get_from_input update_after_deploy) && [[ -n $(get_from_input upgrade_cloudsource) ]]; then
+    if $(get_from_input deploy_cloud) && $(get_from_input update_after_deploy) && [[ -n "$(get_from_input upgrade_cloudsource)" ]]; then
         if [ "$(get_cloud_product)" == "crowbar" ]; then
             ansible_playbook crowbar-upgrade.yml
+        else
+            ansible_playbook ardana-disable-repos.yml
+            ansible_playbook ardana-upgrade.yml -e cloudsource="$(get_from_input upgrade_cloudsource)"
         fi
     fi
 }

--- a/scripts/jenkins/cloud/manual/reboot-ardana.sh
+++ b/scripts/jenkins/cloud/manual/reboot-ardana.sh
@@ -1,5 +1,6 @@
-#
-# (c) Copyright 2019 SUSE LLC
+#!/bin/bash
+
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -12,15 +13,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-#
----
 
-- name: Run ardana-update playbook to update services on all nodes serially
-  command: |
-    ansible-playbook ardana-update.yml \
-      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
-  loop: "['OPS-LM--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"
+set -e
+
+source lib.sh
+
+validate_input
+setup_ansible_venv
+mitogen_enable
+
+trap exit_msg EXIT
+
+ansible_playbook ardana-reboot.yml

--- a/scripts/jenkins/cloud/manual/test-ardana.sh
+++ b/scripts/jenkins/cloud/manual/test-ardana.sh
@@ -1,5 +1,6 @@
-#
-# (c) Copyright 2019 SUSE LLC
+#!/bin/bash
+
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -12,15 +13,16 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-#
----
 
-- name: Run ardana-update playbook to update services on all nodes serially
-  command: |
-    ansible-playbook ardana-update.yml \
-      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
-  loop: "['OPS-LM--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"
+set -e
+
+source lib.sh
+
+validate_input
+setup_ansible_venv
+mitogen_enable
+
+trap exit_msg EXIT
+
+run_tempest
+run_qa_tests

--- a/scripts/jenkins/cloud/manual/update-ardana.sh
+++ b/scripts/jenkins/cloud/manual/update-ardana.sh
@@ -1,5 +1,6 @@
-#
-# (c) Copyright 2019 SUSE LLC
+#!/bin/bash
+
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -12,15 +13,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-#
----
 
-- name: Run ardana-update playbook to update services on all nodes serially
-  command: |
-    ansible-playbook ardana-update.yml \
-      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
-  loop: "['OPS-LM--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"
+set -e
+
+source lib.sh
+
+validate_input
+setup_ansible_venv
+mitogen_enable
+
+trap exit_msg EXIT
+
+update_cloud

--- a/scripts/jenkins/cloud/manual/upgrade-ardana.sh
+++ b/scripts/jenkins/cloud/manual/upgrade-ardana.sh
@@ -1,5 +1,6 @@
-#
-# (c) Copyright 2019 SUSE LLC
+#!/bin/bash
+
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -12,15 +13,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-#
----
 
-- name: Run ardana-update playbook to update services on all nodes serially
-  command: |
-    ansible-playbook ardana-update.yml \
-      --limit {{ item }} -e '{{ ardana_extra_vars|to_json }}'
-  args:
-    chdir: "{{ ardana_scratch_path }}"
-  environment:
-    SKIP_REPO_CHECKS: 1
-  loop: "['OPS-LM--first-member:tempest_all'] + {{ ardana_nodes.stdout_lines }}"
+set -e
+
+source lib.sh
+
+validate_input
+setup_ansible_venv
+mitogen_enable
+
+trap exit_msg EXIT
+
+upgrade_cloud


### PR DESCRIPTION
Add a new role, ardana_upgrade, loosely based on the ardana_update role
which implements the Ardana upgrade workflow.

Note that the upgrade workflow is memory intensive so we are targetting
running it against the mid-scale-kvm scenario model which spreads out
the various services across multiple nodes; the entry-scale-kvm or
standard scenario models will likely be unstable for this reason,
though the entry-scale-kvm-mml model may also work.

Additionally add 2 new top-level playbooks which are used by the Ardana
upgrade workflow:

  * ardana-disable-repos.yml
    - Leverages recent enhancements to the setup_zypper_repos role that
      allow the existing repos on a deployer node to be disabled, which
      is used by the upgrade workflow to disable the repos associated
      with the active cloudsource.

  * ardana-upgrade.yml
    - Upgrades the deployer to the active cloudsource by adding/enabling
      the cloudsource repos to the deployer
    - runs zypper dist-upgrade to upgrade the system to the (new)
      cloudsource.
    - installs/updates the Ardana cloud pattern and runs ardana-init to
      update the deployer's ardana account to the (new) cloudsource
      provided content.
    - addresses mandatory deprecations in the cloud model.
    - runs the configuration processor and regenerates the scratch
      area
    - runs the ardana-upgrade.yml playbook to upgrade the
      whole cloud to the (new) cloudsource.
    - reboots all the nodes to pick up new kernels and/or core services.

Update the openstack-ardana.Jenkinsfile to add the Upgrade stage that
calls the relevant play books with appropriate arguments. Also add the
new upgrade_cloudsource parameter definition to the pipeline template
in cloud-ardana-pipeline-template.yaml.

Ensure that cobbler-deploy.yml is called for update runs if it is a
physical or PXE boot enabled deploy.

Ensure that the bootstrap_ardana/tasks/download_cobbler_requires.yml
will download the SLE 12 SP4 ISO if we are running an upgrade scenario.

Update the flavours used for the mid-scale-kvm model to sizes that
ensure enough RAM/vCPU resources are available to reliably run the
upgrade workflow.

Enhanced the ardana_reboot role to reboot nodes in the this order:
  * deployer node
  * non-deployer controller nodes (if any)
  * compute (NOV-CMP) nodes (if any)

This ensures that we reboot compute nodes last, even if they happen
to appear in the resources earlier.

Implement a script, cloud9-input-model-upgrade, in the ardana_upgrade
role's files tree, that handles upgrading a Cloud8 input model to
Cloud9, applying any mandatory service component deprecations.

Add support to the rocketchat_notify role for the new upgrade related
highlevel playbooks, ardana-disable-repos.yml and ardana-upgrade.yml.

Added a new top-level playbook, ardana-reboot.yml, which can be used
to reboot an Ardana cluster. Also added support for the new playbook
to rocketchat_notify role.

Use OPS-LM rather than ARD-SVC as the host group when looking up the
deployer node, as that is the actual name of the life cycle manager
group.

Update the manual/lib.sh shell library to support Ardana upgrade
workflow.

Add additional utility scripts to the manual area:
  * reboot-ardana.sh
    reboot an already running cloud using new ardana-reboot.yml.
  * test-ardana.sh
    run configured tempest and QA tests against an existing cloud.
  * update-ardana.sh
    update a running cloud to the configured update_to_cloudsource.
  * upgrade-ardana.sh
    upgrade a running cloud to the configured upgrade_cloudsource.

Add git ignorance for the ardana-bm-info area under the cloud/ansible
directory.