### PR TITLE
Set timeout for openstack-(crowbar|ardana) jobs (SOC-10719)

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -2,13 +2,12 @@
  * The openstack-ardana Jenkins Pipeline
  */
 
-def ardana_lib = null
-
 pipeline {
   options {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
     timestamps()
+    timeout(time: 8, unit: 'HOURS', activity: true)
     // reserve a resource if instructed to do so, otherwise use an empty resource list
     lock(
       variable: 'reserved_env',

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
     timestamps()
+    timeout(time: 8, unit: 'HOURS', activity: true)
     // reserve a resource if instructed to do so, otherwise use an empty resource list
     lock(
       variable: 'reserved_env',


### PR DESCRIPTION
Sometimes it happens that the Gating Jobs (cloud-X-gating) are stuck for some
reason. To prevent this, this change adds a timeout to the downstream jobs.