### PR TITLE
enable OpenID Connect by default (SOC-10511)

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -312,6 +312,11 @@
             NOTE: tempest does not support testing RADOS Gateway, so failures on object_storage
             tempest tests are expected when ses_rgw_enabled is set to true.
 
+      - bool:
+          name: openid_connect_enabled
+          default: '{openid_connect_enabled|true}'
+          description: Enable OpenID Connect feature in keystone and configure it with a bogus IdP for testing purposes.
+
       - choice:
           name: rhel_os
           choices:

--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -40,6 +40,7 @@ sles_media_server: "ibs-mirror.prv.suse.net"
 rhel_enabled: "{{ rhel_computes is defined and rhel_computes | int > 0 }}"
 ses_enabled: False
 ses_rgw_enabled: False
+openid_connect_enabled: True
 ardana_ses_integration_version: 2
 cinder_lvm_enabled: '{{ not ses_enabled }}'
 

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
@@ -61,6 +61,9 @@
     - rhel_enabled
     - ses_enabled
 
+- include_tasks: setup_openid_connect.yml
+  when: openid_connect_enabled
+
 - include_tasks: reimage_nodes.yml
   when: is_physical_deploy
 

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/setup_openid_connect.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/setup_openid_connect.yml
@@ -1,0 +1,39 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Enable OpenID Connect in Keystone
+  blockinfile:
+    path: "{{ ardana_openstack_path }}/roles/keystone-common/vars/keystone_deploy_config.yml" 
+    block: |
+      keystone_openid_connect_conf:
+          identity_provider: google
+          response_type: id_token
+          scope: "openid email profile"
+          metadata_url: https://accounts.google.com/.well-known/openid-configuration
+          client_id: bogusclientid
+          client_secret: bogusclientsecret
+          redirect_uri: https://www.myenterprise.com:5000/v3/OS-FEDERATION/identity_providers/google/protocols/openid/auth
+          crypto_passphrase: ""
+  register: openid_connect_bogus_idp_config
+
+- name: Commit Keystone OpenID Connect config changes
+  shell: >-
+    git add -A &&
+    git commit -m 'Configure OpenID Connect'
+  args:
+    chdir: "{{ ardana_openstack_path }}"
+  when: openid_connect_bogus_idp_config is changed

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -206,6 +206,10 @@ ses_enabled: true
 # if ses_enabled is set to true.
 ses_rgw_enabled: false
 
+#============= OpenID Connect =============#
+# Enable OpenID Connect feature in Keystone and configure it with a bogus IdP
+# for validation purposes (i.e. make sure nothing breaks by default).
+openid_connect_enabled: true
 
 #============= Tests =============#
 # Name of the filter file to use for tempest in Ardana.


### PR DESCRIPTION
Enable the OpenID Connect feature in CLM by default. The purpose is to
make sure the binaries are properly loaded and that it does not break
anything. We will not be testing the functionality itself as WebSSO
involves user interaction (with the browser).