### PR TITLE
Unified cloud gating trigger (SOC-10029)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -7,12 +7,23 @@
     cloud_url_trigger_job:
       - cloud-7-gating-trigger:
           version: '7'
+    jobs:
+      - '{cloud_url_trigger_job}'
+
+- project:
+    name: cloud-unified-gating-trigger
+    soc_url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-{version}-devel-staging/media.1/build'
+    socc_url: 'http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-Crowbar-{version}-devel-staging/media.1/build'
+    projects:
+      project: 'cloud-{version}-gating'
+      threshold: SUCCESS
+    cloud_unified_url_trigger_job:
       - cloud-8-gating-trigger:
           version: '8'
       - cloud-9-gating-trigger:
           version: '9'
     jobs:
-        - '{cloud_url_trigger_job}'
+      - '{cloud_unified_url_trigger_job}'
 
 - project:
     name: cloud-gating

--- a/jenkins/ci.suse.de/templates/cloud-unified-url-trigger-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-unified-url-trigger-template.yaml
@@ -1,0 +1,38 @@
+- job-template:
+    name: '{cloud_unified_url_trigger_job}'
+    project-type: multijob
+    node: cloud-ci-trigger
+
+    triggers:
+      - pollurl:
+          cron: 'H/5 * * * *'
+          polling-node: cloud-ci-trigger
+          urls:
+            - url: '{soc_url}'
+              check-date: '{check_date|false}'
+              check-content:
+                - simple: true
+            - url: '{socc_url}'
+              check-date: '{check_date|false}'
+              check-content:
+                - simple: true
+
+    logrotate:
+      numToKeep: -1
+      daysToKeep: 14
+
+    builders:
+      - shell:
+          command: |
+            # Check if Ardana and Crowbar has the same build number and if not,
+            # set the job status to unstable consequently not triggering the
+            # cloud-gating job
+
+            soc_build=$(curl -s {soc_url} | cut -d'-' -f6)
+            socc_build=$(curl -s {socc_url} | cut -d'-' -f7)
+
+            [[ $soc_build == $socc_build ]]
+          unstable-return: 1
+
+    publishers:
+      - trigger: '{projects}'


### PR DESCRIPTION
For cloud 8 and 9 the gating jobs should be triggered whenever there is
a new build for Crowbar or Ardana, however to ensure that both medias
have the latest changes the jobs should be executed only when both
medias have the same build number.

This change adds a new job template for triggering the cloud 8 and 9
gating jobs whenever there is a new build for Crowbar and Ardana, it
also checks if they have the same build number and if not mark the build
as unstable and does not run the cloud gating jobs.