### PR TITLE
enable OpenID Connect by default for Crowbar (SOC-10511)

### DIFF
--- a/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
@@ -18,6 +18,14 @@ proposals:
   attributes:
     api:
       region: 'CustomRegion'
+    federation:
+      openidc:
+        enabled: true
+        identity_provider: 'google'
+        metadata_url: 'https://accounts.google.com/.well-known/openid-configuration'
+        client_id: 'bogusclientid'
+        client_secret: 'bogusclientsecret'
+        redirect_uri: 'https://www.myenterprise.com:5000/v3/OS-FEDERATION/identity_providers/google/protocols/openid/auth'
   deployment:
     elements:
       keystone-server:


### PR DESCRIPTION
Enable the OpenID Connect feature in Crowbar by default. The purpose is to
make sure the binaries are properly loaded and that it does not break
anything. We will not be testing the functionality itself as WebSSO
involves user interaction (with the browser).