### PR TITLE
openstack-crowbar/ardana: remove dummy lockable resource

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -9,11 +9,11 @@ pipeline {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
     timestamps()
-    // reserve a resource if instructed to do so, otherwise use a dummy resource
-    // and a zero quantity to fool Jenkins into thinking it reserved a resource when in fact it didn't
-    lock(label: reserve_env == 'true' ? cloud_env:'dummy-resource',
-         variable: 'reserved_env',
-         quantity: reserve_env == 'true' ? 1:0 )
+    // reserve a resource if instructed to do so, otherwise use an empty resource list
+    lock(
+      variable: 'reserved_env',
+      extra: (reserve_env == 'true' ? [[label: cloud_env, quantity: 1]] : [])
+    )
   }
 
   agent {

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -7,11 +7,11 @@ pipeline {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
     timestamps()
-    // reserve a resource if instructed to do so, otherwise use a dummy resource
-    // and a zero quantity to fool Jenkins into thinking it reserved a resource when in fact it didn't
-    lock(label: reserve_env == 'true' ? cloud_env:'dummy-resource',
-         variable: 'reserved_env',
-         quantity: reserve_env == 'true' ? 1:0 )
+    // reserve a resource if instructed to do so, otherwise use an empty resource list
+    lock(
+      variable: 'reserved_env',
+      extra: (reserve_env == 'true' ? [[label: cloud_env, quantity: 1]] : [])
+    )
   }
 
   agent {


### PR DESCRIPTION
Starting with version 2.6 [1], the Jenkins lockable resource plugin
changed its behavior to fail when a non-existing resource label
name is used, even if the resource count is set to zero. This change
invalidates the hack that we use in our declarative pipelines to
conditionally lock a resource based on job input parameters.

Using the workaround suggested here takes care of this problem:
https://github.com/jenkinsci/lockable-resources-plugin/issues/134#issuecomment-517230676

[1] https://github.com/jenkinsci/lockable-resources-plugin/releases/tag/lockable-resources-2.6