### PR TITLE
openstack-crowbar: add test automation for Octavia (SOC-10289)

### DIFF
--- a/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
@@ -29,7 +29,7 @@
         - include_role:
             name: crowbar_setup
           vars:
-            qa_crowbarsetup_cmd: "setup_trusted_cert {{ ssl_certfile }} {{ ssl_keyfile }}"
+            qa_crowbarsetup_cmd: "setup_trusted_cert server {{ ssl_certfile }} {{ ssl_keyfile }}"
           when:
             - ssl_enabled
             - not ssl_insecure

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
@@ -227,6 +227,7 @@ barclamps:
       - ec2-api
     octavia:
       - octavia-api
+      - octavia-backend
     sahara:
       - sahara-server
     tempest:

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/neutron.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/neutron.yml.j2
@@ -21,6 +21,9 @@
       ml2_type_drivers_default_provider_network: {{ neutron_networkingmode }}
       ml2_type_drivers_default_tenant_network: {{ neutron_networkingmode }}
       use_lbaas: true
+{% if 'octavia' in deployments %}
+      lbaasv2_driver: octavia
+{% endif %}
 {% if neutron_use_l3_ha %}
       l3_ha:
         use_l3_ha: true

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
@@ -1,2 +1,23 @@
   - barclamp: octavia
+    attributes:
+      api:
+        # HTTPs not yet supported by Octavia
+        protocol: http # {{ api_protocol }}
+{% include 'barclamps/lib/ssl.yml.j2' %}
+      certs:
+        # same passphrase used in qa_crowbarsetup.sh setup_octavia_cert to generate the keys
+        passphrase: crowbar
+        server_ca_cert_path: ca.cert.pem
+        server_ca_key_path: private/ca.key.pem
+        client_ca_cert_path: ca.cert.pem
+        client_cert_and_key_path: private/client.cert-and-key.pem
+{% set ns = namespace(net_id=30, vlan_id=gen_subnet_start+scenario.network_groups|length) %}
+{% for network_group in scenario.network_groups if 'NEUTRON-VLAN' in network_group.component_endpoints %}
+      amphora:
+        #manage_vlan: {{ ns.vlan_id }}
+        manage_cidr: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.0/24
+        #manage_allocation_pools: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.10,{{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.250
+        #gateway: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.1
+{% endfor %}
+
 {% include 'barclamps/lib/deployment.yml.j2' %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -121,6 +121,7 @@ export want_ipv6={{ ipv6 | ternary (1, 0) }}
 
 {% set ipsep = ipv6 | ternary (':', '.') %}
 {% set subnet_prefix = ipv6 | ternary (subnet_prefix.ipv6, subnet_prefix.ipv4) %}
+{% set neutron_subnet_prefix = ipv6 | ternary (neutron_subnet_prefix.ipv6, neutron_subnet_prefix.ipv4) %}
 
 export net_public={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+1 }}
 export net_sdn={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+2 }}
@@ -133,5 +134,10 @@ export vlan_sdn={{ gen_subnet_start+2 }}
 export vlan_storage={{ gen_subnet_start+3 }}
 export vlan_fixed={{ gen_subnet_start+4 }}
 export vlan_ceph={{ gen_subnet_start+5 }}
+
+{% if 'octavia' in deployments %}
+export net_octavia={{ neutron_subnet_prefix }}{{ ipsep }}30{{ ipsep }}1
+export vlan_octavia={{ gen_subnet_start+4 }}
+{% endif %}
 
 # NOTE: might also need some of the other variables starting with vlan_ , want_ and net_

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
@@ -9,6 +9,7 @@ network_groups:
       - MANAGEMENT
       - INTERNAL-API
       - EXTERNAL-API
+      - NEUTRON-VLAN
 
   - name: PUBLIC
     hostname_suffix: public

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -399,6 +399,7 @@ function setcloudnetvars
     vlan_public=${vlan_public:-300}
     vlan_fixed=${vlan_fixed:-500}
     vlan_sdn=${vlan_sdn:-400}
+    vlan_octavia=${vlan_octavia:-700}
     if (( ${want_ipv6} > 0 )); then
         net_fixed=${net_fixed:-'fd00:0:0:2'}
         net_public=${net_public:-'fd00:0:0:1'}
@@ -406,6 +407,7 @@ function setcloudnetvars
         net_ceph=${net_ceph:-'fd00:0:0:5'}
         net_ironic=${net_ironic:-'fd00:0:0:6'}
         net_sdn=${net_sdn:-'fd00:0:0:7'}
+        net_octavia=${net_octavia:-'fd00:0:0:8'}
         : ${adminnetmask:=64}
         : ${ironicnetmask:=64}
         : ${defaultnetmask:=64}
@@ -421,6 +423,7 @@ function setcloudnetvars
         net_ceph=${net_ceph:-192.168.127}
         net_ironic=${net_ironic:-192.168.128}
         net_sdn=${net_sdn:-192.168.130}
+        net_octavia=${net_octavia:-192.168.131}
         : ${adminnetmask:=255.255.248.0}
         : ${ironicnetmask:=255.255.255.0}
         : ${defaultnetmask:=255.255.255.0}


### PR DESCRIPTION
Makes the following changes needed to get test automation support
for Octavia in both mkcloud and the unified CI:

 * updates the generated barclamp configurations for Octavia and
 Neutron
 * extends the certificate generation logic in `qa_crowbarsetup.sh`
 to support using a passphrase for the root CA key and to also be
 able to generate client certificates, both required by Octavia
 * updates qa_crowbarsetup.sh and the generated mkcloud.config
 file with two configuration options - `net_octavia` and
 `vlan_octavia` - and, based on these options, adds some automation
 logic that creates the neutron VLAN provider network that is
 used for Octavia amphorae management traffic. This network will be
 created before deploying the Octavia barclamp
 * when using crowbar batch, Octavia is deployed separately, after
 Neutron, because Neutron is required to create the Octavia
 management network

NOTE: for mkcloud, we're still missing the test automation logic to
set up routing between the Octavia management network and the
admin network (TBD for another PR).

(replaces #3719)