### PR TITLE
iscsictl: don't use a hardcoded eth0 when finding the node's address

### DIFF
--- a/scripts/iscsictl.py
+++ b/scripts/iscsictl.py
@@ -301,10 +301,11 @@ class Target(ISCSI):
 
         # Detecting IP
         print("Looking for host IP ...")
-        ip = str(self.ssh.ip('a', 's', 'eth0'))
-        ip = re.findall(r'inet (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+', ip)
-        if ip:
-            ip = ip[0]
+        out = str(self.ssh.ip('route', 'get', '240.0.0.1'))
+        found = re.findall(r'src (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) ',
+                           out)
+        if found:
+            ip = found[0]
         else:
             raise Exception('IP address not found')
 


### PR DESCRIPTION
This breaks when deploying using bonding.

It uses `ip route get <external addr>' for getting the primary address.

240.0.0.0 is an internet-scoped reserved address.