### PR TITLE
cloud-maintenance: Add missing scenario and tests

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -43,9 +43,12 @@
           default-value: ''
           value: >-
             ardana8-deploy,ardana8-update,ardana9-deploy,ardana9-update,
-            crowbar7-no-ha-deploy,crowbar7-ha-deploy,crowbar7-no-ha-update,crowbar7-ha-update,
-            crowbar8-no-ha-deploy,crowbar8-ha-deploy,crowbar8-no-ha-update,crowbar8-ha-update,
-            crowbar9-no-ha-deploy,crowbar9-ha-deploy,crowbar9-no-ha-update,crowbar9-ha-update
+            crowbar7-ha-deploy,crowbar7-ha-update,crowbar7-no-ha-deploy,crowbar7-no-ha-update,
+            crowbar7-linuxbridge-deploy,crowbar7-linuxbridge-update,
+            crowbar8-ha-deploy,crowbar8-ha-update,crowbar8-no-ha-deploy,crowbar8-no-ha-update,
+            crowbar8-linuxbridge-deploy,crowbar8-linuxbridge-update,
+            crowbar9-ha-deploy,crowbar9-ha-update,crowbar9-no-ha-deploy,crowbar9-no-ha-update,
+            crowbar9-linuxbridge-deploy,crowbar9-linuxbridge-update
           description: >-
             Use this parameter to filter the list of jobs that are triggered to test the maintenance
             updates. This is useful e.g. when re-running only the subset of jobs that have failed

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -38,7 +38,7 @@
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             designate,heat,magnum,monasca,lbaas"
     jobs:
-        - '{ardana_job}'
+      - '{ardana_job}'
 
 
 - project:
@@ -89,8 +89,7 @@
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             heat,magnum,manila,lbaas"
     jobs:
-        - '{crowbar_job}'
-
+      - '{crowbar_job}'
 
 - project:
     name: cloud-crowbar-job-mu-ha-x86_64
@@ -140,4 +139,56 @@
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             heat,magnum,manila,lbaas"
     jobs:
-        - '{crowbar_job}'
+      - '{crowbar_job}'
+
+- project:
+    name: cloud-crowbar-job-mu-linuxbridge-x86_64
+    reserve_env: false
+    updates_test_enabled: false
+    reboot_after_deploy: true
+    tempest_retry_failed: 'true'
+    neutron_networkingplugin: linuxbridge
+    crowbar_networkingmode: team
+    scenario_name: standard
+    controllers: '1'
+    computes: '2'
+    triggers: []
+    crowbar_job:
+      - cloud-crowbar7-job-mu-linuxbridge-deploy-x86_64:
+          cloudsource: GM7+up
+          ses_enabled: false
+          update_after_deploy: false
+      - cloud-crowbar7-job-mu-linuxbridge-update-x86_64:
+          cloudsource: GM7+up
+          ses_enabled: false
+          update_after_deploy: true
+      - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
+          cloudsource: GM8+up
+          ses_enabled: false
+          update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+      - cloud-crowbar8-job-mu-linuxbridge-update-x86_64:
+          cloudsource: GM8+up
+          ses_enabled: false
+          update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+      - cloud-crowbar9-job-mu-linuxbridge-deploy-x86_64:
+          cloudsource: GM9+up
+          ses_enabled: true
+          update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
+      - cloud-crowbar9-job-mu-linuxbridge-update-x86_64:
+          cloudsource: GM9+up
+          ses_enabled: true
+          update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
+            heat,magnum,manila,lbaas"
+    jobs:
+      - '{crowbar_job}'

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -64,10 +64,16 @@
           cloudsource: GM8+up
           ses_enabled: false
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-no-ha-update-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
           update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
@@ -109,10 +115,16 @@
           cloudsource: GM8+up
           ses_enabled: false
           update_after_deploy: false
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-ha-update-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
           update_after_deploy: true
+          tempest_filter_list: "\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
+            fwaas,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-ha-deploy-x86_64:
           cloudsource: GM9+up
           ses_enabled: true

--- a/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-maintenance-gating-config.yml
@@ -25,6 +25,12 @@ SOCC7:
   crowbar7-ha-update:
     job_name: cloud-crowbar7-job-mu-ha-update-x86_64
     job_params: []
+  crowbar7-linuxbridge-deploy:
+    job_name: cloud-crowbar7-job-mu-linuxbridge-deploy-x86_64
+    job_params: []
+  crowbar7-linuxbridge-update:
+    job_name: cloud-crowbar7-job-mu-linuxbridge-update-x86_64
+    job_params: []
 SOCC8:
   crowbar8-no-ha-deploy:
     job_name: cloud-crowbar8-job-mu-no-ha-deploy-x86_64
@@ -38,6 +44,12 @@ SOCC8:
   crowbar8-ha-update:
     job_name: cloud-crowbar8-job-mu-ha-update-x86_64
     job_params: []
+  crowbar8-linuxbridge-deploy:
+    job_name: cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64
+    job_params: []
+  crowbar8-linuxbridge-update:
+    job_name: cloud-crowbar8-job-mu-linuxbridge-update-x86_64
+    job_params: []
 SOCC9:
   crowbar9-no-ha-deploy:
     job_name: cloud-crowbar9-job-mu-no-ha-deploy-x86_64
@@ -50,4 +62,10 @@ SOCC9:
     job_params: []
   crowbar9-ha-update:
     job_name: cloud-crowbar9-job-mu-ha-update-x86_64
+    job_params: []
+  crowbar9-linuxbridge-deploy:
+    job_name: cloud-crowbar9-job-mu-linuxbridge-deploy-x86_64
+    job_params: []
+  crowbar9-linuxbridge-update:
+    job_name: cloud-crowbar9-job-mu-linuxbridge-update-x86_64
     job_params: []


### PR DESCRIPTION
- Add tempest full on cloud-crowbar8 maintenance update jobs
- Add the `linuxbridge` scenario to the list of jobs executed to validate a maintenance update.