### PR TITLE
openstack-crowbar: Reapply barclamps on update

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-tests.Jenkinsfile
@@ -4,7 +4,6 @@
  * This job runs tempest and ardana-qa-tests on a pre-deployed CLM cloud.
  */
 
-def ardana_lib = null
 
 pipeline {
 

--- a/scripts/jenkins/cloud/ansible/crowbar-update.yml
+++ b/scripts/jenkins/cloud/ansible/crowbar-update.yml
@@ -77,11 +77,8 @@
           delegate_to: "{{ item }}"
           loop: "{{ groups['cloud_virt_hosts'] + [cloud_env] }}"
 
-        - name: Run 'crowbar batch export | crowbar batch --timeout 2400 build' on the admin node
-          shell: |
-            set -o pipefail
-            crowbar batch export | crowbar batch --timeout 2400 build 2>&1 |\
-              tee -a {{ qa_crowbarsetup_log }}
+        - include_role:
+            name: crowbar_reapply_barclamps
 
       rescue:
         - include_role:

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_reapply_barclamps/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_reapply_barclamps/tasks/main.yml
@@ -1,0 +1,41 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Collect list of available barclamps
+  shell: |
+    crowbarctl barclamp list --plain
+  failed_when: false
+  register: crowbar_barclamp_list
+  when: not crowbar_barclamp_list is defined
+
+- name: Collect list of proposals
+  shell: |
+    crowbarctl proposal list {{ item }} --plain
+  failed_when: false
+  register: crowbar_proposal_list
+  loop: "{{ crowbar_barclamp_list.stdout_lines }}"
+
+- name: Create barclamp - proposals dictionary
+  set_fact:
+    barclamp_proposal_dict: "{{ barclamp_proposal_dict | default([]) + [{'barclamp': item.item, 'proposals': item.stdout_lines}] }}"
+  when: item.stdout_lines | length > 0
+  loop: "{{ crowbar_proposal_list.results }}"
+  loop_control:
+    label: "{{ item.item }}: {{ item.stdout_lines }}"
+
+- include_tasks: reapply_barclamp.yml
+  loop: "{{ barclamp_proposal_dict | subelements('proposals') }}"

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_reapply_barclamps/tasks/reapply_barclamp.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_reapply_barclamps/tasks/reapply_barclamp.yml
@@ -1,0 +1,34 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Reapplying '{{ item.1 }}' proposal of '{{ item.0.barclamp }}' barclamp
+  command: |
+    crowbarctl proposal commit {{ item.0.barclamp }} {{ item.1 }}
+
+- name: Wait for '{{ item.1 }}' proposal of '{{ item.0.barclamp }}' barclamp to finish reapplying
+  shell: |
+    crowbarctl proposal show {{ item.0.barclamp }} {{ item.1 }} --filter \
+      deployment.{{ item.0.barclamp }}.crowbar-status --plain | awk '{ print $2 }'
+  register: _barclamp_status
+  retries: 5
+  delay: 180
+  until: _barclamp_status.stdout in ['success', 'failed']
+
+- name: Fail if barclamp failed to reapply
+  fail:
+    msg: "Reapplying '{{ item.1 }}' proposal of '{{ item.0.barclamp }}' barclamp failed"
+  when: _barclamp_status.stdout != 'success'


### PR DESCRIPTION
Due to SOC-10505, `crowbar batch export/build` cannot be used for applying
the changes from a crowbar update.

This change uses `crowbarctl proposal commit` to reapply the barclamps
instead of `crowbar batch build`.