### PR TITLE
workers: Add cron job for cleaning old workspaces

### DIFF
--- a/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
@@ -28,6 +28,7 @@ jenkins_worker_zypp_repos:
 
 jenkins_worker_zypp_requires:
   - ca-certificates-suse
+  - cronie
   - gcc
   - git-core
   - jenkins-swarm-client

--- a/scripts/jenkins/workers/roles/jenkins_worker/tasks/configure_cron_jobs.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/tasks/configure_cron_jobs.yml
@@ -15,14 +15,9 @@
 #
 ---
 
-- include_tasks: update.yml
-- include_tasks: install_packages.yml
-- include_tasks: configure_swarm_client.yml
-- include_tasks: copy_files.yml
-- include_tasks: setup_venv.yml
-  when:
-    - jenkins_worker_ansible_version is defined
-    - jenkins_worker_ansible_version | length
-- include_tasks: authorized_keys.yml
-- include_tasks: configure_git.yml
-- include_tasks: configure_cron_jobs.yml
+- name: Ensure cron job for deleting old jenkins workspaces
+  cron:
+    name: "Delete jenkins workspaces"
+    special_time: "daily"
+    user: "jenkins"
+    job: "find /home/jenkins/workspace -maxdepth 1 -type d -mtime +6 | xargs rm -rf"


### PR DESCRIPTION
Due to [1] the jenkins jobs are leaving the job's workspace on the worker
node and eventually the worker's disk gets full.

This change adds a cron job to the worker that runs daily and deletes the
job workspace directory if it was not accessed on the last week.

1. https://issues.jenkins-ci.org/browse/JENKINS-50797