### PR TITLE
Update default platforms and set cache dir for tar_scm

### DIFF
--- a/scripts/jenkins/track-upstream-and-package.pl
+++ b/scripts/jenkins/track-upstream-and-package.pl
@@ -101,8 +101,14 @@ sub osc_build()
     elsif ($prj =~ /Devel:Cloud:6/) {
       $OSC_BUILD_DIST = "SLE_12_SP1";
     }
-    else {
+    elsif ($prj =~ /Devel:Cloud:7/) {
       $OSC_BUILD_DIST = "SLE_12_SP2";
+    }
+    elsif ($prj =~ /Devel:Cloud:8/) {
+      $OSC_BUILD_DIST = "SLE_12_SP3";
+    }
+    else {
+      $OSC_BUILD_DIST = "SLE_12_SP4";
     }
   }
 
@@ -249,7 +255,7 @@ sub osc_checkin()
 unless ( -e "$ENV{HOME}/.obs/tar_scm")
 {
   system("mkdir -p $ENV{HOME}/.obs/cache/tar_scm/{incoming,repo,repourl}");
-  system(qq(echo '[tar_scm]\nCACHEDIRECTORY="$ENV{HOME}/.obs/cache/tar_scm"' > ~/.obs/tar_scm));
+  system(qq(echo 'CACHEDIRECTORY="$ENV{HOME}/.obs/cache/tar_scm"' > ~/.obs/tar_scm));
 }
 
 die "Error: can not find .osc project in this directory: " unless ( -d '.osc');


### PR DESCRIPTION
The packages with tar_scm source service are failing because of

1. the default platforms for the respective cloud releases are not
being correctly defined, and
2. for tar_scm, it ran into a nasty error while trying to lookup the
repo cache dir.

File "/usr/lib/obs/service/TarSCM/scm/base.py", line 160, in _calc_repocachedir
    repocachedir = Config().get('tar_scm', 'CACHEDIRECTORY')
...
configparser.DuplicateSectionError: While reading from '<???>' [line  2]: section 'tar_scm' already exists

There's no need to add '[tar_scm]' header as it is accounted for already. See

https://github.com/guangyee/obs-service-tar_scm/blob/master/TarSCM/config.py#L27
https://github.com/guangyee/obs-service-tar_scm/blob/master/TarSCM/config.py#L67-#L70
