### PR TITLE
Skip python-networking-cisco from trackupstream

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -105,6 +105,7 @@
             "openstack-trove",
             "python-monasca-common",
             "python-monasca-statsd",
+            "python-networking-cisco",
             "python-vmware-nsxlib",
             "python-vmware-nsx"
             ].contains(component) ||
@@ -114,6 +115,7 @@
               "openstack-rally",
               "openstack-tempest",
               "python-monasca-statsd",
+              "python-networking-cisco",
               "python-vmware-nsxlib",
               "python-vmware-nsx",
             ].contains(component) ||


### PR DESCRIPTION
The repo has been moved to opendev.org/x namespace and the current
tooling no longer able to effective create an updated tarball from it.

If there are customers out there still using this package, we'll need
to update the tooling to be able to create tarballs from
opendev.org/x repos.