### PR TITLE
Ensure we don't rsync ansible-venv (SOC-10913)

### DIFF
--- a/scripts/.rsync-filter
+++ b/scripts/.rsync-filter
@@ -1,0 +1,1 @@
+- jenkins/cloud/manual/ansible-venv


### PR DESCRIPTION
Sync'ing the local ansible-venv to the Crowbar admin node doesn't
make sense since the local ansible-venv is not statically built
and there is no guarantee that it will be compatible with the
admin node's SLE deployment.