### PR TITLE
Do not use same openssl commands for SP4 as for older releases

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2055,13 +2055,19 @@ function setup_trusted_cert
     fi
 
     if [ ! -f rootca.pem ] ; then
-        # Generate Root CA key
-        openssl genrsa -aes256 -out rootca.key -passout pass:"crowbar" 4096
-        # Generate Root CA
-        openssl req -x509 -key rootca.key -out rootca.pem \
-            -passin pass:"crowbar" \
-            -days 365 -nodes \
-            -subj "/C=DE/ST=Bayern/L=Nuernberg/O=CI/CN=root"
+        if iscloudver 9plus ; then
+            # Generate Root CA key
+            openssl genrsa -aes256 -out rootca.key -passout pass:"crowbar" 4096
+            # Generate Root CA
+            openssl req -x509 -key rootca.key -out rootca.pem \
+                -passin pass:"crowbar" \
+                -days 365 -nodes \
+                -subj "/C=DE/ST=Bayern/L=Nuernberg/O=CI/CN=root"
+        else
+            openssl req -x509 -newkey rsa:2048 -keyout rootca.key -out rootca.pem \
+                -days 365 -nodes \
+                -subj "/C=DE/ST=Bayern/L=Nuernberg/O=CI/CN=root"
+        fi
     fi
 
     subj_alt="DNS:${cn},DNS:public-${cn},DNS:public.${cn}"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2055,19 +2055,13 @@ function setup_trusted_cert
     fi
 
     if [ ! -f rootca.pem ] ; then
-        if iscloudver 9plus ; then
-            # Generate Root CA key
-            openssl genrsa -aes256 -out rootca.key -passout pass:"crowbar" 4096
-            # Generate Root CA
-            openssl req -x509 -key rootca.key -out rootca.pem \
-                -passin pass:"crowbar" \
-                -days 365 -nodes \
-                -subj "/C=DE/ST=Bayern/L=Nuernberg/O=CI/CN=root"
-        else
-            openssl req -x509 -newkey rsa:2048 -keyout rootca.key -out rootca.pem \
-                -days 365 -nodes \
-                -subj "/C=DE/ST=Bayern/L=Nuernberg/O=CI/CN=root"
-        fi
+        # Generate Root CA key
+        openssl genrsa -aes256 -out rootca.key -passout pass:"crowbar" 4096
+        # Generate Root CA
+        openssl req -new -x509 -key rootca.key -out rootca.pem \
+            -passin pass:"crowbar" \
+            -days 365 -nodes \
+            -subj "/C=DE/ST=Bayern/L=Nuernberg/O=CI/CN=root"
     fi
 
     subj_alt="DNS:${cn},DNS:public-${cn},DNS:public.${cn}"


### PR DESCRIPTION
Apparently the change for certificate generation introduced with
b5bdfade859248ba7bd36e893a94bbadb91b0d12 does not work for older
releases. So let's use it for Cloud9 only.

This is an attempt to fix what https://github.com/SUSE-Cloud/automation/pull/3748 brought. See the failure e.g. in https://ci.suse.de/job/openstack-mkcloud/15776/parsed_console/