### PR TITLE
Revert "Set timeout for openstack-(crowbar|ardana) jobs (SOC-10719)"

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
     timestamps()
-    timeout(time: 8, unit: 'HOURS', activity: true)
     // reserve a resource if instructed to do so, otherwise use an empty resource list
     lock(
       variable: 'reserved_env',

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
     // skip the default checkout, because we want to use a custom path
     skipDefaultCheckout()
     timestamps()
-    timeout(time: 8, unit: 'HOURS', activity: true)
     // reserve a resource if instructed to do so, otherwise use an empty resource list
     lock(
       variable: 'reserved_env',


### PR DESCRIPTION
Seems like the timeout function is not working properly as some jobs are
being aborted way before 8 hours of log inactivity, for example [1].

1. https://ci.suse.de/job/cloud-crowbar8-job-mu-ha-update-x86_64/92/console

This reverts commit 49ae4c3d773978636fe839e7aedfbb1eb1097462.