### PR TITLE
openstack-crowbar: Apply dns to controllers when designate enabled

### DIFF
--- a/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-crowbar.yml
@@ -37,6 +37,15 @@
         - include_role:
             name: crowbar_setup
           vars:
+            qa_crowbarsetup_cmd: "{{ item }} dns default"
+          loop:
+            - "custom_configuration"
+            - "crowbar_proposal_commit"
+          when: "'designate' in enabled_services"
+
+        - include_role:
+            name: crowbar_setup
+          vars:
             qa_crowbarsetup_cmd: onadmin_batch
 
         - include_role:


### PR DESCRIPTION
To work properly the designate barclamp expects the DNS barclamp to be applied also on the controllers.