### PR TITLE
Split preparation from installation for Crowbar (SOC-10904)

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -175,6 +175,17 @@ pipeline {
 
         stage('Crowbar') {
           stages {
+            stage('Prepare install crowbar') {
+              steps {
+                script {
+                   // This step does the following on the admin node:
+                   //  - sets up SLES and Cloud repositories
+                   //  - installs the Crowbar packages
+                   cloud_lib.ansible_playbook('prepare-install-crowbar')
+                }
+              }
+            }
+
             stage('Install crowbar') {
               when {
                 expression { deploy_cloud == 'true' }
@@ -182,7 +193,6 @@ pipeline {
               steps {
                 script {
                    // This step does the following on the admin node:
-                   //  - sets up SLES and Cloud repositories
                    //  - installs crowbar
                    cloud_lib.ansible_playbook('install-crowbar')
                 }
@@ -206,7 +216,6 @@ pipeline {
         }
       }
     }
-
 
     stage('Deploy cloud') {
       when {

--- a/scripts/jenkins/cloud/ansible/install-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/install-crowbar.yml
@@ -24,30 +24,11 @@
           debug:
             msg: "http://{{ ansible_host }}:9091/"
 
-        - name: Sync automation scripts onto the admin node
-          synchronize:
-            src: "{{ automation_scripts_path }}"
-            dest: "{{ admin_scripts_path }}"
-            delete: yes
-            recursive: yes
-
-        - name: Copy generated mkcloud.config to admin node
-          copy:
-            src: "{{ mkcloud_config_file }}"
-            dest: "{{ admin_mkcloud_config_file }}"
-
-        - name: Copy generated scenario to admin node
-          copy:
-            src: "{{ crowbar_batch_file }}"
-            dest: "{{ admin_crowbar_batch_file }}"
-
         - include_role:
             name: crowbar_setup
           vars:
             qa_crowbarsetup_cmd: "onadmin_{{ command }}"
           loop:
-            - addupdaterepo
-            - prepareinstallcrowbar
             - bootstrapcrowbar
             - installcrowbar
           loop_control:

--- a/scripts/jenkins/cloud/ansible/prepare-install-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/prepare-install-crowbar.yml
@@ -1,0 +1,82 @@
+---
+
+- name: Prepare install Crowbar on admin node
+  hosts: "{{ cloud_env }}"
+  remote_user: root
+  gather_facts: True
+  vars:
+    task: "deploy"
+
+  pre_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "started"
+        rc_state: "Started"
+      when:
+        - rc_notify
+        - rc_notify_start
+        - not is_physical_deploy
+
+  tasks:
+    - block:
+        - name: Log stream at
+          debug:
+            msg: "http://{{ ansible_host }}:9091/"
+
+        - name: Sync automation scripts onto the admin node
+          synchronize:
+            src: "{{ automation_scripts_path }}"
+            dest: "{{ admin_scripts_path }}"
+            delete: yes
+            recursive: yes
+
+        - name: Copy generated mkcloud.config to admin node
+          copy:
+            src: "{{ mkcloud_config_file }}"
+            dest: "{{ admin_mkcloud_config_file }}"
+
+        - name: Copy generated scenario to admin node
+          copy:
+            src: "{{ crowbar_batch_file }}"
+            dest: "{{ admin_crowbar_batch_file }}"
+
+        - include_role:
+            name: crowbar_setup
+          vars:
+            qa_crowbarsetup_cmd: "onadmin_{{ command }}"
+          loop:
+            - addupdaterepo
+            - prepareinstallcrowbar
+          loop_control:
+            loop_var: command
+
+      rescue:
+        - include_role:
+            name: rocketchat_notify
+          vars:
+            rc_action: "finished"
+            rc_state: "Failed"
+          when: rc_notify
+
+        - name: Stop if something failed
+          fail:
+            msg: "{{ task }} failed."
+      always:
+        - include_role:
+            name: jenkins_artifacts
+          when: lookup("env", "WORKSPACE")
+          vars:
+            jenkins_artifacts_to_collect:
+              - src: "{{ admin_mkcloud_config_file }}"
+              - src: "{{ admin_crowbar_batch_file }}"
+              - src: "{{ qa_crowbarsetup_log }}"
+
+  post_tasks:
+    - include_role:
+        name: rocketchat_notify
+      vars:
+        rc_action: "finished"
+        rc_state: "Success"
+      when:
+        - rc_notify

--- a/scripts/jenkins/cloud/manual/deploy-crowbar.sh
+++ b/scripts/jenkins/cloud/manual/deploy-crowbar.sh
@@ -30,6 +30,7 @@ trap exit_msg EXIT
 bootstrap_crowbar
 deploy_ses_vcloud
 bootstrap_nodes
+prepare_install_crowbar
 install_crowbar
 register_crowbar_nodes
 deploy_cloud

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -232,6 +232,10 @@ function bootstrap_nodes {
     fi
 }
 
+function prepare_install_crowbar {
+    ansible_playbook prepare-install-crowbar.yml
+}
+
 function install_crowbar {
     ansible_playbook install-crowbar.yml
 }


### PR DESCRIPTION
This change introduces a new Jenkins stage and splits the preparation
phase from the installation phase of Crowbar. The goal is to allow for
changes in network.json before Crowbar is bootstrapped and installed.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>