### PR TITLE
Do not fail on jira report playbook errors

### DIFF
--- a/scripts/jenkins/cloud/ansible/report-job-failure.yml
+++ b/scripts/jenkins/cloud/ansible/report-job-failure.yml
@@ -18,6 +18,7 @@
 - name: Report known failures to Jira
   hosts: "localhost"
   gather_facts: no
+  ignore_errors: yes
 
   roles:
     - jira_issue_report


### PR DESCRIPTION
Failing interrupts the execution of other post deployment tasks.