### PR TITLE
openstack-crowbar: enable SSL in test automation for Octavia (SOC-10906)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
@@ -1,8 +1,7 @@
   - barclamp: octavia
     attributes:
       api:
-        # HTTPs not yet supported by Octavia
-        protocol: http # {{ api_protocol }}
+        protocol: {{ api_protocol }}
 {% include 'barclamps/lib/ssl.yml.j2' %}
       certs:
         # same passphrase used in qa_crowbarsetup.sh setup_octavia_cert to generate the keys

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2141,8 +2141,6 @@ function setup_octavia_cert
         ssh $controller sh << EOF
 mkdir -p $certpath/private
 chmod 700 $certpath/private
-groupadd octavia
-useradd -G octavia octavia
 EOF
     done
 
@@ -2152,7 +2150,6 @@ EOF
         scp rootca.pem $controller:$certpath/ca.cert.pem
         scp rootca.key $controller:$certpath/private/ca.key.pem
         ssh $controller sh << EOF
-chown -R octavia:octavia $certpath
 chmod 400 $certpath/private/ca.key.pem
 chmod 700 $certpath/private/client.cert-and-key.pem
 EOF


### PR DESCRIPTION
Enables SSL testing for Octavia in ECP Crowbar deployments.

This commit also changes the Octavia certificate setup logic to
solve the problem described below.

The octavia system group and user are created when the
openstack-octavia package is installed on the controller nodes.
This happens automatically when the octavia barclamp is
applied.

However, setting up the paths for the certificates required for
the two-way SSL amphorae communication needs to be done in advance,
before applying the octavia barclamp, and those paths need to have
their ownership set to the octavia system user/group, which aren't
yet available at that time.

Adding the octavia system user and group is not a good solution,
because it interferes with the barclamp functionality so this change
proposes a different solution to this problem, where the certificate
paths are set up on the controller nodes with root as owner, while
the Octavia barclamp is responsible for switching ownership over
to the octavia user/group during application (also see [this](https://github.com/crowbar/crowbar-openstack/pull/2303)
crowbar-openstack PR for more info on that)