### PR TITLE
openstack-ardana: add dedicated job for monasca on gate

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -53,32 +53,44 @@
     update_services_serial: 'false'
     triggers: []
     ardana_job:
+      - cloud-ardana8-job-gate-entry-scale-kvm-monasca-x86_64:
+          cloudsource: stagingcloud8
+          update_after_deploy: false
+          tempest_filter_list: "smoke,monasca,ceilometer,freezer"
       - cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64:
           cloudsource: stagingcloud8
           update_after_deploy: false
+          disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
-            designate,heat,manila,ceilometer,magnum,freezer,monasca,lbaas"
+            designate,heat,manila,magnum,lbaas"
       - cloud-ardana8-job-gate-entry-scale-kvm-update-x86_64:
           cloudsource: develcloud8
           update_to_cloudsource: stagingcloud8
           update_after_deploy: true
+          disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
-            designate,heat,ceilometer,magnum,freezer,monasca,lbaas"
+            designate,heat,magnum,lbaas"
+      - cloud-ardana9-job-gate-entry-scale-kvm-monasca-x86_64:
+          cloudsource: stagingcloud9
+          update_after_deploy: false
+          tempest_filter_list: "smoke,monasca"
       - cloud-ardana9-job-gate-entry-scale-kvm-deploy-x86_64:
           cloudsource: stagingcloud9
           update_after_deploy: false
+          disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,manila,magnum,monasca,lbaas"
+            designate,heat,manila,magnum,lbaas"
       - cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64:
           cloudsource: develcloud9
           update_to_cloudsource: stagingcloud9
           update_after_deploy: true
+          disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,monasca,lbaas"
+            designate,heat,magnum,lbaas"
     jobs:
         - '{ardana_job}'
 

--- a/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating-config.yml
@@ -1,4 +1,7 @@
 SOC8:
+  ardana8-monasca:
+    job_name: cloud-ardana8-job-gate-entry-scale-kvm-monasca-x86_64
+    job_params: []
   ardana8-deploy:
     job_name: cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64
     job_params: []
@@ -15,6 +18,9 @@ SOC8:
     job_name: cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64
     job_params: []
 SOC9:
+  ardana9-monasca:
+    job_name: cloud-ardana9-job-gate-entry-scale-kvm-monasca-x86_64
+    job_params: []
   ardana9-deploy:
     job_name: cloud-ardana9-job-gate-entry-scale-kvm-deploy-x86_64
     job_params: []
@@ -40,5 +46,3 @@ SOCC7:
   crowbar7-linuxbridge-deploy:
     job_name: cloud-crowbar7-job-gate-linuxbridge-deploy-x86_64
     job_params: []
-
-


### PR DESCRIPTION
This change removes monasca from the deploy/update jobs and add a new job
for deploying and testing monasca.

The reason behind that is that monasca is very resource expensive and
affects other services testing, besides that it also increases the time for
he other jobs to finish by about 50%.