### PR TITLE
remove tar_scm group in existing config file

### DIFF
--- a/scripts/jenkins/track-upstream-and-package.pl
+++ b/scripts/jenkins/track-upstream-and-package.pl
@@ -256,6 +256,9 @@ unless ( -e "$ENV{HOME}/.obs/tar_scm")
 {
   system("mkdir -p $ENV{HOME}/.obs/cache/tar_scm/{incoming,repo,repourl}");
   system(qq(echo 'CACHEDIRECTORY="$ENV{HOME}/.obs/cache/tar_scm"' > ~/.obs/tar_scm));
+} else {
+  # make sure we remove the [tar_scm] group it has already accounted for
+  system(qq(sed -i.bak /^\\\\[tar_scm\\\\]/d $ENV{HOME}/.obs/tar_scm))
 }
 
 die "Error: can not find .osc project in this directory: " unless ( -d '.osc');


### PR DESCRIPTION
This is a follow up to

https://github.com/SUSE-Cloud/automation/pull/3754

In the case where ~/.obs/tar_scm config file already exist
and contain the [tar_scm] group, we need to remove it so that
obs-service-tar_scm doesn't choke on it.