### PR TITLE
openstack-crowbar: deploy designate with SSL

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/designate.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/designate.yml.j2
@@ -1,2 +1,6 @@
   - barclamp: designate
+    attributes:
+      api:
+        protocol: {{ api_protocol }}
+{% include 'barclamps/lib/ssl.yml.j2' %}
 {% include 'barclamps/lib/deployment.yml.j2' %}


### PR DESCRIPTION
When [1] merges designate can be deployed with SSL enabled.

This change enable deploying designate with SSL enabled on
the openstack-crowbar jobs.

1. https://github.com/crowbar/crowbar-openstack/pull/2308