### PR TITLE
octavia: adjust tempest filters (SOC-10965)

### DIFF
--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -51,7 +51,7 @@
           default-value: ''
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,heat,magnum,manila,lbaas,designate
+            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,designate
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -297,7 +297,7 @@
           default-value: '{tempest_filter_list|}'
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,heat,magnum,manila,lbaas,designate
+            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,designate
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -109,6 +109,10 @@ export want_all_ssl=1
 export want_designate_proposal=1
 {% endif %}
 
+{% if 'octavia' in deployments %}
+export want_octavia_proposal=1
+{% endif %}
+
 # export ironicnetmask=
 
 # Use this to override the crowbar node list order in qa_crowbarsetup.sh

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -3761,6 +3761,23 @@ id-301f5a30-1c6f-4ea0-be1a-91fd28d44354
 id-bdbb5441-9204-419d-a225-b4fdbfb1a1a8
 id-6bba729b-3fb6-494b-9e1e-82bbd89a1045
 EOF
+
+        if [[ $want_octavia_proposal > 0 ]]; then
+            cat - > $blacklistfile << EOF
+# The lbaasv2-proxy service plugin doesn't handle the `http_method` attribute correctly (SOC-10965)
+# Upstream bug https://storyboard.openstack.org/#!/story/2006909
+neutron_lbaas.tests.tempest.v2.api.test_health_monitors_non_admin.TestHealthMonitors.test_list_health_monitors_two
+
+# There is no Octavia counterpart for neutron service flavors and flavors
+# cannot be transparently handled by the lbaasv2-proxy service plugin
+neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_create_load_balancer_invalid_flavor_field
+
+# Updating a load balancer with an empty body is not handled by the lbaasv2-proxy service plugin
+neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_update_load_balancer_missing_admin_state_up
+neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_update_load_balancer_missing_description
+neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.LoadBalancersTestJSON.test_update_load_balancer_missing_name
+EOF
+        fi
     fi
 
     tempest cleanup --init-saved-state


### PR DESCRIPTION
Adjust the tempest run filters to account for the fact that
when Octavia is enabled, the neutron lbaasv2 API is actually
proxied to the Octavia API and the neutron-lbaas tempest test
cases aren't properly equipped to handle that.

Creates a tempest filter to be run against Octavia with the
lbaasv2-proxy service plugin. The following test cases are
black-listed in that tempest filter, but also black-listed
in qa_crowbarsetup.sh, because they are not compatible with
the Octavia lbaasv2-proxy service plugin:

 - neutron_lbaas.tests.tempest.v2.api.test_health_monitors_non_admin.
 TestHealthMonitors.test_list_health_monitors_two
   - lbaas-proxy doesn't handle the `http_method` attribute correctly
   - see https://jira.suse.com/browse/SOC-10965

 - neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.
 LoadBalancersTestJSON.test_create_load_balancer_invalid_flavor_field
   - the concept of neutron service flavors doesn't yet have an Octavia
   counterpart in Rocky, so the lbaasv2-proxy service plugin cannot
   transparently convert these attributes
   - see https://blueprints.launchpad.net/octavia/+spec/octavia-lbaas-flavors

 - neutron_lbaas.tests.tempest.v2.api.test_load_balancers_non_admin.
 LoadBalancersTestJSON.test_update_load_balancer_missing*
   - these test cases update an existing load-balancer with an empty
   body (i.e. without actually changing anything)
   - this use case isn't correctly handled by the lbaasv2-proxy
   service plugin