### PR TITLE
openstack-crowbar: get devel iso from provo-clouddata

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -28,9 +28,15 @@ export cloudfqdn={{ cloud_fqdn }}
 
 {% if cloudsource.startswith("stagingcloud") %}
 export cloudsource=develcloud{{ cloudsource[-1] }}
+export want_cloud{{ cloudsource[-1] }}_iso_url={{ clouddata_server }}/repos/x86_64/
+export want_cloud{{ cloudsource[-1] }}_iso={{ cloud_iso_name }}-devel-staging.iso
 export TESTHEAD=1
 {% else %}
 export cloudsource={{ cloudsource }}
+{% if cloudsource.startswith("develcloud") %}
+export want_cloud{{ cloudsource[-1] }}_iso_url={{ clouddata_server }}/repos/x86_64/
+export want_cloud{{ cloudsource[-1] }}_iso={{ cloud_iso_name }}-devel.iso
+{% endif %}
 export TESTHEAD=
 {% endif %}
 

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
@@ -14,3 +14,5 @@ gen_subnet_start: 124
 gen_ip_start: 10
 # Gap to be left between the generated IP for the admin node and the rest of the nodes
 gen_ip_gap: 71
+
+cloud_iso_name: "{{ (cloudsource[-1] == '7') | ternary('SUSE-OpenStack-Cloud-7', 'SUSE-OpenStack-Cloud-Crowbar-' ~ cloudsource[-1]) }}"

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -885,20 +885,20 @@ function onadmin_set_source_variables
         ;;
         develcloud7)
             CLOUDISOURL=${want_cloud7_iso_url:="$susedownload/ibs/Devel:/Cloud:/7/images/iso/"}
-            [ -n "$TESTHEAD" ] && CLOUDISOURL="$susedownload/ibs/Devel:/Cloud:/7:/Staging/images/iso/"
+            [ -n "$TESTHEAD" ] && CLOUDISOURL=${want_cloud7_iso_url:="$susedownload/ibs/Devel:/Cloud:/7:/Staging/images/iso/"}
             CLOUDISONAME=${want_cloud7_iso:="SUSE-OPENSTACK-CLOUD-7-${arch}-Media1.iso"}
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-7-devel"
         ;;
         develcloud8)
-            CLOUDISOURL="$susedownload/ibs/Devel:/Cloud:/8/images/iso/"
-            [ -n "$TESTHEAD" ] && CLOUDISOURL="$susedownload/ibs/Devel:/Cloud:/8:/Staging/images/iso/"
-            CLOUDISONAME="SUSE-OPENSTACK-CLOUD-CROWBAR-8-${arch}-Media1.iso"
+            CLOUDISOURL=${want_cloud8_iso_url:="$susedownload/ibs/Devel:/Cloud:/8/images/iso/"}
+            [ -n "$TESTHEAD" ] && CLOUDISOURL=${want_cloud8_iso_url:="$susedownload/ibs/Devel:/Cloud:/8:/Staging/images/iso/"}
+            CLOUDISONAME=${want_cloud8_iso:="SUSE-OPENSTACK-CLOUD-CROWBAR-8-${arch}-Media1.iso"}
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-Crowbar-8-devel"
         ;;
         develcloud9)
-            CLOUDISOURL="$susedownload/ibs/Devel:/Cloud:/9/images/iso/"
-            [ -n "$TESTHEAD" ] && CLOUDISOURL="$susedownload/ibs/Devel:/Cloud:/9:/Staging/images/iso/"
-            CLOUDISONAME="SUSE-OPENSTACK-CLOUD-CROWBAR-9-${arch}-Media1.iso"
+            CLOUDISOURL=${want_cloud9_iso_url:="$susedownload/ibs/Devel:/Cloud:/9/images/iso/"}
+            [ -n "$TESTHEAD" ] && CLOUDISOURL=${want_cloud9_iso_url:="$susedownload/ibs/Devel:/Cloud:/9:/Staging/images/iso/"}
+            CLOUDISONAME=${want_cloud9_iso:="SUSE-OPENSTACK-CLOUD-CROWBAR-9-${arch}-Media1.iso"}
             CLOUDLOCALREPOS="SUSE-OpenStack-Cloud-Crowbar-9-devel"
         ;;
         GM9|GM9+up)


### PR DESCRIPTION
This change switches the iso source from http://ibs-mirror.prv.suse.net/
to http://provo-clouddata.cloud.suse.de/ for the crowbar devel medias.
The reason behind it is that the trigger is also based on the build
number of the iso in provo-clouddata, also ibs-mirror has some recurring
issues syncing the medias from download.suse.de causing triggered jobs
to test outdated changes.