### PR TITLE
openstack-crowbar: fix python-sh location

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1767,9 +1767,7 @@ function onadmin_post_allocate
         done
 
         if [[ $want_sbd = 1 ]] ; then
-            local backport_slesdist=$slesdist
-            iscloudver 8plus || backport_slesdist=SLE_12
-            $zypper -p http://download.opensuse.org/repositories/devel:/languages:/python:/backports/$backport_slesdist/ install python-sh
+            $zypper -p http://download.suse.de/ibs/SUSE:/Factory:/Head/standard/ install python-sh
             chmod +x $SCRIPTS_DIR/iscsictl.py
             $SCRIPTS_DIR/iscsictl.py --service target --host $(hostname) --no-key
 


### PR DESCRIPTION
Because SLE_12 and SLE_12_SP3 are gone from the
http://download.opensuse.org/repositories/devel:/languages:/python:/backports/
repository, we're better off switching to something that has a longer
lifetime.