### PR TITLE
cloud-gating: re-add downstream job URLs

### DIFF
--- a/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
               if (!combined_extra_params.isEmpty()) {
                  job_params.extra_params = combined_extra_params
               }
-              cloud_lib.trigger_build(job_def.job_name, cloud_lib.convert_to_build_params(job_params))
+              cloud_lib.trigger_build(job_def.job_name, cloud_lib.convert_to_build_params(job_params), false)
             }
           }
 

--- a/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy
+++ b/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy
@@ -73,7 +73,10 @@ def trigger_build(job_name, parameters, propagate=true, wait=true) {
     def jobResult = slaveJob.getResult()
     def jobUrl = slaveJob.buildVariables.blue_ocean_buildurl
     def jobMsg = "Build ${jobUrl} completed with: ${jobResult}"
-    echo jobMsg
+    sh(
+      script: "echo '"+jobMsg+"'",
+      label: jobUrl
+    )
     if (jobResult != 'SUCCESS') {
       error(jobMsg)
     }


### PR DESCRIPTION
The Blue Ocean UI is still acting up, intermittently failing
to render the "Triggered Builds" section that can be used
to quickly navigate to downstream jobs. To account for this
bug, this commit re-enables printing messages during the Jenkins
pipeline stage, with URLs pointing to triggered downstream jobs.

NOTE: these messages will only show up in the Blue Ocean UI after
a triggered job has completed execution, which means that they
cannot be used to access ongoing downstream jobs.