### PR TITLE
openstack-crowbar: Enable designate barclamp for cloud8

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/versioned.yml
@@ -66,6 +66,6 @@ versioned_barclamps:
   aodh:
     enabled: "{{ not when_cloud9 }}"
   designate:
-    enabled: "{{ when_cloud9 }}"
+    enabled: "{{ not when_cloud7 }}"
   octavia:
     enabled: "{{ when_cloud9 }}"


### PR DESCRIPTION
This change enable the designate barclamp also for Cloud 8.