### PR TITLE
cloud-9-gating: enable Octavia in CI (SOC-10685)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -123,7 +123,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
     jobs:
         - '{crowbar_job}'
 
@@ -156,7 +156,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
     jobs:
         - '{crowbar_job}'
 
@@ -191,6 +191,6 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -80,14 +80,14 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
       - cloud-crowbar9-job-mu-no-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
     jobs:
       - '{crowbar_job}'
 
@@ -130,14 +130,14 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
       - cloud-crowbar9-job-mu-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
     jobs:
       - '{crowbar_job}'
 
@@ -182,13 +182,13 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
       - cloud-crowbar9-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            heat,magnum,manila,lbaas-octavia"
     jobs:
       - '{crowbar_job}'

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -168,9 +168,9 @@
           type: multi-select
           visible-items: 10
           multi-select-delimiter: ','
-          # NOTE: keeping designate and octavia disabled by default, until their
+          # NOTE: keeping designate disabled by default, until their
           # implementation is complete
-          default-value: '{enabled_services|database,rabbitmq,keystone,swift,monasca,glance,cinder,neutron,nova,horizon,ceilometer,heat,manila,trove,barbican,magnum,sahara,aodh,tempest}'
+          default-value: '{enabled_services|database,rabbitmq,keystone,swift,monasca,glance,cinder,neutron,nova,horizon,ceilometer,heat,manila,trove,barbican,octavia,magnum,sahara,aodh,tempest}'
           value: >-
             database,rabbitmq,keystone,swift,monasca,glance,cinder,neutron,nova,
             horizon,ceilometer,heat,manila,trove,designate,barbican,octavia,


### PR DESCRIPTION
Add Octavia to the list of barclamps deployed by default in all
SOC9 ECP Crowbar jobs. Also run the lbaas-octavia tempest run
filter instead of lbaas in the SOC9 Crowbar gating jobs.