### PR TITLE
openstack-ardana: ansible role for amphora image setup

### DIFF
--- a/scripts/jenkins/cloud/ansible/ardana-update.yml
+++ b/scripts/jenkins/cloud/ansible/ardana-update.yml
@@ -40,6 +40,10 @@
 
         - include_role:
             name: ardana_update
+
+        # Call this role to also update the Octavia amphora image
+        - include_role:
+            name: setup_amphora_image
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/cloud/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-cloud.yml
@@ -45,6 +45,9 @@
 
         - include_role:
             name: ardana_deploy
+
+        - include_role:
+            name: setup_amphora_image
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/defaults/main.yml
@@ -34,5 +34,3 @@ defcore_refstack_url: "https://10.86.0.98"
 defcore_results: "~/refstack_results.subunit"
 subunit_html_results: "~/testr_results_region1.html"
 subunit_xml_results: "~/testr_results_region1.xml"
-
-octavia_amphora_image_rpm: "find /srv/www/*/x86_64/repos/*OpenStack*/ -name '*octavia-amphora-image*' | tail -n1"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/main.yml
@@ -23,9 +23,6 @@
     extra_vars: "-e router_distributed=False -e enable_distributed_routing=False"
   when: tempest_run_filter in ['vpnaas', 'fwaas']
 
-- include_tasks: import_octavia_image.yml
-  when: tempest_run_filter in ['lbaas', 'heat']
-
 - include_tasks: run_tempest.yml
 
 - include_tasks: reconfigure_neutron.yml

--- a/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/defaults/main.yml
@@ -1,0 +1,20 @@
+#
+# (c) Copyright 2018 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
+
+octavia_amphora_image_rpm: "find /srv/www/*/x86_64/repos/*OpenStack*/ -name '*octavia-amphora-image*' | tail -n1"

--- a/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2019 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,9 +15,10 @@
 #
 ---
 
-- name: Check if octavia amphora image is present
-  shell: source ~/service.osrc;openstack image list | grep octavia-amphora-image | awk '{print $2}'
-  register: octavia_amphora_image_is_present
+- name: Check if octavia service is deployed
+  shell: source ~/service.osrc;openstack service show octavia
+  register: octavia_service_is_present
+  ignore_errors: yes
 
 - name: Import octavia amphora image
   shell: |
@@ -26,4 +27,5 @@
                  -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
-  when: octavia_amphora_image_is_present.stdout == ""
+  when:
+    - octavia_service_is_present.rc == 0


### PR DESCRIPTION
We were previously setting up the amphora image on Ardana
deployments only during tempest testing and only if either
the lbaas or heat filters were enabled.

This change moves that logic to its own role and calls it
during regular cloud deployment as well as after a cloud
update, in case the amphora image was updated.