### PR TITLE
openstack-ardana: don't check for an Octavia service

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/tasks/main.yml
@@ -15,11 +15,6 @@
 #
 ---
 
-- name: Check if octavia service is deployed
-  shell: source ~/service.osrc;openstack service show octavia
-  register: octavia_service_is_present
-  ignore_errors: yes
-
 - name: Import octavia amphora image
   shell: |
     ansible-playbook -i hosts/verb_hosts service-guest-image.yml \
@@ -27,5 +22,4 @@
                  -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
-  when:
-    - octavia_service_is_present.rc == 0
+  when: "'octavia' not in disabled_services | default('')"


### PR DESCRIPTION
In SOC8 Ardana, there are no Octavia endpoints and there is no
'octavia' service registered in the catalogue, so we can't rely
on that to check whether Octavia is deployed when setting up the
amphora image.