### PR TITLE
openstack-[ardana|crowbar]: add support for PXE booting virtual nodes (SOC-7365)

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -210,7 +210,11 @@ pipeline {
       steps{
         script {
           if (cloud_type == 'virtual') {
-            cloud_lib.ansible_playbook('bootstrap-vcloud-nodes')
+            if (pxe_boot_enabled == 'true') {
+              cloud_lib.ansible_playbook('bootstrap-osbmc-nodes')
+            } else {
+              cloud_lib.ansible_playbook('bootstrap-vcloud-nodes')
+            }
           } else {
             cloud_lib.ansible_playbook('bootstrap-pcloud-nodes')
           }

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -139,6 +139,9 @@ pipeline {
     }
 
     stage('Bootstrap nodes') {
+      when {
+        expression { pxe_boot_enabled == 'false' && cloud_type == 'virtual' }
+      }
       steps {
         script {
           // This step does the following on the non-admin nodes:
@@ -197,6 +200,19 @@ pipeline {
                    // This step does the following on the admin node:
                    //  - installs crowbar
                    cloud_lib.ansible_playbook('install-crowbar')
+                }
+              }
+            }
+
+            stage('Bootstrap BMC nodes') {
+              when {
+                expression { pxe_boot_enabled == 'true' && cloud_type == 'virtual' }
+              }
+              steps {
+                script {
+                   // This step does the following on the virtual BMC nodes:
+                   //  - Setup the openstack-bmc service
+                   cloud_lib.ansible_playbook('bootstrap-osbmc-nodes')
                 }
               }
             }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -87,6 +87,12 @@
             If true then cloud will be rebooted after deployment.
 
       - bool:
+          name: pxe_boot_enabled
+          default: '{pxe_boot_enabled|false}'
+          description:
+            Infra nodes (besides the CLM) will be provisioned by cobbler.
+
+      - bool:
           name: updates_test_enabled
           default: '{updates_test_enabled|true}'
           description: >-

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -96,6 +96,12 @@
             repositories, but skip the actual cloud deployment, e.g. for testing purposes.
 
       - bool:
+          name: pxe_boot_enabled
+          default: '{pxe_boot_enabled|false}'
+          description:
+            Infra nodes (besides the admin) will be provisioned by crowbar.
+
+      - bool:
           name: test_cloud
           default: '{test|true}'
           description: >-

--- a/scripts/jenkins/cloud/ansible/_create-vcloud-inventory.yml
+++ b/scripts/jenkins/cloud/ansible/_create-vcloud-inventory.yml
@@ -1,3 +1,18 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
 ---
 
 - name: Create temp inventory with all non-admin virtual nodes
@@ -13,15 +28,15 @@
   tasks:
     - name: Create temp inventory with all non-admin virtual nodes
       add_host:
-        name: "{{ item.0.group }}{{ item.0.ips.index(item.1) + 1 }}"
+        name: "{{ cloud_env }}-cloud_{{ item.0.group }}_{{ '%04d' | format(item.0.ips.index(item.1) + 1) }}_server"
         ansible_host: "{{ item.1 }}"
-        ansible_password: "linux"
+        ansible_password: "{{ (pxe_boot_enabled and cloud_product=='ardana') | ternary('ardana', 'linux') }}"
         group: "{{ item.0.group }}, cloud_virt_hosts"
         ansible_ssh_common_args: >
           -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o
-          StrictHostKeyChecking=no -W %h:%p -q root@{{ hostvars[cloud_env].ansible_host }}'
+          StrictHostKeyChecking=no -W %h:%p -q {{ (pxe_boot_enabled and cloud_product=='ardana') |
+          ternary('ardana', 'root') }}@{{ hostvars[cloud_env].ansible_host }}'
           -o ControlPath='~/.ansible/cp/{{ cloud_env }}-%r@%h:%p'
       loop: "{{ virtual_hosts | subelements('ips') }}"
       loop_control:
-        label: "{{ item.0.group }}{{ item.0.ips.index(item.1) + 1 }} - {{ item.1 }}"
-
+        label: "{{ cloud_env }}-cloud_{{ item.0.group }}_{{ '%04d' | format(item.0.ips.index(item.1) + 1) }}_server - {{ item.1 }}"

--- a/scripts/jenkins/cloud/ansible/bootstrap-osbmc-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-osbmc-nodes.yml
@@ -1,0 +1,77 @@
+#
+# (c) Copyright 2019 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+- name: Create temp inventory with osbmc nodes
+  hosts: "localhost"
+  gather_facts: False
+
+  tasks:
+    - name: Get osbmc node(s) IP(s) and servers to manage
+      command: |
+         openstack --os-cloud "{{ os_cloud }}" --os-project-name {{ os_project_name }} \
+           stack output show {{ heat_stack_name }} {{ item }} -c output_value -f value
+      loop:
+        - "osbmc-server-ips"
+        - "osbmc-managed-servers"
+      register: "osbmc_stack_output"
+
+    - name: Create temp inventory with all osbmc nodes
+      add_host:
+        name: "{{ item.1 | replace('server', 'osbmc_server')}}"
+        ansible_host: "{{ item.0 }}"
+        ansible_password: "linux"
+        ansible_user: root
+        group: "osbmc_all"
+        instance_to_manage: "{{ item.1 }}"
+        ansible_ssh_common_args: >
+          -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o
+          StrictHostKeyChecking=no -W %h:%p -q root@{{ hostvars[cloud_env].ansible_host }}'
+          -o ControlPath='~/.ansible/cp/{{ cloud_env }}-%r@%h:%p'
+      loop: "{{ osbmc_stack_output.results.0.stdout | from_yaml | zip(osbmc_stack_output.results.1.stdout | from_yaml) | list }}"
+      loop_control:
+        label: "{{ item.1 }} bmc managed by: {{ item.0 }}"
+
+- name: Bootstrap openstack-bmc servers
+  hosts: "osbmc_all"
+  gather_facts: False
+
+  roles:
+    - osbmc_server
+
+- name: Disable DHCP on the cloud infra management network
+  hosts: localhost
+
+  tasks:
+    - name: Disable DHCP on the cloud infra management network
+      command: |
+        openstack --os-cloud {{ os_cloud }} --os-project-name {{ os_project_name }} \
+          subnet set --no-dhcp \
+          {{ cloud_env }}-cloud_management_subnet
+
+- name: Set ipmi_ip_addrs on mkcloud.config when crowbar
+  hosts: "{{ cloud_env }}"
+  remote_user: root
+  gather_facts: False
+
+  tasks:
+    - name: Set ipmi_ip_addrs on mkcloud for crowbar
+      lineinfile:
+        dest: "/root/mkcloud.config"
+        regexp: "^export ipmi_ip_addrs="
+        line: "export ipmi_ip_addrs='{{ groups['osbmc_all'] | map('extract', hostvars, ['ansible_host']) | join(' ') }}'"
+        state: present
+      when: cloud_product == 'crowbar'

--- a/scripts/jenkins/cloud/ansible/group_vars/qe_all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/qe_all.yml
@@ -17,6 +17,9 @@
 
 ses_cluster_id: "qe"
 
+cobbler_root_device: "/dev/sda"
+pxe_boot_enabled: True
+
 ardana_extra_vars:
   nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"
   local_image_mirror_url: "http://{{ clouddata_server }}/images/x86_64/openstack/"

--- a/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
@@ -18,6 +18,9 @@
 ses_cluster_id: "virt"
 ses_rgw_port: 8081
 
+cobbler_root_device: "/dev/vda"
+pxe_boot_enabled: False
+
 ardana_common_extra_vars:
   nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"
   nova_cpu_mode: custom

--- a/scripts/jenkins/cloud/ansible/list-or-diff-installed-packages.yml
+++ b/scripts/jenkins/cloud/ansible/list-or-diff-installed-packages.yml
@@ -17,6 +17,15 @@
 
 - import_playbook: _create-vcloud-inventory.yml
 
+- name: Ensure hosts accessible by root user
+  hosts: cloud_virt_hosts
+  remote_user: "{{ (pxe_boot_enabled and cloud_product=='ardana') | ternary('ardana', 'root') }}"
+  gather_facts: True
+  become: yes
+
+  roles:
+    - ssh_keys
+
 - name: Collect list of installed packages in all nodes
   hosts: localhost
   remote_user: root

--- a/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
@@ -16,7 +16,7 @@
   hosts: cloud_virt_hosts
   any_errors_fatal: true
   remote_user: root
-  gather_facts: True
+  gather_facts: False
   vars:
     task: "register"
 
@@ -27,9 +27,33 @@
         - include_role:
             name: crowbar_setup
           vars:
+            qa_crowbarsetup_cmd: "onadmin_allocate"
+
+        # Need to wait until SLESHammer finishes running and reboot the nodes
+        # 2 minutes should be more than enough for that
+        - name: Wait for nodes to be ready to install the OS
+          pause:
+            minutes: 2
+          when: pxe_boot_enabled
+
+        # The iPXE image expects to install the OS on its first boot through PXE, however on
+        # Crowbar it boots SLESHammer which clears the machine disks (deleting the iPXE image).
+        # This gets the instance stuck on 'Booting from Hard Drive'. A way to work around that is
+        # rebuilding the instances which makes it boot through PXE again and installs the OS.
+        - name: Rebuild crowbar nodes when PXE boot enabled
+          command: |
+            openstack --os-cloud {{ os_cloud }} --os-project-name {{ os_project_name }} \
+              server rebuild {{ item }}
+          loop: "{{ groups['cloud_virt_hosts'] }}"
+          when: pxe_boot_enabled
+          delegate_to: localhost
+          run_once: True
+
+        - include_role:
+            name: crowbar_setup
+          vars:
             qa_crowbarsetup_cmd: "onadmin_{{ command }}"
           loop:
-            - allocate
             - waitcloud
             - post_allocate
             - setup_aliases

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
@@ -65,7 +65,7 @@
   when: openid_connect_enabled
 
 - include_tasks: reimage_nodes.yml
-  when: is_physical_deploy
+  when: is_physical_deploy or pxe_boot_enabled
 
 - name: Import Devel:Cloud:X key when cloudsource is staging or devel
   shell: "ansible {{ item }} resources"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/reimage_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/reimage_nodes.yml
@@ -18,12 +18,12 @@
 - name: Run cobbler-deploy
   command: |
     ansible-playbook -i hosts/localhost cobbler-deploy.yml \
-      -e ardanauser_password='ardana'
+      -e ardanauser_password='ardana' -e cobbler_root_device='{{ cobbler_root_device }}'
   args:
     chdir: "{{ ardana_openstack_path }}"
 
 - name: Get list of SLES nodes to reimage
-  shell: 'cobbler profile list | grep "sles12sp{{ ansible_distribution_release }}-x86_64-" | cut -d"-" -f3'
+  shell: 'cobbler profile list | grep "sles12sp{{ ansible_distribution_release }}-x86_64-" | cut -d"-" -f3-'
   become: yes
   register: ardana_sles_nodes
 

--- a/scripts/jenkins/cloud/ansible/roles/bootstrap_ardana/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/bootstrap_ardana/defaults/main.yml
@@ -30,10 +30,10 @@ rhel7_opt_yum:
 cobbler_requires:
   - name: "sles12sp3.iso"
     url: "http://{{ sles_media_server }}/install/SLE-12-SP3-Server-GM/SLE-12-SP3-Server-DVD-x86_64-GM-DVD1.iso"
-    download_when: "{{ cloud_release == 'cloud8' and is_physical_deploy }}"
+    download_when: "{{ cloud_release == 'cloud8' and (is_physical_deploy or pxe_boot_enabled) }}"
   - name: "sles12sp4.iso"
     url: "http://{{ sles_media_server }}/install/SLE-12-SP4-Server-GM/SLE-12-SP4-Server-DVD-x86_64-GM-DVD1.iso"
-    download_when: "{{ cloud_release == 'cloud9' and is_physical_deploy }}"
+    download_when: "{{ cloud_release == 'cloud9' and (is_physical_deploy or pxe_boot_enabled) }}"
   - name: "rhel7.iso"
     url: "http://10.84.144.252/compute_iso/{{ rhel_iso[rhel_os] }}"
     download_when: "{{ rhel_enabled }}"

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
@@ -81,7 +81,7 @@
 {%       if not 'octavia' in disabled_services %}
 {%         set _ = ns.routes.append('OCTAVIA-MGMT-NET') %}
 {%       endif %}
-{%       set _ = ns.routes.append('ILO') %}
+{%       set _ = ns.routes.append('BMC') %}
 {%     else %}
 {%       for neutron_ng in scenario.network_groups if 'NEUTRON-VLAN' in neutron_ng.component_endpoints and
                                                       not 'neutron' in disabled_services %}
@@ -97,7 +97,7 @@
 {%     endfor  %}
 {%   endif %}
 
-{% if network_group.name != 'ILO' %}
+{% if network_group.name != 'BMC' %}
       load-balancers:
 {%   if 'INTERNAL-API' in network_group['component_endpoints'] %}
 

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/servers.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/servers.yml
@@ -14,7 +14,7 @@
 # under the License.
 #
 ---
-{% set ns = namespace(clm_net_id=0, server_idx=0) %}
+{% set ns = namespace(clm_net_id=0, bmc_net_id=0, server_idx=0) %}
 {% for network_group in scenario['network_groups'] %}
 {%   if 'CLM' in network_group['component_endpoints'] %}
 {%     set ns.clm_net_id = loop.index0+gen_subnet_start %}
@@ -26,6 +26,17 @@
 {%       set ns.clm_net_id = loop.index0+gen_subnet_start %}
 {%     endif %}
 {%   endfor  %}
+{% endif %}
+{% if ns.bmc_net_id == 0 %}
+{%   if not scenario['network_groups'] | selectattr('name', 'equalto', 'BMC') | map(attribute='name') | list  %}
+{%     set ns.bmc_net_id = ns.clm_net_id %}
+{%   else %}
+{%     for network_group in scenario['network_groups'] %}
+{%       if network_group['name'] == 'BMC' %}
+{%         set ns.bmc_net_id = loop.index0+gen_subnet_start %}
+{%       endif %}
+{%     endfor  %}
+{%   endif %}
 {% endif %}
   product:
     version: 2
@@ -48,8 +59,13 @@
       ilo-password: {{ bm_info.servers[ns.server_idx].ilo_password }}
       ilo-ip: {{ bm_info.servers[ns.server_idx].ilo_ip }}
       mac-addr: {{ bm_info.servers[ns.server_idx].mac_addr }}
-{% elif bm_info is not defined %}
-      # Generate dummy iLO credentials until bsc#1091459 is fixed
+{% elif bm_info is not defined and pxe_boot_enabled and (idx != 0 or 'CLM' not in service_group['service_components']) %}
+      ilo-user: 'admin'
+      ilo-password: 'password'
+      ilo-ip: {{ subnet_prefix.ipv4 }}.{{ ns.bmc_net_id }}.{{ ns.server_idx + gen_ip_start + bmc_ip_gap }}
+      mac-addr: "{{ (subnet_prefix.ipv4 ~ '.' ~ ns.clm_net_id ~ '.' ~ ns.server_idx) | ip4_hex(':') | random_mac }}"
+{% elif 'CLM' not in service_group.service_components %}
+      # Generate dummy iLO credentials for NON-CLM nodes (required by osconfig)
       ilo-user: 'ilouser'
       ilo-password: 'ilopasswd'
       ilo-ip: 10.1.1.{{ ns.server_idx + gen_ip_start }}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -108,10 +108,16 @@ export UPDATEREPOS={{ extra_repos.split(',') | join('+') }}
 # export JENKINS_WORKSPACE=
 # export test_internet_url=
 # export extraipmipw=
-# export ipmi_ip_addrs=
-# export bmc_user=
-# export bmc_password=
 # export upgrade_progress_file=
+
+{% if pxe_boot_enabled %}
+export want_ipmi=1
+export bmc_user=admin
+export bmc_password=password
+export want_ipmi_username=$bmc_user
+export want_ipmi_extraopts="-I lanplus -P $bmc_password"
+export ipmi_ip_addrs=
+{% endif %}
 
 export nodenumber={{ ns.cloud_nodes }}
 # export nodenumberlonelynode=

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/ardana.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/ardana.yml
@@ -12,3 +12,6 @@ gen_subnet_start: 100
 gen_ip_start: 100
 # Gap to be left between the generated IP for the admin node and the rest of the nodes
 gen_ip_gap: 1
+# Gap to be left between the generated IP for the bmc node and the rest of the nodes
+# As ardana bmc nodes are on a different network that gap can be set to 0
+bmc_ip_gap: 0

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
@@ -14,5 +14,7 @@ gen_subnet_start: 124
 gen_ip_start: 10
 # Gap to be left between the generated IP for the admin node and the rest of the nodes
 gen_ip_gap: 71
-
+# Gap to be left between the generated IP for the bmc node and the rest of the nodes
+# As crowbar bmc nodes are also on the admin network this gap needs to fit the values on network.json bmc network range
+bmc_ip_gap: 80
 cloud_iso_name: "{{ (cloudsource[-1] == '7') | ternary('SUSE-OpenStack-Cloud-7', 'SUSE-OpenStack-Cloud-Crowbar-' ~ cloudsource[-1]) }}"

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/compact.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/compact.yml
@@ -49,6 +49,6 @@ network_groups:
     component_endpoints:
       - NEUTRON-VXLAN
 
-  - name: ILO
-    hostname_suffix: ilo
+  - name: BMC
+    hostname_suffix: bmc
     component_endpoints: []

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/full-spread.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/full-spread.yml
@@ -71,6 +71,6 @@ network_groups:
       - SWIFT
     rack_network: {{ scenario.rack_networks_enabled }}
 
-  - name: ILO
-    hostname_suffix: ilo
+  - name: BMC
+    hostname_suffix: bmc
     component_endpoints: []

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/standard.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/standard.yml
@@ -66,3 +66,8 @@ network_groups:
     hostname_suffix: storage
     tagged_vlan: true
     component_endpoints: []
+
+  - name: BMC
+    hostname_suffix: bmc
+    component_endpoints: []
+

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 
-- name: set crowbar_node_name fact
-  set_fact:
-    crowbar_node_name: "d{{ hostvars[inventory_hostname]['ansible_%s' | format(admin_interface)].macaddress | replace(':', '-') }}.{{ cloud_fqdn }}"
+- include_tasks: set_node_name_{{ pxe_boot_enabled | ternary('crowbar', 'os') }}_provisioned.yml
 
 - name: Create crowbar node list properly sorted
   set_fact:
@@ -23,36 +21,6 @@
 - name: Reserve node admin IP addresses in Crowbar
   include_tasks: reserve_admin_ip.yml
 
-  # When installing extra repositories (such as test-updates), these
-  # repositories are served to cloud nodes using the FQDN instead of the IP,
-  # which confuses crowbar_register
-- name: Ensure admin node FQDN resolvable
-  lineinfile:
-    dest: "/etc/hosts"
-    line: "{{ hostvars['localhost'].admin_conf_ip }}    crowbar.{{ cloud_fqdn }}"
-
-- name: Remove existing repositories
-  shell: |
-    set -e
-    while [ "`zypper lr | grep ^1`" != '' ]; do
-      zypper rr 1
-    done
-
-- name: Run crowbar_register
-  shell: |
-    set -e
-
-    wget {{ crowbar_register_url }} -O {{ crowbar_register_path }}
-    chmod +x {{ crowbar_register_path }}
-
-    SSH_CONNECTION= {{ crowbar_register_path }} -f --interface {{ admin_interface }} --gpg-auto-import-keys 2>&1 | tee {{ crowbar_register_log }}
-    exit ${PIPESTATUS[0]}
-
-- name: Check that node has registered
-  delegate_to: "{{ cloud_env }}"
-  shell: knife node list | tr -d ' '
-  register: _register_tmp
-  # The more nodes we have, the longer this will take
-  retries: "{{ 6 * ( groups['cloud_virt_hosts'] | length ) }}"
-  until: _register_tmp.rc == 0 and crowbar_node_name in _register_tmp.stdout_lines
-  delay: 10
+- name: Register nodes
+  include_tasks: register_nodes.yml
+  when: not pxe_boot_enabled

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/register_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/register_nodes.yml
@@ -1,0 +1,35 @@
+---
+
+# When installing extra repositories (such as test-updates), these
+# repositories are served to cloud nodes using the FQDN instead of the IP,
+# which confuses crowbar_register
+- name: Ensure admin node FQDN resolvable
+  lineinfile:
+    dest: "/etc/hosts"
+    line: "{{ hostvars['localhost'].admin_conf_ip }}    crowbar.{{ cloud_fqdn }}"
+
+- name: Remove existing repositories
+  shell: |
+    set -e
+    while [ "`zypper lr | grep ^1`" != '' ]; do
+      zypper rr 1
+    done
+
+- name: Run crowbar_register
+  shell: |
+    set -e
+
+    wget {{ crowbar_register_url }} -O {{ crowbar_register_path }}
+    chmod +x {{ crowbar_register_path }}
+
+    SSH_CONNECTION= {{ crowbar_register_path }} -f --interface {{ admin_interface }} --gpg-auto-import-keys 2>&1 | tee {{ crowbar_register_log }}
+    exit ${PIPESTATUS[0]}
+
+- name: Check that node has registered
+  delegate_to: "{{ cloud_env }}"
+  shell: knife node list | tr -d ' '
+  register: _register_tmp
+  # The more nodes we have, the longer this will take
+  retries: "{{ 6 * ( groups['cloud_virt_hosts'] | length ) }}"
+  until: _register_tmp.rc == 0 and crowbar_node_name in _register_tmp.stdout_lines
+  delay: 10

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/set_node_name_crowbar_provisioned.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/set_node_name_crowbar_provisioned.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Get nodes MAC addresses
+  command: |
+    openstack --os-cloud {{ os_cloud }} --os-project-name {{ os_project_name }} \
+      port list --network {{ cloud_env }}-cloud_management_net --fixed-ip \
+      ip-address={{ hostvars[item].ansible_host }} -c MAC\ Address -f value
+  loop: "{{ groups['cloud_virt_hosts'] }}"
+  register: _nodes_macs
+  delegate_to: localhost
+  run_once: True
+
+- name: set crowbar_node_name fact
+  set_fact:
+    crowbar_node_name: "d{{ _nodes_macs.results | selectattr('item', 'equalto', inventory_hostname) | map(attribute='stdout') | list | join(',') | replace(':', '-') }}.{{ cloud_fqdn }}"

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/set_node_name_os_provisioned.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/set_node_name_os_provisioned.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Gathering Facts
+  setup:
+
+- name: set crowbar_node_name fact
+  set_fact:
+    crowbar_node_name: "d{{ hostvars[inventory_hostname]['ansible_%s' | format(admin_interface)].macaddress | replace(':', '-') }}.{{ cloud_fqdn }}"

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/defaults/main.yml
@@ -21,6 +21,10 @@ rhel_image: "centos{{ rhel_os_version }}"
 # If SES is disabled, we need a greater disk size for swift
 disk_size: "{{ ses_enabled | ternary(2, 3) }}"
 
+openstack_bmc_image: "osbmc"
+openstack_bmc_flavor: "m1.smaller"
+pxe_boot_image: "ipxe"
+
 # Versioned virtualized configuration artifacts
 virt_artifacts:
   cloud7:

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/library/generate_heat_model.py
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/library/generate_heat_model.py
@@ -706,6 +706,8 @@ def generate_heat_model(input_model, virt_config):
             heat_network['allocation_pools'] = \
                 [[str(mgmt_net_last - EXTERNAL_MGMT_ADDR_RANGE),
                   str(mgmt_net_last - 1)]]
+        elif 'bmc' in network['name'].lower():
+            heat_network['external'] = True
         elif True in [('public' in lb['roles'])
                       for lb in network['network-group'].get('load-balancers',
                                                              [])]:
@@ -880,6 +882,8 @@ def generate_heat_model(input_model, virt_config):
         heat_server = dict(
             name=server['id'],
             ip_addr=server['ip-addr'],
+            ilo_ip=server.get('ilo-ip'),
+            mac_addr=server.get('mac-addr'),
             role=server['role']['name'],
             interface_model=server['role']['interface-model']['name'],
             disk_model=server['role']['disk-model']['name'],

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/templates/heat-template.yaml
@@ -99,7 +99,7 @@ resources:
 {%       endfor %}
 {%     endif  %}
 {%   endif  %}
-      enable_dhcp: {{ network.is_conf or network.is_mgmt }}
+      enable_dhcp: {{ network.is_conf or network.is_mgmt or 'bmc' in name }}
 {%   if network.gateway is defined %}
       gateway_ip: "{{ network.gateway }}"
 {%   endif   %}
@@ -142,10 +142,12 @@ resources:
 {% endfor %}
 
 
+{% set has_bmc_net = 'BMC-NET' in heat_template.networks %}
 {% for server in heat_template.servers %}
 {%   set interface_model = heat_template.interface_models[server.interface_model] %}
 {%   set disk_model = heat_template.disk_models[server.disk_model] %}
 {%   set server_ns = namespace(ports=[], trunk_port_names=[], volume_names=[]) %}
+{%   set need_osbmc_server = pxe_boot_enabled and server['ilo_ip'] %}
 
 {%   set server_name = server.name|lower|replace('-','_') %}
 {%   for port in interface_model.ports %}
@@ -184,11 +186,27 @@ resources:
 
 {%       else %}
       network: { get_resource: {{ network_name }}_network }
+{%         if need_osbmc_server and network.is_conf %}
+      mac_address: "{{ server['mac_addr'] }}"
+{%         endif %}
       fixed_ips:
         - subnet_id: { get_resource: {{ network_name }}_subnet }
 {%         if network.is_conf %}
 {%           set _ = global_ns.conf_ports.append((server, port_name,)) %}
           ip_address: "{{ server.ip_addr }}"
+{%         if need_osbmc_server and network.is_conf %}
+
+  # Port for server hosting BMC for {{ server_name }}
+  {{ server_name }}_osbmc_port:
+    type: OS::Neutron::Port
+    properties:
+      name: {{ heat_resource_name_prefix }}_{{ server_name }}_osbmc_port
+      network: { get_resource: {{ has_bmc_net | ternary('bmc_network', 'management_network') }} }
+      fixed_ips:
+        - subnet_id: { get_resource: {{ has_bmc_net | ternary('bmc_subnet', 'management_subnet') }} }
+          ip_address: "{{ server.ilo_ip }}"
+{%         endif %}
+
 
 {%           if server.is_admin %}
   # floating IP for the admin node
@@ -288,7 +306,7 @@ resources:
 {% if os_key_name is defined %}
       key_name: { get_param: key_name }
 {% endif %}
-      image: {{ server.image }}
+      image: {{ need_osbmc_server | ternary(pxe_boot_image, server.image) }}
       flavor: {{ server.flavor }}
       tags:
 {%   if server.is_admin %}
@@ -310,6 +328,17 @@ resources:
           # interface model: {{ server.interface_model }}
         - port: { get_resource: {{ port_name }}_port }
 {%   endfor %}
+
+{%   if need_osbmc_server %}
+  {{ server_name }}_osbmc_server:
+    type: OS::Nova::Server
+    properties:
+      name: {{ heat_resource_name_prefix }}_{{ server_name }}_osbmc_server
+      image: {{ openstack_bmc_image }}
+      flavor: {{ openstack_bmc_flavor }}
+      networks:
+        - port: { get_resource: {{ server_name }}_osbmc_port }
+{%   endif %}
 {% endfor %}
 
 outputs:
@@ -340,3 +369,21 @@ outputs:
 {% for server, port_name in global_ns.conf_ports if server.is_compute %}
       - { get_attr: [{{ port_name }}_port, fixed_ips, 0, ip_address] }
 {%   endfor %}
+
+{% if pxe_boot_enabled %}
+  # BMC IP addresses of the openstack-bmc nodes
+  osbmc-server-ips:
+    description: IP addresses of the openstack-bmc server nodes
+    value:
+{% for server, port_name in global_ns.conf_ports if server.ilo_ip %}
+      - { get_attr: [{{ server.name|lower|replace('-','_') }}_osbmc_port, fixed_ips, 0, ip_address] }
+{%   endfor %}
+
+  # Name of nodes to be managed by openstack-bmc
+  osbmc-managed-servers:
+    description: Name of nodes to be managed by openstack-bmc
+    value:
+{% for server, port_name in global_ns.conf_ports if server.ilo_ip %}
+      - { get_attr: [{{ server.name|lower|replace('-','_') }}_server, name] }
+{%   endfor %}
+{% endif %}

--- a/scripts/jenkins/cloud/ansible/roles/osbmc_server/handlers/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/osbmc_server/handlers/main.yml
@@ -15,12 +15,8 @@
 #
 ---
 
-- name: Gathering Facts
-  setup:
-
-- include_tasks: add_mu_repos_crowbar.yml
-  when:
-    - maint_updates_list | length
-    - inventory_hostname not in groups['deployer_virt']
-
-- include_tasks: update_cloud.yml
+- name: Restart openstack-bmc
+  service:
+    name: "openstack-bmc"
+    enabled: yes
+    state: restarted

--- a/scripts/jenkins/cloud/ansible/roles/osbmc_server/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/osbmc_server/tasks/main.yml
@@ -15,12 +15,18 @@
 #
 ---
 
-- name: Gathering Facts
-  setup:
+- name: Drop openstack-bmc service file
+  template:
+    src: "openstack-bmc.service.j2"
+    dest: "/usr/lib/systemd/system/openstack-bmc.service"
+  notify:
+    - Restart openstack-bmc
 
-- include_tasks: add_mu_repos_crowbar.yml
-  when:
-    - maint_updates_list | length
-    - inventory_hostname not in groups['deployer_virt']
-
-- include_tasks: update_cloud.yml
+- name: Disable wickedd-dhclient
+  service:
+    name: "{{ item }}"
+    state: "stopped"
+    enabled: no
+  loop:
+    - wickedd-dhcp4
+    - wickedd-dhcp6

--- a/scripts/jenkins/cloud/ansible/roles/osbmc_server/templates/openstack-bmc.service.j2
+++ b/scripts/jenkins/cloud/ansible/roles/osbmc_server/templates/openstack-bmc.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=openstack-bmc Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/opt/osbmc/openstackbmc.py --os-cloud {{ os_cloud }} --os-project-name {{ os_project_name }} --instance {{ instance_to_manage }} --address {{ ansible_host }}
+Restart=always
+User=root
+StandardOutput=tty
+StandardError=inherit
+TTYPath=/dev/ttyS0
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -39,6 +39,9 @@ deploy_cloud: true
 # Reboot cloud after deploy.
 reboot_after_deploy: true
 
+# Infra nodes (besides the CLM/admin) will be provisioned by cobbler/crowbar.
+pxe_boot_enabled: false
+
 #============= Repositories =============#
 # The cloud repository (from provo-clouddata) to be used for testing. This value can take
 # the following form:

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1606,7 +1606,7 @@ function reboot_nodes_via_ipmi
         if [[ $i -gt $nodenumber ]]; then
             # power off extra nodes
             $ipmicmd power off
-            wait_for 30 2 "$ipmicmd power status | grep -q 'is off'" "node ($ip) to power off"
+            wait_for 30 5 "$ipmicmd power status | grep -q 'is off'" "node ($ip) to power off"
         else
             if [[ $ipmi_default_gw ]] ; then
                 $ipmicmd lan set 1 defgw ipaddr "$ipmi_default_gw"
@@ -1617,9 +1617,9 @@ function reboot_nodes_via_ipmi
 
             $ipmicmd chassis bootdev pxe ${want_ipmi_pxeextraopts}
             $ipmicmd power off
-            wait_for 30 2 "timeout 5 $ipmicmd power status | grep -q 'is off'" "node ($ip) to power off"
+            wait_for 30 5 "timeout 5 $ipmicmd power status | grep -q 'is off'" "node ($ip) to power off"
             $ipmicmd power on
-            wait_for 30 2 "timeout 5 $ipmicmd power status | grep -q 'is on'" "node ($ip) to power on"
+            wait_for 30 5 "timeout 5 $ipmicmd power status | grep -q 'is on'" "node ($ip) to power on"
         fi
     done
 }


### PR DESCRIPTION
This change adds support for using cobbler|crowbar for provisioning nodes on
virtual deployments for ardana|crowbar. A new parameter was added to
enable/disable that option (`pxe_boot_enabled`).

There are basically two significant changes when enabling PXE boot:
  1. All nodes besides the CLM will boot using the `pxe` image. This is a
  custom image based on the iPXE image and the process to create it
  is described in [1]. This enable the instances to boot through PXE.
  2. For each infra node (besides the CLM) a new instance will be created.
  Those instances will be running the openstack-bmc [2] service which
  simulates a BMC by accepting ipmi commands and performing such
  operations by running openstack commands.

1. https://kimizhang.wordpress.com/2013/08/26/create-pxe-boot-image-for-openstack/
2. https://github.com/cybertron/openstack-virtual-baremetal/blob/master/openstack_virtual_baremetal/openstackbmc.py