### PR TITLE
octavia: use internally set up management network (SOC-10904)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
@@ -10,13 +10,9 @@
         server_ca_key_path: private/ca.key.pem
         client_ca_cert_path: ca.cert.pem
         client_cert_and_key_path: private/client.cert-and-key.pem
-{% set ns = namespace(net_id=30, vlan_id=gen_subnet_start+scenario.network_groups|length) %}
-{% for network_group in scenario.network_groups if 'NEUTRON-VLAN' in network_group.component_endpoints %}
       amphora:
-        #manage_vlan: {{ ns.vlan_id }}
-        manage_cidr: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.0/24
-        #manage_allocation_pools: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.10,{{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.250
-        #gateway: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.1
-{% endfor %}
+        # use a CIDR that doesn't clash with any of the other networks set up on the
+        # controller nodes
+        manage_cidr: {{ neutron_subnet_prefix.ipv4 }}.254.1.0/24
 
 {% include 'barclamps/lib/deployment.yml.j2' %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -145,9 +145,4 @@ export vlan_storage={{ gen_subnet_start+3 }}
 export vlan_fixed={{ gen_subnet_start+4 }}
 export vlan_ceph={{ gen_subnet_start+5 }}
 
-{% if 'octavia' in deployments %}
-export net_octavia={{ neutron_subnet_prefix }}{{ ipsep }}30{{ ipsep }}1
-export vlan_octavia={{ gen_subnet_start+4 }}
-{% endif %}
-
 # NOTE: might also need some of the other variables starting with vlan_ , want_ and net_

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/crowbar.yml
@@ -9,7 +9,6 @@ network_groups:
       - MANAGEMENT
       - INTERNAL-API
       - EXTERNAL-API
-      - NEUTRON-VLAN
 
   - name: PUBLIC
     hostname_suffix: public

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -399,7 +399,6 @@ function setcloudnetvars
     vlan_public=${vlan_public:-300}
     vlan_fixed=${vlan_fixed:-500}
     vlan_sdn=${vlan_sdn:-400}
-    vlan_octavia=${vlan_octavia:-700}
     if (( ${want_ipv6} > 0 )); then
         net_fixed=${net_fixed:-'fd00:0:0:2'}
         net_public=${net_public:-'fd00:0:0:1'}
@@ -407,7 +406,6 @@ function setcloudnetvars
         net_ceph=${net_ceph:-'fd00:0:0:5'}
         net_ironic=${net_ironic:-'fd00:0:0:6'}
         net_sdn=${net_sdn:-'fd00:0:0:7'}
-        net_octavia=${net_octavia:-'fd00:0:0:8'}
         : ${adminnetmask:=64}
         : ${ironicnetmask:=64}
         : ${defaultnetmask:=64}
@@ -423,7 +421,6 @@ function setcloudnetvars
         net_ceph=${net_ceph:-192.168.127}
         net_ironic=${net_ironic:-192.168.128}
         net_sdn=${net_sdn:-192.168.130}
-        net_octavia=${net_octavia:-192.168.131}
         : ${adminnetmask:=255.255.248.0}
         : ${ironicnetmask:=255.255.255.0}
         : ${defaultnetmask:=255.255.255.0}


### PR DESCRIPTION
The Octavia barclamp now configures a regular neutron tenant
network for the management traffic exchanged between control
services and amphorae. The previous approach of configuring a
custom neutron provider network is no longer needed.