### PR TITLE
Remove existing SP3 based repos during the upgrade

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5533,6 +5533,8 @@ function onadmin_prepare_cloudupgrade_admin_repos
 
     # Cloud repo should not be required for the upgrade (Pool+Updates should be good)
     # onadmin_add_cloud_repo
+    # But we need to delete existing one
+    $zypper rr Cloud
 
     # create skeleton for PTF repositories
     # during installation, this would be done by install-suse-cloud
@@ -5551,6 +5553,7 @@ function onadmin_prepare_cloudupgrade_admin_repos
     elif iscloudver 9; then
         $zypper rr SLES12-SP3-Pool
         $zypper rr SLES12-SP3-Updates
+        $zypper rr SLES12-SP3-LTSS-Updates
     fi
     # remove old PTF repo
     $zypper rr cloud-ptf


### PR DESCRIPTION
Removal of Cloud repo is needed after commit e0d574e761a226811cac4da15e749211b675213f
Before that we were replacing it with the new one.

followup after https://github.com/SUSE-Cloud/automation/pull/3762