### PR TITLE
Let crowbar_register import GPG keys of supported repositories

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/main.yml
@@ -45,7 +45,7 @@
     wget {{ crowbar_register_url }} -O {{ crowbar_register_path }}
     chmod +x {{ crowbar_register_path }}
 
-    SSH_CONNECTION= {{ crowbar_register_path }} -f --interface {{ admin_interface }} --gpg-auto-import-keys --no-gpg-checks 2>&1 | tee {{ crowbar_register_log }}
+    SSH_CONNECTION= {{ crowbar_register_path }} -f --interface {{ admin_interface }} --gpg-auto-import-keys 2>&1 | tee {{ crowbar_register_log }}
     exit ${PIPESTATUS[0]}
 
 - name: Check that node has registered


### PR DESCRIPTION
Seems like the option to ignore GPG checks also means that the
keys are not really imported.