### PR TITLE
upgrade: Add support for multiple upgrade test stacks

### DIFF
--- a/scripts/heat/2-instances-cinder.yaml
+++ b/scripts/heat/2-instances-cinder.yaml
@@ -47,18 +47,25 @@ parameters:
     description: End of private network IP address allocation pool
     default: 172.20.1.99
 
+  suffix:
+    type: string
+    description: Resource name suffix for for multi-stack tests
+    default: ''
+
 resources:
 
   keypair:
     type: OS::Nova::KeyPair
     properties:
-      name: testkey
+      name:
+        list_join: ['', ['testkey', { get_param: suffix }]]
       public_key: { get_file: /root/.ssh/id_rsa.pub }
 
   private_net_east:
     type: OS::Neutron::Net
     properties:
-      name: private_net_east
+      name:
+        list_join: ['', ['private_net_east', { get_param: suffix }]]
 
   private_subnet_east:
     type: OS::Neutron::Subnet
@@ -72,7 +79,8 @@ resources:
   private_net_west:
     type: OS::Neutron::Net
     properties:
-      name: private_net_west
+      name:
+        list_join: ['', ['private_net_west', { get_param: suffix }]]
 
   private_subnet_west:
     type: OS::Neutron::Subnet
@@ -151,7 +159,8 @@ resources:
   east:
     type: OS::Nova::Server
     properties:
-      name: east
+      name:
+        list_join: ['', ['east', { get_param: suffix }]]
       image: { get_param: image }
       flavor: { get_param: flavor }
       key_name: { get_resource: keypair }
@@ -168,7 +177,8 @@ resources:
   west:
     type: OS::Nova::Server
     properties:
-      name: west
+      name:
+        list_join: ['', ['west', { get_param: suffix }]]
       image: { get_param: image }
       flavor: { get_param: flavor }
       key_name: { get_resource: keypair }

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -365,6 +365,7 @@ function sshrun
         export bmc_user=$bmc_user;
         export bmc_password=$bmc_password;
         export upgrade_progress_file=$upgrade_progress_file;
+        export upgrade_test_stack_count=$upgrade_test_stack_count;
 EOF
     # setting these variables within mkcloud does not make them part of the env, so we need to export them
     export nodenumber nodenumberlonelynode nodenumberironicnode clusterconfig ironicnetmask

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5210,9 +5210,8 @@ function oncontroller_testpreupgrade_simple
     for i in $(seq 1 $upgrade_test_stack_count); do
         openstack stack create "upgrade_test$suffix" -t \
             /root/scripts/heat/2-instances-cinder.yaml \
+            --wait \
             --parameter image=$tempest_image --parameter suffix="$suffix" $heat_stack_params
-        wait_for 15 20 "openstack stack show \"upgrade_test$suffix\" | grep CREATE_COMPLETE" \
-                 "heat stack for upgrade tests to complete"
         suffix="_$i"
     done
     ping_fips && \
@@ -5255,9 +5254,7 @@ function oncontroller_testpostupgrade_simple_delete_stack
 {
     suffix=''
     for i in $(seq 1 $upgrade_test_stack_count); do
-        openstack stack delete --yes "upgrade_test$suffix"
-        wait_for 15 20 "! openstack stack show \"upgrade_test$suffix\"" \
-                 "heat stack for upgrade tests to be deleted"
+        openstack stack delete --yes --wait "upgrade_test$suffix"
         suffix="_$i"
     done
     echo "test post-upgrade successful."


### PR DESCRIPTION
When $upgrade_test_stack_count is set to >1, there will be multiple
"east-west" stacks created/checked by testpreupgrade/testpostupgrade
steps in mkcloud.