### PR TITLE
cloud-image-update: use HA jobs for integration testing

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -160,7 +160,7 @@
           image_visibility: shared
       - susecloud:
           image_visibility: private
-    openstack_cloud_job: cloud-ardana8-job-std-min-x86_64
+    openstack_cloud_job: cloud-ardana8-job-std-3cp-x86_64
     download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP3/ardana-jeos-lvm-SLE12SP3.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP3
     triggers:

--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -170,7 +170,7 @@
           image_visibility: shared
       - susecloud:
           image_visibility: private
-    openstack_cloud_job: cloud-ardana9-job-std-min-x86_64
+    openstack_cloud_job: cloud-ardana9-job-std-3cp-x86_64
     download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP4/ardana-jeos-lvm-SLE12SP4.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-lvm-SLE12SP4
     triggers:

--- a/jenkins/ci.suse.de/cloud-crowbar7.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar7.yaml
@@ -3,6 +3,8 @@
     crowbar_job: '{name}'
     cloudsource: stagingcloud7
     cloud_env: cloud-crowbar-ci-slot
+    updates_test_enabled: true
+    reboot_after_deploy: true
     scenario_name: standard
     controllers: '1'
     computes: '1'
@@ -17,6 +19,8 @@
     crowbar_job: '{name}'
     cloudsource: stagingcloud7
     cloud_env: cloud-crowbar-ci-slot
+    updates_test_enabled: true
+    reboot_after_deploy: true
     scenario_name: standard
     controllers: '3'
     computes: '2'
@@ -34,7 +38,7 @@
           image_visibility: shared
       - susecloud:
           image_visibility: private
-    openstack_cloud_job: cloud-crowbar7-job-x86_64
+    openstack_cloud_job: cloud-crowbar7-job-ha-x86_64
     download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP2/ardana-jeos-SLE12SP2.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-SLE12SP2
     triggers:

--- a/jenkins/ci.suse.de/cloud-crowbar8.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar8.yaml
@@ -3,6 +3,8 @@
     crowbar_job: '{name}'
     cloudsource: stagingcloud8
     cloud_env: cloud-crowbar-ci-slot
+    updates_test_enabled: true
+    reboot_after_deploy: true
     scenario_name: standard
     controllers: '1'
     computes: '1'
@@ -17,6 +19,8 @@
     crowbar_job: '{name}'
     cloudsource: stagingcloud8
     cloud_env: cloud-crowbar-ci-slot
+    updates_test_enabled: true
+    reboot_after_deploy: true
     scenario_name: standard
     controllers: '3'
     computes: '2'
@@ -34,7 +38,7 @@
           image_visibility: shared
       - susecloud:
           image_visibility: private
-    openstack_cloud_job: cloud-crowbar8-job-x86_64
+    openstack_cloud_job: cloud-crowbar8-job-ha-x86_64
     download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP3/ardana-jeos-SLE12SP3.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-SLE12SP3
     triggers:

--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -3,6 +3,8 @@
     crowbar_job: '{name}'
     cloudsource: stagingcloud9
     cloud_env: cloud-crowbar-ci-slot
+    updates_test_enabled: true
+    reboot_after_deploy: true
     scenario_name: standard
     controllers: '1'
     computes: '1'
@@ -14,9 +16,12 @@
 
 - project:
     name: cloud-crowbar9-job-ipv6-x86_64
+    disabled: true
     crowbar_job: '{name}'
     cloudsource: stagingcloud9
     cloud_env: cloud-crowbar-ci-slot
+    updates_test_enabled: true
+    reboot_after_deploy: true
     scenario_name: standard
     controllers: '1'
     computes: '1'
@@ -32,6 +37,8 @@
     crowbar_job: '{name}'
     cloudsource: stagingcloud9
     cloud_env: cloud-crowbar-ci-slot
+    updates_test_enabled: true
+    reboot_after_deploy: true
     scenario_name: standard
     controllers: '3'
     computes: '2'
@@ -67,7 +74,7 @@
           image_visibility: shared
       - susecloud:
           image_visibility: private
-    openstack_cloud_job: cloud-crowbar9-job-x86_64
+    openstack_cloud_job: cloud-crowbar9-job-ha-x86_64
     download_image_url: http://download.suse.de/ibs/Devel:/Cloud:/Images/images-SLE_12_SP4/ardana-jeos-SLE12SP4.x86_64.qcow2.xz
     sles_image: cleanvm-jeos-SLE12SP4
     triggers:


### PR DESCRIPTION
Use HA jobs for testing the weekly automated image updates.
This change also enables reboot-after-deploy and test updates for all
Crowbar staging periodic jobs, for better coverage and to be
similar to Ardana jobs, and disables the Crowbar IPv6 job.