### PR TITLE
Revert "Cloud repo should not be required during and after the upgrade"

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5530,11 +5530,7 @@ function onadmin_prepare_cloudupgrade_admin_repos
     # Pool repositories presence are required for nodes repocheck step during upgrade
     addcloudpool
     addcloudmaintupdates
-
-    # Cloud repo should not be required for the upgrade (Pool+Updates should be good)
-    # onadmin_add_cloud_repo
-    # But we need to delete existing one
-    $zypper rr Cloud
+    onadmin_add_cloud_repo
 
     # create skeleton for PTF repositories
     # during installation, this would be done by install-suse-cloud


### PR DESCRIPTION
This reverts commit e0d574e761a226811cac4da15e749211b675213f.

Revert of https://github.com/SUSE-Cloud/automation/pull/3762 and partially https://github.com/SUSE-Cloud/automation/pull/3762

Turns out, we need Cloud repo at least for testing, i.e. to deliver Devel:Cloud packages that were not yet released as MU's