### PR TITLE
Run the octavia tempest test cases in the gate (SOC-8743)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -82,7 +82,7 @@
           disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,manila,magnum,lbaas"
+            designate,heat,manila,magnum,lbaas,octavia"
       - cloud-ardana9-job-gate-entry-scale-kvm-update-x86_64:
           cloudsource: develcloud9
           update_to_cloudsource: stagingcloud9
@@ -90,7 +90,7 @@
           disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,lbaas"
+            designate,heat,magnum,lbaas,octavia"
     jobs:
         - '{ardana_job}'
 
@@ -123,7 +123,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,manila,lbaas-octavia"
+            designate,heat,magnum,manila,lbaas-octavia,octavia"
     jobs:
         - '{crowbar_job}'
 
@@ -156,7 +156,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,manila,lbaas-octavia"
+            designate,heat,magnum,manila,lbaas-octavia,octavia"
     jobs:
         - '{crowbar_job}'
 
@@ -191,6 +191,6 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,manila,lbaas-octavia"
+            designate,heat,magnum,manila,lbaas-octavia,octavia"
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -69,7 +69,7 @@
           default-value: ''
           value: >-
             ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
-            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas
+            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas,octavia
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -108,7 +108,7 @@
           default-value: ''
           value: >-
             ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
-            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas
+            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas,octavia
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -51,7 +51,7 @@
           default-value: ''
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,designate
+            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,octavia,designate
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -340,7 +340,7 @@
           default-value: '{tempest_filter_list|ci}'
           value: >-
             ci,smoke,keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,
-            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas
+            vpnaas,designate,heat,ceilometer,magnum,manila,freezer,monasca,lbaas,octavia
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -295,7 +295,7 @@
           default-value: '{tempest_filter_list|}'
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,designate
+            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,octavia,designate
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.


### PR DESCRIPTION
With the openstack tempest plugin and tempest run filter added
to both Ardana and Crowbar, it is time to run those test cases
in the gating jobs.

NOTE: needs both [the crowbar-openstack GitHub PR](https://github.com/crowbar/crowbar-openstack/pull/2322) and [the tempest-ansible Gerrit patch](https://gerrit.prv.suse.net/c/ardana/tempest-ansible/+/6493) to be merged and available in the staging media before this PR can be merged.