### PR TITLE
mkcloud: add support for Octavia management network (SOC-10685)

### DIFF
--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -416,6 +416,7 @@ function setcloudnetvars
         : ${admingw:=${net}${ip_sep}${ip_sep}1}
         : ${publicgw:=${net_public}${ip_sep}${ip_sep}1}
         : ${ironicgw:=${net_ironic}${ip_sep}${ip_sep}1}
+        : ${octaviagw:=${net_octavia}${ip_sep}${ip_sep}1}
     else
         net_fixed=${net_fixed:-192.168.123}
         net_public=${net_public:-192.168.122}
@@ -431,6 +432,7 @@ function setcloudnetvars
         : ${admingw:=${net}${ip_sep}1}
         : ${publicgw:=${net_public}${ip_sep}1}
         : ${ironicgw:=${net_ironic}${ip_sep}1}
+        : ${octaviagw:=${net_octavia}${ip_sep}1}
     fi
 }
 

--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -345,6 +345,9 @@ function libvirt_do_cleanup()
     # cleanup leftover from last run
     $sudo ${scripts_lib_dir}/libvirt/cleanup $cloud $nodenumber $cloudbr $vlan_public $ironicbr
 
+    if ip link show ${cloudbr}.$vlan_octavia >/dev/null 2>&1; then
+        $sudo ip link set ${cloudbr}.$vlan_octavia down
+    fi
     if ip link show ${cloudbr}.$vlan_public >/dev/null 2>&1; then
         $sudo ip link set ${cloudbr}.$vlan_public down
     fi

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -682,11 +682,12 @@ function mkvlan
     fi
 }
 
-function setuppublicnet
+function setupvlangws
 {
     # workaround https://bugzilla.novell.com/show_bug.cgi?id=845496
     echo 0 > /proc/sys/net/bridge/bridge-nf-call-iptables
     mkvlan $vlan_public $publicgw
+    mkvlan $vlan_octavia $octaviagw
     if [[ $mkch_physcloudif ]] ; then
         $sudo brctl addif $cloudbr $mkch_physcloudif
         $sudo ip link set dev $mkch_physcloudif up
@@ -705,7 +706,7 @@ function restartcloud
     vgchange -ay $cloudvg
     libvirt_net_start
     $sudo virsh start $cloud-admin
-    setuppublicnet
+    setupvlangws
     wait_for_crowbar_ntpd
     local i
     for i in $(nodes ids all) ; do
@@ -718,7 +719,7 @@ function restartcloud
 function setupnodes
 {
     onadmin wait_tftpd || return $?
-    setuppublicnet
+    setupvlangws
     local i
     for i in $(nodes ids normal) ; do
         local macaddress=$(macfunc $i)

--- a/scripts/mkcloudhost/cloudfunc
+++ b/scripts/mkcloudhost/cloudfunc
@@ -22,6 +22,12 @@ function cloudpublicnet()
     echo -n 192.168.$((254-2*n))
 }
 
+function cloudoctavianet()
+{
+    n=$1
+    echo -n 192.168.$((100+n))
+}
+
 function vcloudpublicnet()
 {
     n=$1

--- a/scripts/mkcloudhost/hacloud.common
+++ b/scripts/mkcloudhost/hacloud.common
@@ -10,6 +10,7 @@ fi
 
 export net_admin=192.168.$n
 export net_ironic=$(cloudironicnet $n)
+export net_octavia=$(cloudoctavianet $n)
 export net_public=$(vcloudpublicnet $n)
 export adminnetmask=255.255.255.0
 export virtualcloud=v$(($haoffset + $n))

--- a/scripts/mkcloudhost/routed.cloud
+++ b/scripts/mkcloudhost/routed.cloud
@@ -29,6 +29,7 @@ if (( $want_ipv6 > 0 )); then
 else
     export net_admin=$(cloudadminnet $n)
     export net_ironic=$(cloudironicnet $n)
+    export net_octavia=$(cloudoctavianet $n)
     export net_public=$(routedcloudpublicnet $n)
     export adminnetmask=255.255.255.0
 fi

--- a/scripts/mkcloudhost/runtestmulticloud
+++ b/scripts/mkcloudhost/runtestmulticloud
@@ -13,6 +13,7 @@ cloudfunc=$(dirname $(readlink -e $BASH_SOURCE))/cloudfunc
 
 export net_admin=$(cloudadminnet $n)
 export net_ironic=$(cloudironicnet $n)
+export net_octavia=$(cloudoctavianet $n)
 export net_public=$(cloudpublicnet $n)
 export adminnetmask=255.255.254.0
 export virtualcloud=$vcloudname$n

--- a/scripts/mkcloudhost/runtestn
+++ b/scripts/mkcloudhost/runtestn
@@ -22,6 +22,7 @@ test -e $cloudfunc || cloudfunc=$(dirname $(readlink -e $BASH_SOURCE))/cloudfunc
 #export NOQACROWBARDOWNLOAD=1
 export net_admin=$(cloudadminnet $n)
 export net_ironic=$(cloudironicnet $n)
+export net_octavia=$(cloudoctavianet $n)
 export net_public=$(cloudpublicnet $n)
 export adminnetmask=255.255.254.0
 export virtualcloud=$vcloudname$n

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2799,13 +2799,14 @@ function custom_configuration
             fi
         ;;
         octavia)
-            proposal_set_value octavia default "['attributes']['octavia']['certs']['passphrase']" "crowbar"
-            proposal_set_value octavia default "['attributes']['octavia']['certs']['server_ca_cert_path']" "ca.cert.pem"
-            proposal_set_value octavia default "['attributes']['octavia']['certs']['server_ca_key_path']" "private/ca.key.pem"
-            proposal_set_value octavia default "['attributes']['octavia']['certs']['client_ca_cert_path']" "ca.cert.pem"
-            proposal_set_value octavia default "['attributes']['octavia']['certs']['client_cert_and_key_path']" "private/client.cert-and-key.pem"
+            proposal_set_value octavia default "['attributes']['octavia']['certs']['passphrase']" "'crowbar'"
+            proposal_set_value octavia default "['attributes']['octavia']['certs']['server_ca_cert_path']" "'ca.cert.pem'"
+            proposal_set_value octavia default "['attributes']['octavia']['certs']['server_ca_key_path']" "'private/ca.key.pem'"
+            proposal_set_value octavia default "['attributes']['octavia']['certs']['client_ca_cert_path']" "'ca.cert.pem'"
+            proposal_set_value octavia default "['attributes']['octavia']['certs']['client_cert_and_key_path']" "'private/client.cert-and-key.pem'"
             if [[ $hacloud = 1 ]] && iscloudver 9plus ; then
                 proposal_set_value octavia default "['deployment']['octavia']['elements']['octavia-api']" "['cluster:$clusternameservices']"
+                proposal_set_value octavia default "['deployment']['octavia']['elements']['octavia-backend']" "['cluster:$clusternameservices']"
             fi
         ;;
         neutron)

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -4154,6 +4154,7 @@ function oncontroller_octavia_network_setup
 {
     local octavia_network_name="lb-mgmt-net"
     local octavia_subnet_name=$octavia_network_name
+    setcloudnetvars $cloud
 
     . ~/.openrc
     if ! openstack network list --format value -c Name | grep -q "^${octavia_network_name}$"; then


### PR DESCRIPTION
Deploying Octavia in mkcloud environments requires setting up
the infrastructure networking needed to complement the neutron
provider network used for the Octavia management traffic. More
specifically, this requires creating an additional VLAN interface
on the mkcloud host that can act as the external gateway for the
neutron provider network.