### PR TITLE
ardana-tempest: Add black listed tests on retry filter (SOC-11013)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/retry_failed.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/tasks/retry_failed.yml
@@ -1,8 +1,24 @@
 - block:
+    - name: Get blacklisted tests
+      shell: |
+        if test -f "{{ tempest_run_filter }}_serial.txt.j2"; then
+          for t in $(sed -n -e 's/^-//p' {{ tempest_run_filter }}.txt.j2); do
+            if ! grep -q "+$t" {{ tempest_run_filter }}_serial.txt.j2; then
+              echo "-$t"
+            fi
+          done
+        else
+          grep -h ^- {{ tempest_run_filter }}.txt.j2
+        fi
+      args:
+        chdir: /opt/stack/tempest/run_filters
+      register: _filter_blacklist
+      failed_when: false
+
     - name: Generate filter with failed tests
       template:
         src: "run_filter_{{ item.filter }}.txt.j2"
-        dest: "/opt/stack/tempest/run_filters/{{ tempest_run_filter }}_{{ item .filter}}.txt.j2"
+        dest: "/opt/stack/tempest/run_filters/{{ tempest_run_filter }}_{{ item.filter }}.txt.j2"
         owner: tempest
         group: tempest
         mode: 0644

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
@@ -4,3 +4,5 @@
 {% set regexp = '.*\(|\)$' %}
 {% endif %}
 +{{ test | regex_replace(regexp, '') }}
+
+{{ _filter_blacklist.stdout }}

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
@@ -5,3 +5,5 @@
 {% endif %}
 +{{ test | regex_replace(regexp, '') }}
 {% endfor %}
+
+{{ _filter_blacklist.stdout }}


### PR DESCRIPTION
This change adds a task that gather the existing blacklisted tests and
add them on the generated retry filters for tempest.