### PR TITLE
openstack-crowbar: don't run tempest in onadmin_testsetup

### DIFF
--- a/jenkins/ci.suse.de/cloud-crowbar7.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar7.yaml
@@ -9,6 +9,9 @@
     controllers: '1'
     computes: '1'
     ses_enabled: false
+    # tempest filters not yet supported for SOC7
+    tempest_filter_list: ''
+    run_testsetup_tempest: true
     triggers:
      - timed: 'H H * * *'
     jobs:
@@ -25,6 +28,9 @@
     controllers: '3'
     computes: '2'
     ses_enabled: false
+    # tempest filters not yet supported for SOC7
+    tempest_filter_list: ''
+    run_testsetup_tempest: true
     triggers:
      - timed: 'H H * * *'
     jobs:

--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -110,6 +110,9 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar8-job-gate-no-ha-deploy-x86_64:
           cloudsource: stagingcloud8
           ses_enabled: false
@@ -143,6 +146,9 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar8-job-gate-ha-deploy-x86_64:
           cloudsource: stagingcloud8
           ses_enabled: false
@@ -178,6 +184,9 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64:
           cloudsource: stagingcloud8
           ses_enabled: false

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -109,6 +109,12 @@
           description: >-
             Cloud product (ardana or crowbar)
 
+      - hidden:
+          name: run_testsetup_tempest
+          default: 'false'
+          description: >-
+            Run tempest as part of the onadmin_testsetup step
+
     pipeline-scm:
       scm:
         - git:

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar-tests.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar-tests.Jenkinsfile
@@ -57,7 +57,8 @@ pipeline {
       steps {
         script {
           // This step does the following on the non-admin nodes:
-          //  - runs tempest (smoke) and other tests on the deployed cloud
+          //  - runs tempest smoke (if the run_testsetup_tempest bool parameter is set)
+          //  - runs other tests under qa_crowbarsetup.sh/onadmin_testsetup on the deployed cloud
           cloud_lib.ansible_playbook('run-crowbar-tests')
         }
       }
@@ -65,7 +66,9 @@ pipeline {
         always {
           script {
             archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
-            junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+            if (run_testsetup_tempest.toBoolean()) {
+              junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+            }
           }
         }
       }

--- a/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
@@ -261,7 +261,8 @@ pipeline {
       steps {
         script {
           // This step does the following on the non-admin nodes:
-          //  - runs tempest and other tests on the deployed cloud
+          //  - runs tempest smoke (if the run_testsetup_tempest bool parameter is set)
+          //  - runs other tests under qa_crowbarsetup.sh/onadmin_testsetup on the deployed cloud
           cloud_lib.ansible_playbook('run-crowbar-tests')
         }
       }
@@ -269,7 +270,9 @@ pipeline {
         always {
           script {
             archiveArtifacts artifacts: ".artifacts/**/*", allowEmptyArchive: true
-            junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+            if (run_testsetup_tempest.toBoolean()) {
+              junit testResults: ".artifacts/testr_crowbar.xml", allowEmptyResults: false
+            }
           }
         }
       }

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -292,7 +292,7 @@
           type: multi-select
           visible-items: 10
           multi-select-delimiter: ','
-          default-value: '{tempest_filter_list|}'
+          default-value: '{tempest_filter_list|smoke}'
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
             trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,designate
@@ -394,6 +394,12 @@
           default: '{collect_supportconfig|true}'
           description: >-
             Collect supportconfig files when the job fails
+
+      - hidden:
+          name: run_testsetup_tempest
+          default: '{run_testsetup_tempest|false}'
+          description: >-
+            Run tempest as part of the onadmin_testsetup step
 
     pipeline-scm:
       scm:

--- a/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
@@ -26,3 +26,5 @@ ssl_keyfile: /etc/cloud/private/signing_key.pem
 ssl_ca_certs: /etc/ssl/ca-bundle.pem
 
 upgrade_repos: ''
+
+run_testsetup_tempest: false

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -60,6 +60,12 @@ export cephvolumenumber=1
 # export cct_tests=
 export scenario={{ admin_crowbar_batch_file }}
 
+{% if not (run_testsetup_tempest | bool) %}
+# don't run tempest through qa_crowbarsetup.sh / onadmin_testsetup, the
+# ansible playbooks will take care of that
+export want_tempest=0
+{% endif %}
+
 # export host_mtu=
 # export architectures=
 


### PR DESCRIPTION
The ECP Crowbar Jenkins jobs usually run smoke tempest through
the qa_crowbarsetup.sh onadmin_testsetup function. This commit
proposes that these jobs no longer run tempest through
qa_crowbarsetup.sh and instead use the ansible playbooks and
the tempest run filters. This aligns better with the Ardana
counterpart and also avoids running redundant tests in the
gate (i.e. the smoke test cases are also reflected in the
full-tempest suite).

The only exception to this new rule is SOC7, which doesn't (yet)
have support for running test filters. This will be covered
in a follow-up PR.