### PR TITLE
Add Octavia to SOC9 mkcloud jobs (SOC-10685)

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -13,6 +13,7 @@
     want_barbican_proposal: 1
     want_aodh_proposal: 0
     want_designate_proposal: 1
+    want_octavia_proposal: 1
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
@@ -43,6 +44,7 @@
     want_barbican_proposal: 1
     want_aodh_proposal: 0
     want_designate_proposal: 1
+    want_octavia_proposal: 1
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
@@ -60,6 +62,7 @@
     previous_version: 8
     arch: x86_64
     want_designate_proposal: 1
+    want_octavia_proposal: 1
     tempestoptions: --parallel --concurrency 3
     label: openstack-mkcloud-SLE12-x86_64
     jobs:

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -401,6 +401,11 @@
           default: '1'
           description: set to 0 to not deploy aodh
 
+      - string:
+          name: want_octavia_proposal
+          default:
+          description: set to 1 to deploy octavia
+
       ################################################
       # misc
 

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-tempestfull-template.yaml
@@ -24,5 +24,6 @@
             crowbar_networkingmode=team
             tempestoptions={tempestoptions}
             mkcloudtarget=all_noreboot
+            want_octavia_proposal={want_octavia_proposal|0}
             label={label}
             job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-tempestfull-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-4nodes-linuxbridge-template.yaml
@@ -24,5 +24,6 @@
             crowbar_networkingmode=team
             tempestoptions={tempestoptions}
             mkcloudtarget=all
+            want_octavia_proposal={want_octavia_proposal|0}
             label={label}
             job_name=cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-dvr-template.yaml
@@ -24,5 +24,6 @@
             networkingmode=vlan
             want_dvr=1
             mkcloudtarget=all
+            want_octavia_proposal={want_octavia_proposal|0}
             label={label}
             job_name=cloud-mkcloud{version}-job-dvr-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-compute-template.yaml
@@ -24,6 +24,7 @@
             mkcloudtarget=all_batch
             scenario=cloud{version}-{nodenumber}nodes-compute-ha.yml
             want_node_aliases=controller={nodenumber_controller},compute=2
+            want_octavia_proposal={want_octavia_proposal|0}
             label={label}
             storage_method=swift
             job_name=cloud-mkcloud{version}-job-ha-compute-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-bonding-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-bonding-template.yaml
@@ -27,5 +27,6 @@
             networkingplugin=linuxbridge
             networkingmode=vxlan
             crowbar_networkingmode=team
+            want_octavia_proposal={want_octavia_proposal|0}
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-linuxbridge-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-template.yaml
@@ -26,5 +26,6 @@
             networkingplugin=linuxbridge
             networkingmode=vxlan
             want_node_aliases=controller={nodenumber_controller},compute=2
+            want_octavia_proposal={want_octavia_proposal|0}
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-linuxbridge-{arch}

--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-template.yaml
@@ -27,5 +27,6 @@
             hacloud=1
             want_all_ssl={want_all_ssl}
             mkcloudtarget=all_noreboot
+            want_octavia_proposal={want_octavia_proposal|0}
             label={label}
             job_name=cloud-mkcloud{version}-job-ha-{arch}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -131,7 +131,12 @@ fi
 if [[ $want_magnum_proposal = 1 ]]; then
     : ${compute_node_memory:=6621440}
     : ${computenode_hdd_size:=80}
+# octavia requires 1GB of RAM for every load balancer it creates, so
+# it needs compute nodes to be a little beefier
+elif [[ $want_octavia_proposal = 1 ]]; then
+    : ${compute_node_memory:=3145728}
 fi
+
 # pvlist is filled below
 : ${pvlist:=}
 next_pv_device=


### PR DESCRIPTION
Adds the option to deploy Octavia to the openstack-mkcloud job
and enables this barclamp in jobs with 2 compute nodes or more
(because 2 or more compute nodes are required to get the lbaas
smoke tempest test cases to pass, and the compute node RAM
allocation also needs to be beefed up a bit).
