### PR TITLE
openstack-mkcloud: deploy designate barclamp by default

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -8,7 +8,6 @@
     magnumoptions: --regex '^magnum.tests.functional.api'
     label: openstack-mkcloud-SLE12-x86_64
     database_engine: mysql
-    want_designate_proposal: 1
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
@@ -36,7 +35,6 @@
     storage_method_ha: swift
     database_engine: mysql
     want_all_ssl: 0
-    want_designate_proposal: 1
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
@@ -57,7 +55,6 @@
     previous_version: 7
     arch: x86_64
     tempestoptions: --parallel
-    want_designate_proposal: 1
     label: openstack-mkcloud-SLE12-x86_64
     jobs:
          - 'cloud-mkcloud{version}-job-2nodes-tempestfull-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -12,7 +12,6 @@
     want_monasca_proposal: 1
     want_barbican_proposal: 1
     want_aodh_proposal: 0
-    want_designate_proposal: 1
     jobs:
         - 'cloud-mkcloud{version}-job-2nodes-{arch}'
         - 'cloud-mkcloud{version}-job-4nodes-linuxbridge-{arch}'
@@ -42,7 +41,6 @@
     want_monasca_proposal: 1
     want_barbican_proposal: 1
     want_aodh_proposal: 0
-    want_designate_proposal: 1
     jobs:
         - 'cloud-mkcloud{version}-job-ha-{arch}'
         - 'cloud-mkcloud{version}-job-ha-ceph-{arch}'
@@ -59,7 +57,6 @@
     version: 9
     previous_version: 8
     arch: x86_64
-    want_designate_proposal: 1
     tempestoptions: --parallel --concurrency 3
     label: openstack-mkcloud-SLE12-x86_64
     jobs:

--- a/jenkins/ci.suse.de/openstack-mkcloud.yaml
+++ b/jenkins/ci.suse.de/openstack-mkcloud.yaml
@@ -362,8 +362,8 @@
 
       - string:
           name: want_designate_proposal
-          default:
-          description: Deploy with Designate
+          default: '1'
+          description: set to 0 to not deploy designate
 
       - string:
           name: want_magnum_proposal

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -111,8 +111,8 @@ export want_sbd=1
 export want_all_ssl=1
 {% endif %}
 
-{% if 'designate' in deployments %}
-export want_designate_proposal=1
+{% if 'designate' not in deployments %}
+export want_designate_proposal=0
 {% endif %}
 
 {% if 'octavia' in deployments %}

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -734,7 +734,6 @@ fi
 : ${nodenumberironicnode:=0}
 : ${want_mtu_size:=1500}
 # proposals:
-: ${want_designate_proposal:=0}
 : ${want_magnum_proposal:=0}
 : ${want_monasca_proposal:=0}
 : ${want_octavia_proposal:=0}

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1395,9 +1395,9 @@ Optional
         want_aodh_proposal=0
         want_barbican_proposal=0
         want_sahara_proposal=0
+        want_designate_proposal=0
         The following proposals are default off:
         Set to 1 to enable \$PROPOSAL to be deployed. e.g.
-        want_designate_proposal=1 (Cloud9+ only)
         want_magnum_proposal=1
         want_monasca_proposal=1   (Cloud7+ only)
         want_octavia_proposal=1 (Cloud9+ only)

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2531,7 +2531,9 @@ function custom_configuration
             local cmachines=$(get_all_suse_nodes | head -n 3)
             local dnsnodes=`echo \"$cmachines\" | sed 's/ /", "/g'`
             proposal_set_value dns default "['attributes']['dns']['records']['multi-dns']" "{}"
-            [[ $want_designate_proposal = 1 ]] && proposal_set_value dns default "['attributes']['dns']['enable_designate']" true
+            if iscloudver 8plus && ! [[ $want_designate_proposal = 0 ]]; then
+                proposal_set_value dns default "['attributes']['dns']['enable_designate']" true
+            fi
             # We could do the usual "if iscloudver 6plus ; then", but this
             # would break mkcloud when installing Cloud 6 without updates
             if grep -q CNAME /opt/dell/crowbar_framework/app/helpers/barclamp/dns_helper.rb; then

--- a/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
+++ b/scripts/scenarios/cloud8/cloud8-2nodes-default.yml
@@ -137,6 +137,14 @@ proposals:
     elements:
       heat-server:
       - @@controller@@
+- barclamp: designate
+  attributes:
+  deployment:
+    elements:
+      designate-server:
+      - @@controller@@
+      designate-worker:
+      - @@controller@@
 - barclamp: barbican
   deployment:
     elements:

--- a/scripts/scenarios/cloud8/cloud8-5nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud8/cloud8-5nodes-compute-ha.yml
@@ -160,6 +160,14 @@ proposals:
     elements:
       heat-server:
       - cluster:services
+- barclamp: designate
+  attributes:
+  deployment:
+    elements:
+      designate-server:
+      - cluster:services
+      designate-worker:
+      - cluster:services
 - barclamp: barbican
   deployment:
     elements:

--- a/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
+++ b/scripts/scenarios/cloud9/cloud9-2nodes-default.yml
@@ -143,6 +143,14 @@ proposals:
     elements:
       heat-server:
       - @@controller@@
+- barclamp: designate
+  attributes:
+  deployment:
+    elements:
+      designate-server:
+      - @@controller@@
+      designate-worker:
+      - @@controller@@
 - barclamp: barbican
   deployment:
     elements:

--- a/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
+++ b/scripts/scenarios/cloud9/cloud9-5nodes-compute-ha.yml
@@ -160,6 +160,14 @@ proposals:
     elements:
       heat-server:
       - cluster:services
+- barclamp: designate
+  attributes:
+  deployment:
+    elements:
+      designate-server:
+      - cluster:services
+      designate-worker:
+      - cluster:services
 - barclamp: barbican
   deployment:
     elements:


### PR DESCRIPTION
Deploy designate by default in SOC8 and SOC9.

IMPORTANT: do not merge until designate is fixed in GM8+up and GM9+up, otherwise mkcloud jobs running against those cloudsource values will fail (and this includes some jobs doing GitHub PR gating).