### PR TITLE
export tftpboot after setting source variables (SOC-10758)

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -5748,10 +5748,10 @@ zypper --non-interactive --gpg-auto-import-keys --no-gpg-checks install ses-upgr
 # This will adapt nodes repositories to the ones with next cloud version
 function onadmin_prepare_cloudupgrade_nodes_repos
 {
-    export_tftpboot_dirs
-
     # change CLOUDISONAME/CLOUDISOURL according to the new cloudsource
     onadmin_set_source_variables
+
+    export_tftpboot_dirs
 
     # prepare installation repositories for nodes
     onadmin_prepare_sles_installmedia
@@ -5770,10 +5770,10 @@ function onadmin_prepare_cloudupgrade_nodes_repos
 # This will adapt admin server repositories to the ones needed by next product version
 function onadmin_prepare_cloudupgrade_admin_repos
 {
-    export_tftpboot_dirs
-
     # change CLOUDISONAME/CLOUDISOURL according to the new cloudsource
     onadmin_set_source_variables
+
+    export_tftpboot_dirs
 
     # recreate the SUSE-Cloud Repo with the latest iso
     onadmin_prepare_cloud_repos


### PR DESCRIPTION
This change allows qa_crowbaretup.sh to be sourced manually (i.e. not from
mkcloud) for running onadmin_prepare_cloudupgrade_admin_repos and
onadmin_prepare_cloudupgrade_nodes_repos manually. Before this change they
would have to be run twice in that scenario: in the first run, the Cloud
repository would not get updated to the newer one.

Note: please do not merge, yet. I am currently putting this through its paces for the Cloud 7 to Cloud 8 and the Cloud 8 to Cloud 9 upgrade. Once both are through, I'll remove the "do not merge yet" label (I don't anticipate any trouble, but I want to double-check to make sure).