### PR TITLE
Run ardana-cloud-configure as part of the update workflow (SOC-7028)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/defaults/main.yml
@@ -34,3 +34,7 @@ ardana_openstack_playbooks:
     when: "{{ is_physical_deploy }}"
   - play: "config-processor-run.yml -e encrypt='' -e rekey=''"
   - play: "ready-deployment.yml"
+
+ardana_scratch_playbooks:
+  - play: "ardana-status.yml"
+  - play: "ardana-cloud-configure.yml -e '{{ ardana_extra_vars|to_json }}'"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/main.yml
@@ -40,9 +40,14 @@
 - include_tasks: reboot_nodes.yml
   when: pending_system_reboot
 
-- name: Check ardana services after update
-  command: |
-    ansible-playbook -i hosts/verb_hosts ardana-status.yml
+- name: Run playbooks from "{{ ardana_scratch_path }}"
+  command: "ansible-playbook {{ item.play }}"
   args:
     chdir: "{{ ardana_scratch_path }}"
-  changed_when: False
+  loop: "{{ ardana_scratch_playbooks }}"
+  register: ansible_scratch_plays
+  when:
+    - item.when | default(True)
+    - not (ansible_scratch_plays | default({})) is failed
+  loop_control:
+    label: "{{ item.play }}"


### PR DESCRIPTION
Recently a change in tempest-ansible
https://gerrit.prv.suse.net/c/ardana/tempest-ansible/+/6500
 enabled additional tests that require additional resources
to be setup for these tests to execute sucessfully.

However, in the update workflow, the tests were failing since the
tempest-cloud-configure.yml playbook that sets up these resources
were not run.

This change calls the top level ardana-cloud-configure.yml
playbook which calls the tempest-cloud-configure.yml playbook which
creates resources needed for the newly enabled tests.