### PR TITLE
openstack-crowbar: update repository for python-junitxml

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/tempest_results/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/tempest_results/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # OpenSUSE Leap version number corresponding to the cloud version
 leap_version:
-  cloud7: "42.2"
+  cloud7: "42.3"
   cloud8: "42.3"
   cloud9: "15.0"
 


### PR DESCRIPTION
The Leap 42.2 repository is gone. Use the repository for Leap 42.3
instead (the same used for cloud 8). This should not impact the product
as as soon as the `python-junitxml` package is installed the repo is
removed.