### PR TITLE
cloud-mu-gating: Run tempest on testsetup for Cloud 7

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -56,10 +56,16 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar7-job-mu-no-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -106,10 +112,16 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar7-job-mu-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar8-job-mu-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -158,10 +170,16 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar7-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
+          # tempest filters not yet supported for SOC7
+          tempest_filter_list: ''
+          run_testsetup_tempest: true
       - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false


### PR DESCRIPTION
With [1] an option to skip running tempest on testsetup was added,
however for cloud 7 we need to run tempest on testsetup as it does not
support tempest filters yet.

1. e97954bf98e91538496bd8b60844952db4a902cb