### PR TITLE
openstack-crowbar: do not apply ceilometer-agent on controllers

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/defaults/main.yml
@@ -262,8 +262,6 @@ barclamps:
       - swift-ring-compute
       - swift-dispersion
   SWOBJ:
-    ceilometer:
-      - ceilometer-agent
     monasca:
       - monasca-agent
       - monasca-log-agent


### PR DESCRIPTION
The ceilometer-agent role from Crowbar should be applied on the computes
only.