### PR TITLE
openstack-ardana/crowbar: enable volume flattening (SOC-11054)

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/qe_all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/qe_all.yml
@@ -20,3 +20,5 @@ ses_cluster_id: "qe"
 ardana_extra_vars:
   nova_migrate_enabled: "{{ ardana_nova_migrate_enabled }}"
   local_image_mirror_url: "http://{{ clouddata_server }}/images/x86_64/openstack/"
+  # Required by SOC-11054
+  cinder_ses_flatten_volume_from_snapshot: True

--- a/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/virt_all.yml
@@ -29,6 +29,8 @@ ardana_common_extra_vars:
   # issues
   innodb_flush_log_at_trx_commit: "{{ ardana_dbmq_use_root_volume | ternary(1, 2) }}"
   local_image_mirror_url: "http://{{ clouddata_server }}/images/x86_64/openstack/"
+  # Required by SOC-11054
+  cinder_ses_flatten_volume_from_snapshot: True
 
 ardana_process_count_overrides:
   keystone_wsgi_admin_process_count: 2

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/cinder.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/cinder.yml.j2
@@ -15,7 +15,8 @@
             pool: ''
             user: ''
             secret_uuid: ''
-            flatten_volume_from_snapshot: false
+            # Required by SOC-11054
+            flatten_volume_from_snapshot: true
 {% else %}
         - backend_driver: local
           backend_name: default


### PR DESCRIPTION
This change sets `rbd_flatten_volume_from_snapshot` to true on both
Ardana and Crowbar deployments. This should fix occasional failures on
the cinder `test_create_server_from_volume_snapshot` tempest test.