### PR TITLE
Set the values of want_cloud*_iso also for the upgrade_cloudsource

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -40,6 +40,15 @@ export want_cloud{{ cloudsource[-1] }}_iso={{ cloud_iso_name }}-devel.iso
 export TESTHEAD=
 {% endif %}
 
+{% if upgrade_cloudsource.startswith("stagingcloud") %}
+export want_cloud{{ upgrade_cloudsource[-1] }}_iso_url={{ clouddata_server }}/repos/x86_64/
+export want_cloud{{ upgrade_cloudsource[-1] }}_iso={{ cloud_iso_name }}-devel-staging.iso
+{% endif %}
+{% if upgrade_cloudsource.startswith("develcloud") %}
+export want_cloud{{ upgrade_cloudsource[-1] }}_iso_url={{ clouddata_server }}/repos/x86_64/
+export want_cloud{{ upgrade_cloudsource[-1] }}_iso={{ cloud_iso_name }}-devel.iso
+{% endif %}
+
 # export mkclouddriver=
 # export adminip=
 export libvirt_type=physical


### PR DESCRIPTION
If staging is selected for upgrade_cloudsource, we need to make sure
it is really used when setting up new repositories during the upgrade.