### PR TITLE
openstack-crowbar: Fix upgrade cloud iso name on mkcloud.config template

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -42,11 +42,11 @@ export TESTHEAD=
 
 {% if upgrade_cloudsource.startswith("stagingcloud") %}
 export want_cloud{{ upgrade_cloudsource[-1] }}_iso_url={{ clouddata_server }}/repos/x86_64/
-export want_cloud{{ upgrade_cloudsource[-1] }}_iso={{ upgrade_cloud_iso_name }}-devel-staging.iso
+export want_cloud{{ upgrade_cloudsource[-1] }}_iso=SUSE-OpenStack-Cloud-Crowbar-{{ upgrade_cloudsource[-1] }}-devel-staging.iso
 {% endif %}
 {% if upgrade_cloudsource.startswith("develcloud") %}
 export want_cloud{{ upgrade_cloudsource[-1] }}_iso_url={{ clouddata_server }}/repos/x86_64/
-export want_cloud{{ upgrade_cloudsource[-1] }}_iso={{ upgrade_cloud_iso_name }}-devel.iso
+export want_cloud{{ upgrade_cloudsource[-1] }}_iso=SUSE-OpenStack-Cloud-Crowbar-{{ upgrade_cloudsource[-1] }}-devel.iso
 {% endif %}
 
 # export mkclouddriver=

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/product/crowbar.yml
@@ -16,4 +16,3 @@ gen_ip_start: 10
 gen_ip_gap: 71
 
 cloud_iso_name: "{{ (cloudsource[-1] == '7') | ternary('SUSE-OpenStack-Cloud-7', 'SUSE-OpenStack-Cloud-Crowbar-' ~ cloudsource[-1]) }}"
-upgrade_cloud_iso_name: "SUSE-OpenStack-Cloud-Crowbar-{{ upgrade_cloudsource[-1] }}"


### PR DESCRIPTION
The generate-cloud playbook is failing because mkcloud.config template
is referencing `upgrade_cloudsource[-1]` which is empty by default (not
an upgrade job).