### PR TITLE
mkcloud: beef up compute nodes for Octavia (SOC-10685)

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-bonding-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-mkcloud-job-ha-linuxbridge-bonding-template.yaml
@@ -20,7 +20,6 @@
             TESTHEAD=1
             cloudsource=develcloud{version}
             nodenumber={nodenumber}
-            clusterconfig=data+network+services=3
             storage_method=swift
             hacloud=1
             mkcloudtarget=all_noreboot

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -131,10 +131,6 @@ fi
 if [[ $want_magnum_proposal = 1 ]]; then
     : ${compute_node_memory:=6621440}
     : ${computenode_hdd_size:=80}
-# octavia requires 1GB of RAM for every load balancer it creates, so
-# it needs compute nodes to be a little beefier
-elif [[ $want_octavia_proposal = 1 ]]; then
-    : ${compute_node_memory:=3145728}
 fi
 
 # pvlist is filled below


### PR DESCRIPTION
Some SOC9 mkcloud jobs are failing lately because they have
Octavia enabled, but the RAM allocated on compute nodes is
not enough to allow 4 load balancer instances to run
at the same time, which is what is needed to get lbaas smoke
tempest test cases to pass (each Octavia instance requires
1 GB of RAM).

This change adjust the RAM allowance on mkcloud compute nodes
when 2 or fewer compute nodes are used.