### PR TITLE
cloud-generator: fix the swift-object deployment

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/service/standard.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/service/standard.yml
@@ -44,7 +44,7 @@ service_groups:
       - DBMQ
       - SWPAC
       - NEUTRON
-      - SWOBJ
+      - '{{ (cloud_product == "ardana") | ternary("SWOBJ", '') }}'
   - name: compute
     type: resource
     prefix: sles-comp
@@ -53,6 +53,7 @@ service_groups:
     min_count: 0
     service_components:
       - COMPUTE
+      - '{{ (cloud_product == "crowbar") | ternary("SWOBJ", '') }}'
   - name: rhel-compute
     type: resource
     prefix: rhel-comp

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/service/std-lmm.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/service/std-lmm.yml
@@ -46,7 +46,7 @@ service_groups:
       - DBMQ
       - SWPAC
       - NEUTRON
-      - SWOBJ
+      - '{{ (cloud_product == "ardana") | ternary("SWOBJ", '') }}'
   - name: lmm
     type: cluster
     prefix: c2
@@ -62,6 +62,7 @@ service_groups:
     min_count: 0
     service_components:
       - COMPUTE
+      - '{{ (cloud_product == "crowbar") | ternary("SWOBJ", '') }}'
   - name: rhel-compute
     type: resource
     prefix: rhel-comp


### PR DESCRIPTION
The swift-object role is by default assigned by Crowbar to all
non-controller nodes. To align unified CI jobs to that, we need to
do the same in the generated Crowbar scenarios. This also takes
some of the load off of controller nodes and reduces the overall
time it takes to re-apply the proposals during update.