### PR TITLE
openstack-crowbar: generate filters on tempest retry (SOC-11069)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry.txt.j2
@@ -1,4 +1,4 @@
-{% set regexp = '\[.*]$' %}
+{% set regexp = '(\[.*]$|\[.*\)$)' %}
 {% set test = tempest_failed_tests.stdout_lines[0] %}
 {% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
 {% set regexp = '.*\(|\)$' %}

--- a/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_tempest/templates/run_filter_retry_serial.txt.j2
@@ -1,4 +1,4 @@
-{% set regexp = '\[.*]$' %}
+{% set regexp = '(\[.*]$|\[.*\)$)' %}
 {% for test in tempest_failed_tests.stdout_lines[1:] %}
 {% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
 {% set regexp = '.*\(|\)$' %}

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/tasks/retry_failed.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/tasks/retry_failed.yml
@@ -15,6 +15,21 @@
 #
 ---
 
+- name: Get blacklisted tests
+  shell: |
+    grep -h ^- {{ tempest_run_filter }}.txt
+  args:
+    chdir: "{{ tempest_work_dir }}/run_filters"
+  register: _filter_blacklist
+  failed_when: false
+
+- name: Generate filter with failed tests
+  template:
+    src: "run_filter_retry.txt.j2"
+    dest: "{{ tempest_work_dir }}/run_filters/{{ tempest_run_filter }}_retry.txt"
+    mode: 0644
+  become: yes
+
 - name: Save previous tempest run outputs
   copy:
     src: "{{ item }}"
@@ -27,11 +42,8 @@
 - name: Rerun failed tests
   shell: |
     set -o pipefail
-    if [ -f ".stestr.conf" ]; then
-      stestr run --serial --failing | tee {{ tempest_results_log }}
-    else
-      testr run --failing --subunit | subunit-trace | tee {{ tempest_results_log }}
-    fi
+    filter_regex=$(bin/tests2skip.py run_filters/{{ tempest_run_filter }}_retry.txt)
+    tempest run --serial -r $filter_regex | tee {{ tempest_results_log }}
   args:
     chdir: "{{ tempest_work_dir }}"
   changed_when: false

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/templates/run_filter_retry.txt.j2
@@ -1,4 +1,4 @@
-{% set regexp = '\[.*]$' %}
+{% set regexp = '(\[.*]$|\[.*\)$)' %}
 {% for test in tempest_failed_tests.stdout_lines %}
 {% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
 {% set regexp = '.*\(|\)$' %}

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/templates/run_filter_retry.txt.j2
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_tempest/templates/run_filter_retry.txt.j2
@@ -1,0 +1,9 @@
+{% set regexp = '\[.*]$' %}
+{% for test in tempest_failed_tests.stdout_lines %}
+{% if test.startswith('setUpClass') or test.startswith('tearDownClass') %}
+{% set regexp = '.*\(|\)$' %}
+{% endif %}
++{{ test | regex_replace(regexp, '') }}
+{% endfor %}
+
+{{ _filter_blacklist.stdout }}


### PR DESCRIPTION
Instead of relying on stestr/testr for re-running failed tests. Generate
specific filters based on the list of failed tests, just like it is done
for ardana.

This change also includes a fix for the regex used when building run filter for retrying failed tests
