### PR TITLE
Do not add the OCTAVIA-MGMT-NET when octavia is disabled

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/network_groups.yml
@@ -78,7 +78,9 @@
 {%   set ns.routes=network_group.routes|default([]) %}
 {%   if 'MANAGEMENT' in network_group.component_endpoints %}
 {%     if bm_info is defined %}
-{%       set _ = ns.routes.append('OCTAVIA-MGMT-NET') %}
+{%       if not 'octavia' in disabled_services %}
+{%         set _ = ns.routes.append('OCTAVIA-MGMT-NET') %}
+{%       endif %}
 {%       set _ = ns.routes.append('ILO') %}
 {%     else %}
 {%       for neutron_ng in scenario.network_groups if 'NEUTRON-VLAN' in neutron_ng.component_endpoints and


### PR DESCRIPTION
    When octavia is listed in the disabled_services parameter,
    there is still reference to the OCTAVIA-MGMT-NET in the
    network_groups.yml file which fails the config-processor
    with the following error:
    Network group MANAGEMENT route OCTAVIA-MGMT-NET is not
    a valid network group.
    To avoid this error when octavia is disabled, the
    network_groups.yml is updated