### PR TITLE
Merge pull request #3826 from flaviodsr/ardana_reboot

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -56,10 +56,12 @@
       - cloud-ardana8-job-gate-entry-scale-kvm-monasca-x86_64:
           cloudsource: stagingcloud8
           update_after_deploy: false
+          reboot_after_deploy: true
           tempest_filter_list: "smoke,monasca,ceilometer,freezer"
       - cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64:
           cloudsource: stagingcloud8
           update_after_deploy: false
+          reboot_after_deploy: true
           disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
@@ -68,6 +70,7 @@
           cloudsource: develcloud8
           update_to_cloudsource: stagingcloud8
           update_after_deploy: true
+          reboot_after_deploy: false
           disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm|freezer"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
@@ -75,10 +78,12 @@
       - cloud-ardana9-job-gate-entry-scale-kvm-monasca-x86_64:
           cloudsource: stagingcloud9
           update_after_deploy: false
+          reboot_after_deploy: true
           tempest_filter_list: "smoke,monasca"
       - cloud-ardana9-job-gate-entry-scale-kvm-deploy-x86_64:
           cloudsource: stagingcloud9
           update_after_deploy: false
+          reboot_after_deploy: true
           disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
@@ -87,6 +92,7 @@
           cloudsource: develcloud9
           update_to_cloudsource: stagingcloud9
           update_after_deploy: true
+          reboot_after_deploy: false
           disabled_services: "monasca|logging|ceilometer|cassandra|kafka|spark|storm"
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -16,24 +16,28 @@
       - cloud-ardana8-job-mu-entry-scale-kvm-deploy-x86_64:
           cloudsource: GM8+up
           update_after_deploy: false
+          reboot_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
             designate,heat,manila,ceilometer,magnum,freezer,monasca,lbaas"
       - cloud-ardana8-job-mu-entry-scale-kvm-update-x86_64:
           cloudsource: GM8+up
           update_after_deploy: true
+          reboot_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
             designate,heat,ceilometer,magnum,freezer,monasca,lbaas"
       - cloud-ardana9-job-mu-entry-scale-kvm-deploy-x86_64:
           cloudsource: GM9+up
           update_after_deploy: false
+          reboot_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             designate,heat,manila,magnum,monasca,lbaas"
       - cloud-ardana9-job-mu-entry-scale-kvm-update-x86_64:
           cloudsource: GM9+up
           update_after_deploy: true
+          reboot_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
             designate,heat,magnum,monasca,lbaas"

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -81,6 +81,12 @@
             repositories, but skip the actual cloud deployment, e.g. for testing purposes.
 
       - bool:
+          name: reboot_after_deploy
+          default: '{reboot_after_deploy|false}'
+          description: >-
+            If true then cloud will be rebooted after deployment.
+
+      - bool:
           name: updates_test_enabled
           default: '{updates_test_enabled|true}'
           description: >-

--- a/scripts/jenkins/cloud/ansible/ardana-update.yml
+++ b/scripts/jenkins/cloud/ansible/ardana-update.yml
@@ -40,10 +40,16 @@
 
         - include_role:
             name: ardana_update
+            public: yes
 
         # Call this role to also update the Octavia amphora image
         - include_role:
             name: setup_amphora_image
+
+        - name: Reboot nodes
+          include_role:
+            name: ardana_reboot
+          when: pending_system_reboot
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/cloud/ansible/deploy-cloud.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-cloud.yml
@@ -48,6 +48,13 @@
 
         - include_role:
             name: setup_amphora_image
+
+        - name: Reboot nodes
+          include_role:
+            name: ardana_reboot
+          when:
+            - reboot_after_deploy | default(False)
+            - not update_after_deploy
       rescue:
         - include_role:
             name: rocketchat_notify

--- a/scripts/jenkins/cloud/ansible/roles/ardana_reboot/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_reboot/defaults/main.yml
@@ -1,0 +1,21 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
+ardana_scratch_playbooks:
+  - play: "ardana-status.yml"
+  - play: "ardana-cloud-configure.yml -e '{{ ardana_extra_vars|to_json }}'"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/main.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -27,12 +27,16 @@
     chdir: "{{ ardana_scratch_path }}"
   register: ardana_nodes
 
-- include_tasks: add_mu_repos.yml
-  when: maint_updates_list | length
+- include_tasks: reboot_nodes.yml
 
-- include_tasks: pre_cloudsource_update.yml
+- name: Run playbooks from "{{ ardana_scratch_path }}"
+  command: "ansible-playbook {{ item.play }}"
+  args:
+    chdir: "{{ ardana_scratch_path }}"
+  loop: "{{ ardana_scratch_playbooks }}"
+  register: ansible_scratch_plays
   when:
-    - cloudsource is defined
-    - cloudsource != ''
-
-- include_tasks: update_nodes.yml
+    - item.when | default(True)
+    - not (ansible_scratch_plays | default({})) is failed
+  loop_control:
+    label: "{{ item.play }}"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/reboot_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_reboot/tasks/reboot_nodes.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -16,7 +16,7 @@
 ---
 
 - name: Reboot deployer
-  shell: sleep 2 && shutdown -r now "Ardana updates triggered"
+  shell: sleep 2 && shutdown -r now "Ardana reboot triggered"
   async: 1
   poll: 0
   failed_when: false
@@ -38,9 +38,3 @@
   args:
     chdir: "{{ ardana_scratch_path }}"
   loop: "{{ ardana_nodes.stdout_lines }}"
-
-- name: Ensure spark running on all nodes (bsc#1091479)
-  command: |
-    ansible-playbook spark-start.yml -e '{{ ardana_extra_vars|to_json }}'
-  args:
-    chdir: "{{ ardana_scratch_path }}"

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/defaults/main.yml
@@ -1,5 +1,5 @@
 #
-# (c) Copyright 2018 SUSE LLC
+# (c) Copyright 2020 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -34,7 +34,3 @@ ardana_openstack_playbooks:
     when: "{{ is_physical_deploy }}"
   - play: "config-processor-run.yml -e encrypt='' -e rekey=''"
   - play: "ready-deployment.yml"
-
-ardana_scratch_playbooks:
-  - play: "ardana-status.yml"
-  - play: "ardana-cloud-configure.yml -e '{{ ardana_extra_vars|to_json }}'"

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -36,8 +36,7 @@ local_ssh_key: false
 # repositories, but skip the actual cloud deployment, e.g. for testing purposes.
 deploy_cloud: true
 
-# Reboot cloud after deploy. Primarly used to reboot cloud after installation of
-# Maintenance updates. For now it is valid for **CROWBAR** flavor only.
+# Reboot cloud after deploy.
 reboot_after_deploy: true
 
 #============= Repositories =============#


### PR DESCRIPTION
This change adds an option for rebooting the nodes after ardana is
deployed. Besides that, it also enable it on the deploy scenarios on
gating and maintenance gating jobs.