### PR TITLE
Fix description of `extra_params`

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -72,15 +72,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -54,15 +54,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -177,15 +177,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -166,15 +166,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -135,15 +135,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -93,15 +93,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
       - hidden:
           name: cloud_product

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -140,15 +140,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
       - hidden:
           name: version

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -470,15 +470,15 @@
           name: extra_params
           default: '{extra_params|}'
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
       - hidden:
           name: update_services_serial

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -364,15 +364,15 @@
           name: extra_params
           default: '{extra_params|}'
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
       - hidden:
           name: tempest_retry_failed

--- a/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
@@ -46,15 +46,15 @@
           name: extra_params
           default: '{extra_params|}'
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     logrotate:
       numToKeep: -1

--- a/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
@@ -108,15 +108,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
@@ -94,15 +94,15 @@
           name: extra_params
           default: '{extra_params|}'
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
     pipeline-scm:
       scm:

--- a/jenkins/ci.suse.de/templates/cloud-jenkins-worker-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-jenkins-worker-template.yaml
@@ -99,15 +99,15 @@
           name: extra_params
           default:
           description: >-
-            This field may be used to define additional parameters, one per line, in the form:
-
-              <parameter_name>=<parameter-value>
-
-            These parameters will be injected into the Jenkins job as environment variables that supplement
-            or override the other parameters configured for the Jenkins job.
-            This should not be used by default or regularly. It is meant to run job build customized in ways
-            not already supported by the job's parameters, such as testing automation git pull requests
-            with special configurations.
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
 
 
     pipeline-scm:


### PR DESCRIPTION
The current description is not rendered the way it is in the yaml
files. This change simplifies the formatting of the description so
that the rendering matches the description.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>