### PR TITLE
Run post-update for train not on master changes

### DIFF
--- a/hostscripts/zuul/layout.yaml
+++ b/hostscripts/zuul/layout.yaml
@@ -115,3 +115,6 @@ jobs:
 
   - name: openstack-rpm-packaging-update-Stein
     branch: stable/stein
+
+  - name: openstack-rpm-packaging-update-Train
+    branch: stable/train


### PR DESCRIPTION
There was a missing copy&paste in the previous change. this
adds the filter to ensure that we only run train updates on
train branch changes.