### PR TITLE
mkphyscloud: remove command restrictions

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-1a.yaml
@@ -131,13 +131,10 @@
           name: want_ipmi
           default: "1"
 
-      - choice:
+      - string:
           name: commands
           default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
           description: All the steps that needs to be completed to have cloud installed:When deploying with SSL add "install_ca_certificates" before "batch" command
-          choices:
-            - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases batch
-            - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases install_ca_certificates batch
 
       - string:
           name: want_test_updates

--- a/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
+++ b/jenkins/ci.suse.de/cloud-mkphyscloud-qa-scenario-2a.yaml
@@ -153,9 +153,6 @@
           name: commands
           default: addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases
           description: All the steps that needs to be completed to have cloud installed:When deploying with SSL add "install_ca_certificates" after "setup_aliases" command
-          choices:
-            - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases
-            - addupdaterepo prepareinstallcrowbar runupdate bootstrapcrowbar installcrowbar allocate waitcloud setup_aliases install_ca_certificates
 
       - string:
           name: want_test_updates


### PR DESCRIPTION
Some QA scenarios had unnecessary restrictions on the mkcloud
steps that can be run. This commit removes these restrictions.