### PR TITLE
deployment: Add ZYPP_LOCKFILE_ROOT var to fix locking issue

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/list_packages/tasks/list-packages.yml
+++ b/scripts/jenkins/cloud/ansible/roles/list_packages/tasks/list-packages.yml
@@ -32,7 +32,7 @@
 - name: Collect list of installed packages repo of origin from zypper
   shell: |
     if [ {{ hostvars[item_virtual_hosts].ansible_os_family }} = "Suse" ];then
-      zypper --xmlout se -s -i -t package
+      ZYPP_LOCKFILE_ROOT=/root; zypper --xmlout se -s -i -t package
     else
       echo "<?xml version='1.0'?>"
       echo "<stream>"


### PR DESCRIPTION
Sometimes when listpackages role is getting installed packages fails
due to locks by other tools. We use zypper search(read only command)
to get installed packages. This works normally for the other user then
root. We workaround this by use of different lock file.