### PR TITLE
change mkcloud jobs to not require exactly SP2

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud7.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud7.yaml
@@ -59,7 +59,7 @@
     disabled: false
     version: 7
     arch: x86_64
-    label: openstack-mkcloud-SLE12-SP2-x86_64
+    label: openstack-mkcloud-SLE12-x86_64
     tempestoptions: --smoke
     jobs:
         - 'cloud-mkcloud{version}-job-uefi-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud8.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud8.yaml
@@ -67,7 +67,7 @@
     disabled: false
     version: 8
     arch: x86_64
-    label: openstack-mkcloud-SLE12-SP2-x86_64
+    label: openstack-mkcloud-SLE12-x86_64
     tempestoptions: --smoke
     jobs:
         - 'cloud-mkcloud{version}-job-uefi-{arch}'

--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -73,7 +73,7 @@
     disabled: false
     version: 9
     arch: x86_64
-    label: openstack-mkcloud-SLE12-SP2-x86_64
+    label: openstack-mkcloud-SLE12-x86_64
     tempestoptions: --smoke
     jobs:
         - 'cloud-mkcloud{version}-job-uefi-{arch}'


### PR DESCRIPTION
so now it will select any SLE12.

None of the mkcloud hosts run SP2. The label probably was incorrectly
still there on SP4 hosts, even though they were SP4. The label probably
got updated by fully deploying pending changes in cloudsalt.

This label requirement was added in
565500c02667ea710f26e48ad3dd9b0def2225a0 because these jobs couldn't run
on SP1. As all host are now SP4, the SP2 requirement is not needed
anymore.