### PR TITLE
qa_openstack: Remove duplicate zypper -n switch

### DIFF
--- a/scripts/jenkins/qa_openstack.sh
+++ b/scripts/jenkins/qa_openstack.sh
@@ -195,7 +195,7 @@ $zypper --gpg-auto-import-keys -n ref
 
 # install maintenance updates
 # run twice, first installs zypper update, then the rest
-$zypper -n patch --skip-interactive || $zypper -n patch --skip-interactive
+$zypper patch --skip-interactive || $zypper patch --skip-interactive
 
 # wickedd needs to be configured properly to avoid overriding
 # the hostname (see <https://bugzilla.opensuse.org/show_bug.cgi?id=974661>).
@@ -209,7 +209,7 @@ echo $(ip addr sh eth0 | grep -w inet | awk '{print $2}' | sed 's#/.*##') $(host
 ifup all
 
 # install some basics (which is i.e. not installed in the SLE12SP1 JeOS
-$zypper -n in wget
+$zypper in wget
 
 # Everything below here is fatal
 set -e
@@ -224,8 +224,8 @@ if [ -n "$QUICKSTART_DEBUG" ]; then
 fi
 
 # start with patterns
-$zypper -n install -t pattern cloud_controller cloud_compute cloud_network
-$zypper -n install openstack-quickstart openstack-tempest-test
+$zypper install -t pattern cloud_controller cloud_compute cloud_network
+$zypper install openstack-quickstart openstack-tempest-test
 
 # for debugging, use some files if available after installing
 # the openstack-quickstart package


### PR DESCRIPTION
$zypper already has "--non-interactive". There is no need to add
another "-n".

This fixes the following warning:

Warning: The flag --non-interactive can only be used once.