### PR TITLE
Enable full tempest for ECP gating jobs for SOC7 (SOC-9801)

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -116,9 +116,10 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-gate-no-ha-deploy-x86_64:
           cloudsource: stagingcloud8
           ses_enabled: false
@@ -152,9 +153,10 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-gate-ha-deploy-x86_64:
           cloudsource: stagingcloud8
           ses_enabled: false
@@ -190,9 +192,10 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64:
           cloudsource: stagingcloud8
           ses_enabled: false

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -60,16 +60,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar7-job-mu-no-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -116,16 +118,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar7-job-mu-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-mu-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -174,16 +178,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar7-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # tempest filters not yet supported for SOC7
-          tempest_filter_list: ''
-          run_testsetup_tempest: true
+          # nova, cinder and magnum not fully passing yet
+          tempest_filter_list: "\
+            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false


### PR DESCRIPTION
Adding full tempest to all gating jobs (both staging and maintenance
update) for SOC7. For now, the nova, cinder and magnum filters
are excluded, because there are still a few test cases consistently
failing, that either need to be black-listed because of missing
features, or addressed separately as bugs:

tempest.api.volume.admin.test_volume_type_access.VolumeTypesAccessV2Test*
magnum.tests.functional.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters
tempest.api.compute.admin.test_servers_on_multinodes.ServersOnMultiNodesTest.test_create_servers_on_different_hosts_with_list_of_servers