### PR TITLE
openstack-cleanvm: Do not test SLES for master and train

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -53,7 +53,6 @@
     disabled: false
     release: Train
     image:
-      - SLE_15_SP1
       - openSUSE-Leap-15.1
     jobs:
       - 'openstack-cleanvm-{release}'
@@ -67,7 +66,6 @@
       - timed: 'H 4 * * *'
 
     image:
-      - SLE_15_SP1
       - openSUSE-Leap-15.1
     jobs:
       - 'openstack-cleanvm-{release}'


### PR DESCRIPTION
It's currently broken and nobody looks into it. openSUSE Leap 15.1
looks good so far so keep testing that for now.