### PR TITLE
ci worker: add deepdiff into venv

### DIFF
--- a/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
+++ b/scripts/jenkins/workers/roles/jenkins_worker/defaults/main.yml
@@ -55,6 +55,7 @@ jenkins_worker_venv_requires:
   - "openstackclient"
   - "openstacksdk"
   - "sh"
+  - "deepdiff"
 
 jenkins_worker_ntp_server: "ntp1.suse.de"
 


### PR DESCRIPTION
Add deepdiff module into python venv on the ci worker.
This is prerequisite  for: SOC-11086 - Structured diff of installed packages. (https://github.com/djz88/automation/tree/enhanced_diff)