### PR TITLE
add worker ci2

### DIFF
--- a/jenkins/ci.suse.de/cloud-jenkins-worker.yaml
+++ b/jenkins/ci.suse.de/cloud-jenkins-worker.yaml
@@ -5,7 +5,7 @@
       - ci-trigger:
           jenkins_worker_labels: 'cloud-ci-worker cloud-ci-trigger'
           jenkins_workers_executors: '50'
-      - ci:
+      - ci,ci2:
           jenkins_worker_labels: 'cloud-ci-worker cloud-ci'
           jenkins_workers_executors: '50'
     jobs:


### PR DESCRIPTION
This was manually added when there was a need for more slots to make
progress. Add it in the defaults for the job that updates/installs the
workers.