### PR TITLE
Enable dm-event.socket and lvm2-monitor to restart cinder

### DIFF
--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1708,6 +1708,13 @@ function onadmin_allocate
 Host node$i
     HostName $m
 EOF
+
+        # NOTE(bbobrov): this is a temporary workaround for SOC-11110;
+        # remove when bsc#1166529 is fixed and the fix is available for us
+        ssh $m systemctl enable dm-event.socket
+        ssh $m systemctl enable lvm2-monitor.service
+        ssh $m systemctl start lvm2-monitor.service
+
     done
 
     onadmin_is_crowbar_api_available || \


### PR DESCRIPTION
Cinder cannot restart because dm-eventd restart is too slow (SOC-11110).
This is a temporary workaround similar to what was used in OpenSUSE:
https://build.opensuse.org/request/show/460424.

Something in dm-event in turn requires enabled lvm2-monitor:
https://bugzilla.suse.com/show_bug.cgi?id=1072492,
https://build.opensuse.org/request/show/558339

This commit should be reversed when bsc#1166529 is fixed.