### PR TITLE
mid-scale-kvm scenario broken for Cloud9 CLM (SOC-11169)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/full-spread.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/full-spread.yml
@@ -25,8 +25,6 @@ interface_models:
           - MANAGEMENT
         forced_network_groups:
           - EXTERNAL-API
-      - network_groups:
-          - CONF
 
   - name: CORE
     service_groups:
@@ -35,9 +33,8 @@ interface_models:
       - network_groups:
           - EXTERNAL-API
           - INTERNAL-API
-          - MANAGEMENT
       - network_groups:
-          - CONF
+          - MANAGEMENT
 
   - name: NEUTRON
     service_groups:
@@ -45,11 +42,10 @@ interface_models:
     network_interfaces:
       - network_groups:
           - GUEST
-          - MANAGEMENT
           - EXTERNAL-VM
           - TENANT-VLAN
       - network_groups:
-          - CONF
+          - MANAGEMENT
 
   - name: COMPUTE
     service_groups:
@@ -58,21 +54,19 @@ interface_models:
     network_interfaces:
       - network_groups:
           - GUEST
-          - MANAGEMENT
           - EXTERNAL-VM
           - TENANT-VLAN
       - network_groups:
-          - CONF
+          - MANAGEMENT
 
   - name: SWIFT
     service_groups:
       - swift
     network_interfaces:
       - network_groups:
-          - MANAGEMENT
           - SWIFT
       - network_groups:
-          - CONF
+          - MANAGEMENT
 
   - name: DBMQ
     service_groups:
@@ -80,8 +74,6 @@ interface_models:
     network_interfaces:
       - network_groups:
           - MANAGEMENT
-      - network_groups:
-          - CONF
 
   - name: LMM
     service_groups:
@@ -89,5 +81,3 @@ interface_models:
     network_interfaces:
       - network_groups:
           - MANAGEMENT
-      - network_groups:
-          - CONF

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/full-spread.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/full-spread.yml
@@ -16,16 +16,11 @@
 ---
 
 network_groups:
-  - name: CONF
-    hostname_suffix: conf
-    tagged_vlan: false
-    component_endpoints:
-      - CLM
-
   - name: MANAGEMENT
     hostname_suffix: mgmt
     tagged_vlan: false
     component_endpoints:
+      - CLM
       - MANAGEMENT
     routes:
       - INTERNAL-API


### PR DESCRIPTION
In Cloud9 CLM changes were implemented in the configuration process to
validate that the proposed model didn't try to assign more than one
untagged VLAN to a given network interface. However the dynamically
generated input model for the mid-scale-kvm scenario violates this
requirement, as there exist 3 untagged VLANs (CONF, MANAGEMENT,
TENANT-VLAN) and thus fails the configuration process check.

This patch addresses the problem by merging the CONF and MANAGEMENT
networks together so that there are only 2 untagged VLANs, one for
each network interface.