### PR TITLE
Automate Deployment of Caasp4 using terraform

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-caaspv4.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-caaspv4.yaml
@@ -1,0 +1,124 @@
+- job:
+    name: openstack-ardana-caaspv4
+    project-type: pipeline
+    concurrent: true
+    wrappers:
+      - timestamps
+      - timeout:
+          timeout: 300
+          type: no-activity
+          abort: true
+          write-description: "Job aborted due to 180 minutes of inactivity"
+
+    logrotate:
+      numToKeep: 1000
+      daysToKeep: 90
+
+    properties:
+      - authorization:
+          cloud:
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-delete
+            - job-discover
+            - job-read
+            - job-workspace
+            - run-delete
+            - run-update
+            - scm-tag
+          anonymous:
+            - job-read
+
+    parameters:
+      - validating-string:
+          name: cloud_env
+          default: ''
+          regex: '[A-Za-z0-9-]+'
+          msg: >-
+            Empty or malformed value (only alphanumeric and '-' characters are allowed).
+          description: >-
+            The virtual or hardware environment identifier. This field should either
+            be set to one of the values associated with the known hardware environments
+            (e.g. qe101), or to a value that will identify the created virtual environment.
+
+            WARNING: if a virtual environment associated with the supplied cloud_env already
+            exists, it will be replaced.
+
+      - choice:
+          name: os_cloud
+          choices:
+            - 'engcloud'
+            - 'susecloud'
+          description: >-
+            The OpenStack cloud platform where the virtual cloud environment is
+            running. Possible values are:
+
+              engcloud  - the Provo engineering cloud (engcloud.prv.suse.net)
+              susecloud - the Nuremberg SUSE cloud (cloud.suse.de)
+
+            If the 'cloud_env' value matches one of the virtual cloud slots
+            (https://ci.nue.suse.com/lockable-resources/), the 'os_cloud' parameter is
+            overridden to reflect the OpenStack platform associated with it.
+
+      - bool:
+          name: rc_notify
+          default: true
+          description: >-
+            Notify RocketChat when deployment starts/finishes.
+
+      - string:
+          name: git_automation_repo
+          default: https://github.com/SUSE-Cloud/automation.git
+          description: >-
+            The git automation repository to use
+
+      - string:
+          name: git_automation_branch
+          default: master
+          description: >-
+            The git automation branch
+
+      - text:
+          name: extra_params
+          default:
+          description: >-
+            This field may be used to define additional parameters,
+            one per line, in the form PARAMETER_NAME=PARAMETER-VALUE.
+            These parameters will be injected into the Jenkins job as
+            environment variables that supplement or override the
+            other parameters configured for the Jenkins job. This
+            should not be used by default or regularly. It is meant to
+            run job build customized in ways not already supported by
+            the job's parameters, such as testing automation git pull
+            requests with special configurations.
+
+      - string:
+          name: os_project_name
+          default: ''
+          description: >-
+            The name of the OpenStack project that hosts the virtual cloud deployment
+            in the 'os_cloud' OpenStack cloud platform (leave empty to use the
+            default shared 'cloud' account).
+
+            If the 'cloud_env' value (or the reserved resource, when 'reserve_env' selected),
+            matches one of the virtual cloud slots (https://ci.nue.suse.com/lockable-resources/),
+            the 'cloud-ci' OpenStack project used exclusively for the Cloud CI will be used
+            regardless of this parameter.
+
+      - bool:
+          name: want_caaspv4
+          default: true
+          description: >-
+            Deploy Caaspv4 using terraform
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: ${git_automation_repo}
+            branches:
+              - ${git_automation_branch}
+            browser: auto
+            wipe-workspace: false
+      script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
+      lightweight-checkout: false

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-caaspv4.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-caaspv4.Jenkinsfile
@@ -1,0 +1,65 @@
+/**
+ * The openstack-ardana-caaspv4 Jenkins Pipeline
+ *
+ * This job runs casspv4 deployment on a pre-deployed CLM cloud.
+ */
+
+
+pipeline {
+
+  options {
+    // skip the default checkout, because we want to use a custom path
+    skipDefaultCheckout()
+    timestamps()
+  }
+
+  agent {
+    node {
+      label "cloud-ci"
+      customWorkspace "${JOB_NAME}-${BUILD_NUMBER}"
+    }
+  }
+
+  stages {
+    stage('Setup workspace') {
+      steps {
+        script {
+          if (cloud_env == '') {
+            error("Empty 'cloud_env' parameter value.")
+          }
+          currentBuild.displayName = "#${BUILD_NUMBER}: ${cloud_env}"
+          sh('''
+             git clone $git_automation_repo --branch $git_automation_branch automation-git
+          ''')
+          cloud_lib = load "$WORKSPACE/automation-git/jenkins/ci.suse.de/pipelines/openstack-cloud.groovy"
+          cloud_lib.load_extra_params_as_vars(extra_params)
+          cloud_lib.load_os_params_from_resource(cloud_env)
+          cloud_lib.ansible_playbook('load-job-params')
+          cloud_lib.ansible_playbook('setup-ssh-access')
+          cloud_lib.get_deployer_ip()
+        }
+      }
+    }
+    stage ('Deploy Caaspv4 using Terraform') {
+      when {
+        expression { want_caaspv4 == 'true' }
+      }
+      steps {
+        script {
+          // Generate stage for CaaSPv4 deployment
+          if (want_caaspv4 == 'true') {
+            stage('Deploy CaaSPv4') {
+              cloud_lib.ansible_playbook('deploy-caasp-v4-terraform')
+            }
+          }
+        }
+      }
+    }
+
+  }
+  post {
+    cleanup {
+      cleanWs()
+    }
+  }
+}

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -255,7 +255,7 @@ pipeline {
 
     stage ('Prepare tests') {
       when {
-        expression { tempest_filter_list != '' || qa_test_list != '' || want_caasp == 'true' }
+        expression { tempest_filter_list != '' || qa_test_list != '' || want_caasp == 'true' || want_caaspv4 == 'true' }
       }
       steps {
         script {
@@ -267,6 +267,12 @@ pipeline {
           if (want_caasp == 'true') {
             stage('Deploy CaaSP') {
               cloud_lib.ansible_playbook('deploy-caasp')
+            }
+          }
+          // Generate stage for CaaSPv4 deployment
+          if (want_caaspv4 == 'true') {
+            stage('Deploy CaaSPv4') {
+              cloud_lib.ansible_playbook('deploy-caasp-v4-terraform')
             }
           }
         }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -414,6 +414,12 @@
           description: >-
             Deploy CaaSP using the caasp-openstack-heat-templates.
 
+      - bool:
+          name: want_caaspv4
+          default: false
+          description: >-
+            Deploy CaaSPv4 using terraform
+
       - choice:
           name: cleanup
           choices:

--- a/scripts/jenkins/cloud/ansible/deploy-caasp-v4-terraform.yml
+++ b/scripts/jenkins/cloud/ansible/deploy-caasp-v4-terraform.yml
@@ -1,0 +1,556 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# This playbook supports deployment of caaspv4 using terraform
+# against SOC (ardana) deployments.
+# Once the playbook finishes successfully, you can login into the
+# management machine from the deployer.
+# On deployer node: ssh -i caaspmanagementkey.pem sles@<managementmachinefloatingip>
+# Once you are in the management machine, the caasp bits
+# are in /home/sles/caasp/deployment/openstack.
+---
+- name: Setup Management Machine to Deploy CaaSPv4 using terraform
+  hosts: "{{ cloud_env }}"
+  gather_facts: True
+  remote_user: ardana
+  vars:
+    ca_path: "/etc/pki/trust/anchors/ca-bundle.pem"
+    external_net: "ext-net"
+    soc_home: "/var/lib/ardana"
+    image_url: "http://ibs-mirror.prv.suse.net/install/SLE-15-SP1-JeOS-QU2/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU2.qcow2"
+    image_path: "{{ soc_home }}/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU2.qcow2"
+    image_name: "SLE-15-SP1-JeOS-QU2"
+    keyname: "caaspmanagementkey"
+    management_machine_size: "m1.small"
+    management_machine_name: "caasp_management"
+    management_machine_net: "caasp-mm-net"
+    management_machine_router: "caasp-mm-router"
+    management_machine_subnet: "caasp-mm-subnet"
+    management_machine_subnet_cidr: "2.2.2.0/24"
+    management_machine_gateway: "2.2.2.1"
+    management_machine_secgroup: "caasp-mm-sec-group"
+    #for SOC 8: Use the regular Neutron LBaaS API
+    #conditional check ansible_distribution_release == "3" means SLES12SP3 deployer
+    octavia_enabled: "{{ not (ansible_distribution_release == '3') }}"
+    os_ca_path: "/etc/ssl/ca-bundle.pem"
+    service_osrc: "{{ soc_home }}/service.osrc"
+    ssh_opts: '-o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=error -o ConnectTimeout=30'
+    service_caasp_osrc: "service_caasp.osrc"
+  tasks:
+  - name: Download SLES15SP1 image
+    get_url:
+      url: "{{ image_url }}"
+      dest: "{{ image_path }}"
+      mode: 0600
+    register: _download_caasp_image
+    until: _download_caasp_image is success
+    retries: 5
+    delay: 2
+
+  - name: Upload SLES15SP1 image to glance
+    shell: |
+      source "{{ service_osrc }}"
+      if ! openstack image list | grep "{{ image_name }}"; then openstack image create --public --disk-format qcow2 --container-format bare --file "{{ image_path }}" "{{ image_name }}"; fi
+    args:
+      executable: /bin/bash
+
+  - name: Create Management Machine
+    shell: |
+      source {{ service_osrc }}
+      set -e
+      if ! openstack keypair list | grep {{ keyname }}; then openstack keypair create {{ keyname }} > {{ soc_home }}/{{ keyname }}.pem; fi
+      chmod 600 {{ soc_home }}/{{ keyname }}.pem
+      openstack keypair show --public-key {{ keyname }} > {{ soc_home }}/{{ keyname }}.pub
+      net_id=$(openstack network create {{ management_machine_net }} -c id -f value)
+      subnet_id=$(openstack subnet create --network $net_id --gateway {{ management_machine_gateway }} \
+      --subnet-range {{ management_machine_subnet_cidr}} {{ management_machine_subnet }} -c id -f value)
+      router_id=$(openstack router create {{ management_machine_router }} -c id -f value)
+      openstack router add subnet $router_id $subnet_id
+      openstack router set $router_id --external-gateway {{ external_net }}
+      sec_group=$(openstack security group create {{ management_machine_secgroup }} -c id -f value)
+      openstack security group rule create --protocol icmp $sec_group
+      openstack security group rule create --protocol tcp --dst-port 22 $sec_group
+      vm_id=$(openstack server create --wait --image {{ image_name }} --flavor {{ management_machine_size }} \
+      --key-name {{ keyname }} --network $net_id {{ management_machine_name }} --security-group $sec_group -c id -f value)
+      status=$(openstack server show $vm_id | grep -w status | awk '{print $4}')
+      if [ $status = 'ACTIVE' ]; then echo "Management Machine created successfully."; else echo "Failed to create Management Machine: $status"; exit 1; fi
+      floating_ip=$(openstack floating ip create {{ external_net }} -c floating_ip_address -f value)
+      fixed_ip=$(openstack server show $vm_id -c addresses -f value | awk -F'=' '{print $2}')
+      vmportuuid=$(openstack port list | grep $fixed_ip | grep $subnet_id | awk '{print $2}')
+      openstack floating ip set --port $vmportuuid $floating_ip
+      sleep 200
+      addresses=$(openstack server show $vm_id -c addresses -f value | awk -F'=' '{print $2}')
+      if [[ $addresses =~ $floating_ip ]]; then echo "Floating IP assigned successfully."; else echo "Failed to assign floating IP"; exit 1; fi
+      echo $floating_ip
+    register: results
+    args:
+      executable: /bin/bash
+
+  - name: Save floating IP of the Management Machine
+    set_fact:
+      floating_ip: "{{ results.stdout_lines[-1] }}"
+
+  - name: Store key locally
+    fetch:
+      src: "{{ soc_home }}/{{ keyname }}.pem"
+      dest:  "{{ keyname }}.pem"
+      flat: yes
+
+  - name: Update key permissions
+    file:
+      path: "{{ keyname }}.pem"
+      mode: 0600
+    delegate_to: localhost
+
+  - name: Fetch the project id
+    shell: |
+      source {{ service_osrc }}
+      openstack project show $OS_PROJECT_NAME -c id -f value
+    register: project_id
+
+  - name: Copy service.osrc to service_caasp.osrc
+    copy:
+      src: "{{ service_osrc }}"
+      dest: "{{ service_caasp_osrc }}"
+      mode: '0644'
+      remote_src: yes
+
+  - name: Get public vip
+    shell: grep  'public-KEY-API-extapi' /etc/hosts | awk {'print $1'}
+    register: public_vip
+
+  - name: Update service_caasp.osrc
+    lineinfile:
+      dest: "{{ item.dest }}"
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    loop:
+      - { dest: "{{ service_caasp_osrc }}", regexp: 'export OS_ENDPOINT_TYPE=internalURL', line: 'export OS_ENDPOINT_TYPE=publicURL' }
+      - { dest: "{{ service_caasp_osrc }}", regexp: 'export OS_INTERFACE=internal', line: 'export OS_INTERFACE=public' }
+
+  - name: Update service_caasp.osrc OS_AUTH_URL to public vip
+    replace:
+      path: "{{ service_caasp_osrc }}"
+      regexp: 'export OS_AUTH_URL=http(.*://)((\d{1,3}\.){3}\d{1,3}):5000/v3'
+      replace: 'export OS_AUTH_URL=http\g<1>{{public_vip.stdout}}:5000/v3'
+
+  - name: Update service_caasp.osrc with OS_PROJECT_ID since generate-cpi-conf.sh looks for this var to be set
+    lineinfile:
+      path: "{{ service_caasp_osrc }}"
+      line: 'export OS_PROJECT_ID="{{ project_id.stdout }}"'
+
+  - name: Update service_caasp.osrc with export OS_USE_OCTAVIA=true
+    lineinfile:
+      path: "{{ service_caasp_osrc }}"
+      line: 'export OS_USE_OCTAVIA=true'
+    when: octavia_enabled | bool
+
+  - name: Fetch updated service_caasp.osrc
+    fetch:
+      src: "{{ service_caasp_osrc }}"
+      dest: "{{ service_caasp_osrc }}"
+      flat: yes
+
+  - name: Store CA certificate
+    fetch:
+      src: "{{ os_ca_path }}"
+      dest: "ca-bundle.pem"
+      flat: yes
+
+  - name: Add a host alias that we reach through a tunnel
+    add_host:
+      hostname: '{{ floating_ip }}'
+      ansible_host: '{{ floating_ip }}'
+      ansible_ssh_common_args:  '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ keyname }}.pem -o ProxyCommand="ssh {{ ssh_opts }} -W %h:%p -q ardana@{{ hostvars[cloud_env].ansible_host }}"'
+      groups: managementmachine
+
+- name: Deploy CaaSPv4 using terraform
+  hosts: managementmachine
+  gather_facts: False
+  remote_user: sles
+  vars:
+    ansible_python_interpreter: "/usr/bin/python3"
+    ca_path: "/etc/pki/trust/anchors/ca-bundle.pem"
+    caasp_deployment_path: "/home/sles/caasp/deployment"
+    caasp_openstack_path: "{{ caasp_deployment_path }}/openstack"
+    cpiautotfvars_path: "{{ caasp_openstack_path }}/cpi.auto.tfvars"
+    dns_server_ip1: "10.84.2.20"
+    dns_server_ip2: "10.84.2.21"
+    external_net: "ext-net"
+    image_name: "SLE-15-SP1-JeOS-QU2"
+    internal_net: "caasp-int-net"
+    internal_subnet: "caasp-int-subnet"
+    lb_tf_path: "{{ caasp_openstack_path }}/load-balancer.tf"
+    management_machine_repos:
+      - name: sles-15-sp1
+        repo: http://ibs-mirror.prv.suse.net/ibs/SUSE:/SLE-15-SP1:/GA/standard/
+      - name: sles-15-sp1-update
+        repo: http://ibs-mirror.prv.suse.net/ibs/SUSE:/SLE-15-SP1:/Update/standard/
+      - name: base-system-pool
+        repo: http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
+      - name: base-system-update
+        repo: http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/
+      - name: cassp40-pool
+        repo: http://ibs-mirror.prv.suse.net/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/
+      - name: caasp40-update
+        repo: http://ibs-mirror.prv.suse.net/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/standard/
+    master_size: "m1.medium"
+    network_tf_path: "{{ caasp_openstack_path }}/network.tf"
+    #Due to resource constraints in virtual cloud environment setup, the num_masters and num_workers are set to 1
+    #This can be overidden for baremetal QE cloud environments.
+    num_masters: 1
+    num_workers: 1
+    registration_auto_vars_path: "{{ caasp_openstack_path }}/registration.auto.tfvars"
+    repositories: '\n
+      basesystem_pool = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/" \n
+      serverapps_pool = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/" \n
+      containers_pool = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/" \n
+      basesystem_updates = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/" \n
+      containers_updates = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/" \n
+      serverapps_updates = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/" \n
+    '
+    ssh_key_filename: "id_rsa"
+    stack_name: "auto-caasp"
+    subnet_cidr: "172.28.0.0/24"
+    terraform_destroy: false
+    tfvars_path: "{{ caasp_openstack_path }}/terraform.tfvars"
+    timestamp: ""
+    service_caasp_osrc: "service_caasp.osrc"
+    user: "sles"
+    worker_size: "m1.medium"
+  tasks:
+  - name: Management Machine | Get timestamp
+    set_fact:
+      timestamp: "{{lookup('pipe', 'date +%Y%m%d%H%M%S')}}"
+
+  - name: Managment Machine | Resources names with timestamp
+    # resources named with timestamp
+    set_fact:
+      stack_name: "{{stack_name + '-' + timestamp}}"
+      internal_net: "{{internal_net + '-' + timestamp}}"
+      internal_subnet: "{{internal_subnet + '-' + timestamp}}"
+
+  - name: Management Machine | Update resolv.conf
+    shell:
+      echo "nameserver {{ dns_server_ip1 }}" | sudo tee -a /etc/resolv.conf
+    args:
+      executable: /bin/bash
+    become: yes
+
+  - name: Management Machine | Add zypper repos
+    zypper_repository:
+      name: "{{ item.name }}"
+      repo: "{{ item.repo }}"
+      runrefresh: yes
+    loop: "{{ management_machine_repos }}"
+    when: item.enabled | default(true)
+    become: yes
+
+  - name: Managment Machine | Install SUSE-CaaSP-Management
+    zypper:
+      name: "SUSE-CaaSP-Management"
+      state: present
+      type: pattern
+    become: yes
+
+  - name: Management Machine | Copy caasp
+    shell: |
+      set -e
+      mkdir -p {{ caasp_deployment_path }}
+      cp -r /usr/share/caasp/terraform/openstack/ {{ caasp_deployment_path }}
+      cd {{ caasp_openstack_path }}
+      mv terraform.tfvars.example terraform.tfvars
+    args:
+      executable: /bin/bash
+
+  - name: Management Machine | Copy service.osrc
+    copy:
+      src: "{{ service_caasp_osrc }}"
+      dest: "{{ caasp_openstack_path }}"
+    become: yes
+
+  - name: Management Machine | Copy CA certificate
+    copy:
+      src: "ca-bundle.pem"
+      dest: "{{ ca_path }}"
+    become: yes
+
+  - name: Management Machine | Run update-ca-certificates
+    shell: update-ca-certificates --fresh
+    become: yes
+
+  - name: Management Machine | Generate a ssh keypair
+    user:
+      name: "{{ user }}"
+      generate_ssh_key: yes
+      ssh_key_type: rsa
+      ssh_key_bits: 4096
+      ssh_key_file: .ssh/{{ssh_key_filename}}
+
+  - name: Management Machine | Copy public key contents
+    command:
+      cat /home/sles/.ssh/{{ssh_key_filename}}.pub
+    register: publickey
+
+  # Here we are using the rmt mirror server instead of the SCC product registration code
+  # Since the rmt server does not mirror all the packages, I'm configuring additional repositories hosted provo ibs mirror.
+  - name: Management Machine | Update registration.auto.tfvars to use the RMT server
+    lineinfile:
+      path: "{{ registration_auto_vars_path }}"
+      regexp: '^#?rmt_server_name ='
+      line: 'rmt_server_name = "rmt.scc.suse.de"'
+
+  - name: Management Machine | Update terraform.tfvars
+    lineinfile:
+      dest: "{{ item.dest }}"
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+    loop:
+      - { dest: "{{ tfvars_path }}", regexp: '^image_name = "', line: 'image_name = "{{ image_name }}"' }
+      - { dest: "{{ tfvars_path }}", regexp: '^internal_net = "', line: 'internal_net = "{{ internal_net }}"' }
+      - { dest: "{{ tfvars_path }}", regexp: '^internal_subnet = "', line: 'internal_subnet = "{{ internal_subnet }}"' }
+      - { dest: "{{ tfvars_path }}", regexp: '^external_net = "', line: 'external_net = "{{ external_net }}"' }
+      - { dest: "{{ tfvars_path }}", regexp: '^stack_name = "', line: 'stack_name = "{{stack_name}}"' }
+      - { dest: "{{ tfvars_path }}", regexp: '^subnet_cidr = "', line: 'subnet_cidr = "{{ subnet_cidr }}"' }
+      - { dest: "{{ tfvars_path }}", regexp: '^master_size = "', line: 'master_size = "{{ master_size }}"' }
+      - { dest: "{{ tfvars_path }}", regexp: '^worker_size = "', line: 'worker_size = "{{ worker_size }}"' }
+
+  - name: Management Machine | Update terraform.tfvars authorized_keys
+    replace:
+      path: "{{ tfvars_path }}"
+      regexp: '^authorized_keys = \[\n.*\n]$'
+      replace: 'authorized_keys = [\n  "{{ publickey.stdout }}"\n]'
+
+  - name: Management Machine | Update terraform.tfvars repositories
+    replace:
+      path: "{{ tfvars_path }}"
+      regexp: '^repositories = {}$'
+      replace: 'repositories = {  {{ repositories }} }'
+
+  - name: Management Machine | Update terraform.tfvars number of master nodes
+    replace:
+      path: "{{ tfvars_path }}"
+      regexp: '^masters = .*$'
+      replace: 'masters = {{ num_masters | int }}'
+
+  - name: Management Machine | Update terraform.tfvars number of worker nodes
+    replace:
+      path: "{{ tfvars_path }}"
+      regexp: '^workers = .*$'
+      replace: 'workers = {{ num_workers | int }}'
+
+  - name: Management Machine | Update cpi.auto.tfvars to enable cloud provider integration with Openstack
+    replace:
+      path: "{{ cpiautotfvars_path }}"
+      regexp: '^#cpi_enable = true$'
+      replace: 'cpi_enable = true'
+
+  - name: Management Machine | Update cpi.auto.tfvars to set up the ca_file
+    replace:
+      path: "{{ cpiautotfvars_path }}"
+      regexp: '^#ca_file = "/etc/pki/trust/anchors/.*"$'
+      replace: 'ca_file = "/etc/pki/trust/anchors/ca-bundle.pem"'
+
+  #Update network.tf to set up dns servers so the cloud-init on the caasp nodes does not fail
+  - name: Management Machine | Update network.tf to set up dns servers
+    lineinfile:
+      path: "{{ network_tf_path }}"
+      insertafter: 'resource "openstack_networking_subnet_v2" "subnet" {'
+      line: '  dns_nameservers = [ "{{dns_server_ip1}}", "{{dns_server_ip2}}"]'
+
+  #Update load-balancer.tf to use haproxy provider in SOC 8
+  #For SOC 9, we use octavia provider by default
+  #For SOC 8, we use haproxy provider since the octavia provider in SOC 8 has slowness that cause terraform to fail
+  - name: Management Machine | Update load-balancer.tf to setup haproxy provider
+    lineinfile:
+      path: "{{ lb_tf_path }}"
+      insertafter: 'resource "openstack_lb_loadbalancer_v2" "lb" {'
+      line: '  loadbalancer_provider = "haproxy"'
+    when: hostvars[cloud_env]['ansible_distribution_release'] == '3'
+
+  - name: Management Machine | Run terraform init
+    shell: |
+      set -e
+      cd {{ caasp_openstack_path }}
+      terraform init | tee -a terraform_init.log
+    register:
+      terraform_init_results
+    failed_when: "not ('Terraform has been successfully initialized!' in terraform_init_results.stdout)"
+
+  - name: Management Machine |  Run terraform plan
+    shell: |
+      set -e
+      eval `ssh-agent -s`
+      ssh-add
+      cd {{ caasp_openstack_path }}
+      source {{ caasp_openstack_path }}/{{ service_caasp_osrc }}
+      terraform plan -out caaspdeployplan | tee -a terraform_plan.log
+    register:
+      terraform_plan_results
+    failed_when: "not ('run the following command to apply' in terraform_plan_results.stdout)"
+
+  - name: Management Machine | Run terraform apply
+    shell: |
+      set -e
+      eval `ssh-agent -s`
+      ssh-add
+      cd {{ caasp_openstack_path }}
+      source {{ caasp_openstack_path }}/{{ service_caasp_osrc }}
+      terraform apply "caaspdeployplan" | tee -a terraform_apply.log
+    register:
+      terraform_apply_results
+    failed_when: "not ('Apply complete!' in terraform_apply_results.stdout)"
+
+  - name: Management Machine |  Parse skuba init command
+    set_fact:
+      skuba_init_command: "{{ item | regex_replace('(^.*CMD ]  )', '') }}"
+    when: item|trim is regex("skuba cluster init .*$")
+    loop: "{{ terraform_apply_results.stdout_lines }}"
+
+  - name: Management Machine |  Parse skuba mv command
+    set_fact:
+      skuba_mv_openstack_conf_command: "{{ item | regex_replace('(^.*CMD ]  )', '') }}"
+    when: item|trim is regex("mv openstack.conf .*$")
+    loop: "{{ terraform_apply_results.stdout_lines }}"
+
+  - name: Management Machine |  Parse skuba bootstrap command
+    set_fact:
+      skuba_boostrap_commands: "{{ skuba_bootstrap_commands | default([])}} +  {{ [item | regex_replace('(^.*CMD ]  )', '')] }} "
+    when: item|trim is regex("skuba node bootstrap .*$")
+    loop: "{{ terraform_apply_results.stdout_lines }}"
+
+  - name: Management Machine |  Parse skuba join commands
+    set_fact:
+      skuba_join_commands: "{{ skuba_join_commands | default([])}} +  {{ [item | regex_replace('(^.*CMD ]  )', '')] }}"
+    when: item|trim is regex("skuba node join .*$")
+    loop: "{{ terraform_apply_results.stdout_lines }}"
+
+  - name: Managmenent Machine | Run terraform ouput in json format to capture node info
+    shell: |
+      set -e
+      cd {{ caasp_openstack_path }}
+      terraform output --json
+    register:
+      terraform_output_results
+
+  - name: Management Machine | Set master ips and worker ips
+    set_fact:
+      master_ips: "{{ terraform_output_results.stdout | from_json | json_query('ip_masters')}}"
+      worker_ips: "{{ terraform_output_results.stdout | from_json | json_query('ip_workers')}}"
+
+  - name: Management Machine | Copy certificates to each of the master nodes in the cluster
+    shell: |
+      set -e
+      scp -o StrictHostKeyChecking=no {{ ca_path }} sles@{{item}}:~/ca-bundle.pem
+      ssh -o StrictHostKeyChecking=no sles@{{item}} sudo cp ~/ca-bundle.pem {{ ca_path }}
+      ssh -o StrictHostKeyChecking=no sles@{{item}} sudo update-ca-certificates
+    loop: "{{ master_ips.value.values() | list }}"
+
+  - name: Management Machine | Copy certificates to each of the worker nodes in the cluster
+    shell: |
+      set -e
+      scp -o StrictHostKeyChecking=no {{ ca_path }} sles@{{item}}:~/ca-bundle.pem
+      ssh -o StrictHostKeyChecking=no sles@{{item}}  sudo cp ~/ca-bundle.pem {{ ca_path }}
+      ssh -o StrictHostKeyChecking=no sles@{{item}} sudo update-ca-certificates
+    loop: "{{ worker_ips.value.values() | list }}"
+
+  - name: Management Machine | Run skuba init
+    shell: |
+      set -e
+      cd {{ caasp_openstack_path }}
+      {{ skuba_init_command }} | tee -a skuba_init.log
+    register:
+      skuba_init_command_results
+    failed_when: " not ('[init] configuration files written to' in skuba_init_command_results.stdout)"
+
+  - name: Management Machine | Move openstack.conf
+    shell: |
+      set -e
+      cd {{ caasp_openstack_path }}
+      {{ skuba_mv_openstack_conf_command }}
+    register:
+      skuba_mv_openstack_conf_command_results
+
+  - name: Management Machine | Run skuba bootstrap
+    shell: |
+      set -e
+      eval `ssh-agent -s`
+      ssh-add
+      cd {{ caasp_openstack_path }}/{{ stack_name }}-cluster
+      {{ item }} | tee -a skuba_bootstrap.log
+    loop: "{{ skuba_boostrap_commands }}"
+    register:
+      skuba_bootstrap_commands_results
+    failed_when: " not ('[bootstrap] successfully bootstrapped core add-ons' in skuba_bootstrap_commands_results.stdout)"
+
+  - name: Set expected total nodes in the cluster
+    set_fact:
+      total: "{{ num_masters | int + num_workers | int }}"
+
+  - name: Set expected total nodes joining the cluster after bootstrap
+    set_fact:
+      total_join: "{{ num_masters | int + num_workers | int - 1 }}"
+
+  - name: Management Machine | Run skuba join
+    shell: |
+      set -e
+      eval `ssh-agent -s`
+      ssh-add
+      cd {{ caasp_openstack_path }}/{{ stack_name }}-cluster
+      {{ item }} | tee -a skuba_join.log
+    loop: "{{ skuba_join_commands }}"
+    register:
+      skuba_join_commands_results
+
+  - name: Management Machine | track the count of the nodes that join the cluster successfully
+    set_fact:
+      count: "{{ count | default(0) | int + 1 }}"
+    when: "'node successfully joined the cluster' in item"
+    loop: "{{ skuba_join_commands_results.results|map(attribute='stdout')|list }}"
+
+  - name: Management Machine | Fail when the expected number of nodes do not join the cluster
+    fail:
+      msg: "Not all expected nodes have successfully joined the cluster"
+    when: "count | int != total_join | int"
+
+  - name: Management Machine | Run skuba cluster status to validate all the nodes are in the cluster in Ready state
+    shell: |
+      set -e
+      cd {{ caasp_openstack_path }}/{{ stack_name }}-cluster
+      skuba cluster status
+    register:
+      skuba_cluster_status_results
+    failed_when: "skuba_cluster_status_results.stdout.count(' Ready') != total | int"
+    until: skuba_cluster_status_results is success
+    retries: 30
+    delay: 10
+
+  - name: Management Machine | Copy admin.conf
+    shell: |
+      set -e
+      mkdir -p ~/.kube
+      cp {{ caasp_openstack_path }}/{{ stack_name }}-cluster/admin.conf ~/.kube/config
+    register:
+      kube_config_copy_results
+
+  - name: Management Machine | run terraform destroy
+    shell: |
+      set -e
+      cd {{ caasp_openstack_path }}
+      source {{ caasp_openstack_path }}/{{ service_caasp_osrc }}
+      terraform destroy
+    register:
+      terraform_destroy_results
+    when: terraform_destroy | bool

--- a/scripts/jenkins/cloud/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/vcloud.yml
@@ -21,7 +21,7 @@ os_cloud: "engcloud"
 os_project_name: "cloud"
 
 want_caasp: False
-virt_config_file_name: "{{ 'caasp.yml' if want_caasp else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
+virt_config_file_name: "{{ 'caasp.yml' if ( want_caasp or want_caaspv4 ) else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
 virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 
 # Use the root LVM partition only for Ardana deployments

--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/vars/caasp.yml
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/vars/caasp.yml
@@ -17,4 +17,4 @@
 # compute node.
 ---
 
-compute_flavor: "{{ vcloud_flavor_name_prefix }}-controller"
+compute_flavor: "{{ vcloud_flavor_name_prefix }}-controller-large"


### PR DESCRIPTION
This playbook provides an automated deployment mechanism
to deploy caasp v4 using terraform on SOC openstack deployment.

This playbook currently runs against the ardana flavored version of
SOC.

You can provide various optional parameters to the playbook:
Some examples:
num_workers to define the number of workers in the cluster.
	- Default value is 1.
num_masters to define the number of masters in the cluster.
	- Default value is 1.

It uses octavia provider for SOC 9 and haproxy provider for SOC 8
deployments.