### PR TITLE
Update tempest tests covered in the staging and MU gating jobs 

### DIFF
--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -133,7 +133,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,manila,lbaas-octavia,octavia"
+            designate,heat,magnum,manila,lbaas,octavia"
     jobs:
         - '{crowbar_job}'
 
@@ -170,7 +170,7 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,manila,lbaas-octavia,octavia"
+            designate,heat,magnum,manila,lbaas,octavia"
     jobs:
         - '{crowbar_job}'
 
@@ -209,6 +209,6 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,manila,lbaas-octavia,octavia"
+            designate,heat,magnum,manila,lbaas,octavia"
     jobs:
         - '{crowbar_job}'

--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -116,9 +116,9 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-gate-no-ha-deploy-x86_64:
           cloudsource: stagingcloud8
@@ -153,9 +153,9 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-gate-ha-deploy-x86_64:
           cloudsource: stagingcloud8
@@ -192,9 +192,9 @@
           cloudsource: stagingcloud7
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64:
           cloudsource: stagingcloud8

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -92,14 +92,14 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas-octavia"
+            heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-no-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas-octavia"
+            heat,magnum,manila,lbaas"
     jobs:
       - '{crowbar_job}'
 
@@ -150,14 +150,14 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas-octavia"
+            heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas-octavia"
+            heat,magnum,manila,lbaas"
     jobs:
       - '{crowbar_job}'
 
@@ -210,13 +210,13 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas-octavia"
+            heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas-octavia"
+            heat,magnum,manila,lbaas"
     jobs:
       - '{crowbar_job}'

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -60,17 +60,17 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar7-job-mu-no-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM8+up
@@ -118,17 +118,17 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar7-job-mu-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-mu-ha-deploy-x86_64:
           cloudsource: GM8+up
@@ -178,17 +178,17 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar7-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, cinder and magnum not fully passing yet
+          # magnum not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,fwaas,\
+            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,manila,lbaas"
       - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM8+up

--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -33,14 +33,14 @@
           reboot_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,manila,magnum,monasca,lbaas"
+            designate,heat,manila,magnum,monasca,lbaas,octavia"
       - cloud-ardana9-job-mu-entry-scale-kvm-update-x86_64:
           cloudsource: GM9+up
           update_after_deploy: true
           reboot_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            designate,heat,magnum,monasca,lbaas"
+            designate,heat,magnum,monasca,lbaas,octavia"
     jobs:
       - '{ardana_job}'
 
@@ -78,28 +78,28 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+            fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-no-ha-update-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+            fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            designate,heat,magnum,manila,lbaas,octavia"
       - cloud-crowbar9-job-mu-no-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            designate,heat,magnum,manila,lbaas,octavia"
     jobs:
       - '{crowbar_job}'
 
@@ -136,28 +136,28 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+            fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-ha-update-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+            fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-ha-deploy-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            designate,heat,magnum,manila,lbaas,octavia"
       - cloud-crowbar9-job-mu-ha-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            designate,heat,magnum,manila,lbaas,octavia"
     jobs:
       - '{crowbar_job}'
 
@@ -196,27 +196,27 @@
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+            fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
-            fwaas,trove,aodh,heat,magnum,manila,lbaas"
+            fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar9-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            designate,heat,magnum,manila,lbaas,octavia"
       - cloud-crowbar9-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM9+up
           ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,\
-            heat,magnum,manila,lbaas"
+            designate,heat,magnum,manila,lbaas,octavia"
     jobs:
       - '{crowbar_job}'

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -51,7 +51,7 @@
           default-value: ''
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,octavia,designate
+            trove,aodh,heat,magnum,manila,lbaas,octavia,designate
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -301,7 +301,7 @@
           default-value: '{tempest_filter_list|smoke}'
           value: >-
             smoke,keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,fwaas,
-            trove,aodh,heat,magnum,manila,lbaas,lbaas-octavia,octavia,designate
+            trove,aodh,heat,magnum,manila,lbaas,octavia,designate
           description: >-
             Name of the filter file to use for tempest. Selecting multiple values
             will run tempest for each selected value.


### PR DESCRIPTION
This PR updates the full tempest coverage in the staging and MU gating jobs:
 - adds cinder and nova tempest test runs to the SOC7 gate jobs for
the staging media and maintenance update testing (SOC-9801).
 - replaces the `lbaas-octavia` test run filter with the `lbaas` test filter (with [the
ability to generate test runs dynamically](https://github.com/crowbar/crowbar-openstack/pull/2343) from the chef tempest
recipes, `lbaas-octavia` is deprecated)
 - adds Octavia and Designate tempest test runs to the MU gating jobs for SOC8 and SOC9