### PR TITLE
Use individual Jenkins jobs for ci and ci2 ECP worker nodes

### DIFF
--- a/jenkins/ci.suse.de/cloud-jenkins-worker.yaml
+++ b/jenkins/ci.suse.de/cloud-jenkins-worker.yaml
@@ -5,7 +5,10 @@
       - ci-trigger:
           jenkins_worker_labels: 'cloud-ci-worker cloud-ci-trigger'
           jenkins_workers_executors: '50'
-      - ci,ci2:
+      - ci:
+          jenkins_worker_labels: 'cloud-ci-worker cloud-ci'
+          jenkins_workers_executors: '50'
+      - ci2:
           jenkins_worker_labels: 'cloud-ci-worker cloud-ci'
           jenkins_workers_executors: '50'
     jobs:


### PR DESCRIPTION
Define individual jobs to make it simpler to trigger the rebuild
of individual ECP worker nodes in the ECP Jenkins view.
