### PR TITLE
Use the octavia network.json network for Octavia (SOC-10904)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/octavia.yml.j2
@@ -11,13 +11,4 @@
         server_ca_key_path: private/ca.key.pem
         client_ca_cert_path: ca.cert.pem
         client_cert_and_key_path: private/client.cert-and-key.pem
-{% set ns = namespace(net_id=30, vlan_id=gen_subnet_start+scenario.network_groups|length) %}
-{% for network_group in scenario.network_groups if 'NEUTRON-VLAN' in network_group.component_endpoints %}
-      amphora:
-        #manage_vlan: {{ ns.vlan_id }}
-        manage_cidr: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.0/24
-        #manage_allocation_pools: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.10,{{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.250
-        #gateway: {{ neutron_subnet_prefix.ipv4 }}.{{ ns.net_id }}.1.1
-{% endfor %}
-
 {% include 'barclamps/lib/deployment.yml.j2' %}

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -131,6 +131,7 @@ export want_designate_proposal=1
 
 {% if 'octavia' in deployments %}
 export want_octavia_proposal=1
+export want_octavia_network={{ want_octavia_network|default(1) }}
 {% endif %}
 
 # export ironicnetmask=

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/mkcloud.config.j2
@@ -162,7 +162,7 @@ export net_ceph={{ subnet_prefix }}{{ ipsep }}{{ gen_subnet_start+5 }}
 export vlan_public={{ gen_subnet_start+1 }}
 export vlan_sdn={{ gen_subnet_start+2 }}
 export vlan_storage={{ gen_subnet_start+3 }}
-export vlan_fixed={{ gen_subnet_start+4 }}
+export vlan_fixed={{ gen_subnet_start+6 }}
 export vlan_ceph={{ gen_subnet_start+5 }}
 
 {% if 'octavia' in deployments %}

--- a/scripts/lib/mkcloud-common.sh
+++ b/scripts/lib/mkcloud-common.sh
@@ -397,9 +397,9 @@ function setcloudnetvars
     vlan_storage=${vlan_storage:-200}
     vlan_ceph=${vlan_ceph:-600}
     vlan_public=${vlan_public:-300}
-    vlan_fixed=${vlan_fixed:-500}
+    vlan_fixed=${vlan_fixed:-700}
     vlan_sdn=${vlan_sdn:-400}
-    vlan_octavia=${vlan_octavia:-700}
+    vlan_octavia=${vlan_octavia:-500}
     if (( ${want_ipv6} > 0 )); then
         net_fixed=${net_fixed:-'fd00:0:0:2'}
         net_public=${net_public:-'fd00:0:0:1'}

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -1099,10 +1099,12 @@ EOF
     sed -i.netbak1 -e 's/192\.168\.126/192.168.122/g' $netfile
 
     if (( $want_ipv6 > 0 )); then
-        sed -i.netbak -e 's/"conduit": "bmc",$/& "router": "fd00:0:0:3::1",/' \
+        sed -i.netbak \
+            -e 's/"conduit": "bmc",$/& "router": "fd00:0:0:3::1",/' \
             -e "s/fd00:0:0:3:/$net${ip_sep}/g" \
             -e "s/fd00:0:0:7:/$net_sdn${ip_sep}/g" \
             -e "s/fd00:0:0:4:/$net_storage${ip_sep}/g" \
+            -e "s/fd00:0:0:8:/$net_octavia${ip_sep}/g" \
             -e "s/fd00:0:0:5:/$net_ceph${ip_sep}/g" \
             -e "s/fd00:0:0:2:/$net_fixed${ip_sep}/g" \
             -e "s/fd00:0:0:1:/$net_public${ip_sep}/g" \
@@ -1110,10 +1112,12 @@ EOF
             -e "s/fd00:0:0:3:5054:ff:fe77:7771/$admin_end_range/g" \
             $netfile
     else
-        sed -i.netbak -e 's/"conduit": "bmc",$/& "router": "192.168.124.1",/' \
+        sed -i.netbak \
+            -e 's/"conduit": "bmc",$/& "router": "192.168.124.1",/' \
             -e "s/192.168.124./$net${ip_sep}/g" \
             -e "s/192.168.130./$net_sdn${ip_sep}/g" \
             -e "s/192.168.125./$net_storage${ip_sep}/g" \
+            -e "s/192.168.131./$net_octavia${ip_sep}/g" \
             -e "s/192.168.127./$net_ceph${ip_sep}/g" \
             -e "s/192.168.123./$net_fixed${ip_sep}/g" \
             -e "s/192.168.122./$net_public${ip_sep}/g" \
@@ -1121,6 +1125,7 @@ EOF
     fi
     sed -i.netbak.vlan \
         -e "s/ 200/ $vlan_storage/g" \
+        -e "s/ 500/ $vlan_octavia/g" \
         -e "s/ 600/ $vlan_ceph/g" \
         -e "s/ 300/ $vlan_public/g" \
         -e "s/ 500/ $vlan_fixed/g" \
@@ -1208,7 +1213,7 @@ networks['ironic']=ironic_network
 print json.dumps(networks, indent=4)
 EOPYTHON
         `
-    /opt/dell/bin/json-edit -a attributes.network.networks -r -v "$networks_complete" $netfile
+        /opt/dell/bin/json-edit -a attributes.network.networks -r -v "$networks_complete" $netfile
     fi
 
     if [[ $cloud =~ ^p[0-9]$ ]] ; then
@@ -2806,6 +2811,7 @@ function custom_configuration
             proposal_set_value octavia default "['attributes']['octavia']['certs']['server_ca_key_path']" "'private/ca.key.pem'"
             proposal_set_value octavia default "['attributes']['octavia']['certs']['client_ca_cert_path']" "'ca.cert.pem'"
             proposal_set_value octavia default "['attributes']['octavia']['certs']['client_cert_and_key_path']" "'private/client.cert-and-key.pem'"
+            proposal_set_value octavia default "['attributes']['octavia']['amphora']['manage_cidr']" "'$net_octavia.0/24'"
             if [[ $hacloud = 1 ]] && iscloudver 9plus ; then
                 proposal_set_value octavia default "['deployment']['octavia']['elements']['octavia-api']" "['cluster:$clusternameservices']"
                 proposal_set_value octavia default "['deployment']['octavia']['elements']['octavia-backend']" "['cluster:$clusternameservices']"
@@ -4155,6 +4161,8 @@ function nova_services_up
 
 function oncontroller_octavia_network_setup
 {
+    return
+
     local octavia_network_name="lb-mgmt-net"
     local octavia_subnet_name=$octavia_network_name
     setcloudnetvars $cloud

--- a/scripts/qa_crowbarsetup.sh
+++ b/scripts/qa_crowbarsetup.sh
@@ -2844,7 +2844,6 @@ function custom_configuration
             proposal_set_value octavia default "['attributes']['octavia']['certs']['server_ca_key_path']" "'private/ca.key.pem'"
             proposal_set_value octavia default "['attributes']['octavia']['certs']['client_ca_cert_path']" "'ca.cert.pem'"
             proposal_set_value octavia default "['attributes']['octavia']['certs']['client_cert_and_key_path']" "'private/client.cert-and-key.pem'"
-            proposal_set_value octavia default "['attributes']['octavia']['amphora']['manage_cidr']" "'$net_octavia.0/24'"
             if [[ $hacloud = 1 ]] && iscloudver 9plus ; then
                 proposal_set_value octavia default "['deployment']['octavia']['elements']['octavia-api']" "['cluster:$clusternameservices']"
                 proposal_set_value octavia default "['deployment']['octavia']['elements']['octavia-backend']" "['cluster:$clusternameservices']"


### PR DESCRIPTION
(based on #3827 )

Updates the automation scripts for Octavia, to add support
for configuring a network.json octavia network instead of the
previous way of configuring the Octavia management network
as an externally managed provider network.
 * to aid with debugging, intermediate network.json steps are backed
up so that it's easier to debug the myriad of `sed` commands that
modify `network.json` before bootstrapping crowbar
 * the Neutron barclamp calculates the `vlan_min` value for the ml2
plugin based on the fixed network VLAN ID. In order to avoid VLAN ID
collisions this change moves the fixed network VLAN ID to be above
that used for `octavia` and other VLAN networks
 * adds a `want_octavia_network` option that can be used to switch
between using the octavia network in network.json (default) and
the previous approach of relying on an externally configured provider
network
 * remove the `manage_cidr` attribute from the generated octavia
baclamp. This attribute has been removed and the Octavia recipes
rely entirely on the information extracted from network.json to configure the
management network