### PR TITLE
Fix CI runs for virtual cloud setup

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/vcloud.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/vcloud.yml
@@ -21,6 +21,7 @@ os_cloud: "engcloud"
 os_project_name: "cloud"
 
 want_caasp: False
+want_caaspv4: False
 virt_config_file_name: "{{ 'caasp.yml' if ( want_caasp or want_caaspv4 ) else workspace_path ~ '/' ~ scenario_name ~ '-virt-config.yml' if scenario_name is defined else '' }}"
 virt_config_file: "{{ virt_config_name | default(virt_config_file_name) }}"
 


### PR DESCRIPTION
A recent change https://github.com/SUSE-Cloud/automation/pull/3851
introduced a new parameter called want_caaspv4.
This was not defined for virtual cloud env setup causing CI to fail.
This commit fixes the issue.