### PR TITLE
Re-work dynamically generated mid-scale Cloud9 fix (SOC-11169)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/full-spread.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/interface/full-spread.yml
@@ -25,6 +25,8 @@ interface_models:
           - MANAGEMENT
         forced_network_groups:
           - EXTERNAL-API
+      - network_groups:
+          - CONF
 
   - name: CORE
     service_groups:
@@ -33,8 +35,9 @@ interface_models:
       - network_groups:
           - EXTERNAL-API
           - INTERNAL-API
-      - network_groups:
           - MANAGEMENT
+      - network_groups:
+          - CONF
 
   - name: NEUTRON
     service_groups:
@@ -42,10 +45,11 @@ interface_models:
     network_interfaces:
       - network_groups:
           - GUEST
+          - MANAGEMENT
           - EXTERNAL-VM
           - TENANT-VLAN
       - network_groups:
-          - MANAGEMENT
+          - CONF
 
   - name: COMPUTE
     service_groups:
@@ -54,19 +58,21 @@ interface_models:
     network_interfaces:
       - network_groups:
           - GUEST
+          - MANAGEMENT
           - EXTERNAL-VM
           - TENANT-VLAN
       - network_groups:
-          - MANAGEMENT
+          - CONF
 
   - name: SWIFT
     service_groups:
       - swift
     network_interfaces:
       - network_groups:
+          - MANAGEMENT
           - SWIFT
       - network_groups:
-          - MANAGEMENT
+          - CONF
 
   - name: DBMQ
     service_groups:
@@ -74,6 +80,8 @@ interface_models:
     network_interfaces:
       - network_groups:
           - MANAGEMENT
+      - network_groups:
+          - CONF
 
   - name: LMM
     service_groups:
@@ -81,3 +89,5 @@ interface_models:
     network_interfaces:
       - network_groups:
           - MANAGEMENT
+      - network_groups:
+          - CONF

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/full-spread.yml
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/vars/templates/network/full-spread.yml
@@ -16,11 +16,16 @@
 ---
 
 network_groups:
-  - name: MANAGEMENT
-    hostname_suffix: mgmt
+  - name: CONF
+    hostname_suffix: conf
     tagged_vlan: false
     component_endpoints:
       - CLM
+
+  - name: MANAGEMENT
+    hostname_suffix: mgmt
+    tagged_vlan: true
+    component_endpoints:
       - MANAGEMENT
     routes:
       - INTERNAL-API


### PR DESCRIPTION
Revert the fix for PR#3850 in a86bd0966bbe74c56c17c003c209a0a8df235b37
and try switching the MANAGEMENT network to being tagged to match the
baremetal deployment setup.