### PR TITLE
Disable aarch64 SOC9 mkcloud jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-mkcloud9.yaml
+++ b/jenkins/ci.suse.de/cloud-mkcloud9.yaml
@@ -79,7 +79,7 @@
         - 'cloud-mkcloud{version}-job-uefi-{arch}'
 - project:
     name: cloud-mkcloud9-aarch64
-    disabled: false
+    disabled: true
     version: 9
     previous_version: 8
     arch: aarch64


### PR DESCRIPTION
As aarch64 no longer supported make sense to disable and later remove
corresponding jobs from CI as they not running and only creating queues.