### PR TITLE
Fix supportconfig collection in new CI

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/supportconfig/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/supportconfig/defaults/main.yml
@@ -20,4 +20,4 @@ supportconfig_pkgs:
   - supportutils-plugin-suse-openstack-cloud
 
 supportconfig_filename: "{{ cloud_env }}-{{ (inventory_hostname in groups['deployer_virt']) | ternary('admin', inventory_hostname) }}"
-supportconfig_filepath: "/var/log/nts_{{ supportconfig_filename }}.txz"
+supportconfig_filepath: "/var/log/scc_{{ supportconfig_filename }}.txz"


### PR DESCRIPTION
There was yet another change in the supportconfig generation utility
that broke backwards compatibility: the prefix of the generated
archive filename changed from `nts_` to `scc_`.