### PR TITLE
setup_root_partition: Increase root partition size

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_root_partition/defaults/main.yml
@@ -35,4 +35,4 @@ vm_fdisk_start_field: 2
 # the size (in GB) to which the LVM root partition is resized
 # this needs to be less than 95% of the total available size, otherwise
 # the Ardana osconfig play will fail
-min_deployer_root_part_size: 34
+min_deployer_root_part_size: 44


### PR DESCRIPTION
Ardana 8 maintenance update test jobs are failing during the install
of cloud-patterns because it does not have enough disk space
available.

This change increases the root partition size from 34 GB to 44 GB, the
flavors were already updated to reflect that change.