### PR TITLE
Caapv4: make k8s use octavia endpoint directly

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/deploy_caasp_terraform/tasks/deploy_caasp.yml
+++ b/scripts/jenkins/cloud/ansible/roles/deploy_caasp_terraform/tasks/deploy_caasp.yml
@@ -260,6 +260,13 @@
     skuba_init_command_results
   failed_when: " not ('[init] configuration files written to' in skuba_init_command_results.stdout)"
 
+- name: Management Machine | Update openstack.conf if using Octavia
+  lineinfile:
+    path: "{{ caasp_openstack_path }}/openstack.conf"
+    insertafter: '\[LoadBalancer\]'
+    line: 'use-octavia=true'
+  when: hostvars[cloud_env]['ansible_distribution_release'] == '4'
+
 - name: Management Machine | Move openstack.conf
   shell: |
     set -e


### PR DESCRIPTION
Creating a Service of type LoadBalancer fails with this message:
"http_method is not a valid option for health monitors of type TCP"

The neuutron lbaas proxy is adding this option which octavia rejects.
Avoid this by having k8s use the octavia endpoint directly instead of
via the neutron lbaas proxy.