### PR TITLE
devstack: fix the permission of all directories

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -221,7 +221,7 @@ min_compute_nodes = 1
 global_physnet_mtu = 1450
 EOF
 
-    chown stack:stack -R $DEVSTACK_DIR
+    chown stack:stack -R /opt/stack
 }
 
 


### PR DESCRIPTION
In 352d58a7afd9e2261e639af78e4fb4c99d8f9f81 of openstack/devstack.git
fixing of permissions on existing directories was dropped. The script
that is changed here relied on that. Adapt it to also take over fixing
the permission of the rest of the directories.