### PR TITLE
devstack: remove python3-pycparser

### DIFF
--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -103,6 +103,9 @@ function h_setup_devstack {
     if ! getent group nobody >/dev/null; then
         $zypper in 'group(nogroup)'
     fi
+    # pycparser got pulled in via recommends, but devstack later needs to be
+    # able to update it via pip.
+    $zypper -n remove python3-pycparser
 
     if ! modinfo openvswitch >/dev/null; then
         echo "openvswitch kernel module is not available; maybe you are" \


### PR DESCRIPTION
It gets pulled in via recommends but would later prevent devstack from
installing other things via pip.

Pip would give the following error:
  Attempting uninstall: pycparser
    Found existing installation: pycparser 2.17
ERROR: Cannot uninstall 'pycparser'. It is a distutils installed project
and thus we cannot accurately determine which files belong to it which
would lead to only a partial uninstall.