### PR TITLE
Fixes for the maintenance update gating jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -60,18 +60,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # magnum not fully passing yet
+          # nova, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
-            trove,aodh,heat,manila,lbaas"
+            keystone,swift,glance,neutron,ceilometer,\
+            trove,aodh,heat,lbaas"
       - cloud-crowbar7-job-mu-no-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # magnum not fully passing yet
+          # nova, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
-            trove,aodh,heat,manila,lbaas"
+            keystone,swift,glance,neutron,ceilometer,\
+            trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -118,18 +118,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # magnum not fully passing yet
+          # nova, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
-            trove,aodh,heat,manila,lbaas"
+            keystone,swift,glance,neutron,ceilometer,\
+            trove,aodh,heat,lbaas"
       - cloud-crowbar7-job-mu-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # magnum not fully passing yet
+          # nova, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
-            trove,aodh,heat,manila,lbaas"
+            keystone,swift,glance,neutron,ceilometer,\
+            trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -178,18 +178,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # magnum not fully passing yet
+          # nova, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
-            trove,aodh,heat,manila,lbaas"
+            keystone,swift,glance,neutron,ceilometer,\
+            trove,aodh,heat,lbaas"
       - cloud-crowbar7-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # magnum not fully passing yet
+          # nova, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
-            trove,aodh,heat,manila,lbaas"
+            keystone,swift,glance,neutron,ceilometer,\
+            trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false

--- a/scripts/jenkins/cloud/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/versioned.yml
@@ -50,6 +50,9 @@ versioned_features:
     enabled: "{{ when_cloud9 }}"
   neutron-ml2-port-security:
     enabled: "{{ when_cloud9 or when_cloud8}}"
+  magnum_ssl_enabled:
+    enabled: "{{ when_staging_or_devel and (when_cloud8 or when_cloud9) }}"
+
 
 input_model_versioned_features:
   - manila

--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/magnum.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/magnum.yml.j2
@@ -6,7 +6,7 @@
         domain_admin_name: magnum_domain_admin
       cert:
         cert_manager_type: {{ ('barbican' in deployments) | ternary('barbican', 'x509keypair') }}
-{% if not when_cloud7 %}
+{% if versioned_features.magnum_ssl_enabled.enabled %}
 {% include 'barclamps/lib/ssl.yml.j2' %}
 {% endif %}
 {% include 'barclamps/lib/deployment.yml.j2' %}


### PR DESCRIPTION
Pushing a couple of changes to get the maintenance update gating jobs to pass reliably until the required SOC fixes are released:
- don't enable SSL for magnum in GMx+up: the magnum SSL fixes haven't been released yet in SOC8 and SOC9, so the maintenance gating jobs end up consistently failing because
of this. Modeling this as a versioned feature, until those fixes are released
- remove nova,cinder,magnum,manila and fwaas tempest filters from SOC7: [the set of patches required to get full tempest to pass with SOC7](https://jira.suse.com/browse/SOC-9801?focusedCommentId=979248&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-979248) have not yet been released. Omitting the failing tempest filters from the list of filters unning in the maintenance update jobs, to get those jobs to pass consistently
