### PR TITLE
Sync maintenance gating with staging gating for SOC8

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -74,14 +74,14 @@
             trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM8+up
-          ses_enabled: false
+          ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
             fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-no-ha-update-x86_64:
           cloudsource: GM8+up
-          ses_enabled: false
+          ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
@@ -132,14 +132,14 @@
             trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-ha-deploy-x86_64:
           cloudsource: GM8+up
-          ses_enabled: false
+          ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
             fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-ha-update-x86_64:
           cloudsource: GM8+up
-          ses_enabled: false
+          ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
@@ -192,14 +192,14 @@
             trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM8+up
-          ses_enabled: false
+          ses_enabled: true
           update_after_deploy: false
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\
             fwaas,designate,trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM8+up
-          ses_enabled: false
+          ses_enabled: true
           update_after_deploy: true
           tempest_filter_list: "\
             keystone,swift,glance,cinder,neutron,nova,ceilometer,barbican,\

--- a/scripts/jenkins/cloud/ansible/group_vars/all/versioned.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/versioned.yml
@@ -51,7 +51,7 @@ versioned_features:
   neutron-ml2-port-security:
     enabled: "{{ when_cloud9 or when_cloud8}}"
   magnum_ssl_enabled:
-    enabled: "{{ when_staging_or_devel and (when_cloud8 or when_cloud9) }}"
+    enabled: "{{ when_cloud8 or (when_cloud9 and when_staging_or_devel) }}"
 
 
 input_model_versioned_features:


### PR DESCRIPTION
**NOTE**: do not merge before the next SOC8 maintenance update !

Sync the staging gating jobs with the maintenance update gating
jobs, so that they have the same test coverage.

This wasn't previously possible because not all bugs affecting
the staging gating jobs were released as maintenance updates.