### PR TITLE
Maintenance update gating: remove neutron tempest from SOC7

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -60,17 +60,17 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,\
+            keystone,swift,glance,ceilometer,\
             trove,aodh,heat,lbaas"
       - cloud-crowbar7-job-mu-no-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,\
+            keystone,swift,glance,ceilometer,\
             trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM8+up
@@ -118,17 +118,17 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,\
+            keystone,swift,glance,ceilometer,\
             trove,aodh,heat,lbaas"
       - cloud-crowbar7-job-mu-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,\
+            keystone,swift,glance,ceilometer,\
             trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-ha-deploy-x86_64:
           cloudsource: GM8+up
@@ -178,17 +178,17 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,\
+            keystone,swift,glance,ceilometer,\
             trove,aodh,heat,lbaas"
       - cloud-crowbar7-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
           tempest_filter_list: "\
-            keystone,swift,glance,neutron,ceilometer,\
+            keystone,swift,glance,ceilometer,\
             trove,aodh,heat,lbaas"
       - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM8+up


### PR DESCRIPTION
This is a continuation of the previous change removing some tempest
filters from the SOC7 maintenance update gating jobs, because not
all SOC changes fixing them have been released yet (neutron was
overlooked).