### PR TITLE
Ensure cloud_release_number has sane value (SOC-11252)

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -30,7 +30,7 @@ cloud_admin_user:
   crowbar: root
 
 # The cloud release is encoded in the cloudsource value
-cloud_release_number: "{{ cloudsource | regex_search('\\d') }}"
+cloud_release_number: "{{ cloudsource | regex_search('\\d') | default(sles_cloud_version[ansible_distribution_version], true) }}"
 cloud_release: "cloud{{ cloud_release_number }}"
 cloud_git_branch:
   cloud8: "stable/pike"


### PR DESCRIPTION
When SOC/CLM MUs are being tested the ardana-update.yml playbook can
be invoked with an empty value for cloudsource, which breaks recent
changes landed in PR#3726 which use the derived cloud_release value.

This patch ensures that even if cloudsource is empty in such cases
that a valid cloud_release_number is identified from the runtime
env of the job.