### PR TITLE
Handle ansible_distribution_version not being defined (SOC-11252)

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -30,7 +30,9 @@ cloud_admin_user:
   crowbar: root
 
 # The cloud release is encoded in the cloudsource value
-cloud_release_number: "{{ cloudsource | regex_search('\\d') | default(sles_cloud_version[ansible_distribution_version], true) }}"
+cloud_release_number: "{{ cloudsource | regex_search('\\d') |
+                          default(sles_cloud_version[ansible_distribution_version |
+                                                     default('UNKNOWN')], true) }}"
 cloud_release: "cloud{{ cloud_release_number }}"
 cloud_git_branch:
   cloud8: "stable/pike"


### PR DESCRIPTION
The recent fix for PR#3879 to ensure we select and appropriate cloud
release number when cloudsource is not defined, combined with PR#3880
to handle the renaming of ILO network and BMC network being fixed has
uncovered a follow issue with regard to cloud_release_number handling.

In the case where gathering of facts for an ansible node is disabled,
as is the case with the start-deployer-vm.yml top level playbook, the
use of ansible_distribution_version as a fallback within the PR#3879
fix leads to an error.

This patch addresses this issue in two ways:
1)  Use a default of 'UNKNOWN' for ansible_distribution_version if
    it isn't defined so that it will be easier for any future errors
    related to this issue being diagnosed.
2)  Enable gathering of facts for the start-deployer-vm.yml playbook
    as it isn't going to pose that significant of a performance hit
    and this playbook is likely the only one that runs against the
    gateway nodes in question, so gathering these facts is useful,
    as well as avoids issues where playbooks (justifiably) expect
    such fundamental ansible facts to be defined.