### PR TITLE
Ensure ardana-update.yml called with valid cloudsource (SOC-11252)

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -248,7 +248,12 @@ pipeline {
           // packages. Can be removed when jenkins feature (JENKINS-48315) is merged.
           env.stage_after_update = "true"
 
-          cloud_lib.ansible_playbook('ardana-update', "-e cloudsource=$update_to_cloudsource")
+          if (update_to_cloudsource == '') {
+            cloud_lib.ansible_playbook('ardana-update')
+          } else {
+            cloud_lib.ansible_playbook('ardana-update', "-e cloudsource=$update_to_cloudsource")
+          }
+
           // list-or-diff-installed-packages does not physical deployments
           if (cloud_type == 'virtual') {
             cloud_lib.ansible_playbook('list-or-diff-installed-packages', "-e wanted_action=diff")

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -313,15 +313,22 @@ function deploy_ardana_but_dont_run_site_yml {
 function update_cloud {
     if $(get_from_input deploy_cloud) && $(get_from_input update_after_deploy); then
         if [ "$(get_cloud_product)" == "crowbar" ]; then
-            ansible_playbook crowbar-update.yml -e cloudsource=$(get_from_input update_to_cloudsource)
-        elif $(get_from_input deploy_cloud); then
-            ansible_playbook ardana-update.yml -e cloudsource=$(get_from_input update_to_cloudsource)
+            ansible_playbook crowbar-update.yml
+        else
+            local update_to_cloudsource maint_updates
+
+            update_to_cloudsource="$(get_from_input update_to_cloudsource)"
+            maint_updates="$(get_from_input maint_updates)"
+
+            if [[ -n "${update_to_cloudsource}" ]] || [[ -n "${maint_updates}" ]]; then
+                ansible_playbook ardana-update.yml ${update_to_cloudsource:+-e cloudsource="${update_to_cloudsource}"}
+            fi
         fi
     fi
 }
 
 function upgrade_cloud {
-    if $(get_from_input deploy_cloud) && [[ -n $(get_from_input upgrade_cloudsource) ]]; then
+    if $(get_from_input deploy_cloud) && $(get_from_input update_after_deploy) && [[ -n $(get_from_input upgrade_cloudsource) ]]; then
         if [ "$(get_cloud_product)" == "crowbar" ]; then
             ansible_playbook crowbar-upgrade.yml
         fi


### PR DESCRIPTION
Pass appropriate values for cloudsource when the ardana-update.yml
playbook is invoked, allowing for the case when running MU tests
where update_to_cloudsource is not specified.

Align the logic used to control when the Ardana or Crowbar update and
upgrade playbooks are called in the manual/lib.sh with that used by
the Jenkins pipelines. Namely that update/upgrade should only happen
if update_after_deploy is set.