### PR TITLE
Remove python-networking-cisco from trackupstream jobs (SOC-11267)

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -107,7 +107,8 @@
             "python-monasca-common",
             "python-monasca-statsd",
             "python-vmware-nsxlib",
-            "python-vmware-nsx"
+            "python-vmware-nsx",
+            "python-networking-cisco"
             ].contains(component) ||
             [ "Cloud:OpenStack:Stein:Staging", "Cloud:OpenStack:Rocky:Staging", "Cloud:OpenStack:Queens:Staging", "Cloud:OpenStack:Pike:Staging" ].contains(project) &&
             [
@@ -122,6 +123,7 @@
             [
               "openstack-trove",
               "openstack-horizon-plugin-trove-ui",
+              "python-networking-cisco"
             ].contains(component) ||
             [ "Cloud:OpenStack:Master" ].contains(project) &&
             [


### PR DESCRIPTION
The job hasn't been succeeding since Pike. Doesn't appear our product
needs it either so disabling it from trackupstream jobs.