### PR TITLE
Maintenance update gating: remove lbaas tempest from SOC7

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance.yaml
@@ -60,18 +60,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum, fwaas and lbaas not fully passing yet
           tempest_filter_list: "\
             keystone,swift,glance,ceilometer,\
-            trove,aodh,heat,lbaas"
+            trove,aodh,heat"
       - cloud-crowbar7-job-mu-no-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum, fwaas and lbaas not fully passing yet
           tempest_filter_list: "\
             keystone,swift,glance,ceilometer,\
-            trove,aodh,heat,lbaas"
+            trove,aodh,heat"
       - cloud-crowbar8-job-mu-no-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -118,18 +118,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum, fwaas and lbaas not fully passing yet
           tempest_filter_list: "\
             keystone,swift,glance,ceilometer,\
-            trove,aodh,heat,lbaas"
+            trove,aodh,heat"
       - cloud-crowbar7-job-mu-ha-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum, fwaas and lbaas not fully passing yet
           tempest_filter_list: "\
             keystone,swift,glance,ceilometer,\
-            trove,aodh,heat,lbaas"
+            trove,aodh,heat"
       - cloud-crowbar8-job-mu-ha-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false
@@ -178,18 +178,18 @@
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: false
-          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum, fwaas and lbaas not fully passing yet
           tempest_filter_list: "\
             keystone,swift,glance,ceilometer,\
-            trove,aodh,heat,lbaas"
+            trove,aodh,heat"
       - cloud-crowbar7-job-mu-linuxbridge-update-x86_64:
           cloudsource: GM7+up
           ses_enabled: false
           update_after_deploy: true
-          # nova, neutron, cinder, manila, magnum and fwaas not fully passing yet
+          # nova, neutron, cinder, manila, magnum, fwaas and lbaas not fully passing yet
           tempest_filter_list: "\
             keystone,swift,glance,ceilometer,\
-            trove,aodh,heat,lbaas"
+            trove,aodh,heat"
       - cloud-crowbar8-job-mu-linuxbridge-deploy-x86_64:
           cloudsource: GM8+up
           ses_enabled: false


### PR DESCRIPTION
This is a continuation of the previous change removing some tempest
filters from the SOC7 maintenance update gating jobs, because not
all SOC changes fixing them have been released yet (lbaas was
overlooked - see SOC-11173).