### PR TITLE
Enable vbmc installation for SP5 hosts

### DIFF
--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -848,7 +848,7 @@ function install_vbmc
     vbmc --version 2> /dev/null && return 0
 
     # some simple checks before we try to add SP4-Cloud9 repo
-    grep -q 12-SP4 /etc/os-release || return 1
+    grep -q 12-SP[45] /etc/os-release || return 1
 
     # virtualbmc package is available in cloud9 repo
     $sudo zypper addrepo --priority 500 --refresh \


### PR DESCRIPTION
VirtualBMC is needed for functional testing of Ironic.

Some hosts in the CI are already running SLES12-SP5. While
python-virtualbmc package is available only in
SUSE:SLE-12-SP4:Update:Products:Cloud9 it installs fine on SP5.