### PR TITLE
Tweak integrated deployer/controller VM for physical deploys (SOC-9780)

### DIFF
--- a/scripts/jenkins/cloud/ansible/bootstrap-clm.yml
+++ b/scripts/jenkins/cloud/ansible/bootstrap-clm.yml
@@ -17,6 +17,8 @@
 
 - import_playbook: setup-ssh-access.yml
 
+- import_playbook: integrated-deployer-tweaks.yml
+
 - name: Bootstrap Cloud Lifecycle Manager
   hosts: "{{ cloud_env }}"
   remote_user: root

--- a/scripts/jenkins/cloud/ansible/integrated-deployer-tweaks.yml
+++ b/scripts/jenkins/cloud/ansible/integrated-deployer-tweaks.yml
@@ -1,0 +1,66 @@
+#
+# (c) Copyright 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+---
+
+# The image used to create the deployer/first controller for physical
+# deployments includes apparmor as an installed & enabled service which
+# isn't compatible with Ardana controller node package set leading to
+# issues when starting haproxy after upgrade & reboot.
+- name: Disable and remove apparmor for integrated deployer
+  hosts: "{{ cloud_env }}"
+  remote_user: root
+  gather_facts: no
+  vars:
+    task: "deploy"
+
+  tasks:
+    - block:
+        - name: Stop and disable apparmor service
+          service:
+            name: apparmor
+            state: stopped
+            enabled: false
+          failed_when: false
+
+        # Remove the associated patterns so that dist-upgrade doesn't
+        # try to re-install the associated packages.
+        - name: Remove apparmor pattern
+          zypper:
+            name:
+              - apparmor
+              - sles-apparmor-32bit
+            type: pattern
+            state: absent
+
+        # Remove unnecessary apparmor related packages so that we don't
+        # have to deal with updating or dist-upgrading them.
+        - name: Remove apparmor related packages
+          zypper:
+            name:
+              - apparmor-docs
+              - apparmor-parser
+              - apparmor-profiles
+              - apparmor-utils
+              - patterns-sles-apparmor
+              - patterns-sles-apparmor-32bit
+              - perl-apparmor
+              - yast2-apparmor
+            type: package
+            state: absent
+      when:
+        - cloud_product == "ardana"
+        - clm_model == "integrated"
+        - is_physical_deploy | bool


### PR DESCRIPTION
When doing a baremetal deployment for Ardana with an integrated deployer
the first controller node will be a VM running on the gateway node based
on an appropriate SLES image that has the apparmor pattern installed.

However having apparmor installed on a controller node is not compatible
withe the package set expected for an Ardana controller node, leading to
issues later on after upgrading and rebooting this integrated controller
node from Cloud8/SP3 to Cloud9/SP4.

This patch disables the apparmor service then uninstalls the associated
patterns and unnecessary packages. Note that we leave libapparmor1 as it
is a dependency of other required packages such as rsync.