### PR TITLE
Only trigger openstack-ardana Update phase if needed (SOC-9780)

### DIFF
--- a/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
@@ -239,7 +239,7 @@ pipeline {
 
     stage('Update cloud') {
       when {
-        expression { deploy_cloud == 'true' && update_after_deploy == 'true' }
+        expression { deploy_cloud == 'true' && update_after_deploy == 'true' && (maint_updates != '' || update_to_cloudsource != '') }
       }
       steps {
         script {


### PR DESCRIPTION
As part of cleaning up PR#3732 I inadvertently removed a hacky guard
condition on the Update phase thinking that it was no longer needed
given recent fixes to how the Update phase runs the Ansible playbooks.

However it turns out that we still need some sort of additional guard
contion on the Update phase as otherwise it also gets triggered if we
specify the update_after_deploy flag to trigger the Upgrade phase.