### PR TITLE
Gerrit patches for deploy, update and upgrade (SOC-9780)

### DIFF
--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -29,7 +29,28 @@
           default:
           description: >-
             A comma separated list of IDs for changes in gerrit.prv.suse.net
-            to test. The patchset may be supplied as part of the change ID in the form:
+            to test as part of the deploy. The patchset may be supplied as
+            part of the change ID in the form:
+
+               <change_number>[/<patchset_number>]
+
+      - string:
+          name: update_gerrit_change_ids
+          default:
+          description: >-
+            A comma separated list of IDs for changes in gerrit.prv.suse.net
+            to test as part of the update. The patchset may be supplied as
+            part of the change ID in the form:
+
+               <change_number>[/<patchset_number>]
+
+      - string:
+          name: upgrade_gerrit_change_ids
+          default:
+          description: >-
+            A comma separated list of IDs for changes in gerrit.prv.suse.net
+            to test as part of the upgrade. The patchset may be supplied as
+            part of the change ID in the form:
 
                <change_number>[/<patchset_number>]
 

--- a/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
+++ b/jenkins/ci.suse.de/pipelines/openstack-ardana-testbuild-gerrit.Jenkinsfile
@@ -27,10 +27,10 @@ pipeline {
         script {
           // Set this variable to be used by upstream builds
           env.blue_ocean_buildurl = env.RUN_DISPLAY_URL
-          if (gerrit_change_ids == '') {
-            error("Empty 'gerrit_change_ids' parameter value.")
+          if ((gerrit_change_ids == '') && (update_gerrit_change_ids == '') && (upgrade_gerrit_change_ids == '')) {
+            error("No Gerrit Change-Ids' specified in 'gerrit_change_ids', 'update_gerrit_change_ids' or 'upgrade_gerrit_change_ids' parameter values.")
           }
-          currentBuild.displayName = "#${BUILD_NUMBER}: ${gerrit_change_ids}"
+          currentBuild.displayName = "#${BUILD_NUMBER}: deploy=${gerrit_change_ids} update=${update_gerrit_change_ids} upgrade=${upgrade_gerrit_change_ids}"
           sh('''
             git clone $git_automation_repo --branch $git_automation_branch automation-git
           ''')
@@ -40,16 +40,55 @@ pipeline {
       }
     }
 
-    stage('build test packages') {
+    stage('build test packages for deploy') {
+      when {
+        expression { gerrit_change_ids != '' }
+      }
       steps {
-        sh('echo "IBS project for test packages: https://build.suse.de/project/show/${homeproject}:ardana-ci-${BUILD_NUMBER}"')
-        sh('echo "zypper repository for test packages: http://download.suse.de/ibs/${homeproject//:/:\\/}:/ardana-ci-${BUILD_NUMBER}/standard/${homeproject}:ardana-ci-${BUILD_NUMBER}.repo"')
+        sh('echo "IBS project for test packages: https://build.suse.de/project/show/${homeproject}:ardana-ci-${BUILD_NUMBER}-deploy"')
+        sh('echo "zypper repository for test packages: http://download.suse.de/ibs/${homeproject//:/:\\/}:/ardana-ci-${BUILD_NUMBER}-deploy/standard/${homeproject}:ardana-ci-${BUILD_NUMBER}-deploy.repo"')
         timeout(time: 30, unit: 'MINUTES', activity: true) {
           sh('''
             source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
             cd automation-git/scripts/jenkins/cloud/gerrit
             set -eux
-            run_python_script -u build_test_package.py --homeproject ${homeproject} --buildnumber ${BUILD_NUMBER} -c ${gerrit_change_ids//,/ -c }
+            run_python_script -u build_test_package.py --homeproject ${homeproject} --buildnumber ${BUILD_NUMBER}-deploy -c ${gerrit_change_ids//,/ -c }
+          ''')
+        }
+      }
+    }
+
+    stage('build test packages for update') {
+      when {
+        expression { update_gerrit_change_ids != '' }
+      }
+      steps {
+        sh('echo "IBS project for test packages: https://build.suse.de/project/show/${homeproject}:ardana-ci-${BUILD_NUMBER}-update"')
+        sh('echo "zypper repository for test packages: http://download.suse.de/ibs/${homeproject//:/:\\/}:/ardana-ci-${BUILD_NUMBER}-update/standard/${homeproject}:ardana-ci-${BUILD_NUMBER}-update.repo"')
+        timeout(time: 30, unit: 'MINUTES', activity: true) {
+          sh('''
+            source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
+            cd automation-git/scripts/jenkins/cloud/gerrit
+            set -eux
+            run_python_script -u build_test_package.py --homeproject ${homeproject} --buildnumber ${BUILD_NUMBER}-update -c ${update_gerrit_change_ids//,/ -c }
+          ''')
+        }
+      }
+    }
+
+    stage('build test packages for upgrade') {
+      when {
+        expression { upgrade_gerrit_change_ids != '' }
+      }
+      steps {
+        sh('echo "IBS project for test packages: https://build.suse.de/project/show/${homeproject}:ardana-ci-${BUILD_NUMBER}-upgrade"')
+        sh('echo "zypper repository for test packages: http://download.suse.de/ibs/${homeproject//:/:\\/}:/ardana-ci-${BUILD_NUMBER}-upgrade/standard/${homeproject}:ardana-ci-${BUILD_NUMBER}-upgrade.repo"')
+        timeout(time: 30, unit: 'MINUTES', activity: true) {
+          sh('''
+            source automation-git/scripts/jenkins/cloud/jenkins-helper.sh
+            cd automation-git/scripts/jenkins/cloud/gerrit
+            set -eux
+            run_python_script -u build_test_package.py --homeproject ${homeproject} --buildnumber ${BUILD_NUMBER}-upgrade -c ${upgrade_gerrit_change_ids//,/ -c }
           ''')
         }
       }

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -404,6 +404,33 @@
           msg: The entered value failed validation
           description: >-
             A comma separated list of repository urls to be added on the deployer node
+            during the deploy phase.
+
+            NOTE: The packages from those repositories will be available to all cloud nodes
+            through a repository with a higher priority, meaning that those packages will be
+            installed even if there is a newer package available on other repositories
+
+      - validating-string:
+          name: update_extra_repos
+          default: '{update_extra_repos|}'
+          regex: '((http(s)?:\/\/[^ ,]+)(,http(s)?:\/\/[^ ,]+)*)*'
+          msg: The entered value failed validation
+          description: >-
+            A comma separated list of repository urls to be added on the deployer node
+            during the update phase.
+
+            NOTE: The packages from those repositories will be available to all cloud nodes
+            through a repository with a higher priority, meaning that those packages will be
+            installed even if there is a newer package available on other repositories
+
+      - validating-string:
+          name: upgrade_extra_repos
+          default: '{upgrade_extra_repos|}'
+          regex: '((http(s)?:\/\/[^ ,]+)(,http(s)?:\/\/[^ ,]+)*)*'
+          msg: The entered value failed validation
+          description: >-
+            A comma separated list of repository urls to be added on the deployer node
+            during the upgrade phase.
 
             NOTE: The packages from those repositories will be available to all cloud nodes
             through a repository with a higher priority, meaning that those packages will be
@@ -428,7 +455,34 @@
           msg: The entered value failed validation
           description: >-
             A comma separated list of IDs for changes in
-            gerrit.prv.suse.net to test. The patchset may be supplied as part
+            gerrit.prv.suse.net to test during deploy.
+            The patchset may be supplied as part
+            of the change ID in the form:
+
+               <change_number>[/<patchset_number>]
+
+      - validating-string:
+          name: update_gerrit_change_ids
+          default: ''
+          regex: '(([0-9]+(/[0-9]+)?)(,[0-9]+(/[0-9]+)?)*)*'
+          msg: The entered value failed validation
+          description: >-
+            A comma separated list of IDs for changes in
+            gerrit.prv.suse.net to test during update.
+            The patchset may be supplied as part
+            of the change ID in the form:
+
+               <change_number>[/<patchset_number>]
+
+      - validating-string:
+          name: upgrade_gerrit_change_ids
+          default: ''
+          regex: '(([0-9]+(/[0-9]+)?)(,[0-9]+(/[0-9]+)?)*)*'
+          msg: The entered value failed validation
+          description: >-
+            A comma separated list of IDs for changes in
+            gerrit.prv.suse.net to test during upgrade.
+            The patchset may be supplied as part
             of the change ID in the form:
 
                <change_number>[/<patchset_number>]

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -73,7 +73,8 @@ upgrade_cloudsource: ''
 # List of maintenance update IDs separated by comma (eg. 7396,7487)
 maint_updates: ''
 
-# A comma separated list of repository urls to be added on the deployer/admin node.
+# A comma separated list of repository urls to be added on the deployer/admin node for
+# deploy phase.
 # WARNING: For ARDANA the packages from those repositories will be availabe to all cloud
 # nodes through a repository with a higher priority, meaning that those packages will be
 # installed even if there is a newer package available on other repositories.
@@ -81,10 +82,36 @@ maint_updates: ''
 # nodes it has the default priority.
 extra_repos: ''
 
+# A comma separated list of repository urls to be added on the deployer/admin node for
+# update phase.
+# WARNING: For ARDANA the packages from those repositories will be availabe to all cloud
+# nodes through a repository with a higher priority, meaning that those packages will be
+# installed even if there is a newer package available on other repositories.
+# For CROWBAR the repository has higher priority only on the deployer node, on the other
+# nodes it has the default priority.
+update_extra_repos: ''
+
+# A comma separated list of repository urls to be added on the deployer/admin node for
+# upgrade phase.
+# WARNING: For ARDANA the packages from those repositories will be availabe to all cloud
+# nodes through a repository with a higher priority, meaning that those packages will be
+# installed even if there is a newer package available on other repositories.
+# For CROWBAR the repository has higher priority only on the deployer node, on the other
+# nodes it has the default priority.
+upgrade_extra_repos: ''
+
 #============= Gerrit =============#
-# A comma separated list of IDs for changes in gerrit.prv.suse.net to test.
+# A comma separated list of IDs for changes in gerrit.prv.suse.net to test in deploy stage.
 # The patchset may be supplied as part of the change ID in the form: <change_number>[/<patchset_number>]
 gerrit_change_ids: ''
+
+# A comma separated list of IDs for changes in gerrit.prv.suse.net to test in update stage.
+# The patchset may be supplied as part of the change ID in the form: <change_number>[/<patchset_number>]
+update_gerrit_change_ids: ''
+
+# A comma separated list of IDs for changes in gerrit.prv.suse.net to test in upgrade stage.
+# The patchset may be supplied as part of the change ID in the form: <change_number>[/<patchset_number>]
+upgrade_gerrit_change_ids: ''
 
 # Project in IBS that will act as the parent project for the newly generated test project.
 # E.g. 'home:<username>'


### PR DESCRIPTION
Add support for being able to build Gerrit test patches for the deploy,
update and upgrade phases, rather than just the initial deploy phase.

To support this we add the following additional job paramaters:
  * update_gerrit_change_ids:
    - A list of Gerrit change ids for the same code stream as the
      specified update_to_cloudsource.
  * upgrade_gerrit_change_ids:
    - A list of Gerrit change ids for the same code stream as the
      specified upgrade_cloudsource.

Similarly there are two new job parameters that can be used to
specify extra repos to be added to the deployer during the update
or upgrade phases:
  * update_extra_repos:
    - A list of extra repos for the same code stream as the
      specified update_to_cloudsource.
  * upgrade_extra_repos:
    - A list of extra repos for the same code stream as the
      specified upgrade_cloudsource.

These repos will be leveraged to inject the results of the relevent
update or upgrade gerrit package builds into the deployer served
repos at the appropriate stage.

Update the Jenkins job, template and Jenkinsfile definitions to
define the new job parameters and leverage them at the appropriate
stages in the Jenings jobs.

Update the manual mode lib.sh with equivalent support for using the
new parameters, which have also been added to the input.yml.example.