### PR TITLE
openstack-ardana: add missing packages on CentOS repo

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/files/enable-centos-rpms-on-rhel/roles/deployer-rhel-repo/vars/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/files/enable-centos-rpms-on-rhel/roles/deployer-rhel-repo/vars/main.yml
@@ -198,3 +198,5 @@ rhel_repo_rpms_list:
   - python-munch
   - libsodium23
   - python-PySocks
+  - python-lxml
+  - python-cssselect


### PR DESCRIPTION
Add `python-lxml` and `python-cssselect` to the list of packages that are
downloaded and made available through the CentOS (optional) repository.

Those packages are needed for the new version of python-keystoneauth1.

This fixes the `cloud-ardana9-job-std-min-centos-x86_64` job.