### PR TITLE
Do not send test results to OS-Health

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/defaults/main.yml
@@ -42,9 +42,6 @@ iverify_failed_tests:
 
 # Tempest vars
 tempest_run_filter: "smoke"
-os_health_server: "10.86.0.167"
-os_health_url: "http://{{ os_health_server }}/#/job/{{ os_health_build_name }}"
-os_health_url_msg: "[{{ os_health_url }}]({{ os_health_url }})"
 
 ansible_log_url: "{{ jenkins_build_url }}artifact/.artifacts/ansible.log"
 ansible_log_url_msg: "[{{ ansible_log_url }}]({{ ansible_log_url }})"

--- a/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/ardana-qe-tests.yml
+++ b/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/ardana-qe-tests.yml
@@ -15,7 +15,6 @@
 #
 ---
 
-os_health_build_name: "{{ cloud_env }}_qa_{{ test_name }}"
 ardana_qe_test_log_url: "{{ jenkins_build_url }}artifact/.artifacts/{{ test_name }}.log"
 ardana_qe_test_log_url_msg: "[{{ ardana_qe_test_log_url }}]({{ ardana_qe_test_log_url }})"
 
@@ -37,7 +36,7 @@ rc_msg_fields_started:
     value: "{{ hostvars[cloud_env].ansible_host }}"
     short: True
 
-_rc_msg_fields_finished:
+rc_msg_fields_finished:
   - title: Built by
     value: "{{ jenkins_build_url_msg }}"
     short: False
@@ -62,10 +61,3 @@ _rc_msg_fields_finished:
   - title: Skipped
     value: "{{ ardana_qe_test_results.skipped if ardana_qe_test_results is defined else 'Not available' }}"
     short: True
-
-_rc_os_health_msg:
-  - title: OpenStack-Health
-    value: "[{{ os_health_url }}]({{ os_health_url }})"
-    short: False
-
-rc_msg_fields_finished: "{{ _rc_msg_fields_finished + _rc_os_health_msg if subunit is defined and subunit.stat.exists else _rc_msg_fields_finished }}"

--- a/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/tempest.yml
+++ b/scripts/jenkins/cloud/ansible/roles/rocketchat_notify/vars/tempest.yml
@@ -15,7 +15,6 @@
 #
 ---
 
-os_health_build_name: "{{ cloud_env }}_tempest_{{ tempest_run_filter }}"
 tempest_log_url: "{{ jenkins_build_url }}artifact/.artifacts/testr_results_region1_{{ tempest_run_filter }}.log"
 tempest_log_url_msg: "[{{ tempest_log_url }}]({{ tempest_log_url }})"
 
@@ -68,9 +67,6 @@ rc_msg_fields_finished_temp:
   - title: Failed
     value: "{{ tempest_test_results.failed if tempest_test_results is defined else 'Not available' }}"
     short: True
-  - title: OpenStack-Health
-    value: "{{ os_health_url_msg }}"
-    short: False
 
 refstack_url_msg: "{{ '[' ~ refstack_out.stdout ~ '](' ~ refstack_out.stdout ~ ')' if refstack_out is defined else 'Not available' }}"
 rc_msg_fields_finished_defcore:

--- a/scripts/jenkins/cloud/ansible/run-ardana-qe-tests.yml
+++ b/scripts/jenkins/cloud/ansible/run-ardana-qe-tests.yml
@@ -58,12 +58,6 @@
               - src: "{{ subunit_xml_results }}"
           when: lookup("env", "WORKSPACE")
 
-        - include_role:
-            name: send_to_os_health
-          when:
-            - subunit is defined
-            - subunit.stat.exists
-
   post_tasks:
     - include_role:
         name: rocketchat_notify

--- a/scripts/jenkins/cloud/ansible/run-tempest-ardana.yml
+++ b/scripts/jenkins/cloud/ansible/run-tempest-ardana.yml
@@ -60,11 +60,6 @@
                 dest: "testr_results_region1_{{ tempest_run_filter }}.log"
           when: lookup("env", "WORKSPACE")
 
-        - include_role:
-            name: send_to_os_health
-          when: "'failed' not in tempest_status"
-
-
   post_tasks:
       - include_role:
           name: rocketchat_notify


### PR DESCRIPTION
If there is none activelly using OpenStack-Health makes no sense to keep
sending the test results to it as it just increase the execution time
and the chence of unrelated failures (e.g. [1])

1. https://ci.suse.de/blue/organizations/jenkins/cloud-ardana9-job-gate-entry-scale-kvm-monasca-x86_64/detail/cloud-ardana9-job-gate-entry-scale-kvm-monasca-x86_64/187/pipeline#step-168-log-121