### PR TITLE
Switch to opendev for git downloading

### DIFF
--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-update.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-update.yaml
@@ -20,13 +20,13 @@
           if [ "{release}" != "Master" ]; then
               lcrelease="${{RELEASE,,}}"
               rm -f ${{lcrelease}}.tar.gz
-              wget -c https://github.com/openstack/rpm-packaging/archive/stable/${{lcrelease}}.tar.gz
+              wget -c https://opendev.org/openstack/rpm-packaging/archive/stable/${{lcrelease}}.tar.gz
               rm -rf rpm-packaging-stable-${{lcrelease}}
               tar xf ${{lcrelease}}.tar.gz
               gitcheckout=rpm-packaging-stable-${{lcrelease}}
           else
               rm -f master.tar.gz
-              wget -c https://github.com/openstack/rpm-packaging/archive/master.tar.gz
+              wget -c https://opendev.org/openstack/rpm-packaging/archive/master.tar.gz
               rm -rf rpm-packaging-master
               tar xf master.tar.gz
               gitcheckout=rpm-packaging-master


### PR DESCRIPTION
The github mirror seems unreliably / asynchroneously updated, so
when the post update job runs, it doesn't get the newest state,
causing inconsistencies.

Lets see if using the master repo fixes this problem.