### PR TITLE
openstack-crowbar: add attributes to monasca barclamp template

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/monasca.yml.j2
+++ b/scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/barclamps/monasca.yml.j2
@@ -1,5 +1,6 @@
 {% if 'monasca-server' in deployment %}
   - barclamp: monasca
+    attributes:
       debug: {{ debug }}
 {%   include 'barclamps/lib/deployment.yml.j2' %}
 {%   if not when_cloud9 %}


### PR DESCRIPTION
The monasca barclamp template is missing the `attributes` key on its
definition.