### PR TITLE
Fix fallout from archive url change

### DIFF
--- a/hostscripts/rpm-packaging/createproject.py
+++ b/hostscripts/rpm-packaging/createproject.py
@@ -277,6 +277,10 @@ def create_project(worktree, project, linkproject):
             print("Adding new pkg %s" % pkgname)
             osc_commit_all(workdir, pkgname)
 
+    if not alive_pkgs:
+        print("Worktree does not contain any packages?")
+        sys.exit(1)
+
     # remove no longer alive pkgs
     for i in existing_pkgs:
         if not linkproject and i not in alive_pkgs:

--- a/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-update.yaml
+++ b/jenkins/ci.opensuse.org/templates/openstack-rpm-packaging-update.yaml
@@ -21,14 +21,12 @@
               lcrelease="${{RELEASE,,}}"
               rm -f ${{lcrelease}}.tar.gz
               wget -c https://opendev.org/openstack/rpm-packaging/archive/stable/${{lcrelease}}.tar.gz
-              rm -rf rpm-packaging-stable-${{lcrelease}}
+              rm -rf rpm-packaging
               tar xf ${{lcrelease}}.tar.gz
-              gitcheckout=rpm-packaging-stable-${{lcrelease}}
           else
               rm -f master.tar.gz
               wget -c https://opendev.org/openstack/rpm-packaging/archive/master.tar.gz
-              rm -rf rpm-packaging-master
+              rm -rf rpm-packaging
               tar xf master.tar.gz
-              gitcheckout=rpm-packaging-master
           fi
-          /usr/local/bin/createproject.py ${{gitcheckout}} ${{OBS_PROJECT}}
+          /usr/local/bin/createproject.py rpm-packaging ${{OBS_PROJECT}}


### PR DESCRIPTION
on opendev the archive is always just the gitrepo name, without any
version suffix. adjust.

Add sanity check to avoid that this will ever become a problem some
other time.