### PR TITLE
Handle ardana_qe_tests failures better (SOC-9780)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_qe_tests/tasks/process_test_results.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_qe_tests/tasks/process_test_results.yml
@@ -31,6 +31,11 @@
   failed_when: false
   register: test_results
 
+- name: Report '{{ test_name }}' results output if failed
+  debug:
+    var: test_results
+  when: test_results.rc != 0
+
 - name: Process test results from subunit
   set_fact:
     ardana_qe_test_results: "{{ ardana_qe_test_results | default({}) | combine({item.split()[0] | lower: item.split()[-1]}) }}"
@@ -38,3 +43,9 @@
   loop: "{{ test_results.stdout_lines }}"
   loop_control:
     label: "{{ item.split()[0] | lower }}: {{ item.split()[-1] }}"
+
+- name: Process test results from subunit
+  set_fact:
+    ardana_qe_test_results:
+      failed: 9999999
+  when: ardana_qe_test_results is not defined


### PR DESCRIPTION
Recently when running iverify tests I have seen issues with the iverify
run completes, likely with failures, and then the subsequent subunit run
to extract the results fails resulting in no ardana_qe_test_results fact
being defined which leads to an ansible error later when checking on the
status of the test that were run.

This patch defines a "default" ardana_qe_test_results fact, with failed
set to 9999999 if we fail to initialise an ardana_qe_test_results due
to the above error scenario.