### PR TITLE
Revert "Temporary disable clod9 jobs"

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana9.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana9.yaml
@@ -1,6 +1,5 @@
 - project:
     name: cloud-ardana9-job-std-3cp-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     scenario_name: standard
@@ -16,7 +15,6 @@
 
 - project:
     name: cloud-ardana9-job-dac-3cp-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     scenario_name: standard
@@ -32,7 +30,6 @@
 
 - project:
     name: cloud-ardana9-job-std-min-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     scenario_name: standard
@@ -48,7 +45,6 @@
 
 - project:
     name: cloud-ardana9-job-std-min-lmm-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     scenario_name: std-lmm
@@ -65,7 +61,6 @@
 
 - project:
     name: cloud-ardana9-job-demo-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     scenario_name: standard
@@ -82,7 +77,6 @@
 
 - project:
     name: cloud-ardana9-job-std-split-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     scenario_name: std-split
@@ -100,7 +94,6 @@
 
 - project:
     name: cloud-ardana9-job-std-min-centos-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud9
@@ -118,7 +111,6 @@
 
 - project:
     name: cloud-ardana9-job-entry-scale-kvm-test-maintenance-updates-x86_64
-    disabled: true
     ardana_job: '{name}'
     disabled: false
     cloud_env: cloud-ardana-ci-slot
@@ -139,7 +131,6 @@
 
 - project:
     name: cloud-ardana9-job-std-min-suse-x86_64
-    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: GM9+up
@@ -157,7 +148,6 @@
 
 - project:
     name: cloud-ardana9-job-image-update
-    disabled: true
     cloud_image_update_job: '{name}'
     os_cloud:
       - engcloud:

--- a/jenkins/ci.suse.de/cloud-crowbar9.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar9.yaml
@@ -1,7 +1,6 @@
 - project:
     name: cloud-crowbar9-job-x86_64
     crowbar_job: '{name}'
-    disabled: true
     cloudsource: stagingcloud9
     cloud_env: cloud-crowbar-ci-slot
     updates_test_enabled: true
@@ -35,7 +34,6 @@
 
 - project:
     name: cloud-crowbar9-job-ha-x86_64
-    disabled: true
     crowbar_job: '{name}'
     cloudsource: stagingcloud9
     cloud_env: cloud-crowbar-ci-slot
@@ -52,7 +50,6 @@
 
 - project:
     name: cloud-crowbar9-job-upgrade-x86_64
-    disabled: true
     crowbar_job: '{name}'
     cloudsource: stagingcloud8
     upgrade_cloudsource: stagingcloud9
@@ -70,7 +67,6 @@
 
 - project:
     name: cloud-crowbar9-job-image-update
-    disabled: true
     cloud_image_update_job: '{name}'
     os_cloud:
       - engcloud:

--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -21,7 +21,6 @@
       - cloud-8-gating-trigger:
           version: '8'
       - cloud-9-gating-trigger:
-          disabled: true
           version: '9'
     jobs:
       - '{cloud_unified_url_trigger_job}'
@@ -36,7 +35,6 @@
       - cloud-8-gating:
           version: '8'
       - cloud-9-gating:
-          disabled: true
           version: '9'
     jobs:
         - '{cloud_gating_job}'

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -58,6 +58,7 @@
             - hosdevelcloud8
             - hosGM8
             - hosGM8+up
+            - stagingcloud9
             - develcloud9
             - GM9
             - GM9+up

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -65,6 +65,7 @@
             - develcloud8
             - GM8
             - GM8+up
+            - stagingcloud9
             - develcloud9
             - GM9
             - GM9+up


### PR DESCRIPTION
Reverts SUSE-Cloud/automation#3902
As problematic patch were reverted its safe to enable cloud 9 jobs  back