### PR TITLE
openstack-ses: use SLES12SP4 as base image

### DIFF
--- a/jenkins/ci.suse.de/openstack-ses.yaml
+++ b/jenkins/ci.suse.de/openstack-ses.yaml
@@ -56,7 +56,7 @@
 
       - string:
           name: server_image
-          default: "cleanvm-jeos-SLE12SP3"
+          default: "cleanvm-jeos-SLE12SP4"
           description: >-
             Image used to boot the SES instance
 

--- a/scripts/jenkins/ses/ansible/bootstrap-ses-node.yml
+++ b/scripts/jenkins/ses/ansible/bootstrap-ses-node.yml
@@ -22,13 +22,11 @@
   vars:
     ansible_password: "linux"
     ses_requires_packages:
-      - python-setuptools
       - autoconf
-      - git
+      - git-core
       - gcc
       - iptables
       - make
-      - jq
       - rng-tools
   vars_files:
     - "../../cloud/ansible/group_vars/all/ssh_pub_keys.yml"
@@ -51,14 +49,10 @@
         repo: "{{ item.repo }}"
         runrefresh: yes
       loop:
-        - name: "SLES12-SP3-Pool"
-          repo: "http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Pool/"
-        - name: "SLES12-SP3-Updates"
-          repo: "http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP3-Updates/"
-        - name: "SUSE-OpenStack-Cloud-8-Pool"
-          repo: "http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-8-Pool/"
-        - name: "SUSE-OpenStack-Cloud-8-Updates"
-          repo: "http://provo-clouddata.cloud.suse.de/repos/x86_64/SUSE-OpenStack-Cloud-8-Updates/"
+        - name: "SLES12-SP4-Pool"
+          repo: "http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP4-Pool/"
+        - name: "SLES12-SP4-Updates"
+          repo: "http://provo-clouddata.cloud.suse.de/repos/x86_64/SLES12-SP4-Updates/"
       register: _base_repos
       retries: 6
       delay: 5

--- a/scripts/jenkins/ses/ansible/roles/heat_ses_template/defaults/main.yml
+++ b/scripts/jenkins/ses/ansible/roles/heat_ses_template/defaults/main.yml
@@ -20,7 +20,7 @@ heat_resource_name_prefix: "{{ ses_id }}-ses"
 
 floating_net: "floating"
 subnet_cidr: "192.168.200.0/24"
-server_image: "cleanvm-jeos-SLE12SP3"
+server_image: "cleanvm-jeos-SLE12SP4"
 server_flavor: "cloud-ses"
 network: ""
 router: ""


### PR DESCRIPTION
By default use the `cleanvm-jeos-SLE12SP4` image instead of
`cleanvm-jeos-SLE12SP3` for deploying SES.

This change also removes the SOC8 repositories and some packages
not needed that were installed on bootstrap.

Signed-off-by: Flávio Ramalho <framalho@suse.com>