### PR TITLE
Temporarily disable SOC8 jobs

### DIFF
--- a/jenkins/ci.suse.de/cloud-ardana8.yaml
+++ b/jenkins/ci.suse.de/cloud-ardana8.yaml
@@ -1,5 +1,6 @@
 - project:
     name: cloud-ardana8-job-std-3cp-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
@@ -16,6 +17,7 @@
 
 - project:
     name: cloud-ardana8-job-dac-3cp-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
@@ -32,6 +34,7 @@
 
 - project:
     name: cloud-ardana8-job-std-min-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
@@ -48,6 +51,7 @@
 
 - project:
     name: cloud-ardana8-job-std-min-lmm-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
@@ -65,6 +69,7 @@
 
 - project:
     name: cloud-ardana8-job-demo-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloudsource: stagingcloud8
     cloud_env: cloud-ardana-ci-slot
@@ -82,6 +87,7 @@
 
 - project:
     name: cloud-ardana8-job-std-split-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
@@ -100,6 +106,7 @@
 
 - project:
     name: cloud-ardana8-job-entry-scale-kvm-test-maintenance-updates-x86_64
+    disabled: true
     ardana_job: '{name}'
     disabled: false
     cloud_env: cloud-ardana-ci-slot
@@ -120,6 +127,7 @@
 
 - project:
     name: cloud-ardana8-job-std-min-suse-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: GM8+up
@@ -137,6 +145,7 @@
 
 - project:
     name: cloud-ardana8-job-std-min-centos-x86_64
+    disabled: true
     ardana_job: '{name}'
     cloud_env: cloud-ardana-ci-slot
     cloudsource: stagingcloud8
@@ -154,6 +163,7 @@
 
 - project:
     name: cloud-ardana8-job-image-update
+    disabled: true
     cloud_image_update_job: '{name}'
     os_cloud:
       - engcloud:

--- a/jenkins/ci.suse.de/cloud-crowbar8.yaml
+++ b/jenkins/ci.suse.de/cloud-crowbar8.yaml
@@ -1,5 +1,6 @@
 - project:
     name: cloud-crowbar8-job-x86_64
+    disabled: true
     crowbar_job: '{name}'
     cloudsource: stagingcloud8
     cloud_env: cloud-crowbar-ci-slot
@@ -16,6 +17,7 @@
 
 - project:
     name: cloud-crowbar8-job-ha-x86_64
+    disabled: true
     crowbar_job: '{name}'
     cloudsource: stagingcloud8
     cloud_env: cloud-crowbar-ci-slot
@@ -32,6 +34,7 @@
 
 - project:
     name: cloud-crowbar8-job-image-update
+    disabled: true
     cloud_image_update_job: '{name}'
     os_cloud:
       - engcloud:

--- a/jenkins/ci.suse.de/cloud-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-gating.yaml
@@ -19,6 +19,7 @@
       threshold: SUCCESS
     cloud_unified_url_trigger_job:
       - cloud-8-gating-trigger:
+          disabled: true
           version: '8'
       - cloud-9-gating-trigger:
           version: '9'
@@ -33,6 +34,7 @@
       - cloud-7-gating:
           version: '7'
       - cloud-8-gating:
+          disabled: true
           version: '8'
       - cloud-9-gating:
           version: '9'
@@ -54,11 +56,13 @@
     triggers: []
     ardana_job:
       - cloud-ardana8-job-gate-entry-scale-kvm-monasca-x86_64:
+          disabled: true
           cloudsource: stagingcloud8
           update_after_deploy: false
           reboot_after_deploy: true
           tempest_filter_list: "smoke,monasca,ceilometer,freezer"
       - cloud-ardana8-job-gate-entry-scale-kvm-deploy-x86_64:
+          disabled: true
           cloudsource: stagingcloud8
           update_after_deploy: false
           reboot_after_deploy: true
@@ -67,6 +71,7 @@
             keystone,swift,glance,cinder,neutron,nova,barbican,fwaas,vpnaas,\
             designate,heat,manila,magnum,lbaas"
       - cloud-ardana8-job-gate-entry-scale-kvm-update-x86_64:
+          disabled: true
           cloudsource: develcloud8
           update_to_cloudsource: stagingcloud8
           update_after_deploy: true
@@ -120,6 +125,7 @@
             keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-gate-no-ha-deploy-x86_64:
+          disabled: true
           cloudsource: stagingcloud8
           ses_enabled: true
           update_after_deploy: false
@@ -156,6 +162,7 @@
             keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-gate-ha-deploy-x86_64:
+          disabled: true
           cloudsource: stagingcloud8
           ses_enabled: true
           update_after_deploy: false
@@ -194,6 +201,7 @@
             keystone,swift,glance,cinder,neutron,nova,ceilometer,fwaas,\
             trove,aodh,heat,magnum,manila,lbaas"
       - cloud-crowbar8-job-gate-linuxbridge-deploy-x86_64:
+          disabled: true
           cloudsource: stagingcloud8
           ses_enabled: true
           update_after_deploy: false

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -51,7 +51,6 @@
           name: cloudsource
           choices:
             - '{cloudsource|stagingcloud9}'
-            - stagingcloud8
             - develcloud8
             - GM8
             - GM8+up
@@ -112,7 +111,6 @@
           name: update_to_cloudsource
           choices:
             - '{update_to_cloudsource|}'
-            - stagingcloud8
             - develcloud8
             - GM8
             - GM8+up
@@ -131,7 +129,6 @@
           name: upgrade_cloudsource
           choices:
             - '{upgrade_cloudsource|}'
-            - stagingcloud8
             - develcloud8
             - GM8
             - GM8+up

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -61,7 +61,6 @@
             - develcloud7
             - GM7
             - GM7+up
-            - stagingcloud8
             - develcloud8
             - GM8
             - GM8+up
@@ -161,7 +160,6 @@
           name: upgrade_cloudsource
           choices:
             - '{upgrade_cloudsource|}'
-            - stagingcloud8
             - develcloud8
             - GM8+up
             - stagingcloud9


### PR DESCRIPTION
Disable SOC8 jobs using stagingcloud8 as cloudsource until [1] reaches
D:C:8:Staging.

1. https://build.opensuse.org/request/show/822222