### PR TITLE
Adjust GIT_ORIGIN location calcuation

### DIFF
--- a/jenkins/ci.opensuse.org/macros.yaml
+++ b/jenkins/ci.opensuse.org/macros.yaml
@@ -65,7 +65,7 @@
           fi
 
           if [ -z "$GIT_ORIGIN" ] || [ -n "$ZUUL_NEWREV" ]; then
-            GIT_ORIGIN="$GERRIT_SITE/p"
+            GIT_ORIGIN="$GERRIT_SITE"
           fi
 
           if [ -z "$ZUUL_REF" ]; then


### PR DESCRIPTION
With current opendev's gerrit, accessing the /p/ url gives

  The requested URL returned error: 403

I wasn't able to figure out why that happens, but the download
urls from gerrit webui point to the path without /p/, which appears
to be working fine. Adjusting accordingly.