### PR TITLE
Restore openstack-cleanvm-Newton

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -1,3 +1,13 @@
+
+- project:
+    name: openstack-cleanvm-Newton
+    disabled: false
+    release: Newton
+    image:
+      - SLE_12_SP2
+    jobs:
+      - 'openstack-cleanvm-{release}'
+
 - project:
     name: openstack-cleanvm-Pike
     disabled: false


### PR DESCRIPTION
We still have a change for Newton.

Revert the Newton part of "Remove Newton and Queens from cleanvm"

This partially reverts commit fdcfca89035395020c2b3c29df33eef8d7d7c3b8 https://github.com/SUSE-Cloud/automation/pull/3837 .