### PR TITLE
Remove staging job for Newton

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-staging.yaml
+++ b/jenkins/ci.opensuse.org/openstack-staging.yaml
@@ -2,7 +2,6 @@
     name: openstack-staging
     disabled: false
     release:
-      - Newton
       - Pike
       - Rocky
       - Train


### PR DESCRIPTION
it won't work as its cleanvm job was removed in
https://github.com/SUSE-Cloud/automation/pull/3837
fdcfca89035395020c2b3c29df33eef8d7d7c3b8

Changes should be submitted to
https://build.opensuse.org/project/show/Cloud:OpenStack:Newton instead
of Cloud:OpenStack:Newton:Staging