### PR TITLE
Remove trackupstream for Train+

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
+++ b/jenkins/ci.opensuse.org/openstack-trackupstream.yaml
@@ -16,9 +16,6 @@
           values:
             - Cloud:OpenStack:Pike:Staging
             - Cloud:OpenStack:Rocky:Staging
-            - Cloud:OpenStack:Train:Staging
-            - Cloud:OpenStack:Ussuri:Staging
-            - Cloud:OpenStack:Master
       - axis:
           type: user-defined
           name: component


### PR DESCRIPTION
Currently noone cares about that, lets stop the bleeding