### PR TITLE
Temporary fix to skip failing diffs between jobs 

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/list_packages/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/list_packages/defaults/main.yml
@@ -22,7 +22,9 @@ effective_user: "{{ (cloud_product == 'ardana') | ternary('ardana','root') }}"
 local_tmp_dir: "/tmp"
 diff_tmp_dir: "{{ lookup('env', 'WORKSPACE') | ternary (workspace_path, local_tmp_dir) }}"
 build_id: "{{ lookup('env', 'BUILD_ID')|default('',true) }}"
-no_diff_old_builds: "{{ lookup('env', 'no_diff_old_builds') | default('false',true) }}"
+# temporary set to true till issue with empty previous jobs will be fixed
+#no_diff_old_builds: "{{ lookup('env', 'no_diff_old_builds') | default('false',true) }}"
+no_diff_old_builds: "{{ lookup('env', 'no_diff_old_builds') | default('true',true) }}"                                                                                                                                           
 last_build_ids: []
 testing: {}
 _old_jobs_values: []


### PR DESCRIPTION
Temporary fix to skip diffs between jobs till issue with failing taks when no previous jobs found will be resolved.