### PR TITLE
No 'Cloud' in HOS repo name (SOC-11184)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/main.yml
@@ -75,7 +75,7 @@
     ANSIBLE_HOST_KEY_CHECKING: False
     ANSIBLE_SSH_ARGS: '-o UserKnownHostsFile=/dev/null'
   loop:
-    - '-m copy -a "src=`find /srv/www/*/x86_64/repos/*Cloud* -name content.key` dest=/tmp/"'
+    - '-m copy -a "src=`find /srv/www/*/x86_64/repos/*OpenStack* -name content.key` dest=/tmp/"'
     - '-b -a "rpm --import /tmp/content.key"'
   when: "'staging' in cloudsource or 'devel' in cloudsource"
 

--- a/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/pre_cloudsource_update.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_update/tasks/pre_cloudsource_update.yml
@@ -23,7 +23,7 @@
     ANSIBLE_HOST_KEY_CHECKING: False
     ANSIBLE_SSH_ARGS: '-o UserKnownHostsFile=/dev/null'
   loop:
-    - '-m copy -a "src=`find /srv/www/*/x86_64/repos/*Cloud* -name content.key` dest=/tmp/"'
+    - '-m copy -a "src=`find /srv/www/*/x86_64/repos/*OpenStack* -name content.key` dest=/tmp/"'
     - '-b -a "rpm --import /tmp/content.key"'
   when: "'staging' in cloudsource or 'devel' in cloudsource"
 

--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/pre_cloudsource_upgrade.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/pre_cloudsource_upgrade.yml
@@ -23,7 +23,7 @@
     ANSIBLE_HOST_KEY_CHECKING: False
     ANSIBLE_SSH_ARGS: '-o UserKnownHostsFile=/dev/null'
   loop:
-    - '-m copy -a "src=`find /srv/www/*/x86_64/repos/*Cloud* -name content.key` dest=/tmp/"'
+    - '-m copy -a "src=`find /srv/www/*/x86_64/repos/*OpenStack* -name content.key` dest=/tmp/"'
     - '-b -a "rpm --import /tmp/content.key"'
   when: when_staging_or_devel | bool
 


### PR DESCRIPTION
When trying to deploy a hosdevelcloud8 I see a failure in the step
looking for the repo signing key because it is searching for a key
in directories with 'Cloud' in the name.

However the HOS repo name doesn't have 'Cloud' in it, and hasn't
for a long time if memory serves, since it was renamed during the
final stages of the HOS 8 release.

Instead we should search for "OpenStack" which is common to both
the SOC and HOS repo directory names.