### PR TITLE
Disable cct run in mkcloud jobs

### DIFF
--- a/mkcloudruns/install_suse_cloud
+++ b/mkcloudruns/install_suse_cloud
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o nounset
 
-commands="cleanup prepare setupadmin addupdaterepo runupdate prepareinstcrowbar instcrowbar rebootcrowbar setupnodes instnodes proposal testsetup cct rebootcloud $@" # all_noreboot
+commands="cleanup prepare setupadmin addupdaterepo runupdate prepareinstcrowbar instcrowbar rebootcrowbar setupnodes instnodes proposal testsetup rebootcloud $@" # all_noreboot
 currentdir=$(pwd)
 
 function deploy_upgrade_clouds() {

--- a/scripts/mkcloud
+++ b/scripts/mkcloud
@@ -1652,19 +1652,19 @@ function expand_steps
                         runcmds="$runcmds setupnodes instnodes setup_aliases proposal"
                     ;;
                     all)
-                        runcmds="$runcmds `expand_steps _new_admin` rebootcrowbar `expand_steps _compute` testsetup cct rebootcloud"
+                        runcmds="$runcmds `expand_steps _new_admin` rebootcrowbar `expand_steps _compute` testsetup rebootcloud"
                     ;;
                     all_noreboot)
-                        runcmds="$runcmds `expand_steps _new_admin` `expand_steps _compute` testsetup cct"
+                        runcmds="$runcmds `expand_steps _new_admin` `expand_steps _compute` testsetup"
                     ;;
                     all_batch)
-                        runcmds="$runcmds `expand_steps _new_admin` rebootcrowbar setupnodes instnodes setup_aliases batch testsetup cct rebootcloud"
+                        runcmds="$runcmds `expand_steps _new_admin` rebootcrowbar setupnodes instnodes setup_aliases batch testsetup rebootcloud"
                     ;;
                     all_batch_noreboot)
-                        runcmds="$runcmds `expand_steps _new_admin` setupnodes instnodes setup_aliases batch testsetup cct"
+                        runcmds="$runcmds `expand_steps _new_admin` setupnodes instnodes setup_aliases batch testsetup"
                     ;;
                     _testupdate|testupdate)
-                        runcmds="$runcmds addupdaterepo runupdate testsetup cct"
+                        runcmds="$runcmds addupdaterepo runupdate testsetup"
                     ;;
                     _test_setuphost)
                         runcmds="$runcmds cleanup prepare setupadmin onadmin+test_setuphost"


### PR DESCRIPTION
As CCT is no longer used in SOC testing and it's blocking
automation PR's to be merged cct run will be disabled in mkcloud jobs.