### PR TITLE
ardana_upgrade needs ardana_extra_vars (SOC-11209)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/upgrade_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_upgrade/tasks/upgrade_nodes.yml
@@ -20,7 +20,7 @@
 
 - name: Run ardana-upgrade playbook for all nodes
   command: >
-    ansible-playbook ardana-upgrade.yml
+    ansible-playbook ardana-upgrade.yml -e '{{ ardana_extra_vars|to_json }}'
   args:
     chdir: "{{ ardana_scratch_path }}"
 


### PR DESCRIPTION
The ardana_upgrade role's update_nodes.yml task needs to include the
ardana_extra_vars when running the ardana-upgrade.yml playbook to
ensure that the relevant override settings that were applied to the
Cloud8 deployment are also being applied to upgrade cloud.