### PR TITLE
Ensure extra_repos repo metadata updated (SOC-11390)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/add_extra_repos.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/tasks/add_extra_repos.yml
@@ -35,9 +35,7 @@
 
 - name: Create extra-repos repository
   command: |
-    createrepo -o {{ local_repos_base_dir }}/extra-repos {{ local_repos_base_dir }}/extra-repos
-  args:
-    creates: "{{ local_repos_base_dir }}/extra-repos/repodata/repomd.xml"
+    createrepo --update -o {{ local_repos_base_dir }}/extra-repos {{ local_repos_base_dir }}/extra-repos
 
 - name: Manage extra-repos repository
   zypper_repository:


### PR DESCRIPTION
If the setup_zypper_repos role is included more than once, and the
extra_repos value is different, we want to ensure that the metadata
for the repo will be updated to include any additional RPMs added.

To ensure this happens we want the createrepo command to be run
whenever the role is included to add/enable repos, rather than just
the first time it is included, meaning that we don't want to guard
the running of the command with an args: creates: repodata file.

Additionally to speed up subsequent runs of createrepo we can use
the --update option, which re-uses existing repo metadata for files
that previously existed.