### PR TITLE
Ardana manual mode enhancements (SOC-9780)

### DIFF
--- a/scripts/jenkins/cloud/manual/delete-stack.sh
+++ b/scripts/jenkins/cloud/manual/delete-stack.sh
@@ -22,5 +22,4 @@ validate_input
 setup_ansible_venv
 mitogen_enable
 
-run_tempest
-run_qa_tests
+delete_stack

--- a/scripts/jenkins/cloud/manual/input.yml.example
+++ b/scripts/jenkins/cloud/manual/input.yml.example
@@ -264,3 +264,12 @@ rc_notify: false
 # 2.0 value has been proven experimentally to work best with virtual Crowbar
 # deployments.
 sync_mark_timeout_multiplier: 2.0
+
+
+#============= QA Test Args =============#
+# Similarly to using the <AllCaps_QA_Test_Name>_ARGS setting in the Jenkins
+# job extra params settings you can specify those settings here as a input
+# param or by specifying them as environment variables.
+
+# For example to disable the heat and lbaas tests in an inverify run uncomment
+#IVERIFY_ARGS: '-Sheat -Slbaas'

--- a/scripts/jenkins/cloud/manual/lib.sh
+++ b/scripts/jenkins/cloud/manual/lib.sh
@@ -64,7 +64,7 @@ function determine_python_bin {
 }
 
 function get_from_input {
-    echo $(grep -v "^#" $ARDANA_INPUT | awk '$0 ~ '"/^${1}:/"' { print $2 }' | tr -d "'")
+    echo $(grep -v "^#" $ARDANA_INPUT | grep "^${1}:" | cut -d: -f2- | tr -d "'" | tr -d '"')
 }
 
 function is_defined {
@@ -392,6 +392,12 @@ function run_qa_tests {
     if $(is_defined qa_test_list); then
         qa_test_list=($(echo "$(get_from_input qa_test_list)" | tr ',' '\n'))
         for qa_test in "${qa_test_list[@]}"; do
+            test_args_name="${qa_test^^}_ARGS"
+            test_args=($(echo "$(get_from_input ${test_args_name})"))
+            if [ -z "${!test_args_name}" ] && (( ${#test_args[@]} > 0 ))
+            then
+                export ${test_args_name}="${test_args[*]}"
+            fi
             ansible_playbook run-ardana-qe-tests.yml -e test_name=$qa_test
         done
     fi

--- a/scripts/jenkins/cloud/manual/manual.sh
+++ b/scripts/jenkins/cloud/manual/manual.sh
@@ -22,5 +22,4 @@ validate_input
 setup_ansible_venv
 mitogen_enable
 
-run_tempest
-run_qa_tests
+${@}

--- a/scripts/jenkins/cloud/manual/qa-test-ardana.sh
+++ b/scripts/jenkins/cloud/manual/qa-test-ardana.sh
@@ -22,5 +22,4 @@ validate_input
 setup_ansible_venv
 mitogen_enable
 
-run_tempest
 run_qa_tests

--- a/scripts/jenkins/cloud/manual/tempest-ardana.sh
+++ b/scripts/jenkins/cloud/manual/tempest-ardana.sh
@@ -23,4 +23,3 @@ setup_ansible_venv
 mitogen_enable
 
 run_tempest
-run_qa_tests


### PR DESCRIPTION
As part of working on the Ardana Cloud 8to9 upgrade task I developed
some enhancements to the manual mode tooling.

New scripts:
  * delete-stack.sh
  * qa-test-ardana.sh
  * tempest-ardana.sh
  * manual.sh

== manual.sh ==
The manual.sh script is useful for anyone who uses a shell other
than bash, e.g. zsh, who my see problems sourcing the lib.sh into
then shell environment. It allows you to run functions out of the
lib.sh with specific arguments, e.g. to build the gerrit packages
for a particular stage using build_test_packages_for_stage.

Also updated test-ardana.sh to not print the exit_msg on script
exit.

Updated lib.sh's get_from_input function to handle getting values
that contain spaces appropriately. Leveraged that change to handle
specifying the arguments for QA test tools, such as iverify, in
the input.yml, via <AllCaps_QA_test_name>_ARGS parameters.

Updated input.yml.example to include IVERIFY_ARGS example for new
QA test args support.