### PR TITLE
Fix openstack-devstack CI jobs (SOC-11405)

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-devstack.yaml
+++ b/jenkins/ci.opensuse.org/openstack-devstack.yaml
@@ -9,7 +9,7 @@
 - job-template:
     name: 'openstack-devstack-{ipversion}'
     id: 'openstack-devstack-{ipversion}'
-    node: cloud-cleanvm
+    node: cloud-cleanvm-new
     description: |
       Job to periodically run devstack against the latest openSUSE release.
       <b>This job is managed by JJB!</b>
@@ -32,7 +32,8 @@
     builders:
       - update-automation
       - shell: |
-          sudo /usr/local/sbin/freshvm cleanvm openSUSE-Leap-15.1
+          ci1_ssh="ssh ci1-opensuse.suse.de"
+          $ci1_ssh sudo /usr/local/sbin/freshvm cleanvm openSUSE-Leap-15.2
           sleep 100
 
           set -u
@@ -42,15 +43,15 @@
           ssh root@cleanvm "bash -x ~/qa_devstack.sh {ipversion}"
           ret=$?
           if [ "$ret" != 0 ] ; then
-              virsh shutdown cleanvm
+              $ci1_ssh virsh shutdown cleanvm
               # wait for clean shutdown
-              n=20 ; while [[ $n > 0 ]] && virsh list |grep cleanvm.*running ; do sleep 2 ; n=$(($n-1)) ; done
-              virsh destroy cleanvm
-              find /mnt/cleanvmbackup -mtime +5 -type f | xargs --no-run-if-empty rm
+              n=20 ; while [[ $n > 0 ]] && $ci1_ssh "virsh list |grep cleanvm.*running" ; do sleep 2 ; n=$(($n-1)) ; done
+              $ci1_ssh virsh destroy cleanvm
+              $ci1_ssh "find /mnt/cleanvmbackup -mtime +5 -type f | xargs --no-run-if-empty rm"
               # backup /dev/vg0/cleanvm disk image
               file=/mnt/cleanvmbackup/$BUILD_NUMBER-devstack.raw.gz
-              time gzip -c1 /dev/vg0/cleanvm > $file
-              du $file
+              $ci1_ssh "time gzip -c1 /dev/vg0/cleanvm > $file"
+              $ci1_ssh du $file
               exit 1
           fi
           scp root@cleanvm:/opt/stack/results.html .

--- a/scripts/jenkins/qa_devstack.sh
+++ b/scripts/jenkins/qa_devstack.sh
@@ -62,7 +62,7 @@ function h_setup_base_repos {
         # Python 2.7 is scheduled for end-of-life in 2020
         # Openstack goal is to have python3 supported on the end of the T cycle
         # https://governance.openstack.org/tc/resolutions/20180529-python2-deprecation-timeline.html
-        if [[ $DIST_VERSION == "15.0" ]]; then
+        if [[ "${DIST_VERSION%%.*}" == "15" ]]; then
             USE_PYTHON3=True
             PYTHON3_VERSION=3.6
         fi
@@ -78,6 +78,14 @@ function h_setup_base_repos {
             $zypper ar -f http://download.opensuse.org/update/${DIST_VERSION}/${DIST_NAME}:${DIST_VERSION}:Update.repo || true
         fi
     fi
+
+    # ensure PYTHON env var specifies correct python command
+    if [[ "${USE_PYTHON3:-False}" == "True" ]]; then
+        PYTHON=python3
+    else
+        PYTHON=python
+    fi
+    export PYTHON
 }
 
 
@@ -135,6 +143,12 @@ function h_setup_devstack {
         popd
     fi
 
+    if [ "$DEVSTACK_BRANCH" = "master" ]; then
+        MEMORY_TRACKER=memory_tracker
+    else
+        MEMORY_TRACKER=peakmem_tracker
+    fi
+
     # setup non-root user (username is "stack")
     (cd $DEVSTACK_DIR && ./tools/create-stack-user.sh)
 
@@ -164,7 +178,7 @@ enable_service tempest
 enable_service q-l3
 enable_service c-sch
 enable_service n-novnc
-enable_service peakmem_tracker
+enable_service $MEMORY_TRACKER
 enable_service n-cauth
 enable_service q-metering
 enable_service rabbit


### PR DESCRIPTION
Update the job definitions for the openstack-devstack-ipv{4,6} jobs
to use the Leap 15.2 image when creating a cleanvm instance, and to
manage the cleanvm vm on the ci1-opensuse system rather than locally.

Update the qa_devstack.sh script to specify memory_tracker rather
than peakmem_tracker when defining the devstack local.conf config
for the master branch.

Additionally the upstream devstack scripts now expect an env var,
PYTHON, defined specifing the appropriate python command to use
when running scripts such as outfilter.py, which are not marked
as being executable.
