### PR TITLE
Fix CentOS Ceph dependent package downloads (SOC-10966)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/setup_rhel_ceph_client_repo.yml
+++ b/scripts/jenkins/cloud/ansible/roles/ardana_deploy/tasks/setup_rhel_ceph_client_repo.yml
@@ -28,7 +28,7 @@
 
 - name: Download RHEL ceph client requires
   get_url:
-    url: "{{ ardana_centos_pkg_repo }}/{{ item }}"
+    url: "{{ ardana_centos_pkg_repo }}/Packages/{{ item[0] }}/{{ item }}"
     dest: "{{ ardana_ceph_third_party_dir }}"
   loop: "{{ ardana_rhel_ceph_client_pkg_requires }}"
 


### PR DESCRIPTION
The ceph-luminous repo package hierarchy has been restructed from being
a flat directory structure to use a Packages/<pkg_name_first_letter>
scheme, so we need to use the same scheme when downloading the needed
packages.