### PR TITLE
Fix amphora image rpm selection process (SOC-11407)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_amphora_image/defaults/main.yml
@@ -17,4 +17,4 @@
 
 ardana_scratch_path: "~/scratch/ansible/next/ardana/ansible"
 
-octavia_amphora_image_rpm: "find /srv/www/*/x86_64/repos/*OpenStack*/ -name '*octavia-amphora-image*' | tail -n1"
+octavia_amphora_image_rpm: "find /srv/www/*/x86_64/repos/*OpenStack*/ -name '*octavia-amphora-image*' | sort --version-sort | tail -n1"


### PR DESCRIPTION
The linux find command returns the list of files found in a directory
in the order they are found in the directory listing which is usually
some form of inode order, and not necessarily lexically sorted.

This patch fixes the issue by including a 'sort --version-sort' in
the shell command pipeline before the 'tail -n1' so that the list of
RPM packages is version sorted.