### PR TITLE
jenkins cleanvm: Use openSUSE Leap 15.2 for master

### DIFF
--- a/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
+++ b/jenkins/ci.opensuse.org/openstack-cleanvm.yaml
@@ -55,6 +55,6 @@
       - timed: 'H 4 * * *'
 
     image:
-      - openSUSE-Leap-15.1
+      - openSUSE-Leap-15.2
     jobs:
       - 'openstack-cleanvm-{release}'


### PR DESCRIPTION
That's the latest version and we only build packages for that.