### PR TITLE
openstack-crowbar: add MU repos before register node

### DIFF
--- a/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
+++ b/scripts/jenkins/cloud/ansible/register-crowbar-nodes.yml
@@ -23,6 +23,12 @@
   tasks:
     - block:
         - include_role:
+            name: crowbar_update
+          when:
+            - not update_after_deploy
+            - maint_updates_list | length
+
+        - include_role:
             name: crowbar_register
         - include_role:
             name: crowbar_setup
@@ -59,13 +65,6 @@
             - setup_aliases
           loop_control:
             loop_var: command
-
-        - include_role:
-            name: crowbar_update
-          when:
-            - not update_after_deploy
-            - maint_updates_list | length
-
 
       rescue:
         - include_role:

--- a/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/register_nodes.yml
+++ b/scripts/jenkins/cloud/ansible/roles/crowbar_register/tasks/register_nodes.yml
@@ -8,11 +8,11 @@
     dest: "/etc/hosts"
     line: "{{ hostvars['localhost'].admin_conf_ip }}    crowbar.{{ cloud_fqdn }}"
 
-- name: Remove existing repositories
+- name: Remove existing repositories (except Maint. Updates)
   shell: |
     set -e
-    while [ "`zypper lr | grep ^1`" != '' ]; do
-      zypper rr 1
+    for repo in $(zypper lr | grep -v "Maint-Update-" | awk '/Yes/ { print $3 }'); do
+      zypper rr $repo
     done
 
 - name: Run crowbar_register


### PR DESCRIPTION
The MU repositories needs to be setup before registering the node so it
can install the latest packages coming from the MU repositories during
the crowbar register step.