### PR TITLE
Enable SLE12-SP4-LTSS repos for Cloud9 CI/Gating jobs

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -106,7 +106,7 @@ sles_ltss_test_repos:
 sles_ltss_enabled:
   cloud7: true
   cloud8: true
-  cloud9: false
+  cloud9: true
 
 cloud_update_repos_enabled: "{{ '+up' in cloudsource }}"
 sles_test_repos_enabled: "{{ updates_test_enabled and ((task == 'deploy' and not (update_after_deploy and 'GM' in cloudsource)) or (task in ['update', 'disable-repos', 'upgrade'])) }}"


### PR DESCRIPTION
Now that we have mirrored the SLE12-SP4-LTSS repos to Provo, we can
enable the inclusion of the SLE12-SP4-LTSS repos in the Cloud9 CI
and Gating test runs.