### PR TITLE
WIP: Test hack for SLE 12 SP3 LTSS causing SOC8 update issues (DO NO MERGE)

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_zypper_repos/defaults/main.yml
@@ -105,7 +105,7 @@ sles_ltss_test_repos:
 
 sles_ltss_enabled:
   cloud7: true
-  cloud8: true
+  cloud8: false
   cloud9: true
 
 cloud_update_repos_enabled: "{{ '+up' in cloudsource }}"


### PR DESCRIPTION
Test running with SLE 12 SP3 LTSS configuration disabled in SOC8 deploys to enable checking if this breaks things for the update scenario