### PR TITLE
Switch Cloud8 to use legacy ISO server (SOC-11466)

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/all.yml
@@ -45,6 +45,7 @@ cloud_git_branch:
 
 clouddata_server: "provo-clouddata.cloud.suse.de"
 sles_media_server: "ibs-mirror.prv.suse.net"
+sles_alt_media_server: "ardana.ci.prv.suse.net"
 
 rhel_enabled: "{{ rhel_computes is defined and rhel_computes | int > 0 }}"
 ses_enabled: False

--- a/scripts/jenkins/cloud/ansible/roles/bootstrap_ardana/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/bootstrap_ardana/defaults/main.yml
@@ -29,7 +29,7 @@ rhel7_opt_yum:
 
 cobbler_requires:
   - name: "sles12sp3.iso"
-    url: "http://{{ sles_media_server }}/install/SLE-12-SP3-Server-GM/SLE-12-SP3-Server-DVD-x86_64-GM-DVD1.iso"
+    url: "http://{{ sles_alt_media_server }}/install/SLE-12-SP3-Server-GM/SLE-12-SP3-Server-DVD-x86_64-GM-DVD1.iso"
     download_when: "{{ cloud_release == 'cloud8' and (is_physical_deploy or pxe_boot_enabled) }}"
   - name: "sles12sp4.iso"
     url: "http://{{ sles_media_server }}/install/SLE-12-SP4-Server-GM/SLE-12-SP4-Server-DVD-x86_64-GM-DVD1.iso"
@@ -38,5 +38,5 @@ cobbler_requires:
     url: "http://10.84.144.252/compute_iso/{{ rhel_iso[rhel_os] }}"
     download_when: "{{ rhel_enabled }}"
   - name: "rhel7-opt-yum.tgz"
-    url: "http://ardana.suse.provo.cloud/yum-extras/{{ rhel7_opt_yum[rhel_os_version] }}"
+    url: "http://{{ sles_alt_media_server }}/yum-extras/{{ rhel7_opt_yum[rhel_os_version] }}"
     download_when: "{{ rhel_enabled }}"


### PR DESCRIPTION
Recent changes to the mirroring policies for ibs-mirror.prv.suse.net
mean that it no longer mirrors the SLE 12 SP3 ISO that is needed by
the SOC 8 CLM cobbler (PXE Boot) re-imaging process.

I have manually setup a mirror of the necessary ISO on the legacy
CI artifacts server for Ardana, ardana.ci.prv.suse.net, with the
same directory hierarchy, so we can just switch the hostname in
the URL to fix this.

Also updated an occurrence of the old suse.provo.cloud version of
the name for the legacy CI artifacts server.