### PR TITLE
Clarify extra_repos job argument doc

### DIFF
--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -318,7 +318,7 @@
           regex: '((http(s)?:\/\/[^ ,]+)(\,http(s)?:\/\/[^ ,]+)*)*'
           msg: The entered value failed validation
           description: >-
-            A comma separated list of repository urls to be configured on the admin node
+            A comma separated list of repository urls to be downloaded to the admin node and then used from other nodes
 
       - bool:
           name: rc_notify


### PR DESCRIPTION
It was misunderstood as to only be available on the admin node.

Guang Yee tested that the repos were also used on the other nodes.