### PR TITLE
Move from travis to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,103 @@
+pipeline {
+  agent { label "cloud-trigger" }
+
+  parameters {
+    booleanParam(name: 'usejenkinsrepo', defaultValue: true,
+      description: 'Prefer the repo url and branch that Jenkins passed e.g. from the Multibranch Github Plugin. Otherwise use the repourl and branch parameter below.')
+    string(name: 'repourl', defaultValue: 'git@github.com:SUSE-Cloud/automation.git', description: 'url to use of a automation.git repository')
+    string(name: 'branch', defaultValue: 'master', description: 'branch to use of the automation.git')
+  }
+
+  options {
+    ansiColor('xterm')
+  }
+
+  stages {
+    stage('Output environment') {
+      steps {
+        sh "env"
+      }
+    }
+
+    stage('Checkout from Multibranch') {
+      when { expression { params.usejenkinsrepo } }
+      steps {
+        git branch: "${env.BRANCH_NAME}",
+            url: "${env.GIT_URL}"
+      }
+    }
+
+    stage('Checkout from parameters') {
+      when { not { expression { params.usejenkinsrepo } } }
+      steps {
+        git branch: "${params.branch}",
+            url: "${params.repourl}"
+      }
+    }
+
+    stage('make clean') {
+      steps {
+        sh 'make clean'
+      }
+    }
+
+    stage('Run checks') {
+      parallel {
+
+        stage('make filecheck') {
+          steps {
+            sh 'make filecheck'
+          }
+        }
+        stage('make bashate') {
+          steps {
+            sh 'echo TODO install python3-bashate to run make bashate'
+          }
+        }
+        stage('make rounduptest') {
+          steps {
+            sh 'echo TODO package roundup to run make rounduptest'
+          }
+        }
+        stage('make perlcheck') {
+          steps {
+            sh 'make perlcheck'
+          }
+        }
+        stage('make rubycheck') {
+          steps {
+            sh 'make rubycheck'
+          }
+        }
+        stage('make pythoncheck') {
+          steps {
+            sh 'make pythoncheck'
+          }
+        }
+        stage('make flake8') {
+          steps {
+            sh 'make flake8'
+          }
+        }
+        stage('make python_unittest') {
+          steps {
+            sh 'make python_unittest'
+          }
+        }
+        stage('make jjb_test') {
+          steps {
+            sh 'make jjb_test'
+          }
+        }
+
+      }
+    }
+
+    stage('final make clean') {
+      steps {
+        sh 'make clean'
+      }
+    }
+
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,7 @@ shellcheck:
 	shellcheck `grep -Erl '^#! ?/bin/b?a?sh'`
 
 install:
-	sudo zypper install perl-JSON-XS perl-libxml-perl perl-libwww-perl python-pip python3-pip libvirt-python python3-libvirt-python
-	sudo pip2 install -U bashate flake8 flake8-import-order jenkins-job-builder
-	sudo pip3 install -U bashate flake8 flake8-import-order jenkins-job-builder
+	sudo zypper install perl-JSON perl-JSON-XS perl-libxml-perl perl-libwww-perl python-pip python3-pip libvirt-python python3-libvirt-python python2-flake8-import-order python3-bashate python3-jenkins-job-builder
 	git clone https://github.com/SUSE-Cloud/roundup && \
 	cd roundup && \
 	./configure && \


### PR DESCRIPTION
Travis shut down or something, use this chance to move the tests to
the existing Jenkins.

This adds a Jenkinsfile to call each of the targets in make test
individually so that the output is easier to read in Jenkins.

Replace pip packages with zypper packages in make install.

Add perl-JSON to make install. It was was missed until now.