### PR TITLE
Add job cloud-automation-test to replace Travis

### DIFF
--- a/jenkins/ci.suse.de/cloud-automation-test.yaml
+++ b/jenkins/ci.suse.de/cloud-automation-test.yaml
@@ -1,0 +1,24 @@
+- job:
+    name: 'cloud-automation-test'
+    project-type: multibranch
+    node: cloud-trigger
+
+    scm:
+      - github:
+          repo: automation
+          repo-owner: SUSE-Cloud
+          credentials-id: c2350527-476a-45df-b406-84f028614682
+          branch-discovery: no-pr
+          discover-pr-origin: merge-current
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+    periodic-folder-trigger: 5m
+    days-to-keep: 14
+    script-path: Jenkinsfile
+
+    wrappers:
+      - timeout:
+          fail: true
+          timeout: 120
+      - timestamps
+


### PR DESCRIPTION
It uses the Jenkinsfile in this repo.

The current job was manually created, this overwrites it with JJB to have it in git.