### PR TITLE
Allow changing the HA sync mark timeout multiplier

### DIFF
--- a/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/group_vars/all/crowbar.yml
@@ -9,7 +9,7 @@ cloud_fqdn: "{{ cloud_env }}.prv.suse.net"
 
 mkcloud_config_file: "{{ workspace_path }}/mkcloud.config"
 crowbar_batch_file: "{{ workspace_path }}/scenario.yml"
-sync_mark_timeout_multiplier: "1.0"
+sync_mark_timeout_multiplier: "2.0"
 
 ssl_enabled: true
 

--- a/scripts/jenkins/cloud/ansible/install-crowbar.yml
+++ b/scripts/jenkins/cloud/ansible/install-crowbar.yml
@@ -34,6 +34,7 @@
           loop_control:
             loop_var: command
 
+        # TODO replace the below with environment var crowbar_sync_mark_timeout_multiplier to qa_crowbarsetup above
         - name: Check if sync mark timeout_multiplier feature is present
           command: "knife data bag show crowbar-config -F json"
           register: _crowbar_config_json


### PR DESCRIPTION
This was already supported in the jobs running with Openstack Heat
stacks. Implement the same thing when running with mkcloud.

Both implementations are now changed to by default set it to 2.0, before
the default was to not change it.

I leave the implementation used by Heat stacks as is to reduce risk, as
a result there it will be set it twice.