### PR TITLE
SOC-11594: force wipe new LVs in mkcloud

### DIFF
--- a/scripts/lib/mkcloud-driver-libvirt.sh
+++ b/scripts/lib/mkcloud-driver-libvirt.sh
@@ -232,8 +232,8 @@ function _lvcreate()
 
     # first: create on the PV device (spread IO)
     # fallback: create in VG (if PVs with different size exist)
-    $sudo lvcreate -n $lv_name -L ${lv_size}G $lv_vg $lv_pv || \
-        safely $sudo lvcreate -n $lv_name -L ${lv_size}G $lv_vg
+    $sudo lvcreate --yes -W y -n $lv_name -L ${lv_size}G $lv_vg $lv_pv || \
+        safely $sudo lvcreate --yes -W y -n $lv_name -L ${lv_size}G $lv_vg
 }
 
 function wipe_volume


### PR DESCRIPTION
Sometimes, logical volumes created by mkcloud may end up
aligned such that they contain GPT signatures from the
previous run. The resulting prompt will stop mkcloud dead in
its tracks. In order to avoid this situation, this commit
forces overwriting such leftover signatures.