### PR TITLE
fix yaml.load to use safe loader

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/heat-generator/library/load_input_model.py
+++ b/scripts/jenkins/cloud/ansible/roles/heat-generator/library/load_input_model.py
@@ -54,7 +54,7 @@ def merge_input_model(data, input_model):
 def load_input_model_file(file_name, input_model):
     if file_name.endswith('.yml') or file_name.endswith('.yaml'):
         with open(file_name, 'r') as data_file:
-            data = yaml.load(data_file.read())
+            data = yaml.safe_load(data_file.read())
             merge_input_model(
                 data,
                 input_model)


### PR DESCRIPTION
Found because of the following error:
15:44:09  fatal: [localhost]: FAILED! => changed=false
15:44:09    msg: |-
15:44:09      load_input_model.py: Traceback (most recent call last):
15:44:09        File "/tmp/ansible_load_input_model_payload_23nundi2/__main__.py", line 93, in main
15:44:09          input_model = load_input_model(input_model_path)
15:44:09        File "/tmp/ansible_load_input_model_payload_23nundi2/__main__.py", line 74, in load_input_model
15:44:09          input_model)
15:44:09        File "/tmp/ansible_load_input_model_payload_23nundi2/__main__.py", line 57, in load_input_model_file
15:44:09          data = yaml.load(data_file.read())
15:44:09      TypeError: load() missing 1 required positional argument: 'Loader'

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation