### PR TITLE
increase size for root fs of ardana deployer

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_root_partition/defaults/main.yml
@@ -35,4 +35,4 @@ vm_fdisk_start_field: 2
 # the size (in GB) to which the LVM root partition is resized
 # this needs to be less than 95% of the total available size, otherwise
 # the Ardana osconfig play will fail
-min_deployer_root_part_size: 44
+min_deployer_root_part_size: 54


### PR DESCRIPTION
otherwise CI fails due to not enough free disk space