### PR TITLE
Fix comment: root fs size must be smaller than 65%

### DIFF
--- a/scripts/jenkins/cloud/ansible/roles/setup_root_partition/defaults/main.yml
+++ b/scripts/jenkins/cloud/ansible/roles/setup_root_partition/defaults/main.yml
@@ -33,6 +33,6 @@ lvm_resize_tools:
 vm_fdisk_start_field: 2
 
 # the size (in GB) to which the LVM root partition is resized
-# this needs to be less than 95% of the total available size, otherwise
+# this needs to be less than 65% of the total available size, otherwise
 # the Ardana osconfig play will fail
 min_deployer_root_part_size: 54


### PR DESCRIPTION
If the root parition is not smaller than 65% of the disk then a later step would shrink the volume
which is thus aborted and fails the job.

This value is from line 44 of
scripts/jenkins/cloud/ansible/roles/cloud_generator/templates/input_model/data/disk_models.yml