### PR TITLE
Switching jobs to use lightweight checkout

### DIFF
--- a/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
+++ b/jenkins/ci.suse.de/cloud-maintenance-gating.yaml
@@ -85,10 +85,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/cloud-maintenance-gating.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-testbuild-gerrit.yaml
@@ -88,10 +88,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/openstack-ardana-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-tests.yaml
@@ -190,10 +190,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update-and-test.yaml
@@ -179,10 +179,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/openstack-ardana-update.yaml
+++ b/jenkins/ci.suse.de/openstack-ardana-update.yaml
@@ -148,10 +148,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/openstack-caaspv4.yaml
+++ b/jenkins/ci.suse.de/openstack-caaspv4.yaml
@@ -115,10 +115,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
+++ b/jenkins/ci.suse.de/openstack-crowbar-tests.yaml
@@ -118,10 +118,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/openstack-ses.yaml
+++ b/jenkins/ci.suse.de/openstack-ses.yaml
@@ -117,10 +117,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${git_automation_repo}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${git_automation_branch}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/${JOB_NAME}.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-job-gerrit-template.yaml
@@ -159,10 +159,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${{git_automation_repo}}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${{git_automation_branch}}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/openstack-ardana-gerrit.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-ardana-pipeline-template.yaml
@@ -592,10 +592,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${{git_automation_repo}}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${{git_automation_branch}}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/openstack-ardana.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-crowbar-pipeline-template.yaml
@@ -422,10 +422,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${{git_automation_repo}}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${{git_automation_branch}}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/openstack-crowbar.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-gating-template.yaml
@@ -64,10 +64,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${{git_automation_repo}}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight checkout ${{git_automation_repo}}
             branches:
-              - ${{git_automation_branch}}
+              - master
+                #${{git_automation_branch}}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/cloud-gating.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-heat-template.yaml
@@ -121,10 +121,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${{git_automation_repo}}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${{git_automation_branch}}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/openstack-cloud-heat.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-image-update-template.yaml
@@ -107,10 +107,12 @@
     pipeline-scm:
       scm:
         - git:
-            url: ${{git_automation_repo}}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${{git_automation_branch}}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/openstack-cloud-image-update.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true

--- a/jenkins/ci.suse.de/templates/cloud-jenkins-worker-template.yaml
+++ b/jenkins/ci.suse.de/templates/cloud-jenkins-worker-template.yaml
@@ -109,14 +109,15 @@
             the job's parameters, such as testing automation git pull
             requests with special configurations.
 
-
     pipeline-scm:
       scm:
         - git:
-            url: ${{git_automation_repo}}
+            url: https://github.com/SUSE-Cloud/automation.git
+            #bug in lightweight-checkout ${git_automation_repo}
             branches:
-              - ${{git_automation_branch}}
+              - master
+                #${git_automation_branch}
             browser: auto
             wipe-workspace: false
       script-path: jenkins/ci.suse.de/pipelines/cloud-jenkins-worker.Jenkinsfile
-      lightweight-checkout: false
+      lightweight-checkout: true


### PR DESCRIPTION
After recent Jenkins security updates all CI pipeline jobs start to
fail. Adding work around by enabling lightweight checkout.